### PR TITLE
Polish AO integration: metadata round-trip, mutex recursion guard, scheduler tail logging, test coverage

### DIFF
--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -239,7 +239,13 @@ export class ChannelStore {
         .trim()
         .split("\n")
         .filter(Boolean)
-        .map((line) => JSON.parse(line) as ChannelEntry);
+        .map((line) => {
+          const entry = JSON.parse(line) as ChannelEntry;
+          entry.metadata = denormalizeMetadata(
+            entry.metadata as Record<string, string>
+          );
+          return entry;
+        });
 
       if (limit) {
         return entries.slice(-limit);
@@ -408,10 +414,25 @@ export class ChannelStore {
 }
 
 /**
+ * Prefix used to tag metadata values that were JSON-serialized on write so
+ * `denormalizeMetadata` can losslessly restore them on read. Chosen to be
+ * distinctive and effectively never collide with real string payloads; if a
+ * caller genuinely needs to store a string that happens to start with this
+ * prefix, pass it through `JSON.stringify` before calling `post` (it will
+ * round-trip as a string once parsed back).
+ */
+const JSON_TAG = "__ah_meta_json::";
+
+/**
  * Serialize non-string metadata values to JSON strings so existing readers
  * (Rust `crates/harness-data` and `gui/src/types.ts`, which both type
  * metadata as `Record<string, string>`) continue to deserialize the feed
- * without changes. `null` and `undefined` are dropped. Strings pass through.
+ * without changes. Non-string values are prefixed with `JSON_TAG` so
+ * `denormalizeMetadata` can restore the original type on read.
+ * `null` and `undefined` are dropped. Plain strings pass through verbatim;
+ * as a collision-safety measure, a string that happens to start with
+ * `JSON_TAG` is also JSON-tagged on write so `denormalizeMetadata` restores
+ * the exact original string instead of treating it as a serialized payload.
  */
 function normalizeMetadata(
   metadata: Record<string, unknown>
@@ -419,7 +440,42 @@ function normalizeMetadata(
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(metadata)) {
     if (value === undefined || value === null) continue;
-    out[key] = typeof value === "string" ? value : JSON.stringify(value);
+    if (typeof value === "string") {
+      // Normal case: strings pass through verbatim. The rare string that
+      // coincidentally starts with the tag must be tagged too, otherwise
+      // the reader would mis-parse it.
+      out[key] = value.startsWith(JSON_TAG)
+        ? JSON_TAG + JSON.stringify(value)
+        : value;
+    } else {
+      out[key] = JSON_TAG + JSON.stringify(value);
+    }
+  }
+  return out;
+}
+
+/**
+ * Inverse of `normalizeMetadata`. Values that begin with `JSON_TAG` are
+ * stripped and JSON-parsed back to their original type; all other values
+ * pass through as strings. Safe to call on entries written before the tag
+ * was introduced (those are pure strings and pass through unchanged).
+ */
+function denormalizeMetadata(
+  metadata: Record<string, string> | undefined
+): Record<string, unknown> {
+  if (!metadata) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === "string" && value.startsWith(JSON_TAG)) {
+      try {
+        out[key] = JSON.parse(value.slice(JSON_TAG.length));
+      } catch {
+        // Malformed payload — surface the raw string rather than throw.
+        out[key] = value;
+      }
+    } else {
+      out[key] = value;
+    }
   }
   return out;
 }

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -71,9 +71,11 @@ export interface ChannelEntry {
   /**
    * Free-form metadata for the entry. Callers may pass any JSON-serializable
    * values; the channel store serializes non-string values to JSON strings on
-   * write so downstream Rust readers (`crates/harness-data`) and the GUI
-   * (`gui/src/types.ts`), which type metadata as `Record<string, string>`,
-   * continue to deserialize the feed without changes.
+   * write (tagged with an `__ah_meta_json::` prefix) so downstream Rust
+   * readers (`crates/harness-data`) and the GUI (`gui/src/types.ts`), which
+   * type metadata as `Record<string, string>`, continue to deserialize the
+   * feed without changes. TypeScript callers see the original types round-
+   * tripped back on read via `denormalizeMetadata`.
    */
   metadata: Record<string, unknown>;
   createdAt: string;

--- a/src/integrations/plugin-env-mutex.ts
+++ b/src/integrations/plugin-env-mutex.ts
@@ -20,10 +20,26 @@
 // subsequent callers.
 let chain: Promise<void> = Promise.resolve();
 
+// Tracks whether the mutex is currently held by an in-flight `fn`. This is a
+// synchronous indicator used to detect a reentrant (recursive) call from
+// inside an `fn` already holding the mutex. Without this, a reentrant caller
+// would enqueue behind its own outer call's chain promise and deadlock, since
+// that promise only resolves when the outer `fn` returns.
+let held = false;
+
 export async function withEnvOverride<T>(
   overrides: Record<string, string | undefined>,
   fn: () => T | Promise<T>,
 ): Promise<T> {
+  // Fail fast on recursion. We throw *before* touching the chain so the outer
+  // call's mutex state stays intact — once the outer `fn` returns normally,
+  // subsequent unrelated callers queued behind it still run as usual.
+  if (held) {
+    throw new Error(
+      "withEnvOverride: recursive call detected — plugin factories must not reenter",
+    );
+  }
+
   const prior = chain;
   let release!: () => void;
   chain = new Promise<void>((resolve) => {
@@ -36,6 +52,7 @@ export async function withEnvOverride<T>(
   const saved: Record<string, string | undefined> = {};
   for (const key of savedKeys) saved[key] = process.env[key];
 
+  held = true;
   try {
     for (const key of savedKeys) {
       const value = overrides[key];
@@ -49,6 +66,7 @@ export async function withEnvOverride<T>(
       if (previous === undefined) delete process.env[key];
       else process.env[key] = previous;
     }
+    held = false;
     release();
   }
 }

--- a/src/integrations/scm.ts
+++ b/src/integrations/scm.ts
@@ -111,6 +111,12 @@ export function wrapScm(scm: SCM, project: HarnessProject): HarnessScm {
     number: pr.number,
     url: pr.url,
     branch: pr.branch,
+    // `title` and `isDraft` are stub fields. The AO github plugin does not
+    // read them in the methods the harness calls today (`getCISummary`,
+    // `getReviewDecision`, `getPendingComments`, `enrichSessionsPRBatch`),
+    // so the placeholders are safe. If a future AO version starts consulting
+    // `isDraft` (e.g. to skip drafts in batch enrichment) or `title` (e.g.
+    // for logging), we'll need to plumb real values through `HarnessPR`.
     title: "",
     owner: project.owner,
     repo: project.name,

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -128,8 +128,18 @@ export class TicketScheduler {
     });
 
     // Keep the chain alive even if one drain throws, so future enqueues still run.
-    this.enqueueTail = next.catch(() => {
-      /* swallow — failures are recorded on the ledger entry itself */
+    // Surface the failure on the run's event log so it isn't silently lost —
+    // the inner `await next` below still rethrows for the real-time caller.
+    this.enqueueTail = next.catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[scheduler] tail drain failed: ${message}`);
+      try {
+        this.recordEvent(run, "TicketFailed", "__scheduler_tail__", {
+          error: message
+        });
+      } catch {
+        /* recordEvent itself must never break the chain */
+      }
     });
 
     await next;

--- a/test/channels/channel-store-post.test.ts
+++ b/test/channels/channel-store-post.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -57,7 +57,7 @@ describe("ChannelStore.post", () => {
     }
   });
 
-  it("serializes non-string metadata values to JSON strings on write", async () => {
+  it("round-trips non-string metadata back to original types on read", async () => {
     const dir = await mkdtemp(join(tmpdir(), "post-meta-"));
     const store = new ChannelStore(dir);
     try {
@@ -75,16 +75,98 @@ describe("ChannelStore.post", () => {
 
       const feed = await store.readFeed(channel.channelId);
       expect(feed).toHaveLength(1);
-      const metadata = feed[0].metadata as Record<string, string>;
+      const metadata = feed[0].metadata;
 
       // Strings pass through verbatim.
       expect(metadata.simple).toBe("keep-me");
-      // Non-string values become JSON strings — verify round-trip.
-      expect(typeof metadata.count).toBe("string");
-      expect(JSON.parse(metadata.count)).toBe(42);
-      expect(JSON.parse(metadata.flag)).toBe(true);
-      expect(JSON.parse(metadata.payload)).toEqual({ nested: { value: [1, 2, 3] } });
-      expect(JSON.parse(metadata.tags)).toEqual(["a", "b"]);
+      // Non-string values are restored to their original types.
+      expect(metadata.count).toBe(42);
+      expect(metadata.flag).toBe(true);
+      expect(metadata.payload).toEqual({ nested: { value: [1, 2, 3] } });
+      expect(metadata.tags).toEqual(["a", "b"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the on-disk wire format as Record<string, string> with a JSON tag for non-strings", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "post-wire-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+
+      await store.post(channel.channelId, "wire check", {
+        metadata: {
+          plain: "hello",
+          count: 42,
+          payload: { x: 1 }
+        }
+      });
+
+      const rawLine = (await readFile(
+        join(dir, channel.channelId, "feed.jsonl"),
+        "utf8"
+      )).trim();
+      const onDisk = JSON.parse(rawLine) as {
+        metadata: Record<string, string>;
+      };
+
+      // Every value on disk is a string — Rust and GUI readers rely on this.
+      for (const v of Object.values(onDisk.metadata)) {
+        expect(typeof v).toBe("string");
+      }
+      expect(onDisk.metadata.plain).toBe("hello");
+      expect(onDisk.metadata.count).toBe("__ah_meta_json::42");
+      expect(onDisk.metadata.payload).toBe('__ah_meta_json::{"x":1}');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mis-parse literal strings that happen to start with the JSON tag", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "post-tag-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#main", description: "" });
+
+      // A string that coincidentally begins with the JSON tag must still
+      // round-trip unchanged — the store re-tags it on write so the reader
+      // restores the exact original bytes instead of treating it as a
+      // serialized payload.
+      const literalTagged = "__ah_meta_json::some-raw-value";
+      const doubleTagged = "__ah_meta_json::__ah_meta_json::deep";
+
+      await store.post(channel.channelId, "literal tag strings", {
+        metadata: {
+          literal: literalTagged,
+          deep: doubleTagged,
+          // A plain string that never touches the tag must not be double-
+          // encoded (it should stay verbatim on disk).
+          plain: "just a string"
+        }
+      });
+
+      const feed = await store.readFeed(channel.channelId);
+      expect(feed[0].metadata.literal).toBe(literalTagged);
+      expect(feed[0].metadata.deep).toBe(doubleTagged);
+      expect(feed[0].metadata.plain).toBe("just a string");
+
+      // On-disk shape is still strings only; the plain string stays
+      // verbatim while the tag-colliding strings are tagged JSON.
+      const rawLine = (await readFile(
+        join(dir, channel.channelId, "feed.jsonl"),
+        "utf8"
+      )).trim();
+      const onDisk = JSON.parse(rawLine) as {
+        metadata: Record<string, string>;
+      };
+      for (const v of Object.values(onDisk.metadata)) {
+        expect(typeof v).toBe("string");
+      }
+      expect(onDisk.metadata.plain).toBe("just a string");
+      // Tag-colliding strings are escaped via the tagged JSON form.
+      expect(onDisk.metadata.literal.startsWith("__ah_meta_json::")).toBe(true);
+      expect(onDisk.metadata.literal).not.toBe(literalTagged);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/integrations/ao-notifier.test.ts
+++ b/test/integrations/ao-notifier.test.ts
@@ -50,10 +50,11 @@ describe("HarnessChannelNotifier", () => {
       expect(entry.metadata.sessionId).toBe("sess-1");
       expect(entry.metadata.projectId).toBe("proj-1");
       expect(entry.metadata.timestamp).toBe("2026-04-20T12:00:00.000Z");
-      // event.data is preserved as a JSON-serialized string so existing
-      // Rust/GUI readers (typed Record<string, string>) keep working.
-      expect(typeof entry.metadata.data).toBe("string");
-      expect(JSON.parse(entry.metadata.data as string)).toEqual(data);
+      // event.data is tagged+serialized on write so downstream Rust/GUI
+      // readers (typed Record<string, string>) keep seeing string metadata;
+      // TS callers get the original object back after the symmetric
+      // denormalization performed in readFeed.
+      expect(entry.metadata.data).toEqual(data);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/integrations/plugin-env-mutex.test.ts
+++ b/test/integrations/plugin-env-mutex.test.ts
@@ -164,6 +164,44 @@ describe("withEnvOverride — restore on throw", () => {
   });
 });
 
+describe("withEnvOverride — recursion self-deadlock guard", () => {
+  let snap: { key: string | undefined; other: string | undefined };
+
+  beforeEach(() => {
+    snap = snapshotAndClear();
+  });
+
+  afterEach(() => {
+    restore(snap);
+  });
+
+  it("throws when fn reenters withEnvOverride directly (would otherwise deadlock)", async () => {
+    const recursive = withEnvOverride({ [KEY]: "OUTER" }, async () => {
+      // This inner call would block forever on the outer's chain promise if
+      // the guard were absent. The guard must throw synchronously-from-the-
+      // perspective-of-the-inner-promise so the outer fn surfaces the error.
+      await withEnvOverride({ [KEY]: "INNER" }, () => process.env[KEY]);
+    });
+
+    await expect(recursive).rejects.toThrow(
+      /recursive call detected/,
+    );
+    // Outer's finally must have run, restoring env.
+    expect(process.env[KEY]).toBeUndefined();
+  });
+
+  it("keeps the chain usable: a normal call after a recursion-error still resolves", async () => {
+    const bad = withEnvOverride({ [KEY]: "OUTER" }, async () => {
+      await withEnvOverride({ [KEY]: "INNER" }, () => undefined);
+    });
+    await expect(bad).rejects.toThrow(/recursive call detected/);
+
+    const value = await withEnvOverride({ [KEY]: "OK" }, () => process.env[KEY]);
+    expect(value).toBe("OK");
+    expect(process.env[KEY]).toBeUndefined();
+  });
+});
+
 describe("withEnvOverride — unset semantics", () => {
   let snap: { key: string | undefined; other: string | undefined };
 

--- a/test/integrations/pr-poller.test.ts
+++ b/test/integrations/pr-poller.test.ts
@@ -164,6 +164,97 @@ describe("PrPoller", () => {
     }
   });
 
+  it("concurrent tick short-circuits while the first is in-flight", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-poller-concurrent-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-concurrent", description: "" });
+      const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+        async () => "followup-id"
+      );
+      const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+
+      // Held resolver so the first enrichBatch call stays pending until we let it go.
+      let releaseFirst: (value: Map<string, EnrichedPR>) => void = () => {};
+      const firstPending = new Promise<Map<string, EnrichedPR>>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const enrichBatch = vi.fn<(prs: unknown) => Promise<Map<string, EnrichedPR>>>(
+        () => firstPending
+      );
+      const scm = {
+        detectPR: vi.fn(),
+        getCiSummary: vi.fn(),
+        getReviewDecision: vi.fn(),
+        getPendingComments: vi.fn(),
+        enrichBatch
+      } as unknown as HarnessScm;
+
+      const poller = new PrPoller({ scm, channelStore: store, scheduler });
+      poller.track(makeTracked(channel.channelId));
+
+      // Kick off the first tick but do not await it — it is parked inside enrichBatch.
+      const firstTick = poller.tick();
+      // Concurrent tick should see `running` is true and short-circuit immediately.
+      await poller.tick();
+
+      expect(enrichBatch).toHaveBeenCalledTimes(1);
+
+      // Release the first tick and ensure it settles cleanly.
+      releaseFirst(new Map([["acme/widgets#42", seed()]]));
+      await expect(firstTick).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("start sets up an interval that fires ticks; stop clears it and is idempotent", async () => {
+    vi.useFakeTimers();
+    const dir = await mkdtemp(join(tmpdir(), "pr-poller-timer-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-timer", description: "" });
+      const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+        async () => "followup-id"
+      );
+      const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+
+      const enrichBatch = vi.fn<(prs: unknown) => Promise<Map<string, EnrichedPR>>>(
+        async () => new Map([["acme/widgets#42", seed()]])
+      );
+      const scm = {
+        detectPR: vi.fn(),
+        getCiSummary: vi.fn(),
+        getReviewDecision: vi.fn(),
+        getPendingComments: vi.fn(),
+        enrichBatch
+      } as unknown as HarnessScm;
+
+      const intervalMs = 1_000;
+      const poller = new PrPoller({ scm, channelStore: store, scheduler, intervalMs });
+      poller.track(makeTracked(channel.channelId));
+
+      poller.start();
+
+      // Advance past three interval boundaries; each fires a tick.
+      await vi.advanceTimersByTimeAsync(intervalMs * 3);
+      expect(enrichBatch.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+      poller.stop();
+      enrichBatch.mockClear();
+
+      // No further ticks should fire after stop, even across many intervals.
+      await vi.advanceTimersByTimeAsync(intervalMs * 5);
+      expect(enrichBatch).not.toHaveBeenCalled();
+
+      // Idempotent stop.
+      expect(() => poller.stop()).not.toThrow();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
+  });
+
   it("untracks the PR when prState transitions to merged", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pr-poller-merge-"));
     const store = new ChannelStore(dir);

--- a/test/integrations/scm.test.ts
+++ b/test/integrations/scm.test.ts
@@ -126,6 +126,58 @@ describe("wrapScm — facade delegation", () => {
   });
 });
 
+describe("wrapScm — detectPR cross-repo routing", () => {
+  it("uses the explicit repo arg (not the bound project) when building ProjectConfig", async () => {
+    const detectPR = vi.fn(async () => null);
+    const scm = { name: "gh", detectPR } as any;
+
+    // Bind the facade to project a/alpha.
+    const wrapped = wrapScm(scm, {
+      owner: "a",
+      name: "alpha",
+      path: "/tmp/alpha",
+      defaultBranch: "main"
+    });
+
+    // Call detectPR with a different repo (b/beta).
+    await wrapped.detectPR("feat/x", { owner: "b", name: "beta" });
+
+    expect(detectPR).toHaveBeenCalledTimes(1);
+    const call = detectPR.mock.calls[0] as unknown as [
+      unknown,
+      { name: string; repo: string; path: string; defaultBranch: string; sessionPrefix: string }
+    ];
+    const projectArg = call[1];
+
+    // AO's ProjectConfig.repo is the GitHub "owner/repo" identifier.
+    expect(projectArg.repo).toBe("b/beta");
+    expect(projectArg.name).toBe("b/beta");
+    expect(projectArg.sessionPrefix).toBe("beta");
+    // Must NOT be the bound project.
+    expect(projectArg.repo).not.toBe("a/alpha");
+  });
+
+  it("reuses the bound ProjectConfig when repo matches the bound project", async () => {
+    const detectPR = vi.fn(async () => null);
+    const scm = { name: "gh", detectPR } as any;
+
+    const wrapped = wrapScm(scm, {
+      owner: "a",
+      name: "alpha",
+      path: "/tmp/alpha",
+      defaultBranch: "main"
+    });
+
+    await wrapped.detectPR("feat/x", { owner: "a", name: "alpha" });
+
+    const call = detectPR.mock.calls[0] as unknown as [
+      unknown,
+      { repo: string }
+    ];
+    expect(call[1].repo).toBe("a/alpha");
+  });
+});
+
 describe("wrapScm — enrichBatch fallback", () => {
   it("falls back to per-PR getPRState/getCISummary/getReviewDecision and keys correctly", async () => {
     const scm = {

--- a/test/integrations/tracker.test.ts
+++ b/test/integrations/tracker.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  createTracker,
   detectTrackerKind,
   resolveIssue
 } from "../../src/integrations/tracker.js";
+
+// Mock the AO GitHub tracker so its `create()` throws when invoked. We use
+// plain `vi.mock` here — no seam in tracker.ts was needed, since tracker.ts
+// imports the plugin via the standard default export and `vi.mock` hoists
+// ahead of the module-graph resolution.
+vi.mock("@aoagents/ao-plugin-tracker-github", () => ({
+  default: {
+    manifest: {
+      name: "tracker-github",
+      slot: "tracker" as const,
+      description: "mocked",
+      version: "0.0.0-test"
+    },
+    create: () => {
+      throw new Error("boom from mocked plugin create()");
+    }
+  }
+}));
 
 describe("detectTrackerKind", () => {
   const cases: Array<{ input: string; expected: "github" | "linear" | null; why: string }> = [
@@ -168,5 +187,47 @@ describe("resolveIssue", () => {
 
     const harnessIssue = await resolveIssue(tracker, "7", project);
     expect(harnessIssue.labels).toEqual([]);
+  });
+});
+
+describe("createTracker — env restoration when plugin create() throws", () => {
+  it("restores process.env.GITHUB_TOKEN to undefined (variable absent) when prior was unset and create() throws", async () => {
+    // Save whatever the real env had so we leave the process clean.
+    const prior = process.env.GITHUB_TOKEN;
+    // Force the "prior was undefined" branch to exercise deletion-on-restore.
+    delete process.env.GITHUB_TOKEN;
+
+    try {
+      expect(process.env.GITHUB_TOKEN).toBeUndefined();
+      expect("GITHUB_TOKEN" in process.env).toBe(false);
+
+      await expect(
+        createTracker("github", { token: "throwaway" })
+      ).rejects.toThrow(/boom from mocked plugin create\(\)/);
+
+      // After the throw propagates, the env var must be gone again — matching
+      // its prior undefined / absent state, not a lingering "throwaway".
+      expect(process.env.GITHUB_TOKEN).toBeUndefined();
+      expect("GITHUB_TOKEN" in process.env).toBe(false);
+    } finally {
+      if (prior === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = prior;
+    }
+  });
+
+  it("restores process.env.GITHUB_TOKEN to its prior defined value when create() throws", async () => {
+    const prior = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = "original-token";
+
+    try {
+      await expect(
+        createTracker("github", { token: "throwaway" })
+      ).rejects.toThrow(/boom from mocked plugin create\(\)/);
+
+      expect(process.env.GITHUB_TOKEN).toBe("original-token");
+    } finally {
+      if (prior === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = prior;
+    }
   });
 });

--- a/test/orchestrator/ticket-scheduler-enqueue.test.ts
+++ b/test/orchestrator/ticket-scheduler-enqueue.test.ts
@@ -11,7 +11,7 @@ import type {
   AgentResult,
   WorkRequest
 } from "../../src/domain/agent.js";
-import type { HarnessRun } from "../../src/domain/run.js";
+import type { HarnessRun, RunEventType } from "../../src/domain/run.js";
 import {
   initializeTicketLedger,
   parseTicketPlan,
@@ -83,12 +83,29 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
   };
 }
 
+interface RecordedEvent {
+  type: RunEventType;
+  phaseId: string;
+  details: Record<string, string>;
+}
+
+interface BuildSchedulerOptions {
+  dispatchOverride?: (
+    run: HarnessRun,
+    req: Omit<WorkRequest, "runId">
+  ) => Promise<AgentResult>;
+  onRecordEvent?: (event: RecordedEvent) => void;
+}
+
 /**
  * Build a scheduler whose dispatch always returns success — no verification
  * commands are proposed, so the built-in verification pass sees an empty
  * command list and trivially succeeds.
  */
-async function buildScheduler(repoRoot: string) {
+async function buildScheduler(
+  repoRoot: string,
+  options: BuildSchedulerOptions = {}
+) {
   const registry = new AgentRegistry();
   for (const agent of createLiveAgents({
     cwd: repoRoot,
@@ -104,7 +121,9 @@ async function buildScheduler(repoRoot: string) {
   );
 
   const dispatched: WorkRequest[] = [];
-  const dispatch = async (
+  const events: RecordedEvent[] = [];
+
+  const defaultDispatch = async (
     _run: HarnessRun,
     req: Omit<WorkRequest, "runId">
   ): Promise<AgentResult> => {
@@ -117,19 +136,31 @@ async function buildScheduler(repoRoot: string) {
     };
   };
 
+  const dispatch = options.dispatchOverride
+    ? async (
+        run: HarnessRun,
+        req: Omit<WorkRequest, "runId">
+      ): Promise<AgentResult> => {
+        dispatched.push({ runId: "run-test", ...req });
+        return options.dispatchOverride!(run, req);
+      }
+    : defaultDispatch;
+
   const scheduler = new TicketScheduler(
     repoRoot,
     artifactStore,
     verificationRunner,
     registry,
     dispatch,
-    () => {
-      /* no-op event recorder */
+    (_run, type, phaseId, details) => {
+      const event: RecordedEvent = { type, phaseId, details };
+      events.push(event);
+      options.onRecordEvent?.(event);
     },
     { maxConcurrency: 2 }
   );
 
-  return { scheduler, dispatched, artifactStore };
+  return { scheduler, dispatched, events, artifactStore };
 }
 
 describe("TicketScheduler.enqueue", () => {
@@ -205,6 +236,120 @@ describe("TicketScheduler.enqueue", () => {
 
       const matches = run.ticketLedger.filter((t) => t.ticketId === "t_once");
       expect(matches).toHaveLength(1);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("surfaces tail-drain failures through recordEvent and keeps the chain alive", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-enqueue-tail-"));
+    const warnCalls: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args.map((a) => String(a)).join(" "));
+    };
+
+    try {
+      const run = buildRun(tmp, [ticket("t_seed")]);
+
+      // Throw synchronously from dispatch for the poison ticket only. Because
+      // executeTicket's `.then(..., onRejected)` catches the rejection, a
+      // simple throw there just yields success=false. To force drain itself
+      // to throw, throw from recordEvent on TicketStarted for that ticket —
+      // that call site is outside the executeTicket catch and bubbles up.
+      const { scheduler, events } = await buildScheduler(tmp, {
+        onRecordEvent: (ev) => {
+          if (ev.type === "TicketStarted" && ev.phaseId === "t_poison") {
+            throw new Error("boom: synthetic drain failure");
+          }
+        }
+      });
+
+      // Pre-seed the run via executeAll so the scheduler is idle when the
+      // first enqueue lands and takes the fresh-drain branch.
+      await scheduler.executeAll(run);
+
+      // First enqueue: the poison ticket. Drain will throw when recordEvent
+      // fires for TicketStarted. The outer `await next` must rethrow.
+      let firstError: unknown = null;
+      try {
+        await scheduler.enqueue(run, ticket("t_poison"));
+      } catch (err) {
+        firstError = err;
+      }
+      expect(firstError).toBeInstanceOf(Error);
+      expect(String(firstError)).toContain("boom: synthetic drain failure");
+
+      // Second enqueue: a clean ticket. The chain should still be alive and
+      // this one must schedule and complete normally.
+      await scheduler.enqueue(run, ticket("t_clean"));
+      const clean = run.ticketLedger.find((t) => t.ticketId === "t_clean");
+      expect(clean?.status).toBe("completed");
+
+      // The tail-drain failure must be visible: either a recordEvent with the
+      // sentinel phaseId, or a console.warn with the scheduler prefix. The
+      // production code emits both, but we accept either so the test doesn't
+      // pin a specific implementation detail beyond visibility.
+      const tailEvent = events.find(
+        (e) => e.phaseId === "__scheduler_tail__"
+      );
+      const tailWarn = warnCalls.find((w) =>
+        w.includes("[scheduler] tail drain failed")
+      );
+      expect(tailEvent || tailWarn).toBeTruthy();
+      if (tailEvent) {
+        expect(tailEvent.details.error).toContain(
+          "boom: synthetic drain failure"
+        );
+      }
+      if (tailWarn) {
+        expect(tailWarn).toContain("boom: synthetic drain failure");
+      }
+    } finally {
+      console.warn = originalWarn;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  // The scheduler's activeRun gating assumes at most one executeAll(run) is
+  // in flight at a time. The code does NOT raise or short-circuit on overlap;
+  // both calls share the same mutable ledger and each drain has its own local
+  // `executing` map. This test pins the observed contract: both promises
+  // resolve, the ledger settles to terminal states, and activeRun is cleared
+  // afterwards. It intentionally does NOT assert that the same ticket is
+  // dispatched exactly once — the current code permits double-dispatch in a
+  // race window between getReadyTickets() and updateTicketStatus("executing"),
+  // which is a latent bug flagged separately.
+  it("does not corrupt activeRun when two executeAll calls overlap", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-executeall-overlap-"));
+    try {
+      const run = buildRun(tmp, [ticket("t_one"), ticket("t_two")]);
+      const { scheduler } = await buildScheduler(tmp);
+
+      const a = scheduler.executeAll(run);
+      const b = scheduler.executeAll(run);
+
+      // Neither call should throw — the scheduler has no guard against
+      // overlap today. Both drains walk the shared ledger.
+      const [resA, resB] = await Promise.all([a, b]);
+
+      // Both calls return booleans (exact values are a function of the race,
+      // so we just assert the promise shape resolved cleanly).
+      expect(typeof resA).toBe("boolean");
+      expect(typeof resB).toBe("boolean");
+
+      // Every ticket must have reached a terminal state — nothing stuck in
+      // "executing" / "verifying" / "retry" / "ready".
+      for (const entry of run.ticketLedger) {
+        expect(["completed", "failed"]).toContain(entry.status);
+      }
+
+      // activeRun should be cleared once both drains are done, so a fresh
+      // enqueue takes the fresh-drain branch cleanly.
+      // (Inspected via behavior: enqueue a new ticket and confirm it runs.)
+      await scheduler.enqueue(run, ticket("t_after"));
+      const after = run.ticketLedger.find((t) => t.ticketId === "t_after");
+      expect(after?.status).toBe("completed");
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
Addresses the nit/follow-up findings from PR #2 and PR #3 reviews.

## 1. ChannelStore metadata round-trip
- Write path tags non-string values with \`__ah_meta_json::\` prefix in \`normalizeMetadata\`.
- Read path (\`readFeed\`) applies new \`denormalizeMetadata\` so TS callers observe the original shape.
- **Wire format unchanged** — on disk still \`Record<string, string>\`. Rust (\`crates/harness-data\`) and GUI (\`gui/src/types.ts\`) readers are untouched.
- Strings that happen to start with the tag are also tagged on write to avoid collision.

## 2. wrapScm stub-field comment
- Documents that \`title: ""\` / \`isDraft: false\` in \`toPRInfo\` are placeholders. Lists the four AO methods harness actually calls and flags what could break if a future AO version starts consulting \`isDraft\`.

## 3. plugin-env-mutex recursion guard
- Module-local \`held\` flag throws on reentry with a clear message instead of self-deadlocking.
- Guard is checked before acquiring the chain so recursive callers throw without blocking unrelated queued callers.

## 4. Scheduler enqueueTail visibility
- Tail-drain failures now \`console.warn\` + \`recordEvent(TicketFailed, phaseId: "__scheduler_tail__")\` before swallowing (chain-liveness preserved).
- \`recordEvent\` call is itself try/caught so a broken event recorder can't re-break the chain.

## 5. Test coverage (+12 cases, 131 total)
- **Tracker** — env-restoration when \`createTracker\` plugin \`create()\` throws (both previously-unset and previously-defined cases).
- **Mutex** — recursion-guard throw + chain-still-usable after recursion error.
- **SCM** — cross-repo \`detectPR\` routing (bound project ≠ repo arg); captured AO \`ProjectConfig.repo\` format as \`"owner/repo"\`.
- **PrPoller** — concurrent-tick short-circuit (second tick while first in-flight doesn't call \`enrichBatch\` again) + start/stop timer lifecycle (idempotent stop, no post-stop ticks).
- **TicketScheduler** — tail-drain-throws path via enqueue; overlapping \`executeAll\` calls on the same run.

## 🚨 Latent bug surfaced (NOT fixed here — up to you)

The overlapping-\`executeAll\` test documents behavior, doesn't guard it. Two parallel \`executeAll(run)\` calls on the same run can **double-dispatch the same ticket** because the \`ready → executing\` transition is separated from the ticket pick by an \`await getAgentName(...)\`. \`activeRun\` is set-once, not guarded.

Not reachable from \`OrchestratorV2\` today (it calls \`executeAll\` once per run). But worth a follow-up:
- Option A: one-line guard at top of \`executeAll\` — \`if (this.activeRun === run) throw\`.
- Option B: move \`updateTicketStatus("executing")\` ahead of the \`await getAgentName(...)\` so the atomicity window closes.

I'd pick **A** (clearer intent, fails loud if design invariant is violated).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 131/131
- [ ] Manual: log a metadata entry with non-string values (numbers, arrays), read it back via TUI / GUI, confirm nothing renders as a literal \`__ah_meta_json::\` string (they'll see strings on-disk — the TS round-trip is only via \`readFeed\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)