### PR TITLE
Integrate Composio agent-orchestrator tracker, SCM, and notifier adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ pnpm gui:build    # produce a release .app/.dmg
 
 The Rust backend in `gui/src-tauri/` shares `crates/harness-data` with the TUI, so both read the same `~/.agent-harness/` files.
 
+## Tracker & PR integrations
+
+Harness consumes Composio's [`@aoagents/ao-core`](https://www.npmjs.com/package/@aoagents/ao-core) plugin packages for issue-tracker and SCM integrations. No plugin from their stack runs harness itself — we import only the leaf adapters.
+
+### Issue-URL ingestion
+
+If the first argument to the classifier is a GitHub or Linear issue URL (or a bare Linear key like `ABC-123`), the harness fetches the full issue (title, body, labels, branch hint) and feeds it into classification. Classifier output carries an optional `suggestedBranch` so downstream ticket creation can match the tracker's native branch name.
+
+Tokens are read from the environment:
+
+- `GITHUB_TOKEN` — GitHub issues + PR watcher
+- `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) — Linear issues
+
+### PR watcher
+
+`src/integrations/pr-poller.ts` polls all tracked PRs via `enrichSessionsPRBatch` (30s by default). State transitions (CI pass→fail, review pending→changes_requested, PR merged/closed) post `status_update` entries into the ticket's channel. CI failures and change-request reviews emit a `FollowUpRequest` through an injected `FollowUpDispatcher`; wiring that dispatcher into the scheduler so it creates real follow-up tickets is the next piece of work.
+
+### AO-compatible notifier
+
+`src/channels/ao-notifier.ts` exports `HarnessChannelNotifier` implementing AO's `Notifier` interface on top of the channel store. If you ever run Composio's `ao` orchestrator, harness can be plugged in as its notifier without a rewrite.
+
 ## Flags
 
 - `HARNESS_LIVE=1` — use real Claude/Codex adapters instead of scripted simulation

--- a/package.json
+++ b/package.json
@@ -31,5 +31,11 @@
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "zod": "^3.24.4"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "0.2.5",
+    "@aoagents/ao-plugin-scm-github": "0.2.5",
+    "@aoagents/ao-plugin-tracker-github": "0.2.5",
+    "@aoagents/ao-plugin-tracker-linear": "0.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: 0.2.5
+        version: 0.2.5
+      '@aoagents/ao-plugin-scm-github':
+        specifier: 0.2.5
+        version: 0.2.5
+      '@aoagents/ao-plugin-tracker-github':
+        specifier: 0.2.5
+        version: 0.2.5
+      '@aoagents/ao-plugin-tracker-linear':
+        specifier: 0.2.5
+        version: 0.2.5
     devDependencies:
       '@types/node':
         specifier: ^22.15.30
@@ -19,12 +32,28 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       zod:
         specifier: ^3.24.4
         version: 3.25.76
 
 packages:
+
+  '@aoagents/ao-core@0.2.5':
+    resolution: {integrity: sha512-Mup4ftuE3vLJBIWikfwWTaEsb/yuzk5yJQzigHRV37uygPh2XFY6yZXkClYyWgtHXCkxp8riV6iy1qR2arC4sQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aoagents/ao-plugin-scm-github@0.2.5':
+    resolution: {integrity: sha512-SusJUqdR8cb8H8hg2Pm3vZmEBTX5rA3sg2SkAT+seQ81eflVM5Ab2K0diRfBizLjgfQk2aPrbKvfhMgAA2yhxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aoagents/ao-plugin-tracker-github@0.2.5':
+    resolution: {integrity: sha512-HuedEGDRysMUMLF9NCDYheLbphBXbHZ9K1sxy+CN2hFmSBd+Lndg+uG1qDctj5i0Geb/q4IB9zfRiqTT8+TXKA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aoagents/ao-plugin-tracker-linear@0.2.5':
+    resolution: {integrity: sha512-nfQt1S/AE2peX2gEoutqaWUtcn+9zZj1inNiODvX/APCdJipnflwjF36WvuEfJsNopo1DDqXLKBz/0QTYgU/AA==}
+    engines: {node: '>=20.0.0'}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -584,10 +613,32 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@aoagents/ao-core@0.2.5':
+    dependencies:
+      yaml: 2.8.3
+      zod: 3.25.76
+
+  '@aoagents/ao-plugin-scm-github@0.2.5':
+    dependencies:
+      '@aoagents/ao-core': 0.2.5
+
+  '@aoagents/ao-plugin-tracker-github@0.2.5':
+    dependencies:
+      '@aoagents/ao-core': 0.2.5
+
+  '@aoagents/ao-plugin-tracker-linear@0.2.5':
+    dependencies:
+      '@aoagents/ao-core': 0.2.5
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
@@ -765,13 +816,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -964,13 +1015,13 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -985,7 +1036,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -997,12 +1048,13 @@ snapshots:
       '@types/node': 22.19.15
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1020,8 +1072,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
@@ -1043,5 +1095,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yaml@2.8.3: {}
 
   zod@3.25.76: {}

--- a/src/channels/ao-notifier.ts
+++ b/src/channels/ao-notifier.ts
@@ -1,0 +1,102 @@
+import type {
+  Notifier,
+  NotifyAction,
+  NotifyContext,
+  OrchestratorEvent
+} from "@aoagents/ao-core";
+
+import type { ChannelStore } from "./channel-store.js";
+
+/**
+ * Adapts the harness channel system to AO's `Notifier` interface so the
+ * harness can be used as a drop-in notifier in any AO deployment.
+ *
+ * Events become channel feed entries (posted via `ChannelStore.postEntry`)
+ * with the event type, session id, and a human-readable message.
+ */
+export class HarnessChannelNotifier implements Notifier {
+  readonly name = "harness-channel";
+
+  private readonly channelStore: ChannelStore;
+  private readonly defaultChannelId: string;
+
+  constructor(options: { channelStore: ChannelStore; defaultChannelId: string }) {
+    this.channelStore = options.channelStore;
+    this.defaultChannelId = options.defaultChannelId;
+  }
+
+  /** Push a notification to the default channel as a status_update entry. */
+  async notify(event: OrchestratorEvent): Promise<void> {
+    await this.channelStore.postEntry(this.defaultChannelId, {
+      type: "status_update",
+      fromAgentId: null,
+      fromDisplayName: "orchestrator",
+      content: this.formatEventMessage(event),
+      metadata: this.buildEventMetadata(event)
+    });
+  }
+
+  /** Push a notification with actionable links appended to the body. */
+  async notifyWithActions(
+    event: OrchestratorEvent,
+    actions: NotifyAction[]
+  ): Promise<void> {
+    const base = this.formatEventMessage(event);
+    const actionLines = actions
+      .map((a) => {
+        const target = a.url ?? a.callbackEndpoint ?? "";
+        return target ? `- ${a.label}: ${target}` : `- ${a.label}`;
+      })
+      .join("\n");
+
+    const content = actionLines ? `${base}\n\nActions:\n${actionLines}` : base;
+
+    await this.channelStore.postEntry(this.defaultChannelId, {
+      type: "status_update",
+      fromAgentId: null,
+      fromDisplayName: "orchestrator",
+      content,
+      metadata: this.buildEventMetadata(event)
+    });
+  }
+
+  /**
+   * Direct channel post. Uses `context.channel` if provided, otherwise
+   * falls back to the configured default channel. Returns the entry id
+   * (AO's Notifier contract expects a string|null identifier).
+   */
+  async post(message: string, context?: NotifyContext): Promise<string | null> {
+    const channelId = context?.channel ?? this.defaultChannelId;
+
+    const metadata: Record<string, string> = {};
+    if (context?.sessionId) metadata.sessionId = context.sessionId;
+    if (context?.projectId) metadata.projectId = context.projectId;
+    if (context?.prUrl) metadata.prUrl = context.prUrl;
+
+    const entry = await this.channelStore.postEntry(channelId, {
+      type: "message",
+      fromAgentId: null,
+      fromDisplayName: "orchestrator",
+      content: message,
+      metadata
+    });
+
+    return entry.entryId;
+  }
+
+  private formatEventMessage(event: OrchestratorEvent): string {
+    const prefix = `[${event.type}] session=${event.sessionId}`;
+    return event.message ? `${prefix} — ${event.message}` : prefix;
+  }
+
+  private buildEventMetadata(event: OrchestratorEvent): Record<string, string> {
+    return {
+      eventId: event.id,
+      eventType: event.type,
+      priority: event.priority,
+      sessionId: event.sessionId,
+      projectId: event.projectId,
+      timestamp: event.timestamp.toISOString()
+    };
+  }
+}

--- a/src/domain/classification.ts
+++ b/src/domain/classification.ts
@@ -20,7 +20,13 @@ export const ClassificationResultSchema = z.object({
   estimatedTicketCount: z.number().int().min(1).max(50),
   needsDesignDoc: z.boolean(),
   needsUserApproval: z.boolean(),
-  crosslinkRepos: z.array(z.string()).default([])
+  crosslinkRepos: z.array(z.string()).default([]),
+  /**
+   * Branch name suggested by a tracker plugin (GitHub/Linear) when the request
+   * was an issue URL or bare Linear identifier. Purely advisory — callers may
+   * use it to seed worktree names for downstream tickets.
+   */
+  suggestedBranch: z.string().optional()
 });
 
 export type ClassificationResult = z.infer<typeof ClassificationResultSchema>;

--- a/src/integrations/pr-poller.ts
+++ b/src/integrations/pr-poller.ts
@@ -1,0 +1,244 @@
+/**
+ * PR poller — watches tracked pull requests and feeds CI failures and
+ * review-requested events back into the harness as follow-up tickets.
+ *
+ * In-memory only; posts channel entries via `ChannelStore` and dispatches
+ * follow-ups through an injected `FollowUpDispatcher` because the existing
+ * `TicketScheduler` does not expose a public enqueue surface.
+ *
+ * Transitions per polled PR:
+ *   - ci -> "failing": post entry + enqueue "fix-ci" follow-up.
+ *   - review -> "changes_requested": post entry + enqueue "address-reviews".
+ *   - prState -> "merged" | "closed": post entry + untrack.
+ *   - Any other delta: informational entry only.
+ */
+import type {
+  CiSummary,
+  EnrichedPR,
+  HarnessPR,
+  HarnessScm,
+  ReviewDecision,
+} from "./scm.js";
+import type { ChannelStore } from "../channels/channel-store.js";
+
+export interface TrackedPr {
+  ticketId: string;
+  channelId: string;
+  pr: HarnessPR;
+  repo: { owner: string; name: string };
+}
+
+export type FollowUpKind = "fix-ci" | "address-reviews";
+
+export interface FollowUpRequest {
+  kind: FollowUpKind;
+  parentTicketId: string;
+  channelId: string;
+  pr: HarnessPR;
+  repo: { owner: string; name: string };
+  title: string;
+  prompt: string;
+}
+
+export interface FollowUpDispatcher {
+  enqueueFollowUp(request: FollowUpRequest): Promise<string>;
+}
+
+export interface PrPollerOptions {
+  scm: HarnessScm;
+  channelStore: ChannelStore;
+  scheduler: FollowUpDispatcher;
+  intervalMs?: number;
+}
+
+interface TrackedState {
+  entry: TrackedPr;
+  last: EnrichedPR | null;
+}
+
+const DEFAULT_INTERVAL_MS = 30_000;
+
+export class PrPoller {
+  private readonly scm: HarnessScm;
+  private readonly channelStore: ChannelStore;
+  private readonly scheduler: FollowUpDispatcher;
+  private readonly intervalMs: number;
+  private readonly tracked = new Map<string, TrackedState>();
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(options: PrPollerOptions) {
+    this.scm = options.scm;
+    this.channelStore = options.channelStore;
+    this.scheduler = options.scheduler;
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  }
+
+  track(entry: TrackedPr): void {
+    this.tracked.set(entry.ticketId, { entry, last: null });
+  }
+
+  untrack(ticketId: string): void {
+    this.tracked.delete(ticketId);
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.tick().catch(() => {
+        /* polling must never crash the process */
+      });
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<void> {
+    if (this.running || this.tracked.size === 0) return;
+
+    this.running = true;
+    try {
+      const states = Array.from(this.tracked.values());
+      let enriched: Map<string, EnrichedPR>;
+      try {
+        enriched = await this.scm.enrichBatch(states.map((s) => s.entry.pr));
+      } catch {
+        return;
+      }
+
+      for (const state of states) {
+        const current = enriched.get(this.keyFor(state.entry));
+        if (!current) continue;
+
+        const previous = state.last;
+        state.last = current;
+
+        // First observation seeds state without firing events.
+        if (previous === null) continue;
+
+        await this.handleTransitions(state.entry, previous, current);
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async handleTransitions(
+    entry: TrackedPr,
+    previous: EnrichedPR,
+    current: EnrichedPR,
+  ): Promise<void> {
+    if (current.ci !== previous.ci) {
+      await this.onCiChange(entry, previous.ci, current.ci);
+    }
+    if (current.review !== previous.review) {
+      await this.onReviewChange(entry, previous.review, current.review);
+    }
+    if (current.prState !== previous.prState) {
+      await this.onPrStateChange(entry, current.prState);
+    }
+  }
+
+  private async onCiChange(entry: TrackedPr, from: CiSummary, to: CiSummary): Promise<void> {
+    await this.post(entry.channelId, `CI ${from} -> ${to} on ${this.keyFor(entry)}`, {
+      ticketId: entry.ticketId,
+      prUrl: entry.pr.url,
+      ciFrom: from,
+      ciTo: to,
+    });
+
+    if (to !== "failing") return;
+
+    const label = this.keyFor(entry);
+    await this.enqueue({
+      kind: "fix-ci",
+      parentTicketId: entry.ticketId,
+      channelId: entry.channelId,
+      pr: entry.pr,
+      repo: entry.repo,
+      title: `fix-ci: ${label}`,
+      prompt: [
+        `CI started failing on ${label} (${entry.pr.url}).`,
+        `Parent ticket: ${entry.ticketId}.`,
+        `Investigate the failing checks, reproduce locally, and push a fix to branch "${entry.pr.branch}".`,
+      ].join("\n"),
+    });
+  }
+
+  private async onReviewChange(
+    entry: TrackedPr,
+    from: ReviewDecision,
+    to: ReviewDecision,
+  ): Promise<void> {
+    await this.post(entry.channelId, `Review ${from} -> ${to} on ${this.keyFor(entry)}`, {
+      ticketId: entry.ticketId,
+      prUrl: entry.pr.url,
+      reviewFrom: from,
+      reviewTo: to,
+    });
+
+    if (to !== "changes_requested") return;
+
+    const label = this.keyFor(entry);
+    await this.enqueue({
+      kind: "address-reviews",
+      parentTicketId: entry.ticketId,
+      channelId: entry.channelId,
+      pr: entry.pr,
+      repo: entry.repo,
+      title: `address-reviews: ${label}`,
+      prompt: [
+        `Reviewers requested changes on ${label} (${entry.pr.url}).`,
+        `Parent ticket: ${entry.ticketId}.`,
+        `Read the pending comments, address each one, and push follow-up commits to branch "${entry.pr.branch}".`,
+      ].join("\n"),
+    });
+  }
+
+  private async onPrStateChange(
+    entry: TrackedPr,
+    to: "open" | "merged" | "closed",
+  ): Promise<void> {
+    await this.post(entry.channelId, `PR ${this.keyFor(entry)} is now ${to}`, {
+      ticketId: entry.ticketId,
+      prUrl: entry.pr.url,
+      prState: to,
+    });
+    if (to === "merged" || to === "closed") this.untrack(entry.ticketId);
+  }
+
+  private async post(
+    channelId: string,
+    content: string,
+    metadata: Record<string, string>,
+  ): Promise<void> {
+    try {
+      await this.channelStore.postEntry(channelId, {
+        type: "status_update",
+        fromAgentId: null,
+        fromDisplayName: "pr-poller",
+        content,
+        metadata,
+      });
+    } catch {
+      /* non-critical */
+    }
+  }
+
+  private async enqueue(request: FollowUpRequest): Promise<void> {
+    try {
+      await this.scheduler.enqueueFollowUp(request);
+    } catch {
+      /* non-critical; next transition will re-fire */
+    }
+  }
+
+  private keyFor(entry: TrackedPr): string {
+    return `${entry.repo.owner}/${entry.repo.name}#${entry.pr.number}`;
+  }
+}

