### PR TITLE
GUI board: real statuses, hide empty columns, click-to-view tickets, per-column scroll

### DIFF
--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -137,7 +137,7 @@ export function CenterPane({
         />
       )}
       {tab === "board" && (
-        <div className="content">
+        <div className="content board-content">
           <BoardView tickets={tickets} />
         </div>
       )}
@@ -381,35 +381,155 @@ function parseAliasPrefix(
   return { alias: candidate, body: match[2] };
 }
 
+// Canonical ticket statuses + display labels. "pending" shows as "Backlog"
+// because that's what a kanban board reader expects.
+const BOARD_COLUMNS: Array<{ status: string; label: string }> = [
+  { status: "pending", label: "Backlog" },
+  { status: "ready", label: "Ready" },
+  { status: "executing", label: "Executing" },
+  { status: "verifying", label: "Verifying" },
+  { status: "retry", label: "Retry" },
+  { status: "blocked", label: "Blocked" },
+  { status: "completed", label: "Completed" },
+  { status: "failed", label: "Failed" },
+];
+
 function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
+  const [selected, setSelected] = useState<TicketLedgerEntry | null>(null);
+
   if (tickets.length === 0)
     return <div className="empty">No tickets in this channel</div>;
-  const cols = ["pending", "ready", "in_progress", "completed", "blocked"];
-  const grouped = Object.fromEntries(
-    cols.map((c) => [c, [] as TicketLedgerEntry[]]),
-  ) as Record<string, TicketLedgerEntry[]>;
+
+  const grouped: Record<string, TicketLedgerEntry[]> = {};
   for (const t of tickets) {
-    const key = grouped[t.status] ? t.status : "pending";
-    grouped[key].push(t);
+    const key = BOARD_COLUMNS.some((c) => c.status === t.status)
+      ? t.status
+      : "pending";
+    (grouped[key] ||= []).push(t);
   }
