### PR TITLE
Close follow-up gaps from AO integration (scheduler enqueue, channel-store API, plugin env mutex)

### DIFF
--- a/src/channels/ao-notifier.ts
+++ b/src/channels/ao-notifier.ts
@@ -25,13 +25,11 @@ export class HarnessChannelNotifier implements Notifier {
     this.defaultChannelId = options.defaultChannelId;
   }
 
-  /** Push a notification to the default channel as a status_update entry. */
+  /** Push a notification to the default channel as an `event` entry. */
   async notify(event: OrchestratorEvent): Promise<void> {
-    await this.channelStore.postEntry(this.defaultChannelId, {
-      type: "status_update",
-      fromAgentId: null,
+    await this.channelStore.post(this.defaultChannelId, this.formatEventMessage(event), {
+      type: "event",
       fromDisplayName: "orchestrator",
-      content: this.formatEventMessage(event),
       metadata: this.buildEventMetadata(event)
     });
   }
@@ -51,11 +49,9 @@ export class HarnessChannelNotifier implements Notifier {
 
     const content = actionLines ? `${base}\n\nActions:\n${actionLines}` : base;
 
-    await this.channelStore.postEntry(this.defaultChannelId, {
-      type: "status_update",
-      fromAgentId: null,
+    await this.channelStore.post(this.defaultChannelId, content, {
+      type: "event",
       fromDisplayName: "orchestrator",
-      content,
       metadata: this.buildEventMetadata(event)
     });
   }
@@ -68,20 +64,16 @@ export class HarnessChannelNotifier implements Notifier {
   async post(message: string, context?: NotifyContext): Promise<string | null> {
     const channelId = context?.channel ?? this.defaultChannelId;
 
-    const metadata: Record<string, string> = {};
+    const metadata: Record<string, unknown> = {};
     if (context?.sessionId) metadata.sessionId = context.sessionId;
     if (context?.projectId) metadata.projectId = context.projectId;
     if (context?.prUrl) metadata.prUrl = context.prUrl;
 
-    const entry = await this.channelStore.postEntry(channelId, {
+    return this.channelStore.post(channelId, message, {
       type: "message",
-      fromAgentId: null,
       fromDisplayName: "orchestrator",
-      content: message,
       metadata
     });
-
-    return entry.entryId;
   }
 
   private formatEventMessage(event: OrchestratorEvent): string {
@@ -89,14 +81,17 @@ export class HarnessChannelNotifier implements Notifier {
     return event.message ? `${prefix} — ${event.message}` : prefix;
   }
 
-  private buildEventMetadata(event: OrchestratorEvent): Record<string, string> {
+  private buildEventMetadata(event: OrchestratorEvent): Record<string, unknown> {
     return {
       eventId: event.id,
       eventType: event.type,
       priority: event.priority,
       sessionId: event.sessionId,
       projectId: event.projectId,
-      timestamp: event.timestamp.toISOString()
+      timestamp: event.timestamp.toISOString(),
+      // Preserve the event payload — the channel store will JSON-serialize
+      // this so downstream readers keep seeing string-valued metadata.
+      data: event.data
     };
   }
 }

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -178,7 +178,7 @@ export class ChannelStore {
       fromAgentId: string | null;
       fromDisplayName: string | null;
       content: string;
-      metadata: Record<string, string>;
+      metadata: Record<string, unknown>;
     }
   ): Promise<ChannelEntry> {
     const feedDir = join(this.channelsDir, channelId);
@@ -191,7 +191,7 @@ export class ChannelStore {
       fromAgentId: input.fromAgentId,
       fromDisplayName: input.fromDisplayName,
       content: input.content,
-      metadata: input.metadata,
+      metadata: normalizeMetadata(input.metadata),
       createdAt: new Date().toISOString()
     };
 
@@ -201,6 +201,33 @@ export class ChannelStore {
     );
 
     return entry;
+  }
+
+  /**
+   * Thin wrapper over `postEntry` with ergonomic defaults for the common
+   * "drop a message into a channel" case. Returns the created entry id.
+   *
+   * Defaults: `type: "message"`, `fromAgentId: null`,
+   * `fromDisplayName: "system"`, empty metadata.
+   */
+  async post(
+    channelId: string,
+    content: string,
+    options?: {
+      type?: ChannelEntryType;
+      fromAgentId?: string | null;
+      fromDisplayName?: string;
+      metadata?: Record<string, unknown>;
+    }
+  ): Promise<string> {
+    const entry = await this.postEntry(channelId, {
+      type: options?.type ?? "message",
+      fromAgentId: options?.fromAgentId ?? null,
+      fromDisplayName: options?.fromDisplayName ?? "system",
+      content,
+      metadata: options?.metadata ?? {}
+    });
+    return entry.entryId;
   }
 
   async readFeed(channelId: string, limit?: number): Promise<ChannelEntry[]> {
@@ -378,4 +405,21 @@ export class ChannelStore {
       return [];
     }
   }
+}
+
+/**
+ * Serialize non-string metadata values to JSON strings so existing readers
+ * (Rust `crates/harness-data` and `gui/src/types.ts`, which both type
+ * metadata as `Record<string, string>`) continue to deserialize the feed
+ * without changes. `null` and `undefined` are dropped. Strings pass through.
+ */
+function normalizeMetadata(
+  metadata: Record<string, unknown>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined || value === null) continue;
+    out[key] = typeof value === "string" ? value : JSON.stringify(value);
+  }
+  return out;
 }

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -14,6 +14,7 @@ export type ChannelRefType = z.infer<typeof ChannelRefTypeSchema>;
 export const ChannelEntryTypeSchema = z.enum([
   "message",
   "status_update",
+  "event",
   "decision",
   "artifact",
   "agent_joined",
@@ -67,7 +68,14 @@ export interface ChannelEntry {
   fromAgentId: string | null;
   fromDisplayName: string | null;
   content: string;
-  metadata: Record<string, string>;
+  /**
+   * Free-form metadata for the entry. Callers may pass any JSON-serializable
+   * values; the channel store serializes non-string values to JSON strings on
+   * write so downstream Rust readers (`crates/harness-data`) and the GUI
+   * (`gui/src/types.ts`), which type metadata as `Record<string, string>`,
+   * continue to deserialize the feed without changes.
+   */
+  metadata: Record<string, unknown>;
   createdAt: string;
 }
 

--- a/src/integrations/plugin-env-mutex.ts
+++ b/src/integrations/plugin-env-mutex.ts
@@ -1,0 +1,54 @@
+/**
+ * Tiny serialization primitive for AO plugin factories that read credentials
+ * from `process.env` at construction time.
+ *
+ * The AO plugin packages (`@aoagents/ao-plugin-tracker-github`,
+ * `-tracker-linear`, `-scm-github`) expose zero-arg `create()` factories that
+ * snapshot env vars like `GITHUB_TOKEN` / `LINEAR_API_KEY` / `COMPOSIO_API_KEY`
+ * immediately. To honor per-caller tokens we must temporarily overlay those
+ * env vars, run the factory, then restore. If two such overlays race, they
+ * can observe each other's values.
+ *
+ * `withEnvOverride` serializes every call behind a shared module-local
+ * promise chain so at most one `fn` ever executes inside an overlay at a
+ * time, across all callers in the process.
+ */
+
+// Shared chain: every call appends its work here, and the next caller waits
+// on the returned promise. We never surface rejections from `fn` onto the
+// chain — always settle with `undefined` so a single failure does not poison
+// subsequent callers.
+let chain: Promise<void> = Promise.resolve();
+
+export async function withEnvOverride<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const prior = chain;
+  let release!: () => void;
+  chain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await prior;
+
+  const savedKeys = Object.keys(overrides);
+  const saved: Record<string, string | undefined> = {};
+  for (const key of savedKeys) saved[key] = process.env[key];
+
+  try {
+    for (const key of savedKeys) {
+      const value = overrides[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return await fn();
+  } finally {
+    for (const key of savedKeys) {
+      const previous = saved[key];
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    release();
+  }
+}

--- a/src/integrations/pr-poller.ts
+++ b/src/integrations/pr-poller.ts
@@ -107,7 +107,8 @@ export class PrPoller {
       let enriched: Map<string, EnrichedPR>;
       try {
         enriched = await this.scm.enrichBatch(states.map((s) => s.entry.pr));
-      } catch {
+      } catch (error) {
+        console.warn("[pr-poller] enrichBatch failed; skipping tick", error);
         return;
       }
 
@@ -225,16 +226,19 @@ export class PrPoller {
         content,
         metadata,
       });
-    } catch {
-      /* non-critical */
+    } catch (error) {
+      console.warn("[pr-poller] failed to post channel entry", error);
     }
   }
 
   private async enqueue(request: FollowUpRequest): Promise<void> {
     try {
       await this.scheduler.enqueueFollowUp(request);
-    } catch {
-      /* non-critical; next transition will re-fire */
+    } catch (error) {
+      console.warn(
+        `[pr-poller] failed to enqueue follow-up ${request.kind}; next transition will re-fire`,
+        error
+      );
     }
   }
 

--- a/src/integrations/scheduler-follow-up-dispatcher.ts
+++ b/src/integrations/scheduler-follow-up-dispatcher.ts
@@ -1,0 +1,76 @@
+/**
+ * Bridge between the PR poller's `FollowUpDispatcher` interface and the
+ * `TicketScheduler.enqueue` surface.
+ *
+ * The poller produces `FollowUpRequest`s (CI failures, review rework). This
+ * dispatcher synthesizes a minimal `TicketDefinition` for each request and
+ * hands it to the scheduler, which lands it on the run's ticket ledger and
+ * kicks off execution under the existing concurrency cap.
+ *
+ * Keep the synthesized ticket deliberately small: the scheduler only needs
+ * enough shape to dispatch work to whatever agent/worker the run already has
+ * configured. Any richer prompting/context should live in the poller.
+ */
+import type { HarnessRun } from "../domain/run.js";
+import type { TicketDefinition } from "../domain/ticket.js";
+import type { TicketScheduler } from "../orchestrator/ticket-scheduler.js";
+import type {
+  FollowUpDispatcher,
+  FollowUpRequest
+} from "./pr-poller.js";
+
+export interface SchedulerFollowUpDispatcherOptions {
+  scheduler: Pick<TicketScheduler, "enqueue">;
+  run: HarnessRun;
+}
+
+const DEFAULT_RETRY_POLICY = {
+  maxAgentAttempts: 2,
+  maxTestFixLoops: 2
+} as const;
+
+export class SchedulerFollowUpDispatcher implements FollowUpDispatcher {
+  private readonly scheduler: Pick<TicketScheduler, "enqueue">;
+  private readonly run: HarnessRun;
+
+  constructor(options: SchedulerFollowUpDispatcherOptions) {
+    this.scheduler = options.scheduler;
+    this.run = options.run;
+  }
+
+  async enqueueFollowUp(request: FollowUpRequest): Promise<string> {
+    const ticket = this.buildTicket(request);
+    await this.scheduler.enqueue(this.run, ticket);
+    return ticket.id;
+  }
+
+  private buildTicket(request: FollowUpRequest): TicketDefinition {
+    return {
+      id: buildFollowUpTicketId(request),
+      title: request.title,
+      objective: request.prompt,
+      specialty: "general",
+      acceptanceCriteria: [
+        request.kind === "fix-ci"
+          ? "CI checks on the PR are passing after the follow-up commits."
+          : "All reviewer comments on the PR are addressed and resolved."
+      ],
+      allowedCommands: [],
+      verificationCommands: [],
+      docsToUpdate: [],
+      // Follow-ups are independent executions — they intentionally don't
+      // block on the parent ticket, which by this point has already produced
+      // a PR and moved on.
+      dependsOn: [],
+      retryPolicy: DEFAULT_RETRY_POLICY
+    };
+  }
+}
+
+/**
+ * Stable id so repeated fires for the same (parent, kind) pair are idempotent
+ * from the scheduler's perspective (it de-dupes by ticket id on enqueue).
+ */
+export function buildFollowUpTicketId(request: FollowUpRequest): string {
+  return `followup_${request.kind}_${request.parentTicketId}`;
+}

--- a/src/integrations/scm.ts
+++ b/src/integrations/scm.ts
@@ -13,6 +13,8 @@ import type {
 } from "@aoagents/ao-core";
 import { create as createGithubScm } from "@aoagents/ao-plugin-scm-github";
 
+import { withEnvOverride } from "./plugin-env-mutex.js";
+
 /** Narrow PR shape the harness operates on. */
 export interface HarnessPR {
   number: number;
@@ -66,20 +68,39 @@ export interface HarnessScm {
  * Build a configured AO `SCM` instance. The returned value is intentionally
  * typed as `SCM` so callers can pass it to `wrapScm`; callers outside this
  * module should not depend on any method beyond what `HarnessScm` exposes.
+ *
+ * Overloads:
+ *  - No-token call: synchronous. The github plugin reads `GITHUB_TOKEN` via
+ *    the `gh` CLI at command time, not at construction time, so no overlay
+ *    is needed when the caller has already exported the env var.
+ *  - With-token call: routes through the shared env-mutex so concurrent
+ *    builds with different tokens can't observe each other's values.
  */
+export function createScm(kind: "github"): SCM;
+export function createScm(
+  kind: "github",
+  opts: { token?: undefined },
+): SCM;
+export function createScm(
+  kind: "github",
+  opts: { token: string },
+): Promise<SCM>;
 export function createScm(
   kind: "github",
   opts: { token?: string } = {},
-): SCM {
+): SCM | Promise<SCM> {
   if (kind !== "github") {
     throw new Error(`createScm: unsupported kind "${kind as string}"`);
   }
-  const token = opts.token ?? process.env.GITHUB_TOKEN;
-  if (token && !process.env.GITHUB_TOKEN) {
-    // The github plugin shells out to `gh`, which reads GITHUB_TOKEN from env.
-    process.env.GITHUB_TOKEN = token;
+  if (opts.token === undefined) {
+    return createGithubScm();
   }
-  return createGithubScm();
+  // The github plugin shells out to `gh`, which reads GITHUB_TOKEN from env.
+  // Serialize overlays so two concurrent calls with different tokens can't
+  // race through the env.
+  return withEnvOverride({ GITHUB_TOKEN: opts.token }, () =>
+    createGithubScm(),
+  );
 }
 
 /** Produce the narrow facade from a raw AO `SCM`. */

--- a/src/integrations/tracker.ts
+++ b/src/integrations/tracker.ts
@@ -4,7 +4,8 @@
  * The AO plugin packages expose a `create(): Tracker` factory and read their
  * credentials from `process.env` (GITHUB_TOKEN / LINEAR_API_KEY). We honor
  * `opts.token` by installing it into the expected env var for the duration of
- * the factory call, then restoring the previous value.
+ * the factory call via a shared serialization primitive so concurrent calls
+ * with different tokens cannot observe each other's values.
  *
  * Keep this file as the single boundary: no other module in the harness should
  * import from `@aoagents/*`.
@@ -12,6 +13,8 @@
 import type { ProjectConfig, Tracker } from "@aoagents/ao-core";
 import githubTracker from "@aoagents/ao-plugin-tracker-github";
 import linearTracker from "@aoagents/ao-plugin-tracker-linear";
+
+import { withEnvOverride } from "./plugin-env-mutex.js";
 
 export type TrackerKind = "github" | "linear";
 
@@ -32,26 +35,37 @@ const ENV_VAR: Record<TrackerKind, string> = {
 
 /**
  * Build a configured Tracker. The AO plugin factories consume their token from
- * env vars at construction time, so we temporarily overlay `opts.token` into
- * the matching var if provided.
+ * env vars at construction time, so when `opts.token` is provided we overlay
+ * the matching env var through `withEnvOverride`, which serializes concurrent
+ * callers so they cannot observe each other's tokens.
+ *
+ * Overloads:
+ *  - No-token call returns `Tracker` synchronously; this preserves the legacy
+ *    call site in `classifier.ts` (`const tracker = createTracker(kind)`).
+ *  - With-token call returns `Promise<Tracker>` because the shared env-mutex
+ *    is fundamentally async.
  */
+export function createTracker(kind: TrackerKind): Tracker;
+export function createTracker(
+  kind: TrackerKind,
+  opts: { token?: undefined },
+): Tracker;
+export function createTracker(
+  kind: TrackerKind,
+  opts: { token: string },
+): Promise<Tracker>;
 export function createTracker(
   kind: TrackerKind,
   opts: { token?: string } = {},
-): Tracker {
-  const envVar = ENV_VAR[kind];
-  const previous = process.env[envVar];
-  if (opts.token !== undefined) {
-    process.env[envVar] = opts.token;
+): Tracker | Promise<Tracker> {
+  const build = (): Tracker =>
+    kind === "github" ? githubTracker.create() : linearTracker.create();
+
+  if (opts.token === undefined) {
+    // No overlay needed — plugin reads whatever is already in env.
+    return build();
   }
-  try {
-    return kind === "github" ? githubTracker.create() : linearTracker.create();
-  } finally {
-    if (opts.token !== undefined) {
-      if (previous === undefined) delete process.env[envVar];
-      else process.env[envVar] = previous;
-    }
-  }
+  return withEnvOverride({ [ENV_VAR[kind]]: opts.token }, build);
 }
 
 /**

--- a/src/orchestrator/classifier.ts
+++ b/src/orchestrator/classifier.ts
@@ -138,7 +138,7 @@ async function tryResolveTrackerIssue(
   if (!identifier) return null;
 
   try {
-    const tracker = createTracker(kind);
+    const tracker = await createTracker(kind);
     const project = buildProjectConfig(repoRoot, featureRequest, kind);
     return await resolveIssue(tracker, identifier, project);
   } catch (err) {

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -24,7 +24,27 @@ import { decomposePlanToTickets, buildTicketPlanFromPhases } from "./ticket-deco
 import { checkApproval } from "./approval-gate.js";
 import { TicketScheduler } from "./ticket-scheduler.js";
 
+/**
+ * Anything the orchestrator can hook into for follow-up enqueueing (PR poller,
+ * review watcher, etc.). Must expose a `stop()` the orchestrator can call when
+ * the run finalizes. Kept as a structural type so the orchestrator does not
+ * depend on `@aoagents/*` — callers build and attach pollers from the CLI.
+ */
+export interface PollerHandle {
+  start(): void;
+  stop(): void;
+}
+
+/** Factory supplied by callers that want a poller built per-run. */
+export type PollerFactory = (input: {
+  run: HarnessRun;
+  scheduler: TicketScheduler;
+}) => PollerHandle | null;
+
 export class OrchestratorV2 {
+  /** Optional poller factory registered via `attachPoller`. */
+  private pollerFactory: PollerFactory | null = null;
+
   constructor(
     private readonly registry: AgentRegistry,
     private readonly repoRoot: string,
@@ -34,6 +54,20 @@ export class OrchestratorV2 {
     private readonly channelStore?: ChannelStore,
     private readonly workspaceId?: string
   ) {}
+
+  /**
+   * Register a factory that builds a poller (typically a `PrPoller` wired to
+   * a `SchedulerFollowUpDispatcher`) once a scheduler exists for the run.
+   *
+   * Chosen over baking SCM/tracker construction into the orchestrator because
+   * the poller needs a `HarnessProject`, a `GITHUB_TOKEN` (optional), and SCM
+   * plugin wiring — none of which belong in orchestrator-v2's core contract.
+   * The CLI/startup path owns env + project config and is the right place to
+   * skip this when `GITHUB_TOKEN` is missing.
+   */
+  attachPoller(factory: PollerFactory): void {
+    this.pollerFactory = factory;
+  }
 
   async run(featureRequest: string, runId?: string): Promise<HarnessRun> {
     const now = new Date().toISOString();
@@ -226,7 +260,14 @@ export class OrchestratorV2 {
       (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details)
     );
 
-    const allTicketsSucceeded = await scheduler.executeAll(run);
+    const poller = this.startPoller(run, scheduler);
+
+    let allTicketsSucceeded = false;
+    try {
+      allTicketsSucceeded = await scheduler.executeAll(run);
+    } finally {
+      poller?.stop();
+    }
 
     if (allTicketsSucceeded) {
       this.recordEvent(run, "AllTicketsComplete", "phase_00", {
@@ -303,7 +344,12 @@ export class OrchestratorV2 {
       (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details)
     );
 
-    await scheduler.executeAll(run);
+    const poller = this.startPoller(run, scheduler);
+    try {
+      await scheduler.executeAll(run);
+    } finally {
+      poller?.stop();
+    }
 
     run.completedAt = new Date().toISOString();
     run.updatedAt = run.completedAt;
@@ -320,6 +366,20 @@ export class OrchestratorV2 {
     }
 
     return run;
+  }
+
+  private startPoller(
+    run: HarnessRun,
+    scheduler: TicketScheduler
+  ): PollerHandle | null {
+    if (!this.pollerFactory) return null;
+    try {
+      const poller = this.pollerFactory({ run, scheduler });
+      poller?.start();
+      return poller;
+    } catch {
+      return null;
+    }
   }
 
   private async dispatch(

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -3,8 +3,14 @@ import { getAgentName } from "../domain/agent-names.js";
 import { roleForWork } from "../domain/agent.js";
 import type { AgentRegistry } from "../agents/registry.js";
 import type { HarnessRun, RunEventType } from "../domain/run.js";
-import type { TicketDefinition, TicketLedgerEntry } from "../domain/ticket.js";
-import { getReadyTickets } from "../domain/ticket.js";
+import type {
+  TicketDefinition,
+  TicketLedgerEntry
+} from "../domain/ticket.js";
+import {
+  getReadyTickets,
+  initializeTicketLedger
+} from "../domain/ticket.js";
 import type { ArtifactStore } from "../execution/artifact-store.js";
 import type { VerificationRunner } from "../execution/verification-runner.js";
 import { selectVerificationCommands } from "../execution/verification-runner.js";
@@ -23,8 +29,25 @@ const DEFAULT_OPTIONS: TicketSchedulerOptions = {
   maxConcurrency: 3
 };
 
+// Sentinel marker returned by the wake-up channel — distinct from any real
+// ticket completion record so the scheduler loop can detect and ignore it.
+const WAKE_SENTINEL = { ticketId: "__wake__", success: false, wake: true } as const;
+
+type RaceResult =
+  | { ticketId: string; success: boolean; wake?: false }
+  | { ticketId: "__wake__"; success: false; wake: true };
+
 export class TicketScheduler {
   private readonly options: TicketSchedulerOptions;
+
+  /** The run that the active `executeAll` is driving, if any. */
+  private activeRun: HarnessRun | null = null;
+
+  /** Resolves the next time an in-flight `executeAll` loop should re-scan. */
+  private wakeResolve: (() => void) | null = null;
+
+  /** Tail of queued single-ticket executions after `executeAll` resolved. */
+  private enqueueTail: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly repoRoot: string,
@@ -47,7 +70,73 @@ export class TicketScheduler {
   }
 
   async executeAll(run: HarnessRun): Promise<boolean> {
-    const executing = new Map<string, Promise<{ ticketId: string; success: boolean }>>();
+    this.activeRun = run;
+    try {
+      return await this.drain(run);
+    } finally {
+      // Only clear the active-run marker if we are still the active session.
+      // (Defensive: `enqueue` never calls executeAll concurrently.)
+      if (this.activeRun === run) {
+        this.activeRun = null;
+        this.wakeResolve = null;
+      }
+    }
+  }
+
+  /**
+   * Append a ticket to the run's ledger and make sure it will be executed.
+   *
+   * Semantics:
+   *  - Appends the ticket to `run.ticketPlan.tickets` and a matching entry to
+   *    `run.ticketLedger` so persisted snapshots see it.
+   *  - If an `executeAll` loop is currently driving this run, wake it so the
+   *    new ticket is picked up on the next iteration.
+   *  - Otherwise, spawn a fresh drain for just the new ticket. Concurrent
+   *    `enqueue` calls in this mode are serialized behind a tail promise so
+   *    we never run two drains for the same run at once.
+   *
+   * The concurrency cap from `TicketSchedulerOptions` is always respected —
+   * the drain loop is the single place tickets transition to `executing`.
+   */
+  async enqueue(run: HarnessRun, ticket: TicketDefinition): Promise<void> {
+    this.appendTicketToRun(run, ticket);
+
+    if (this.activeRun === run) {
+      // Loop is alive — poke it so the next iteration re-scans the ledger.
+      this.wake();
+      return;
+    }
+
+    // No active loop. Serialize fresh drains so we don't start a second one
+    // while an earlier enqueue is still working.
+    const next = this.enqueueTail.then(async () => {
+      // If somebody started a real executeAll between scheduling and now,
+      // the ticket is already in the ledger and that loop will see it.
+      if (this.activeRun === run) {
+        this.wake();
+        return;
+      }
+      this.activeRun = run;
+      try {
+        await this.drain(run);
+      } finally {
+        if (this.activeRun === run) {
+          this.activeRun = null;
+          this.wakeResolve = null;
+        }
+      }
+    });
+
+    // Keep the chain alive even if one drain throws, so future enqueues still run.
+    this.enqueueTail = next.catch(() => {
+      /* swallow — failures are recorded on the ledger entry itself */
+    });
+
+    await next;
+  }
+
+  private async drain(run: HarnessRun): Promise<boolean> {
+    const executing = new Map<string, Promise<RaceResult>>();
 
     while (true) {
       const allCompleted = run.ticketLedger.every(
@@ -92,18 +181,32 @@ export class TicketScheduler {
         });
 
         const promise = this.executeTicket(run, ticketDef).then(
-          (success) => ({ ticketId: ticket.ticketId, success }),
-          () => ({ ticketId: ticket.ticketId, success: false })
+          (success): RaceResult => ({ ticketId: ticket.ticketId, success }),
+          (): RaceResult => ({ ticketId: ticket.ticketId, success: false })
         );
 
         executing.set(ticket.ticketId, promise);
       }
 
       if (executing.size === 0) {
+        // No in-flight work and nothing ready to dispatch. Preserve the
+        // original contract: signal failure so the caller knows the drain
+        // ended without completing every ticket. Fresh `enqueue` calls after
+        // this point spawn their own drain via the enqueueTail chain.
         return false;
       }
 
-      const completed = await Promise.race(executing.values());
+      const wakePromise = this.makeWakePromise();
+      const completed = await Promise.race<RaceResult>([
+        ...executing.values(),
+        wakePromise
+      ]);
+
+      if ("wake" in completed && completed.wake) {
+        // Wake signal fired — re-scan the ledger for newly appended work.
+        continue;
+      }
+
       executing.delete(completed.ticketId);
 
       if (completed.success) {
@@ -127,6 +230,41 @@ export class TicketScheduler {
       }
 
       await this.persistTicketLedger(run);
+    }
+  }
+
+  /**
+   * Build a promise that resolves when `wake()` is called. Each iteration of
+   * the drain loop consumes one and replaces it, so a wake signal only fires
+   * the next Promise.race — never a stale one.
+   */
+  private makeWakePromise(): Promise<RaceResult> {
+    return new Promise<RaceResult>((resolve) => {
+      this.wakeResolve = () => {
+        this.wakeResolve = null;
+        resolve(WAKE_SENTINEL);
+      };
+    });
+  }
+
+  private wake(): void {
+    const resolver = this.wakeResolve;
+    this.wakeResolve = null;
+    resolver?.();
+  }
+
+  private appendTicketToRun(run: HarnessRun, ticket: TicketDefinition): void {
+    // Don't double-append. Idempotency keeps retries from accidentally cloning
+    // a ticket onto the ledger twice.
+    if (run.ticketLedger.some((t) => t.ticketId === ticket.id)) {
+      return;
+    }
+
+    const [entry] = initializeTicketLedger([ticket]);
+    run.ticketLedger.push(entry);
+
+    if (run.ticketPlan) {
+      run.ticketPlan.tickets.push(ticket);
     }
   }
 

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -74,8 +74,8 @@ export class TicketScheduler {
     try {
       return await this.drain(run);
     } finally {
-      // Only clear the active-run marker if we are still the active session.
-      // (Defensive: `enqueue` never calls executeAll concurrently.)
+      // Defensive double-clear: drain's finally already cleared the marker
+      // on the normal path. This catches the throw-without-clearing case.
       if (this.activeRun === run) {
         this.activeRun = null;
         this.wakeResolve = null;
@@ -138,6 +138,23 @@ export class TicketScheduler {
   private async drain(run: HarnessRun): Promise<boolean> {
     const executing = new Map<string, Promise<RaceResult>>();
 
+    try {
+      return await this.drainLoop(run, executing);
+    } finally {
+      // Clear the active-run marker BEFORE drain returns, so a concurrent
+      // enqueue() that races with drain-just-returning takes the fresh-drain
+      // branch via enqueueTail instead of a no-op wake() on a dead loop.
+      if (this.activeRun === run) {
+        this.activeRun = null;
+        this.wakeResolve = null;
+      }
+    }
+  }
+
+  private async drainLoop(
+    run: HarnessRun,
+    executing: Map<string, Promise<RaceResult>>
+  ): Promise<boolean> {
     while (true) {
       const allCompleted = run.ticketLedger.every(
         (t) => t.status === "completed" || t.status === "failed"

--- a/test/channels/channel-store-post.test.ts
+++ b/test/channels/channel-store-post.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+
+describe("ChannelStore.post", () => {
+  it("applies defaults (message type, null agent id, system display name, empty metadata)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "post-defaults-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+
+      const entryId = await store.post(channel.channelId, "hello world");
+      expect(typeof entryId).toBe("string");
+      expect(entryId).toMatch(/^entry-/);
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed).toHaveLength(1);
+      const entry = feed[0];
+      expect(entry.entryId).toBe(entryId);
+      expect(entry.type).toBe("message");
+      expect(entry.fromAgentId).toBeNull();
+      expect(entry.fromDisplayName).toBe("system");
+      expect(entry.content).toBe("hello world");
+      expect(entry.metadata).toEqual({});
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors overrides for type, fromAgentId, fromDisplayName, and metadata", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "post-overrides-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+
+      await store.post(channel.channelId, "PR opened", {
+        type: "event",
+        fromAgentId: "agent-7",
+        fromDisplayName: "PR Bot",
+        metadata: { eventId: "evt-1", priority: "info" }
+      });
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed).toHaveLength(1);
+      const entry = feed[0];
+      expect(entry.type).toBe("event");
+      expect(entry.fromAgentId).toBe("agent-7");
+      expect(entry.fromDisplayName).toBe("PR Bot");
+      expect(entry.content).toBe("PR opened");
+      expect(entry.metadata).toEqual({ eventId: "evt-1", priority: "info" });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes non-string metadata values to JSON strings on write", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "post-meta-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+
+      await store.post(channel.channelId, "rich metadata", {
+        metadata: {
+          simple: "keep-me",
+          count: 42,
+          flag: true,
+          payload: { nested: { value: [1, 2, 3] } },
+          tags: ["a", "b"]
+        }
+      });
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed).toHaveLength(1);
+      const metadata = feed[0].metadata as Record<string, string>;
+
+      // Strings pass through verbatim.
+      expect(metadata.simple).toBe("keep-me");
+      // Non-string values become JSON strings — verify round-trip.
+      expect(typeof metadata.count).toBe("string");
+      expect(JSON.parse(metadata.count)).toBe(42);
+      expect(JSON.parse(metadata.flag)).toBe(true);
+      expect(JSON.parse(metadata.payload)).toEqual({ nested: { value: [1, 2, 3] } });
+      expect(JSON.parse(metadata.tags)).toEqual(["a", "b"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops null and undefined metadata values", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "post-drop-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+
+      await store.post(channel.channelId, "drop test", {
+        metadata: {
+          keep: "yes",
+          droppedNull: null,
+          droppedUndef: undefined
+        }
+      });
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed[0].metadata).toEqual({ keep: "yes" });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/integrations/ao-notifier.test.ts
+++ b/test/integrations/ao-notifier.test.ts
@@ -23,7 +23,7 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
 }
 
 describe("HarnessChannelNotifier", () => {
-  it("notify posts a status_update entry with event metadata", async () => {
+  it("notify posts an event entry with event metadata and preserves event.data", async () => {
     const dir = await mkdtemp(join(tmpdir(), "ao-notif-"));
     const store = new ChannelStore(dir);
     try {
@@ -33,12 +33,13 @@ describe("HarnessChannelNotifier", () => {
         defaultChannelId: channel.channelId
       });
 
-      await notifier.notify(buildEvent());
+      const data = { prNumber: 42, reviewer: "alice", labels: ["urgent", "bug"] };
+      await notifier.notify(buildEvent({ data }));
 
       const feed = await store.readFeed(channel.channelId);
       expect(feed).toHaveLength(1);
       const entry = feed[0];
-      expect(entry.type).toBe("status_update");
+      expect(entry.type).toBe("event");
       expect(entry.fromDisplayName).toBe("orchestrator");
       expect(entry.content).toContain("[pr.updated]");
       expect(entry.content).toContain("session=sess-1");
@@ -49,6 +50,10 @@ describe("HarnessChannelNotifier", () => {
       expect(entry.metadata.sessionId).toBe("sess-1");
       expect(entry.metadata.projectId).toBe("proj-1");
       expect(entry.metadata.timestamp).toBe("2026-04-20T12:00:00.000Z");
+      // event.data is preserved as a JSON-serialized string so existing
+      // Rust/GUI readers (typed Record<string, string>) keep working.
+      expect(typeof entry.metadata.data).toBe("string");
+      expect(JSON.parse(entry.metadata.data as string)).toEqual(data);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/integrations/plugin-env-mutex.test.ts
+++ b/test/integrations/plugin-env-mutex.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { withEnvOverride } from "../../src/integrations/plugin-env-mutex.js";
+
+const KEY = "PLUGIN_ENV_MUTEX_TEST_VAR";
+const OTHER_KEY = "PLUGIN_ENV_MUTEX_TEST_VAR_B";
+
+function snapshotAndClear(): { key: string | undefined; other: string | undefined } {
+  const snap = { key: process.env[KEY], other: process.env[OTHER_KEY] };
+  delete process.env[KEY];
+  delete process.env[OTHER_KEY];
+  return snap;
+}
+
+function restore(snap: { key: string | undefined; other: string | undefined }): void {
+  if (snap.key === undefined) delete process.env[KEY];
+  else process.env[KEY] = snap.key;
+  if (snap.other === undefined) delete process.env[OTHER_KEY];
+  else process.env[OTHER_KEY] = snap.other;
+}
+
+describe("withEnvOverride — trivial overlay and restore", () => {
+  let snap: { key: string | undefined; other: string | undefined };
+
+  beforeEach(() => {
+    snap = snapshotAndClear();
+  });
+
+  afterEach(() => {
+    restore(snap);
+  });
+
+  it("sets the env var for the duration of fn and restores after", async () => {
+    expect(process.env[KEY]).toBeUndefined();
+    const inner = await withEnvOverride({ [KEY]: "A" }, () => process.env[KEY]);
+    expect(inner).toBe("A");
+    expect(process.env[KEY]).toBeUndefined();
+  });
+
+  it("restores prior value when the key was already set", async () => {
+    process.env[KEY] = "PRIOR";
+    const inner = await withEnvOverride({ [KEY]: "OVERLAY" }, () => process.env[KEY]);
+    expect(inner).toBe("OVERLAY");
+    expect(process.env[KEY]).toBe("PRIOR");
+  });
+
+  it("returns the value produced by fn (including async fns)", async () => {
+    const value = await withEnvOverride({ [KEY]: "X" }, async () => {
+      await new Promise((r) => setTimeout(r, 1));
+      return `${process.env[KEY]}!`;
+    });
+    expect(value).toBe("X!");
+    expect(process.env[KEY]).toBeUndefined();
+  });
+});
+
+describe("withEnvOverride — serialization of concurrent overlays", () => {
+  let snap: { key: string | undefined; other: string | undefined };
+
+  beforeEach(() => {
+    snap = snapshotAndClear();
+  });
+
+  afterEach(() => {
+    restore(snap);
+  });
+
+  it("never lets concurrent callers observe each other's overlays even with internal awaits", async () => {
+    // Both callers look at process.env[KEY] before and after an await.
+    // If the mutex is correct, each caller sees only its own value at both
+    // observation points.
+    const observations: Array<{ who: "A" | "B"; before: string | undefined; after: string | undefined }> = [];
+
+    const callA = withEnvOverride({ [KEY]: "AAA" }, async () => {
+      const before = process.env[KEY];
+      await new Promise((r) => setTimeout(r, 20));
+      const after = process.env[KEY];
+      observations.push({ who: "A", before, after });
+    });
+
+    const callB = withEnvOverride({ [KEY]: "BBB" }, async () => {
+      const before = process.env[KEY];
+      await new Promise((r) => setTimeout(r, 20));
+      const after = process.env[KEY];
+      observations.push({ who: "B", before, after });
+    });
+
+    await Promise.all([callA, callB]);
+
+    expect(observations).toHaveLength(2);
+    for (const obs of observations) {
+      const expected = obs.who === "A" ? "AAA" : "BBB";
+      expect(obs.before).toBe(expected);
+      expect(obs.after).toBe(expected);
+    }
+
+    expect(process.env[KEY]).toBeUndefined();
+  });
+
+  it("runs overlays strictly in queued order", async () => {
+    const order: string[] = [];
+    const jobs: Array<Promise<void>> = [];
+    for (let i = 0; i < 5; i++) {
+      const label = `job-${i}`;
+      jobs.push(
+        withEnvOverride({ [KEY]: label }, async () => {
+          order.push(`start:${label}:${process.env[KEY]}`);
+          await new Promise((r) => setTimeout(r, 5));
+          order.push(`end:${label}:${process.env[KEY]}`);
+        }),
+      );
+    }
+    await Promise.all(jobs);
+
+    // Each job's start and end must appear consecutively (no interleaving),
+    // and each must see its own label in env[KEY].
+    for (let i = 0; i < 5; i++) {
+      expect(order[i * 2]).toBe(`start:job-${i}:job-${i}`);
+      expect(order[i * 2 + 1]).toBe(`end:job-${i}:job-${i}`);
+    }
+  });
+});
+
+describe("withEnvOverride — restore on throw", () => {
+  let snap: { key: string | undefined; other: string | undefined };
+
+  beforeEach(() => {
+    snap = snapshotAndClear();
+  });
+
+  afterEach(() => {
+    restore(snap);
+  });
+
+  it("restores env even when fn throws synchronously", async () => {
+    process.env[KEY] = "PRIOR";
+    await expect(
+      withEnvOverride({ [KEY]: "OVERLAY" }, () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(process.env[KEY]).toBe("PRIOR");
+  });
+
+  it("restores env even when fn rejects asynchronously", async () => {
+    process.env[KEY] = "PRIOR";
+    await expect(
+      withEnvOverride({ [KEY]: "OVERLAY" }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        throw new Error("async boom");
+      }),
+    ).rejects.toThrow("async boom");
+    expect(process.env[KEY]).toBe("PRIOR");
+  });
+
+  it("does not poison the chain: later callers still run after a rejection", async () => {
+    const rejected = withEnvOverride({ [KEY]: "BAD" }, () => {
+      throw new Error("nope");
+    });
+    await expect(rejected).rejects.toThrow("nope");
+
+    const value = await withEnvOverride({ [KEY]: "OK" }, () => process.env[KEY]);
+    expect(value).toBe("OK");
+  });
+});
+
+describe("withEnvOverride — unset semantics", () => {
+  let snap: { key: string | undefined; other: string | undefined };
+
+  beforeEach(() => {
+    snap = snapshotAndClear();
+  });
+
+  afterEach(() => {
+    restore(snap);
+  });
+
+  it("deletes process.env[KEY] when override value is undefined, and restores prior value", async () => {
+    process.env[KEY] = "PRIOR";
+    const inner = await withEnvOverride({ [KEY]: undefined }, () => process.env[KEY]);
+    expect(inner).toBeUndefined();
+    expect(process.env[KEY]).toBe("PRIOR");
+  });
+
+  it("handles the unset case when the key had no prior value", async () => {
+    expect(process.env[KEY]).toBeUndefined();
+    const inner = await withEnvOverride({ [KEY]: undefined }, () => process.env[KEY]);
+    expect(inner).toBeUndefined();
+    expect(process.env[KEY]).toBeUndefined();
+  });
+
+  it("supports multiple keys in the same call", async () => {
+    process.env[KEY] = "prior-A";
+    process.env[OTHER_KEY] = "prior-B";
+    const [a, b] = await withEnvOverride({ [KEY]: "new-A", [OTHER_KEY]: undefined }, () => [
+      process.env[KEY],
+      process.env[OTHER_KEY],
+    ]);
+    expect(a).toBe("new-A");
+    expect(b).toBeUndefined();
+    expect(process.env[KEY]).toBe("prior-A");
+    expect(process.env[OTHER_KEY]).toBe("prior-B");
+  });
+});

--- a/test/integrations/scheduler-follow-up-dispatcher.test.ts
+++ b/test/integrations/scheduler-follow-up-dispatcher.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HarnessRun } from "../../src/domain/run.js";
+import type { TicketDefinition } from "../../src/domain/ticket.js";
+import {
+  SchedulerFollowUpDispatcher,
+  buildFollowUpTicketId
+} from "../../src/integrations/scheduler-follow-up-dispatcher.js";
+import type {
+  FollowUpKind,
+  FollowUpRequest
+} from "../../src/integrations/pr-poller.js";
+
+function makeRun(): HarnessRun {
+  const now = new Date().toISOString();
+  return {
+    id: "run-fu",
+    featureRequest: "feature",
+    state: "TICKETS_EXECUTING",
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    channelId: null,
+    classification: null,
+    plan: null,
+    ticketPlan: null,
+    events: [],
+    evidence: [],
+    artifacts: [],
+    phaseLedger: [],
+    phaseLedgerPath: null,
+    ticketLedger: [],
+    ticketLedgerPath: null,
+    runIndexPath: null
+  };
+}
+
+function request(overrides: Partial<FollowUpRequest> = {}): FollowUpRequest {
+  const kind: FollowUpKind = overrides.kind ?? "fix-ci";
+  return {
+    kind,
+    parentTicketId: overrides.parentTicketId ?? "ticket_01",
+    channelId: overrides.channelId ?? "chan-1",
+    pr: overrides.pr ?? {
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      branch: "feat/7"
+    },
+    repo: overrides.repo ?? { owner: "acme", name: "widgets" },
+    title: overrides.title ?? `${kind}: acme/widgets#7`,
+    prompt: overrides.prompt ?? "Investigate and fix the failing CI run."
+  };
+}
+
+describe("SchedulerFollowUpDispatcher", () => {
+  it("synthesizes a ticket and forwards it to scheduler.enqueue", async () => {
+    const run = makeRun();
+    const enqueue = vi.fn(
+      async (_r: HarnessRun, _t: TicketDefinition) => undefined
+    );
+    const dispatcher = new SchedulerFollowUpDispatcher({
+      scheduler: { enqueue },
+      run
+    });
+
+    const req = request({
+      kind: "fix-ci",
+      parentTicketId: "ticket_42",
+      title: "fix-ci: acme/widgets#7",
+      prompt: "CI is failing; reproduce and push a fix to feat/7."
+    });
+
+    const ticketId = await dispatcher.enqueueFollowUp(req);
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const [passedRun, passedTicket] = enqueue.mock.calls[0]!;
+    expect(passedRun).toBe(run);
+
+    expect(ticketId).toBe(buildFollowUpTicketId(req));
+    expect(ticketId).toContain("fix-ci");
+    expect(ticketId).toContain("ticket_42");
+
+    expect(passedTicket.id).toBe(ticketId);
+    expect(passedTicket.title).toBe(req.title);
+    expect(passedTicket.objective).toBe(req.prompt);
+    expect(passedTicket.specialty).toBe("general");
+    expect(passedTicket.dependsOn).toEqual([]);
+    expect(passedTicket.acceptanceCriteria.length).toBeGreaterThan(0);
+    expect(passedTicket.retryPolicy.maxAgentAttempts).toBeGreaterThanOrEqual(1);
+    expect(passedTicket.retryPolicy.maxTestFixLoops).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses a distinct acceptance line for address-reviews follow-ups", async () => {
+    const run = makeRun();
+    const enqueue = vi.fn(
+      async (_r: HarnessRun, _t: TicketDefinition) => undefined
+    );
+    const dispatcher = new SchedulerFollowUpDispatcher({
+      scheduler: { enqueue },
+      run
+    });
+
+    const req = request({
+      kind: "address-reviews",
+      parentTicketId: "ticket_99",
+      title: "address-reviews: acme/widgets#7"
+    });
+
+    await dispatcher.enqueueFollowUp(req);
+
+    const [, ticket] = enqueue.mock.calls[0]!;
+    expect(ticket.id).toBe(buildFollowUpTicketId(req));
+    expect(ticket.id).toContain("address-reviews");
+    expect(ticket.acceptanceCriteria.join(" ").toLowerCase()).toContain(
+      "comments"
+    );
+  });
+
+  it("produces stable ids per (parentTicketId, kind) pair", () => {
+    const a = buildFollowUpTicketId(
+      request({ kind: "fix-ci", parentTicketId: "x" })
+    );
+    const b = buildFollowUpTicketId(
+      request({ kind: "fix-ci", parentTicketId: "x" })
+    );
+    const c = buildFollowUpTicketId(
+      request({ kind: "address-reviews", parentTicketId: "x" })
+    );
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+});

--- a/test/orchestrator/ticket-scheduler-enqueue.test.ts
+++ b/test/orchestrator/ticket-scheduler-enqueue.test.ts
@@ -1,0 +1,212 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { NodeCommandInvoker } from "../../src/agents/command-invoker.js";
+import { createLiveAgents } from "../../src/agents/factory.js";
+import { AgentRegistry } from "../../src/agents/registry.js";
+import type {
+  AgentResult,
+  WorkRequest
+} from "../../src/domain/agent.js";
+import type { HarnessRun } from "../../src/domain/run.js";
+import {
+  initializeTicketLedger,
+  parseTicketPlan,
+  type TicketDefinition
+} from "../../src/domain/ticket.js";
+import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
+import { VerificationRunner } from "../../src/execution/verification-runner.js";
+import { TicketScheduler } from "../../src/orchestrator/ticket-scheduler.js";
+import { ScriptedInvoker } from "../../src/simulation/scripted-invoker.js";
+
+const RETRY_POLICY = { maxAgentAttempts: 1, maxTestFixLoops: 1 } as const;
+
+function ticket(id: string, title = `Ticket ${id}`): TicketDefinition {
+  return {
+    id,
+    title,
+    objective: `Do ${id}`,
+    specialty: "general",
+    acceptanceCriteria: ["Complete the work"],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    dependsOn: [],
+    retryPolicy: { ...RETRY_POLICY }
+  };
+}
+
+function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
+  const now = new Date().toISOString();
+  const ticketPlan = parseTicketPlan({
+    version: 1,
+    task: {
+      title: "Test run",
+      featureRequest: "Test feature",
+      repoRoot
+    },
+    classification: {
+      tier: "feature_small",
+      rationale: "test",
+      suggestedSpecialties: ["general"],
+      estimatedTicketCount: tickets.length,
+      needsDesignDoc: false,
+      needsUserApproval: false
+    },
+    tickets,
+    finalVerification: { commands: [] },
+    docsToUpdate: []
+  });
+
+  return {
+    id: "run-test",
+    featureRequest: "Test feature",
+    state: "TICKETS_EXECUTING",
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    channelId: null,
+    classification: ticketPlan.classification,
+    plan: null,
+    ticketPlan,
+    events: [],
+    evidence: [],
+    artifacts: [],
+    phaseLedger: [],
+    phaseLedgerPath: null,
+    ticketLedger: initializeTicketLedger(tickets),
+    ticketLedgerPath: null,
+    runIndexPath: null
+  };
+}
+
+/**
+ * Build a scheduler whose dispatch always returns success — no verification
+ * commands are proposed, so the built-in verification pass sees an empty
+ * command list and trivially succeeds.
+ */
+async function buildScheduler(repoRoot: string) {
+  const registry = new AgentRegistry();
+  for (const agent of createLiveAgents({
+    cwd: repoRoot,
+    invoker: new ScriptedInvoker(repoRoot)
+  })) {
+    registry.register(agent);
+  }
+
+  const artifactStore = new LocalArtifactStore(join(repoRoot, "artifacts"));
+  const verificationRunner = new VerificationRunner(
+    new NodeCommandInvoker(),
+    artifactStore
+  );
+
+  const dispatched: WorkRequest[] = [];
+  const dispatch = async (
+    _run: HarnessRun,
+    req: Omit<WorkRequest, "runId">
+  ): Promise<AgentResult> => {
+    dispatched.push({ runId: "run-test", ...req });
+    return {
+      summary: `ok:${req.kind}`,
+      evidence: [],
+      proposedCommands: [],
+      blockers: []
+    };
+  };
+
+  const scheduler = new TicketScheduler(
+    repoRoot,
+    artifactStore,
+    verificationRunner,
+    registry,
+    dispatch,
+    () => {
+      /* no-op event recorder */
+    },
+    { maxConcurrency: 2 }
+  );
+
+  return { scheduler, dispatched, artifactStore };
+}
+
+describe("TicketScheduler.enqueue", () => {
+  it("executes a ticket enqueued after executeAll has resolved", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-enqueue-"));
+    try {
+      const run = buildRun(tmp, [ticket("t_initial")]);
+      const { scheduler } = await buildScheduler(tmp);
+
+      const ok = await scheduler.executeAll(run);
+      expect(ok).toBe(true);
+
+      const initial = run.ticketLedger.find((t) => t.ticketId === "t_initial");
+      expect(initial?.status).toBe("completed");
+
+      // Now enqueue a follow-up after executeAll resolved.
+      await scheduler.enqueue(run, ticket("t_followup", "Follow-up ticket"));
+
+      const follow = run.ticketLedger.find((t) => t.ticketId === "t_followup");
+      expect(follow).toBeDefined();
+      expect(follow!.status).toBe("completed");
+
+      // Both tickets ended up in the ledger.
+      const ids = run.ticketLedger.map((t) => t.ticketId);
+      expect(ids).toEqual(["t_initial", "t_followup"]);
+
+      // And in the ticket plan so snapshots see it.
+      expect(run.ticketPlan!.tickets.map((t) => t.id)).toEqual([
+        "t_initial",
+        "t_followup"
+      ]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("picks up a ticket enqueued while executeAll is mid-flight", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-enqueue-live-"));
+    try {
+      const run = buildRun(tmp, [ticket("t_a")]);
+      const { scheduler } = await buildScheduler(tmp);
+
+      // Kick off executeAll, then enqueue an extra ticket on the next tick so
+      // the scheduler sees it while the loop is still alive.
+      const execute = scheduler.executeAll(run);
+      queueMicrotask(() => {
+        void scheduler.enqueue(run, ticket("t_b", "Live enqueue"));
+      });
+
+      const ok = await execute;
+      expect(ok).toBe(true);
+
+      const ids = run.ticketLedger.map((t) => t.ticketId).sort();
+      expect(ids).toEqual(["t_a", "t_b"]);
+      for (const entry of run.ticketLedger) {
+        expect(entry.status).toBe("completed");
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("is idempotent on repeated enqueues of the same ticket id", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-enqueue-idem-"));
+    try {
+      const run = buildRun(tmp, [ticket("t_seed")]);
+      const { scheduler } = await buildScheduler(tmp);
+
+      await scheduler.executeAll(run);
+
+      await scheduler.enqueue(run, ticket("t_once"));
+      await scheduler.enqueue(run, ticket("t_once"));
+
+      const matches = run.ticketLedger.filter((t) => t.ticketId === "t_once");
+      expect(matches).toHaveLength(1);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Stacked on **#2**. Closes the three known follow-ups from that PR's body.

## 1. Scheduler: dynamic enqueue surface
- `TicketScheduler.enqueue(run, ticket)` — idempotent on id, appends to both the ledger and the ticket plan.
- Mid-flight wake via `Promise.race` so live drains pick up new tickets immediately.
- Post-`executeAll` enqueues spawn a tail-chained drain so concurrent calls don't overlap. Concurrency cap preserved.
- `SchedulerFollowUpDispatcher` — concrete implementation of the `FollowUpDispatcher` seam PR #2 introduced, synthesizing a ticket from each `FollowUpRequest`.
- `OrchestratorV2.attachPoller(factory)` hook — the CLI owns SCM + env wiring so `@aoagents/*` imports stay scoped to `src/integrations/`. Poller is `stop()`'d in a `finally` around `executeAll`.

## 2. ChannelStore: API gaps
- `ChannelEntry.metadata` widened to `Record<string, unknown>`; non-string values are JSON-serialized on the write path so **Rust reader (`crates/harness-data`) and GUI still see `Record<string, string>` on disk — no cross-stack break.**
- New `"event"` variant on `ChannelEntryType` (alongside existing `status_update`, `message`, etc.).
- New `ChannelStore.post(channelId, content, options?)` helper that thin-wraps `postEntry` with sensible defaults.
- `ao-notifier` now writes `type: "event"` and preserves `event.data` in metadata (was being dropped).

## 3. AO plugin factory: thread-safety
- `src/integrations/plugin-env-mutex.ts` exports `withEnvOverride(overrides, fn)` — a module-local promise-chain mutex. Serializes concurrent `create()` calls so AO's zero-arg plugin factories can't observe each other's `process.env` mutations. Restores prior env (including unset) in a `finally`. A rejected `fn` doesn't poison the chain.
- `tracker.ts` / `scm.ts` use TypeScript overloads: no-token calls remain sync (API-compatible), with-token calls route through the mutex and return `Promise<Tracker | SCM>`.

## Tests
**119/119 passing** (73 baseline → 98 after #2 → **119 here**, +21):
- `test/orchestrator/ticket-scheduler-enqueue.test.ts` (3)
- `test/integrations/scheduler-follow-up-dispatcher.test.ts` (3)
- `test/integrations/plugin-env-mutex.test.ts` (11)
- `test/channels/channel-store-post.test.ts` (4)
- Updated `test/integrations/ao-notifier.test.ts` for the new `"event"` entry type + `event.data` round-trip

`pnpm typecheck` clean.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] Manual: enable the poller via `attachPoller`, watch a forced CI failure on a real PR, confirm a `fix-ci` ticket appears in the run ledger and gets executed.
- [ ] Manual: two simultaneous `createTracker(kind, { token })` calls with different tokens — confirm no cross-contamination via inspector or a log.

## Merge order
Merge **#2 first**, then this. The branch is based on `feat/ao-integration`; `--base feat/ao-integration` in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)