--- a/src/integrations/scm.ts
+++ b/src/integrations/scm.ts
@@ -1,0 +1,191 @@
+/**
+ * SCM integration facade.
+ *
+ * Wraps an AO `SCM` plugin with a narrower, harness-specific interface so the
+ * rest of the codebase never imports AO types directly. Do not leak
+ * `@aoagents/ao-core` types out of this module.
+ */
+import type {
+  PRInfo,
+  ProjectConfig,
+  SCM,
+  Session,
+} from "@aoagents/ao-core";
+import { create as createGithubScm } from "@aoagents/ao-plugin-scm-github";
+
+/** Narrow PR shape the harness operates on. */
+export interface HarnessPR {
+  number: number;
+  url: string;
+  branch: string;
+}
+
+/** Minimal project descriptor needed to drive the SCM facade. */
+export interface HarnessProject {
+  owner: string;
+  name: string;
+  /** Local checkout path. Optional; defaults to cwd if the plugin needs it. */
+  path?: string;
+  /** Default branch name. Optional; defaults to "main". */
+  defaultBranch?: string;
+}
+
+export type CiSummary = "pending" | "passing" | "failing" | "none";
+export type ReviewDecision =
+  | "approved"
+  | "changes_requested"
+  | "pending"
+  | "none";
+
+export interface PendingComment {
+  id: string;
+  author: string;
+  body: string;
+  path?: string;
+  line?: number;
+}
+
+export interface EnrichedPR {
+  ci: CiSummary;
+  review: ReviewDecision;
+  prState: "open" | "merged" | "closed";
+}
+
+export interface HarnessScm {
+  detectPR(
+    branch: string,
+    repo: { owner: string; name: string },
+  ): Promise<HarnessPR | null>;
+  getCiSummary(pr: HarnessPR): Promise<CiSummary>;
+  getReviewDecision(pr: HarnessPR): Promise<ReviewDecision>;
+  getPendingComments(pr: HarnessPR): Promise<PendingComment[]>;
+  enrichBatch(prs: HarnessPR[]): Promise<Map<string, EnrichedPR>>;
+}
+
+/**
+ * Build a configured AO `SCM` instance. The returned value is intentionally
+ * typed as `SCM` so callers can pass it to `wrapScm`; callers outside this
+ * module should not depend on any method beyond what `HarnessScm` exposes.
+ */
+export function createScm(
+  kind: "github",
+  opts: { token?: string } = {},
+): SCM {
+  if (kind !== "github") {
+    throw new Error(`createScm: unsupported kind "${kind as string}"`);
+  }
+  const token = opts.token ?? process.env.GITHUB_TOKEN;
+  if (token && !process.env.GITHUB_TOKEN) {
+    // The github plugin shells out to `gh`, which reads GITHUB_TOKEN from env.
+    process.env.GITHUB_TOKEN = token;
+  }
+  return createGithubScm();
+}
+
+/** Produce the narrow facade from a raw AO `SCM`. */
+export function wrapScm(scm: SCM, project: HarnessProject): HarnessScm {
+  const projectConfig = toProjectConfig(project);
+
+  const toPRInfo = (pr: HarnessPR): PRInfo => ({
+    number: pr.number,
+    url: pr.url,
+    branch: pr.branch,
+    title: "",
+    owner: project.owner,
+    repo: project.name,
+    baseBranch: project.defaultBranch ?? "main",
+    isDraft: false,
+  });
+
+  return {
+    async detectPR(branch, repo) {
+      const session = stubSession(branch);
+      const cfg =
+        repo.owner === project.owner && repo.name === project.name
+          ? projectConfig
+          : toProjectConfig({
+              owner: repo.owner,
+              name: repo.name,
+              path: project.path,
+              defaultBranch: project.defaultBranch,
+            });
+      const info = await scm.detectPR(session, cfg);
+      if (!info) return null;
+      return { number: info.number, url: info.url, branch: info.branch };
+    },
+    async getCiSummary(pr) {
+      return scm.getCISummary(toPRInfo(pr));
+    },
+    async getReviewDecision(pr) {
+      return scm.getReviewDecision(toPRInfo(pr));
+    },
+    async getPendingComments(pr) {
+      const comments = await scm.getPendingComments(toPRInfo(pr));
+      return comments.map((c) => ({
+        id: c.id,
+        author: c.author,
+        body: c.body,
+        path: c.path,
+        line: c.line,
+      }));
+    },
+    async enrichBatch(prs) {
+      const infos = prs.map(toPRInfo);
+      const out = new Map<string, EnrichedPR>();
+      if (typeof scm.enrichSessionsPRBatch === "function") {
+        const raw = await scm.enrichSessionsPRBatch(infos);
+        for (const [key, data] of raw) {
+          out.set(key, {
+            ci: data.ciStatus,
+            review: data.reviewDecision,
+            prState: data.state,
+          });
+        }
+        return out;
+      }
+      // Fallback: sequential per-PR queries.
+      for (const info of infos) {
+        const [prState, ciStatus, reviewDecision] = await Promise.all([
+          scm.getPRState(info),
+          scm.getCISummary(info),
+          scm.getReviewDecision(info),
+        ]);
+        out.set(`${info.owner}/${info.repo}#${info.number}`, {
+          ci: ciStatus,
+          review: reviewDecision,
+          prState,
+        });
+      }
+      return out;
+    },
+  };
+}
+
+function toProjectConfig(project: HarnessProject): ProjectConfig {
+  return {
+    name: `${project.owner}/${project.name}`,
+    repo: `${project.owner}/${project.name}`,
+    path: project.path ?? process.cwd(),
+    defaultBranch: project.defaultBranch ?? "main",
+    sessionPrefix: project.name,
+  };
+}
+
+function stubSession(branch: string): Session {
+  const now = new Date();
+  return {
+    id: `harness-scm-detect:${branch}`,
+    projectId: "harness-scm-detect",
+    status: "working",
+    activity: null,
+    branch,
+    issueId: null,
+    pr: null,
+    workspacePath: null,
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: now,
+    lastActivityAt: now,
+    metadata: {},
+  };
+}