+  const visible = BOARD_COLUMNS.filter(
+    (c) => (grouped[c.status]?.length ?? 0) > 0,
+  );
+
   return (
-    <div className="board-columns">
-      {cols.map((c) => (
-        <div key={c} className="board-column">
-          <h4>
-            {c} ({grouped[c].length})
-          </h4>
-          {grouped[c].map((t) => (
-            <div key={t.ticketId} className="ticket">
-              <div>{t.title}</div>
-              <div className="ticket-meta">
-                {t.specialty} · attempt {t.attempt}
-                {t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""}
-              </div>
+    <>
+      <div className="board-columns">
+        {visible.map(({ status, label }) => (
+          <div key={status} className="board-column">
+            <h4>
+              {label} ({grouped[status].length})
+            </h4>
+            <div className="board-column-body">
+              {grouped[status].map((t) => (
+                <div
+                  key={t.ticketId}
+                  className="ticket clickable"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setSelected(t)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelected(t);
+                    }
+                  }}
+                >
+                  <div>{t.title}</div>
+                  <div className="ticket-meta">
+                    {t.specialty} · attempt {t.attempt}
+                    {t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""}
+                  </div>
+                </div>
+              ))}
             </div>
-          ))}
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <TicketDetailModal
+          ticket={selected}
+          tickets={tickets}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </>
+  );
+}
+
+function TicketDetailModal({
+  ticket,
+  tickets,
+  onClose,
+}: {
+  ticket: TicketLedgerEntry;
+  tickets: TicketLedgerEntry[];
+  onClose: () => void;
+}) {
+  const deps = ticket.dependsOn.map((depId) => {
+    const found = tickets.find((x) => x.ticketId === depId);
+    return {
+      id: depId,
+      title: found?.title ?? "(not in this channel's ledger)",
+      status: found?.status ?? "?",
+    };
+  });
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        className="modal ticket-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">{ticket.title}</div>
+        <div className="modal-body">
+          <div className="detail-row">
+            <span className="detail-label">ID</span>
+            <code>{ticket.ticketId}</code>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Status</span>
+            <span>{ticket.status}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Specialty</span>
+            <span>{ticket.specialty}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Verification</span>
+            <span>{ticket.verification}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Attempt</span>
+            <span>{ticket.attempt}</span>
+          </div>
+          {ticket.assignedAgentName && (
+            <div className="detail-row">
+              <span className="detail-label">Assigned</span>
+              <span>{ticket.assignedAgentName}</span>
+            </div>
+          )}
+          {deps.length > 0 && (
+            <div className="detail-row detail-row-block">
+              <span className="detail-label">
+                Depends on ({deps.length})
+              </span>
+              <ul className="dep-list">
+                {deps.map((d) => (
+                  <li key={d.id}>
+                    <code>{d.id}</code>{" "}
+                    <span className="dep-status">{d.status}</span>
+                    <div className="dep-title">{d.title}</div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
-      ))}
+        <div className="modal-footer">
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -107,6 +107,9 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
 }
 
 .content { flex: 1; overflow-y: auto; padding: 12px 16px; min-height: 0; }
+/* Board tab manages its own per-column scroll, so the outer container must
+   not itself overflow — otherwise the columns stretch to natural height. */
+.content.board-content { overflow-y: hidden; display: flex; flex-direction: column; }
 
 .feed-entry {
   margin-bottom: 12px;
@@ -177,8 +180,16 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
 
 .board-columns {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 12px;
+  height: 100%;
+  min-height: 0;
+  align-items: stretch;
+}
+.board-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 .board-column h4 {
   font-size: 11px;
@@ -186,6 +197,13 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   letter-spacing: 0.06em;
   color: var(--text-dim);
   margin: 0 0 8px;
+  flex-shrink: 0;
+}
+.board-column-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 .ticket {
   background: var(--bg-alt);
@@ -195,7 +213,76 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   margin-bottom: 6px;
   font-size: 12px;
 }
+.ticket.clickable {
+  cursor: pointer;
+  transition: border-color 80ms ease, background 80ms ease;
+}
+.ticket.clickable:hover {
+  border-color: var(--accent);
+  background: var(--bg);
+}
+.ticket.clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .ticket .ticket-meta { color: var(--text-muted); font-size: 10px; margin-top: 4px; }
+
+/* Ticket detail modal */
+.ticket-modal {
+  width: 520px;
+}
+.ticket-modal .detail-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 13px;
+}
+.ticket-modal .detail-row-block {
+  display: block;
+}
+.ticket-modal .detail-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+.ticket-modal code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.ticket-modal .dep-list {
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ticket-modal .dep-list li {
+  padding: 6px 8px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+}
+.ticket-modal .dep-status {
+  margin-left: 4px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ticket-modal .dep-title {
+  margin-top: 4px;
+  color: var(--text-muted);
+}
 
 .decision {
   margin-bottom: 16px;


### PR DESCRIPTION
Fixes four board-tab issues in one pass.

## Why "backlog" was missing
The old column list was \`[pending, ready, **in_progress**, completed, blocked]\`. \`in_progress\` **isn't a real status** — the canonical enum is \`pending | ready | executing | verifying | retry | blocked | completed | failed\`. So everything in executing / verifying / retry / failed was falling through to a default bucket labeled "pending" alongside the real backlog tickets, and nothing was rendering in the phantom \`in_progress\` column. That's the mystery the blocked-column count exposed.

## Changes
- **Canonical statuses** — every real status now has a column. Unknown values still bucket into Backlog (defensive) rather than being dropped.
- **"Backlog" label** — \`pending\` renders as "Backlog" because that's what users reading a kanban expect.
- **Hide empty columns** — channels with only blocked + completed tickets show exactly those two full-width lanes.
- **Per-column scroll** — each column body is a flex-1 \`overflow-y: auto\` container. The board tab sets \`overflow: hidden\` on its content wrapper so column heights can't stretch past the pane. 21 tickets in Blocked now scroll inside Blocked.
- **Ticket click-to-view** — every card is keyboard-accessible (role=button + Enter/Space) and opens a detail modal with id / status / specialty / verification / attempt / assigned agent / dependency list. Each dependency is resolved against the current ledger so status + title render inline — answers "why is this blocked?" in one click.

## Test plan
- [x] \`pnpm typecheck\` clean (137/137 tests still pass — no TS change)
- [x] \`pnpm build\` clean
- [x] \`cd gui && pnpm build\` clean (Vite bundle builds)
- [ ] Manual: \`rly gui\` → open a channel with many blocked tickets; confirm scroll + modal dependency view.
- [ ] Manual: open a channel with only completed tickets; confirm only that column renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)