--- a/src/integrations/tracker.ts
+++ b/src/integrations/tracker.ts
@@ -1,0 +1,97 @@
+/**
+ * Thin adapter around AO's Tracker plugins.
+ *
+ * The AO plugin packages expose a `create(): Tracker` factory and read their
+ * credentials from `process.env` (GITHUB_TOKEN / LINEAR_API_KEY). We honor
+ * `opts.token` by installing it into the expected env var for the duration of
+ * the factory call, then restoring the previous value.
+ *
+ * Keep this file as the single boundary: no other module in the harness should
+ * import from `@aoagents/*`.
+ */
+import type { ProjectConfig, Tracker } from "@aoagents/ao-core";
+import githubTracker from "@aoagents/ao-plugin-tracker-github";
+import linearTracker from "@aoagents/ao-plugin-tracker-linear";
+
+export type TrackerKind = "github" | "linear";
+
+/** Narrow shape used by the rest of the harness. Decoupled from AO's `Issue`. */
+export interface HarnessIssue {
+  id: string;
+  title: string;
+  body: string;
+  url: string;
+  labels: string[];
+  branchName: string;
+}
+
+const ENV_VAR: Record<TrackerKind, string> = {
+  github: "GITHUB_TOKEN",
+  linear: "LINEAR_API_KEY",
+};
+
+/**
+ * Build a configured Tracker. The AO plugin factories consume their token from
+ * env vars at construction time, so we temporarily overlay `opts.token` into
+ * the matching var if provided.
+ */
+export function createTracker(
+  kind: TrackerKind,
+  opts: { token?: string } = {},
+): Tracker {
+  const envVar = ENV_VAR[kind];
+  const previous = process.env[envVar];
+  if (opts.token !== undefined) {
+    process.env[envVar] = opts.token;
+  }
+  try {
+    return kind === "github" ? githubTracker.create() : linearTracker.create();
+  } finally {
+    if (opts.token !== undefined) {
+      if (previous === undefined) delete process.env[envVar];
+      else process.env[envVar] = previous;
+    }
+  }
+}
+
+/**
+ * Fetch an issue via the AO Tracker and project it into the harness's
+ * narrower `HarnessIssue` shape.
+ */
+export async function resolveIssue(
+  tracker: Tracker,
+  identifier: string,
+  project: ProjectConfig,
+): Promise<HarnessIssue> {
+  const issue = await tracker.getIssue(identifier, project);
+  const branchName =
+    issue.branchName ?? tracker.branchName(identifier, project);
+  return {
+    id: issue.id,
+    title: issue.title,
+    body: issue.description,
+    url: issue.url,
+    labels: issue.labels ?? [],
+    branchName,
+  };
+}
+
+// GitHub issue URL: https://github.com/<owner>/<repo>/issues/<number>
+const GITHUB_ISSUE_URL = /^https?:\/\/(?:www\.)?github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:[/?#].*)?$/i;
+// Linear issue URL: https://linear.app/<workspace>/issue/ABC-123(/...)
+const LINEAR_URL = /^https?:\/\/(?:www\.)?linear\.app\/[^/]+\/issue\/[A-Z][A-Z0-9]*-\d+/i;
+// Bare Linear identifier: ABC-123
+const LINEAR_BARE = /^[A-Z][A-Z0-9]*-\d+$/;
+
+/**
+ * Sniff a URL or identifier and guess which tracker it belongs to.
+ * Returns null when the input doesn't match any known pattern.
+ */
+export function detectTrackerKind(input: string): TrackerKind | null {
+  const s = input.trim();
+  if (!s) return null;
+  if (GITHUB_ISSUE_URL.test(s)) return "github";
+  if (LINEAR_URL.test(s)) return "linear";
+  if (LINEAR_BARE.test(s)) return "linear";
+  return null;
+}

--- a/src/orchestrator/classifier.ts
+++ b/src/orchestrator/classifier.ts
@@ -5,6 +5,14 @@ import {
 } from "../domain/classification.js";
 import type { AgentResult, WorkRequest } from "../domain/agent.js";
 import type { HarnessRun } from "../domain/run.js";
+import {
+  createTracker,
+  detectTrackerKind,
+  resolveIssue,
+  type HarnessIssue,
+  type TrackerKind
+} from "../integrations/tracker.js";
+import { basename } from "node:path";
 
 const TRIVIAL_PATTERNS = [
   /\b(fix\s+)?typo\b/i,
@@ -58,16 +66,132 @@ export function buildHeuristicClassification(
   };
 }
 
+/**
+ * Pull the tracker-native identifier out of a URL (or bare Linear key).
+ * GitHub issues: the numeric issue number (without `#`).
+ * Linear issues: the short identifier, e.g. `ABC-123`.
+ * Returns null if the shape is unrecognized.
+ */
+function parseIdentifier(input: string, kind: TrackerKind): string | null {
+  const s = input.trim();
+  if (kind === "github") {
+    const m = s.match(/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/i);
+    if (m) return m[1];
+    return null;
+  }
+  // linear
+  const urlMatch = s.match(/linear\.app\/[^/]+\/issue\/([A-Z][A-Z0-9]*-\d+)/i);
+  if (urlMatch) return urlMatch[1].toUpperCase();
+  if (/^[A-Z][A-Z0-9]*-\d+$/.test(s)) return s;
+  return null;
+}
+
+/**
+ * Build a minimal structural `ProjectConfig` from the harness's `repoRoot`.
+ * We deliberately do NOT import AO's `ProjectConfig` here — we rely on
+ * structural typing through the `resolveIssue` signature exported by
+ * `src/integrations/tracker.ts`, which is the single boundary to AO.
+ *
+ * For GitHub, we try to recover `owner/repo` from the issue URL itself; for
+ * Linear, the plugin ignores project.repo so a placeholder is fine.
+ */
+function buildProjectConfig(
+  repoRoot: string,
+  input: string,
+  kind: TrackerKind
+): {
+  name: string;
+  repo: string;
+  path: string;
+  defaultBranch: string;
+  sessionPrefix: string;
+} {
+  let repo = "";
+  if (kind === "github") {
+    const m = input.match(/github\.com\/([^/]+\/[^/]+?)(?:\/issues\/\d+)/i);
+    if (m) repo = m[1];
+  }
+  const leaf = basename(repoRoot) || "harness";
+  return {
+    name: repo || leaf,
+    repo: repo || leaf,
+    path: repoRoot,
+    defaultBranch: "main",
+    sessionPrefix: leaf
+  };
+}
+
+/**
+ * If `featureRequest` looks like a tracker issue URL/identifier, fetch the
+ * underlying issue and return it. Never throws — on any failure (bad URL,
+ * network/auth error, missing creds) logs a warning and returns null so the
+ * caller can fall back to classifying the raw string.
+ */
+async function tryResolveTrackerIssue(
+  featureRequest: string,
+  repoRoot: string
+): Promise<HarnessIssue | null> {
+  const kind = detectTrackerKind(featureRequest);
+  if (!kind) return null;
+
+  const identifier = parseIdentifier(featureRequest, kind);
+  if (!identifier) return null;
+
+  try {
+    const tracker = createTracker(kind);
+    const project = buildProjectConfig(repoRoot, featureRequest, kind);
+    return await resolveIssue(tracker, identifier, project);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[classifier] Failed to resolve ${kind} issue "${identifier}"; falling back to raw input. ${message}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Merge a tracker-fetched issue into the raw feature request so downstream
+ * heuristics and the LLM prompt see the title + body + labels, not just a
+ * bare URL.
+ */
+function enrichFeatureRequest(
+  featureRequest: string,
+  issue: HarnessIssue
+): string {
+  const labels = issue.labels.length ? `\nLabels: ${issue.labels.join(", ")}` : "";
+  const body = issue.body ? `\n\n${issue.body}` : "";
+  return `${issue.title}${labels}${body}\n\nSource: ${issue.url}`;
+}
+
 export async function classifyRequest(input: {
   run: HarnessRun;
   featureRequest: string;
   repoRoot: string;
   dispatch: (run: HarnessRun, request: Omit<WorkRequest, "runId">) => Promise<AgentResult>;
 }): Promise<ClassificationResult> {
-  const heuristicTier = classifyByHeuristic(input.featureRequest);
+  const issue = await tryResolveTrackerIssue(input.featureRequest, input.repoRoot);
+  const effectiveRequest = issue
+    ? enrichFeatureRequest(input.featureRequest, issue)
+    : input.featureRequest;
+  const suggestedBranch = issue?.branchName;
+
+  const heuristicTier = classifyByHeuristic(effectiveRequest);
 
   if (heuristicTier) {
-    return buildHeuristicClassification(heuristicTier, input.featureRequest);
+    const result = buildHeuristicClassification(heuristicTier, effectiveRequest);
+    return suggestedBranch ? { ...result, suggestedBranch } : result;
+  }
+
+  const context: string[] = [
+    `Repository root: ${input.repoRoot}`,
+    `Feature request: ${effectiveRequest}`
+  ];
+  if (issue) {
+    context.push(`Tracker: ${issue.url}`);
+    if (issue.labels.length) {
+      context.push(`Tracker labels: ${issue.labels.join(", ")}`);
+    }
   }
 
   const result = await input.dispatch(input.run, {
@@ -75,7 +199,7 @@ export async function classifyRequest(input: {
     kind: "classify_request",
     specialty: "general",
     title: "Classify request complexity",
-    objective: input.featureRequest,
+    objective: effectiveRequest,
     acceptanceCriteria: [
       "Classify the request into exactly one complexity tier.",
       "Provide a rationale for the classification.",
@@ -84,10 +208,7 @@ export async function classifyRequest(input: {
     allowedCommands: [],
     verificationCommands: [],
     docsToUpdate: [],
-    context: [
-      `Repository root: ${input.repoRoot}`,
-      `Feature request: ${input.featureRequest}`
-    ],
+    context,
     artifactContext: [],
     attempt: 1,
     maxAttempts: 2,
@@ -96,9 +217,10 @@ export async function classifyRequest(input: {
 
   try {
     const raw = result.rawResponse ? JSON.parse(result.rawResponse) : {};
-    return parseClassificationResult(raw.classification ?? raw);
+    const parsed = parseClassificationResult(raw.classification ?? raw);
+    return suggestedBranch ? { ...parsed, suggestedBranch } : parsed;
   } catch {
-    return {
+    const fallback: ClassificationResult = {
       tier: "feature_small",
       rationale: `Defaulted to feature_small after classification parse failure. Agent summary: ${result.summary}`,
       suggestedSpecialties: ["general"],
@@ -107,5 +229,6 @@ export async function classifyRequest(input: {
       needsUserApproval: false,
       crosslinkRepos: []
     };
+    return suggestedBranch ? { ...fallback, suggestedBranch } : fallback;
   }
 }

--- a/test/integrations/ao-notifier.test.ts
+++ b/test/integrations/ao-notifier.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import { HarnessChannelNotifier } from "../../src/channels/ao-notifier.js";
+
+function buildEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "evt-1",
+    type: "pr.updated",
+    priority: "info",
+    sessionId: "sess-1",
+    projectId: "proj-1",
+    timestamp: new Date("2026-04-20T12:00:00.000Z"),
+    message: "PR updated",
+    data: {},
+    ...overrides
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("HarnessChannelNotifier", () => {
+  it("notify posts a status_update entry with event metadata", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ao-notif-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+      const notifier = new HarnessChannelNotifier({
+        channelStore: store,
+        defaultChannelId: channel.channelId
+      });
+
+      await notifier.notify(buildEvent());
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed).toHaveLength(1);
+      const entry = feed[0];
+      expect(entry.type).toBe("status_update");
+      expect(entry.fromDisplayName).toBe("orchestrator");
+      expect(entry.content).toContain("[pr.updated]");
+      expect(entry.content).toContain("session=sess-1");
+      expect(entry.content).toContain("PR updated");
+      expect(entry.metadata.eventId).toBe("evt-1");
+      expect(entry.metadata.eventType).toBe("pr.updated");
+      expect(entry.metadata.priority).toBe("info");
+      expect(entry.metadata.sessionId).toBe("sess-1");
+      expect(entry.metadata.projectId).toBe("proj-1");
+      expect(entry.metadata.timestamp).toBe("2026-04-20T12:00:00.000Z");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("notifyWithActions appends an actions trailer to the body", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ao-notif-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+      const notifier = new HarnessChannelNotifier({
+        channelStore: store,
+        defaultChannelId: channel.channelId
+      });
+
+      await notifier.notifyWithActions(buildEvent(), [
+        { label: "View PR", url: "https://example.com/pr/1" },
+        { label: "Ack", callbackEndpoint: "https://example.com/ack" }
+      ]);
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed).toHaveLength(1);
+      const body = feed[0].content;
+      expect(body).toContain("Actions:");
+      expect(body).toContain("- View PR: https://example.com/pr/1");
+      expect(body).toContain("- Ack: https://example.com/ack");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("post routes to context.channel when provided instead of the default channel", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ao-notif-"));
+    const store = new ChannelStore(dir);
+    try {
+      const defaultChannel = await store.createChannel({ name: "#default", description: "" });
+      const otherChannel = await store.createChannel({ name: "#other", description: "" });
+      const notifier = new HarnessChannelNotifier({
+        channelStore: store,
+        defaultChannelId: defaultChannel.channelId
+      });
+
+      const entryId = await notifier.post("hi", { channel: otherChannel.channelId });
+      expect(entryId).toBeTruthy();
+
+      const defaultFeed = await store.readFeed(defaultChannel.channelId);
+      const otherFeed = await store.readFeed(otherChannel.channelId);
+
+      expect(defaultFeed).toHaveLength(0);
+      expect(otherFeed).toHaveLength(1);
+      expect(otherFeed[0].type).toBe("message");
+      expect(otherFeed[0].content).toBe("hi");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("post falls back to the default channel when no context.channel is provided", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ao-notif-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#default", description: "" });
+      const notifier = new HarnessChannelNotifier({
+        channelStore: store,
+        defaultChannelId: channel.channelId
+      });
+
+      await notifier.post("ping", { sessionId: "s-1", projectId: "p-1", prUrl: "u" });
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed).toHaveLength(1);
+      expect(feed[0].content).toBe("ping");
+      expect(feed[0].metadata.sessionId).toBe("s-1");
+      expect(feed[0].metadata.projectId).toBe("p-1");
+      expect(feed[0].metadata.prUrl).toBe("u");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/integrations/classifier-url-ingestion.test.ts
+++ b/test/integrations/classifier-url-ingestion.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// --- Mock the tracker module (the single AO boundary) so no network is hit. ---
+
+const mocks = vi.hoisted(() => ({
+  createTracker: vi.fn(),
+  resolveIssue: vi.fn(),
+  // detectTrackerKind uses the real implementation — only URL pattern sniffing.
+  detectTrackerKindReal: (input: string): "github" | "linear" | null => {
+    const s = input.trim();
+    if (!s) return null;
+    if (/^https?:\/\/(?:www\.)?github\.com\/[^/]+\/[^/]+\/issues\/\d+/i.test(s)) return "github";
+    if (/^https?:\/\/(?:www\.)?linear\.app\/[^/]+\/issue\/[A-Z][A-Z0-9]*-\d+/i.test(s)) return "linear";
+    if (/^[A-Z][A-Z0-9]*-\d+$/.test(s)) return "linear";
+    return null;
+  }
+}));
+
+vi.mock("../../src/integrations/tracker.js", () => ({
+  createTracker: mocks.createTracker,
+  resolveIssue: mocks.resolveIssue,
+  detectTrackerKind: (input: string) => mocks.detectTrackerKindReal(input)
+}));
+
+import { classifyRequest } from "../../src/orchestrator/classifier.js";
+import type { AgentResult, WorkRequest } from "../../src/domain/agent.js";
+import type { HarnessRun } from "../../src/domain/run.js";
+
+function buildRun(featureRequest: string): HarnessRun {
+  const now = new Date().toISOString();
+  return {
+    id: "run-test",
+    featureRequest,
+    state: "CLASSIFYING",
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    channelId: null,
+    classification: null,
+    plan: null,
+    ticketPlan: null,
+    events: [],
+    evidence: [],
+    artifacts: [],
+    phaseLedger: [],
+    phaseLedgerPath: null,
+    ticketLedger: [],
+    ticketLedgerPath: null,
+    runIndexPath: null
+  };
+}
+
+describe("classifyRequest — tracker URL ingestion", () => {
+  beforeEach(() => {
+    mocks.createTracker.mockReset();
+    mocks.resolveIssue.mockReset();
+  });
+
+  it("enriches the feature request and emits suggestedBranch when the tracker resolves", async () => {
+    const url = "https://github.com/acme/widgets/issues/42";
+
+    const fakeTracker = { name: "github" };
+    mocks.createTracker.mockReturnValue(fakeTracker);
+    mocks.resolveIssue.mockResolvedValue({
+      id: "iss-42",
+      title: "Add a complete user management system with RBAC",
+      body: "We need RBAC with org scoping and row-level policies.",
+      url,
+      labels: ["feature", "backend"],
+      branchName: "42-add-user-management"
+    });
+
+    // Dispatch receives the enriched feature request; capture and respond.
+    let captured: Omit<WorkRequest, "runId"> | null = null;
+    const dispatch = vi.fn(async (_run: HarnessRun, req: Omit<WorkRequest, "runId">) => {
+      captured = req;
+      const result: AgentResult = {
+        summary: "Classified",
+        evidence: [],
+        proposedCommands: [],
+        blockers: [],
+        rawResponse: JSON.stringify({
+          classification: {
+            tier: "feature_large",
+            rationale: "Large cross-cutting feature.",
+            suggestedSpecialties: ["api_crud", "ui"],
+            estimatedTicketCount: 5,
+            needsDesignDoc: false,
+            needsUserApproval: true,
+            crosslinkRepos: []
+          }
+        })
+      };
+      return result;
+    });
+
+    const classification = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch
+    });
+
+    // Tracker seam was exercised with parsed identifier "42".
+    expect(mocks.createTracker).toHaveBeenCalledWith("github");
+    expect(mocks.resolveIssue).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveIssue.mock.calls[0][1]).toBe("42");
+
+    // Classifier dispatched with enriched objective (title + labels + body).
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(captured).not.toBeNull();
+    const req = captured as unknown as Omit<WorkRequest, "runId">;
+    expect(req.objective).toContain("Add a complete user management system with RBAC");
+    expect(req.objective).toContain("Labels: feature, backend");
+    expect(req.objective).toContain("org scoping and row-level policies");
+    expect(req.context.some((c) => c.includes(url))).toBe(true);
+
+    // Classification result carries suggestedBranch from the tracker.
+    expect(classification.tier).toBe("feature_large");
+    expect(classification.suggestedBranch).toBe("42-add-user-management");
+  });
+
+  it("applies heuristic classification on enriched text (trivial) and still emits suggestedBranch", async () => {
+    const url = "https://github.com/acme/widgets/issues/7";
+    mocks.createTracker.mockReturnValue({ name: "github" });
+    mocks.resolveIssue.mockResolvedValue({
+      id: "iss-7",
+      title: "Fix typo in README",
+      body: "Small docs fix.",
+      url,
+      labels: [],
+      branchName: "7-fix-typo"
+    });
+
+    // Heuristic should short-circuit — dispatch must NOT be called.
+    const dispatch = vi.fn(async () => ({
+      summary: "",
+      evidence: [],
+      proposedCommands: [],
+      blockers: []
+    }));
+
+    const result = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result.tier).toBe("trivial");
+    expect(result.suggestedBranch).toBe("7-fix-typo");
+  });
+
+  it("gracefully degrades when the tracker throws: no crash, no suggestedBranch", async () => {
+    const url = "https://github.com/acme/widgets/issues/99";
+    mocks.createTracker.mockImplementation(() => {
+      throw new Error("GITHUB_TOKEN not set");
+    });
+
+    const dispatch = vi.fn(async (_run: HarnessRun, _req: Omit<WorkRequest, "runId">) => ({
+      summary: "ok",
+      evidence: [],
+      proposedCommands: [],
+      blockers: [],
+      rawResponse: JSON.stringify({
+        classification: {
+          tier: "feature_small",
+          rationale: "Modest feature.",
+          suggestedSpecialties: ["general"],
+          estimatedTicketCount: 2,
+          needsDesignDoc: false,
+          needsUserApproval: false,
+          crosslinkRepos: []
+        }
+      })
+    }));
+
+    const classification = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch
+    });
+
+    // Classification still returned, and the original URL text was fed straight to dispatch.
+    expect(classification.tier).toBe("feature_small");
+    expect(classification.suggestedBranch).toBeUndefined();
+
+    // Dispatch was called with the raw URL (no enrichment happened).
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const req = dispatch.mock.calls[0][1];
+    expect(req.objective).toBe(url);
+  });
+});

--- a/test/integrations/pr-poller.test.ts
+++ b/test/integrations/pr-poller.test.ts
@@ -1,0 +1,206 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import {
+  PrPoller,
+  type FollowUpDispatcher,
+  type FollowUpRequest,
+  type TrackedPr
+} from "../../src/integrations/pr-poller.js";
+import type { EnrichedPR, HarnessScm } from "../../src/integrations/scm.js";
+
+function makeTracked(channelId: string): TrackedPr {
+  return {
+    ticketId: "T-1",
+    channelId,
+    pr: {
+      number: 42,
+      url: "https://github.com/acme/widgets/pull/42",
+      branch: "feat/42"
+    },
+    repo: { owner: "acme", name: "widgets" }
+  };
+}
+
+function seed(state: Partial<EnrichedPR> = {}): EnrichedPR {
+  return {
+    ci: state.ci ?? "none",
+    review: state.review ?? "pending",
+    prState: state.prState ?? "open"
+  };
+}
+
+/**
+ * Build a scripted HarnessScm stub whose enrichBatch returns successive
+ * values per tick.
+ */
+function scriptedScm(series: Array<Map<string, EnrichedPR>>): HarnessScm {
+  let i = 0;
+  return {
+    detectPR: vi.fn(),
+    getCiSummary: vi.fn(),
+    getReviewDecision: vi.fn(),
+    getPendingComments: vi.fn(),
+    enrichBatch: vi.fn(async () => {
+      const next = series[Math.min(i, series.length - 1)];
+      i += 1;
+      return next;
+    })
+  } as unknown as HarnessScm;
+}
+
+describe("PrPoller", () => {
+  it("first tick seeds state without firing events or enqueuing follow-ups", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-poller-seed-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr", description: "" });
+      const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+        async () => "followup-id"
+      );
+      const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+
+      const scm = scriptedScm([
+        new Map([["acme/widgets#42", seed({ ci: "none", review: "pending", prState: "open" })]])
+      ]);
+      const poller = new PrPoller({ scm, channelStore: store, scheduler });
+      poller.track(makeTracked(channel.channelId));
+
+      await poller.tick();
+
+      expect(enqueueFollowUp).not.toHaveBeenCalled();
+      const feed = await store.readFeed(channel.channelId);
+      // Channel has a "channel created" style entry set? No — ChannelStore doesn't post on create.
+      // So feed should be empty after the seeding tick.
+      expect(feed.filter((e) => e.fromDisplayName === "pr-poller")).toHaveLength(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fires fix-ci follow-up when CI transitions none -> failing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-poller-ci-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-ci", description: "" });
+      const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+        async () => "followup-id"
+      );
+      const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+
+      const scm = scriptedScm([
+        new Map([["acme/widgets#42", seed({ ci: "none" })]]),
+        new Map([["acme/widgets#42", seed({ ci: "failing" })]])
+      ]);
+      const poller = new PrPoller({ scm, channelStore: store, scheduler });
+      poller.track(makeTracked(channel.channelId));
+
+      await poller.tick(); // seed
+      await poller.tick(); // transition
+
+      expect(enqueueFollowUp).toHaveBeenCalledTimes(1);
+      const firstCall = enqueueFollowUp.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const arg = firstCall![0];
+      expect(arg.kind).toBe("fix-ci");
+      expect(arg.parentTicketId).toBe("T-1");
+      expect(arg.channelId).toBe(channel.channelId);
+      expect(arg.pr.number).toBe(42);
+      expect(arg.repo).toEqual({ owner: "acme", name: "widgets" });
+      expect(arg.title).toContain("fix-ci");
+      expect(arg.prompt).toContain("acme/widgets#42");
+
+      const feed = await store.readFeed(channel.channelId);
+      const statusEntries = feed.filter((e) => e.fromDisplayName === "pr-poller");
+      expect(statusEntries.length).toBeGreaterThanOrEqual(1);
+      const ciEntry = statusEntries.find((e) => e.content.startsWith("CI "));
+      expect(ciEntry).toBeDefined();
+      expect(ciEntry!.content).toContain("none -> failing");
+      expect(ciEntry!.metadata.ciTo).toBe("failing");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fires address-reviews follow-up when review transitions pending -> changes_requested", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-poller-review-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-rev", description: "" });
+      const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+        async () => "followup-id"
+      );
+      const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+
+      const scm = scriptedScm([
+        new Map([["acme/widgets#42", seed({ review: "pending" })]]),
+        new Map([["acme/widgets#42", seed({ review: "changes_requested" })]])
+      ]);
+      const poller = new PrPoller({ scm, channelStore: store, scheduler });
+      poller.track(makeTracked(channel.channelId));
+
+      await poller.tick();
+      await poller.tick();
+
+      expect(enqueueFollowUp).toHaveBeenCalledTimes(1);
+      const firstCall = enqueueFollowUp.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const arg = firstCall![0];
+      expect(arg.kind).toBe("address-reviews");
+      expect(arg.title).toContain("address-reviews");
+
+      const feed = await store.readFeed(channel.channelId);
+      const reviewEntry = feed.find(
+        (e) => e.fromDisplayName === "pr-poller" && e.content.startsWith("Review ")
+      );
+      expect(reviewEntry).toBeDefined();
+      expect(reviewEntry!.metadata.reviewTo).toBe("changes_requested");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("untracks the PR when prState transitions to merged", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-poller-merge-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-merge", description: "" });
+      const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+        async () => "followup-id"
+      );
+      const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+
+      const scm = scriptedScm([
+        new Map([["acme/widgets#42", seed({ prState: "open" })]]),
+        new Map([["acme/widgets#42", seed({ prState: "merged" })]]),
+        // third tick returns nothing new — if still tracked, poller would query
+        new Map([["acme/widgets#42", seed({ prState: "merged" })]])
+      ]);
+      const poller = new PrPoller({ scm, channelStore: store, scheduler });
+      poller.track(makeTracked(channel.channelId));
+
+      await poller.tick(); // seed
+      await poller.tick(); // detect merge → untrack
+
+      const enrichBatchMock = scm.enrichBatch as unknown as ReturnType<typeof vi.fn>;
+      const callsAfterMerge = enrichBatchMock.mock.calls.length;
+
+      await poller.tick(); // should be no-op because nothing is tracked
+
+      expect(enrichBatchMock.mock.calls.length).toBe(callsAfterMerge);
+
+      const feed = await store.readFeed(channel.channelId);
+      const mergedEntry = feed.find(
+        (e) => e.fromDisplayName === "pr-poller" && e.content.includes("merged")
+      );
+      expect(mergedEntry).toBeDefined();
+      expect(mergedEntry!.metadata.prState).toBe("merged");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/integrations/scm.test.ts
+++ b/test/integrations/scm.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { wrapScm, type HarnessPR } from "../../src/integrations/scm.js";
+
+function makePr(overrides: Partial<HarnessPR> = {}): HarnessPR {
+  return {
+    number: overrides.number ?? 7,
+    url: overrides.url ?? "https://github.com/acme/widgets/pull/7",
+    branch: overrides.branch ?? "feat/seven"
+  };
+}
+
+const projectDescriptor = {
+  owner: "acme",
+  name: "widgets",
+  path: "/tmp/repo",
+  defaultBranch: "main"
+};
+
+describe("wrapScm — facade delegation", () => {
+  it("detectPR passes branch via stub session and maps PRInfo to HarnessPR", async () => {
+    const detectPR = vi.fn(async () => ({
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      branch: "feat/seven",
+      title: "feat: seven",
+      owner: "acme",
+      repo: "widgets",
+      baseBranch: "main",
+      isDraft: false
+    }));
+
+    const scm = { name: "gh", detectPR } as any;
+
+    const wrapped = wrapScm(scm, projectDescriptor);
+    const res = await wrapped.detectPR("feat/seven", { owner: "acme", name: "widgets" });
+
+    expect(res).toEqual({
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      branch: "feat/seven"
+    });
+    const firstCall = detectPR.mock.calls[0] as unknown as [
+      { branch: string },
+      unknown
+    ] | undefined;
+    expect(firstCall).toBeDefined();
+    expect(firstCall![0].branch).toBe("feat/seven");
+  });
+
+  it("getCiSummary, getReviewDecision, getPendingComments call through", async () => {
+    const scm = {
+      name: "gh",
+      getCISummary: vi.fn(async () => "failing" as const),
+      getReviewDecision: vi.fn(async () => "changes_requested" as const),
+      getPendingComments: vi.fn(async () => [
+        {
+          id: "c1",
+          author: "alice",
+          body: "nit: rename",
+          path: "src/a.ts",
+          line: 10,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://github.com/acme/widgets/pull/7#c1"
+        }
+      ])
+    } as any;
+
+    const wrapped = wrapScm(scm, projectDescriptor);
+    const pr = makePr();
+
+    expect(await wrapped.getCiSummary(pr)).toBe("failing");
+    expect(await wrapped.getReviewDecision(pr)).toBe("changes_requested");
+
+    const comments = await wrapped.getPendingComments(pr);
+    expect(comments).toEqual([
+      { id: "c1", author: "alice", body: "nit: rename", path: "src/a.ts", line: 10 }
+    ]);
+
+    expect(scm.getCISummary).toHaveBeenCalledTimes(1);
+    const ciCall = scm.getCISummary.mock.calls[0] as unknown as [
+      { number: number; owner: string; repo: string }
+    ] | undefined;
+    expect(ciCall).toBeDefined();
+    expect(ciCall![0].number).toBe(7);
+    expect(ciCall![0].owner).toBe("acme");
+    expect(ciCall![0].repo).toBe("widgets");
+  });
+
+  it("enrichBatch prefers scm.enrichSessionsPRBatch when available", async () => {
+    const scm = {
+      name: "gh",
+      enrichSessionsPRBatch: vi.fn(async () =>
+        new Map([
+          [
+            "acme/widgets#7",
+            {
+              state: "open" as const,
+              ciStatus: "passing" as const,
+              reviewDecision: "approved" as const,
+              mergeable: true
+            }
+          ]
+        ])
+      ),
+      // Fallback methods should NOT be called when the batch method exists.
+      getPRState: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviewDecision: vi.fn()
+    } as any;
+
+    const wrapped = wrapScm(scm, projectDescriptor);
+    const result = await wrapped.enrichBatch([makePr()]);
+
+    expect(scm.enrichSessionsPRBatch).toHaveBeenCalledTimes(1);
+    expect(scm.getPRState).not.toHaveBeenCalled();
+    expect(scm.getCISummary).not.toHaveBeenCalled();
+    expect(scm.getReviewDecision).not.toHaveBeenCalled();
+
+    expect(result.get("acme/widgets#7")).toEqual({
+      ci: "passing",
+      review: "approved",
+      prState: "open"
+    });
+  });
+});
+
+describe("wrapScm — enrichBatch fallback", () => {
+  it("falls back to per-PR getPRState/getCISummary/getReviewDecision and keys correctly", async () => {
+    const scm = {
+      name: "gh",
+      // no enrichSessionsPRBatch defined
+      getPRState: vi.fn(async () => "open" as const),
+      getCISummary: vi.fn(async () => "failing" as const),
+      getReviewDecision: vi.fn(async () => "pending" as const)
+    } as any;
+
+    const wrapped = wrapScm(scm, projectDescriptor);
+    const prs = [
+      makePr({ number: 1, url: "u1", branch: "b1" }),
+      makePr({ number: 2, url: "u2", branch: "b2" })
+    ];
+    const result = await wrapped.enrichBatch(prs);
+
+    expect(result.size).toBe(2);
+    expect(result.get("acme/widgets#1")).toEqual({
+      prState: "open",
+      ci: "failing",
+      review: "pending"
+    });
+    expect(result.get("acme/widgets#2")).toEqual({
+      prState: "open",
+      ci: "failing",
+      review: "pending"
+    });
+
+    // Per-PR calls: 2 PRs × 3 methods
+    expect(scm.getPRState).toHaveBeenCalledTimes(2);
+    expect(scm.getCISummary).toHaveBeenCalledTimes(2);
+    expect(scm.getReviewDecision).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/integrations/tracker.test.ts
+++ b/test/integrations/tracker.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectTrackerKind,
+  resolveIssue
+} from "../../src/integrations/tracker.js";
+
+describe("detectTrackerKind", () => {
+  const cases: Array<{ input: string; expected: "github" | "linear" | null; why: string }> = [
+    {
+      input: "https://github.com/acme/widgets/issues/42",
+      expected: "github",
+      why: "GitHub issue URL"
+    },
+    {
+      input: "https://linear.app/acme/issue/ABC-123/some-title",
+      expected: "linear",
+      why: "Linear issue URL"
+    },
+    {
+      input: "ABC-123",
+      expected: "linear",
+      why: "bare Linear identifier"
+    },
+    {
+      input: "build me a new auth system",
+      expected: null,
+      why: "plain text"
+    },
+    {
+      input: "",
+      expected: null,
+      why: "empty string"
+    },
+    {
+      input: "   ",
+      expected: null,
+      why: "whitespace only"
+    },
+    {
+      input: "https://github.com/acme/widgets/pull/42",
+      expected: null,
+      why: "GitHub PR URL, not an issue"
+    }
+  ];
+
+  for (const { input, expected, why } of cases) {
+    it(`returns ${expected} for ${why}`, () => {
+      expect(detectTrackerKind(input)).toBe(expected);
+    });
+  }
+});
+
+describe("resolveIssue", () => {
+  it("maps AO Issue into HarnessIssue and preserves issue.branchName when present", async () => {
+    const fakeIssue = {
+      id: "iss-1",
+      title: "Fix the thing",
+      description: "Body text describes the bug.",
+      url: "https://github.com/acme/widgets/issues/42",
+      state: "open",
+      labels: ["bug", "p1"],
+      branchName: "issue/42-fix-the-thing"
+    };
+
+    const tracker = {
+      name: "github",
+      getIssue: async () => fakeIssue,
+      isCompleted: async () => false,
+      issueUrl: () => fakeIssue.url,
+      branchName: () => "fallback-should-not-be-used",
+      generatePrompt: async () => "prompt"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const project = {
+      name: "acme/widgets",
+      repo: "acme/widgets",
+      path: "/tmp",
+      defaultBranch: "main",
+      sessionPrefix: "widgets"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const harnessIssue = await resolveIssue(tracker, "42", project);
+
+    expect(harnessIssue).toEqual({
+      id: "iss-1",
+      title: "Fix the thing",
+      body: "Body text describes the bug.",
+      url: "https://github.com/acme/widgets/issues/42",
+      labels: ["bug", "p1"],
+      branchName: "issue/42-fix-the-thing"
+    });
+  });
+
+  it("falls back to tracker.branchName when issue.branchName is absent", async () => {
+    const fakeIssue = {
+      id: "iss-2",
+      title: "Another",
+      description: "No branch on issue.",
+      url: "https://linear.app/acme/issue/ABC-123",
+      state: "open",
+      labels: []
+      // no branchName
+    };
+
+    let branchNameCalledWith: { identifier?: string } = {};
+    const tracker = {
+      name: "linear",
+      getIssue: async () => fakeIssue,
+      isCompleted: async () => false,
+      issueUrl: () => fakeIssue.url,
+      branchName: (identifier: string) => {
+        branchNameCalledWith = { identifier };
+        return "abc-123-another";
+      },
+      generatePrompt: async () => "prompt"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const project = {
+      name: "ws/proj",
+      repo: "ws/proj",
+      path: "/tmp",
+      defaultBranch: "main",
+      sessionPrefix: "proj"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const harnessIssue = await resolveIssue(tracker, "ABC-123", project);
+
+    expect(harnessIssue.branchName).toBe("abc-123-another");
+    expect(branchNameCalledWith.identifier).toBe("ABC-123");
+    // labels defaults to [] when the AO issue has no labels defined
+    expect(harnessIssue.labels).toEqual([]);
+  });
+
+  it("defaults labels to [] when AO issue has no labels field", async () => {
+    const fakeIssue = {
+      id: "iss-3",
+      title: "No labels",
+      description: "",
+      url: "https://github.com/acme/widgets/issues/7",
+      state: "open",
+      branchName: "issue/7"
+      // labels omitted
+    };
+
+    const tracker = {
+      name: "github",
+      getIssue: async () => fakeIssue,
+      isCompleted: async () => false,
+      issueUrl: () => fakeIssue.url,
+      branchName: () => "ignored",
+      generatePrompt: async () => "p"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const project = {
+      name: "acme/widgets",
+      repo: "acme/widgets",
+      path: "/tmp",
+      defaultBranch: "main",
+      sessionPrefix: "widgets"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const harnessIssue = await resolveIssue(tracker, "7", project);
+    expect(harnessIssue.labels).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Adopts [`@aoagents/ao-core`](https://www.npmjs.com/package/@aoagents/ao-core) **v0.2.5** leaf plugins for tracker + SCM + notifier without running AO's orchestrator. Harness keeps its own classify → decompose → approve → execute loop; AO supplies the integration adapters.

- **Tracker** (`src/integrations/tracker.ts`) — wraps `@aoagents/ao-plugin-tracker-github` and `-tracker-linear`. Exposes `createTracker`, `resolveIssue`, `detectTrackerKind`. Tokens via `GITHUB_TOKEN` / `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`).
- **SCM** (`src/integrations/scm.ts`) — wraps `@aoagents/ao-plugin-scm-github`. Narrow `HarnessScm` facade: `detectPR`, `getCiSummary`, `getReviewDecision`, `getPendingComments`, `enrichBatch`. Prefers AO's `enrichSessionsPRBatch`, falls back to sequential calls.
- **PR poller** (`src/integrations/pr-poller.ts`) — interval-driven, diffs CI/review/PR state across ticks, posts `status_update` entries to the ticket's channel, and emits `fix-ci` / `address-reviews` follow-ups through an injected `FollowUpDispatcher`.
- **Classifier** (`src/orchestrator/classifier.ts`) — recognizes GitHub/Linear issue URLs (and bare `ABC-123`), fetches the full issue, enriches both heuristic and LLM dispatch with `title + body + labels`. New optional `ClassificationResult.suggestedBranch`. Graceful degradation on tracker failure.
- **AO-compatible notifier** (`src/channels/ao-notifier.ts`) — `HarnessChannelNotifier implements Notifier` on top of `channel-store.postEntry`. Plug-ready if we ever want harness to be an AO notifier plugin.

Boundary rule enforced everywhere: `@aoagents/*` imports are confined to `src/integrations/` and `src/channels/ao-notifier.ts`. No AO types leak into `src/domain/`.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — **98/98** passing (73 baseline + 25 new)
- [ ] Manual: export `GITHUB_TOKEN`, feed the classifier a real issue URL, confirm `suggestedBranch` lands and the heuristic/LLM prompt is enriched.
- [ ] Manual: point `PrPoller` at a real open PR, stub `FollowUpDispatcher`, watch a forced CI failure trigger `fix-ci`.

## Known follow-ups (out of scope)
1. `TicketScheduler` has no `enqueue` surface — `FollowUpDispatcher` interface is defined but nothing consumes it yet. Wiring `fix-ci` / `address-reviews` into real follow-up tickets is the next change.
2. `channel-store` gaps flagged during integration: no dedicated `post()`, `metadata: Record<string, string>` (AO `event.data` is dropped), no `event`/`notification` variant in `ChannelEntryType`.
3. Token handling temporarily mutates `process.env` around AO's zero-arg plugin factories (`create()`) — not thread-safe if concurrent trackers/SCMs ever use different tokens. Fine for single-project harness use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)