### PR TITLE
Unify chat + orchestrator tickets on a single channel board

### DIFF
--- a/scripts/seed-plan-tickets.ts
+++ b/scripts/seed-plan-tickets.ts
@@ -1,12 +1,16 @@
 /**
  * One-shot seeder: creates a synthetic Relay run for the storage/executor/MCP
  * refactor plan, writes the unified channel ticket board, and links the run
- * so both `rly board <channelId>` and the GUI render the 23 tickets.
+ * so both `rly board <channelId>` and the GUI render the plan's tickets.
  *
  * Usage:
  *   tsx scripts/seed-plan-tickets.ts <channelId>
+ *   RELAY_REPO=/path/to/other/repo tsx scripts/seed-plan-tickets.ts <channelId>
  *
- * Idempotency: not provided — each invocation creates a new run and overwrites
+ * Repo resolution: `RELAY_REPO` env var wins; otherwise `process.cwd()` is
+ * used so the seeder works on any machine without editing source.
+ *
+ * Idempotency: not provided — each invocation creates a new run and upserts
  * the channel board. Archive/remove unwanted runs manually if re-seeded.
  */
 
@@ -23,7 +27,7 @@ import {
 import { buildRunId } from "../src/orchestrator/orchestrator-v2.js";
 import { join } from "node:path";
 
-const REPO = "/Users/jonathanlancaster/projects/agent-harness";
+const REPO = process.env.RELAY_REPO ?? process.cwd();
 
 type Phase = 0 | 1 | 2 | 3 | 4 | 5;
 type Effort = "S" | "M" | "L";

--- a/scripts/seed-plan-tickets.ts
+++ b/scripts/seed-plan-tickets.ts
@@ -1,0 +1,528 @@
+/**
+ * One-shot seeder: creates a synthetic Relay run for the storage/executor/MCP
+ * refactor plan, writes the unified channel ticket board, and links the run
+ * so both `rly board <channelId>` and the GUI render the 23 tickets.
+ *
+ * Usage:
+ *   tsx scripts/seed-plan-tickets.ts <channelId>
+ *
+ * Idempotency: not provided — each invocation creates a new run and overwrites
+ * the channel board. Archive/remove unwanted runs manually if re-seeded.
+ */
+
+import { ChannelStore } from "../src/channels/channel-store.js";
+import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import type { HarnessRun } from "../src/domain/run.js";
+import type { TicketDefinition } from "../src/domain/ticket.js";
+import { initializeTicketLedger } from "../src/domain/ticket.js";
+import {
+  getWorkspaceDir,
+  resolveWorkspaceForRepo,
+  registerWorkspace
+} from "../src/cli/workspace-registry.js";
+import { buildRunId } from "../src/orchestrator/orchestrator-v2.js";
+import { join } from "node:path";
+
+const REPO = "/Users/jonathanlancaster/projects/agent-harness";
+
+type Phase = 0 | 1 | 2 | 3 | 4 | 5;
+type Effort = "S" | "M" | "L";
+
+interface PlanItem {
+  id: string;
+  phase: Phase;
+  effort: Effort;
+  title: string;
+  objective: string;
+  acceptanceCriteria: string[];
+  specialty: TicketDefinition["specialty"];
+  dependsOn: string[];
+}
+
+const PLAN: PlanItem[] = [
+  {
+    id: "T-001",
+    phase: 0,
+    effort: "M",
+    title: "Define HarnessStore interface + file impl",
+    objective:
+      "Introduce a HarnessStore interface (getDoc/putDoc/listDocs/deleteDoc, appendLog/readLog, putBlob/getBlob, mutate, watch) and implement FileHarnessStore over the current ~/.relay layout. No production callers yet.",
+    acceptanceCriteria: [
+      "src/storage/store.ts exports the interface with full types",
+      "FileHarnessStore passes unit tests covering all methods",
+      "LocalArtifactStore remains untouched this ticket"
+    ],
+    specialty: "general",
+    dependsOn: []
+  },
+  {
+    id: "T-002",
+    phase: 0,
+    effort: "S",
+    title: "Composition root for store injection",
+    objective:
+      "Consolidate HarnessStore construction to a single point in src/index.ts driven by HARNESS_STORE env. Pass it into downstream modules by ctor; delete scattered homedir/join imports.",
+    acceptanceCriteria: [
+      "pnpm build && pnpm test pass",
+      "grep of node:fs/promises outside src/storage returns only an explicit allowlist",
+      "Env var HARNESS_STORE=file selects FileHarnessStore"
+    ],
+    specialty: "general",
+    dependsOn: ["T-001"]
+  },
+  {
+    id: "T-003",
+    phase: 0,
+    effort: "S",
+    title: "Define AgentExecutor + SandboxProvider interfaces",
+    objective:
+      "Add AgentExecutor (start -> ExecutionHandle with wait/kill/stream) and SandboxProvider (create/destroy/resolvePath) in src/execution/. Ship a NoopExecutor for tests; orchestrator untouched.",
+    acceptanceCriteria: [
+      "Types compile across the repo",
+      "Existing orchestrator + scheduler tests unchanged and passing",
+      "A test double AgentExecutor is available for unit tests"
+    ],
+    specialty: "general",
+    dependsOn: []
+  },
+  {
+    id: "T-101",
+    phase: 1,
+    effort: "M",
+    title: "Migrate ChannelStore to HarnessStore",
+    objective:
+      "Rewrite channel-store.ts to accept an injected HarnessStore. Channel docs use putDoc; feed.jsonl becomes appendLog. Preserve the normalize/denormalize JSON-tag contract for Rust/GUI readers.",
+    acceptanceCriteria: [
+      "All existing channel tests pass",
+      "A migration test reads fixtures written by the pre-migration code and validates round-trip",
+      "GUI + Rust TUI continue to parse the feed correctly"
+    ],
+    specialty: "general",
+    dependsOn: ["T-001", "T-002"]
+  },
+  {
+    id: "T-102",
+    phase: 1,
+    effort: "S",
+    title: "Migrate workspace registry + session store",
+    objective:
+      "Move src/cli/workspace-registry.ts and src/cli/session-store.ts onto HarnessStore; drop hardcoded GLOBAL_ROOT.",
+    acceptanceCriteria: [
+      "rly up / rly status / rly list-workspaces all work unchanged",
+      "Pre-migration workspace registry JSON still reads successfully",
+      "Tests updated to inject a store"
+    ],
+    specialty: "general",
+    dependsOn: ["T-101"]
+  },
+  {
+    id: "T-103",
+    phase: 1,
+    effort: "M",
+    title: "Migrate LocalArtifactStore to store-backed blobs/logs",
+    objective:
+      "Collapse LocalArtifactStore onto HarnessStore: docs for snapshots/classifications/ledgers, blobs for stdout/stderr, log for events.jsonl. Orchestrator unchanged.",
+    acceptanceCriteria: [
+      "End-to-end `pnpm demo` produces an equivalent artifact tree",
+      "Orchestrator + scheduler tests unchanged",
+      "Artifacts round-trip via readCommandResult / readFailureClassification"
+    ],
+    specialty: "general",
+    dependsOn: ["T-101"]
+  },
+  {
+    id: "T-104",
+    phase: 1,
+    effort: "S",
+    title: "Migrate crosslink + agent-names + decisions",
+    objective:
+      "Remaining fs-direct modules (src/crosslink/store.ts, src/domain/agent-names.ts, and decision files inside channels) switch to HarnessStore.",
+    acceptanceCriteria: [
+      "rly crosslink status, rly decisions, named agents all work",
+      "No new hardcoded homedir() calls introduced",
+      "Unit tests updated to inject store"
+    ],
+    specialty: "general",
+    dependsOn: ["T-101"]
+  },
+  {
+    id: "T-105",
+    phase: 1,
+    effort: "M",
+    title: "Unify ticket storage on channel board",
+    objective:
+      "Make channels/<id>/tickets.json the canonical live ticket store for both chat-created and orchestrator-generated tickets. Tag each entry with an optional runId. Keep per-run ticket-ledger.json as the immutable decomposition snapshot. Update chat system prompt to the full TicketLedgerEntry schema. Point rly board and GUI Board at the same source.",
+    acceptanceCriteria: [
+      "Orchestrator runs and chat sessions produce indistinguishable ticket entries on the channel board",
+      "rly board and GUI Board render identical contents",
+      "Legacy per-run-ledger readers fall back cleanly when channel board is empty"
+    ],
+    specialty: "general",
+    dependsOn: []
+  },
+  {
+    id: "T-201",
+    phase: 2,
+    effort: "M",
+    title: "GitWorktreeSandbox provider",
+    objective:
+      "Implement SandboxProvider that creates one git worktree per active ticket, keyed by runId/ticketId. Cleanup on success; preserve on failure.",
+    acceptanceCriteria: [
+      "Two concurrent tickets on the same repo use separate worktrees",
+      "Killing mid-ticket leaves worktree + .relay-state.json on disk",
+      "Worktrees are removed after successful completion"
+    ],
+    specialty: "general",
+    dependsOn: ["T-003"]
+  },
+  {
+    id: "T-202",
+    phase: 2,
+    effort: "M",
+    title: "LocalChildProcessExecutor",
+    objective:
+      "Implement AgentExecutor wrapping the existing CommandInvoker + dispatch path. ExecutionHandle exposes wait/kill/stream. Scheduler replaces dispatch() with executor.start(...).wait().",
+    acceptanceCriteria: [
+      "TicketScheduler constructed with AgentExecutor instead of dispatch callback",
+      "All orchestrator tests pass",
+      "Stream yields at least start/stdout/exit events"
+    ],
+    specialty: "general",
+    dependsOn: ["T-003", "T-201"]
+  },
+  {
+    id: "T-203",
+    phase: 2,
+    effort: "M",
+    title: "Resume-on-crash for orphaned tickets",
+    objective:
+      "On harness start, scan for orphan sandboxes + state checkpoints; re-enter the scheduler for recoverable tickets, park unresumable ones as 'recovered' for user review.",
+    acceptanceCriteria: [
+      "kill -9 during a ticket -> restart -> ticket resumes and completes",
+      "Recovered tickets surface in rly board",
+      "Integration test covers kill-restart-complete cycle"
+    ],
+    specialty: "general",
+    dependsOn: ["T-202", "T-103", "T-105"]
+  },
+  {
+    id: "T-204",
+    phase: 2,
+    effort: "S",
+    title: "Global executor concurrency cap",
+    objective:
+      "Add a semaphore above TicketScheduler keyed on the AgentExecutor. Config via HARNESS_MAX_AGENTS or settings store.",
+    acceptanceCriteria: [
+      "Two concurrent runs with 3 tickets each + cap=4 -> max 4 in-flight agents",
+      "Cap respects hot-reload of the config value",
+      "Metric/log line on block/unblock"
+    ],
+    specialty: "general",
+    dependsOn: ["T-202"]
+  },
+  {
+    id: "T-301",
+    phase: 3,
+    effort: "M",
+    title: "Stuck-agent detection",
+    objective:
+      "Track last tool-use/output event per ExecutionHandle. A patroller thread fires stuck_agent if silence exceeds a configurable threshold (default 3m).",
+    acceptanceCriteria: [
+      "A simulated hang fires stuck_agent within threshold + 10s",
+      "Threshold configurable per ticket/run",
+      "Event posted to channel feed"
+    ],
+    specialty: "general",
+    dependsOn: ["T-202"]
+  },
+  {
+    id: "T-302",
+    phase: 3,
+    effort: "M",
+    title: "Recovery actions on stuck tickets",
+    objective:
+      "On stuck_agent: kill + retry within ticket retry policy. On retries exhausted: mark failed_stuck and trigger escalation.",
+    acceptanceCriteria: [
+      "Single hang recovers by retry",
+      "Repeated hang escalates via harness_escalate",
+      "Ticket ledger ends in failed_stuck status when exhausted"
+    ],
+    specialty: "general",
+    dependsOn: ["T-301"]
+  },
+  {
+    id: "T-303",
+    phase: 3,
+    effort: "S",
+    title: "Escalation MCP tool + router",
+    objective:
+      "New MCP tool harness_escalate({severity, reason, runId, channelId?}). Severity P0/P1/P2 fans out: channel (always), email webhook (P1+), pager (P0). Config in store under settings/escalation.",
+    acceptanceCriteria: [
+      "Three integration tests, one per severity",
+      "Channel always receives an escalation post",
+      "Webhook/pager endpoints configurable at runtime"
+    ],
+    specialty: "general",
+    dependsOn: ["T-101", "T-105"]
+  },
+  {
+    id: "T-304",
+    phase: 3,
+    effort: "S",
+    title: "TUI/GUI surface for stuck + escalated state",
+    objective:
+      "New ticket statuses visible in rly board, Rust TUI, and Tauri GUI. Real-time update of status changes.",
+    acceptanceCriteria: [
+      "rly board renders stuck + escalated tickets distinctly",
+      "Rust TUI and Tauri GUI show the new statuses",
+      "Status changes propagate within a render tick"
+    ],
+    specialty: "general",
+    dependsOn: ["T-301", "T-303"]
+  },
+  {
+    id: "T-401",
+    phase: 4,
+    effort: "M",
+    title: "HTTP/SSE MCP transport",
+    objective:
+      "Add HttpSseMcpTransport alongside stdio. Token-based auth scoped per workspace. Entrypoint: rly serve --port 7420.",
+    acceptanceCriteria: [
+      "External Claude session with remote MCP URL can call harness_list_runs",
+      "Auth: missing/invalid token rejected",
+      "Existing stdio path unchanged"
+    ],
+    specialty: "general",
+    dependsOn: ["T-002"]
+  },
+  {
+    id: "T-402",
+    phase: 4,
+    effort: "L",
+    title: "PostgresHarnessStore",
+    objective:
+      "Second impl of HarnessStore: JSONB docs, append-only log table, S3/GCS blobs, pg_notify for watch. SQL migrations under src/storage/migrations/.",
+    acceptanceCriteria: [
+      "pnpm demo works end-to-end against Postgres",
+      "Two harness processes on the same DB don't corrupt state",
+      "Migrations run idempotently"
+    ],
+    specialty: "general",
+    dependsOn: ["T-001"]
+  },
+  {
+    id: "T-403",
+    phase: 4,
+    effort: "L",
+    title: "PodExecutor + PVCSandbox (K8s)",
+    objective:
+      "AgentExecutor impl that creates a K8s Job wrapping the Claude/Codex container image. Workdir on a PVC cloned from git via init container. Logs stream back over SSE.",
+    acceptanceCriteria: [
+      "2-ticket demo against a kind cluster completes",
+      "Artifacts land in the configured HarnessStore",
+      "Failed pods leave logs + PVC preserved for inspection"
+    ],
+    specialty: "devops",
+    dependsOn: ["T-202", "T-401"]
+  },
+  {
+    id: "T-404",
+    phase: 4,
+    effort: "S",
+    title: "Dockerfile + daemon container image",
+    objective:
+      "Dockerfile bundles node + Claude/Codex CLIs + the relay daemon. docker-compose.yml for quickstart (daemon + Postgres).",
+    acceptanceCriteria: [
+      "docker compose up boots a working relay over HTTP backed by Postgres",
+      "Image is reproducible (no host mounts required)",
+      "README quickstart section added"
+    ],
+    specialty: "devops",
+    dependsOn: ["T-401", "T-402"]
+  },
+  {
+    id: "T-501",
+    phase: 5,
+    effort: "M",
+    title: "Graphify integration as opt-in plugin",
+    objective:
+      "New src/integrations/graphify.ts + MCP wrapper. ensureGraph(workspaceId) builds graphify-out/ on demand. Proxy graphify MCP tools (query_graph, get_node, get_neighbors, shortest_path). Planner prompt update. Config flag off by default.",
+    acceptanceCriteria: [
+      "Plugin off: harness behavior unchanged",
+      "Plugin on: planner classification pulls graph results instead of grep for architecture queries",
+      "Graph rebuild triggered on branch switch inside the sandbox worktree, not the user's repo"
+    ],
+    specialty: "general",
+    dependsOn: ["T-401", "T-102"]
+  },
+  {
+    id: "T-502",
+    phase: 5,
+    effort: "S",
+    title: "Hooks-base + role overrides",
+    objective:
+      "Layered config: ~/.relay/hooks-base.json + hooks-overrides/{role}.json + hooks-overrides/{workspace}__{role}.json. Merge at spawn, write per-agent --settings.",
+    acceptanceCriteria: [
+      "Adding hooks-overrides/atlas.json affects only Atlas sessions",
+      "Merge precedence matches docs: base -> role -> workspace+role",
+      "No regression to existing single-settings callers"
+    ],
+    specialty: "general",
+    dependsOn: ["T-102"]
+  },
+  {
+    id: "T-503",
+    phase: 5,
+    effort: "S",
+    title: "Agent mail protocol (1:1 async inbox)",
+    objective:
+      "Per-agent mailbox namespace in HarnessStore. MCP tools agent_mail_send / agent_mail_check. Distinct from channels (many-to-many) and crosslink (session discovery).",
+    acceptanceCriteria: [
+      "Atlas can DM an implementer; recipient sees message on next tool call",
+      "Mail survives restarts",
+      "Tests cover send / check / unread counting"
+    ],
+    specialty: "general",
+    dependsOn: ["T-101"]
+  },
+  {
+    id: "T-504",
+    phase: 5,
+    effort: "L",
+    title: "Formula/Molecule DAG templates (deferred)",
+    objective:
+      "TOML templates under ~/.relay/formulas/*.toml that plug into the planner as reusable plan structures (release, add-endpoint, etc). Low priority until repeat workflows materialize.",
+    acceptanceCriteria: [
+      "A formula TOML is discovered and selectable by the planner",
+      "Selected formula produces a deterministic ticket plan",
+      "At least one shipped formula exercised by the demo"
+    ],
+    specialty: "general",
+    dependsOn: ["T-304", "T-204"]
+  }
+];
+
+async function main(): Promise<void> {
+  const channelId = process.argv[2];
+  if (!channelId) {
+    console.error("Usage: tsx scripts/seed-plan-tickets.ts <channelId>");
+    process.exit(1);
+  }
+
+  const channelStore = new ChannelStore();
+  const channel = await channelStore.getChannel(channelId);
+  if (!channel) {
+    console.error(`Channel not found: ${channelId}`);
+    process.exit(1);
+  }
+
+  const workspace =
+    (await resolveWorkspaceForRepo(REPO)) ?? (await registerWorkspace(REPO));
+  const artifactsDir = join(getWorkspaceDir(workspace.workspaceId), "artifacts");
+  const artifactStore = new LocalArtifactStore(artifactsDir);
+
+  const runId = buildRunId();
+  const now = new Date().toISOString();
+
+  const tickets: TicketDefinition[] = PLAN.map((item) => ({
+    id: item.id,
+    title: `[P${item.phase} · ${item.effort}] ${item.title}`,
+    objective: item.objective,
+    specialty: item.specialty,
+    acceptanceCriteria: item.acceptanceCriteria,
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    dependsOn: item.dependsOn,
+    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+  }));
+
+  const ticketLedger = initializeTicketLedger(tickets, runId);
+
+  const classification = {
+    tier: "architectural" as const,
+    rationale:
+      "Cross-cutting refactor across storage, execution, and transport layers; enables cloud deployment without breaking local usage.",
+    suggestedSpecialties: ["general", "devops"] as string[],
+    estimatedTicketCount: tickets.length,
+    needsDesignDoc: false,
+    needsUserApproval: true,
+    crosslinkRepos: []
+  };
+
+  const run: HarnessRun = {
+    id: runId,
+    featureRequest:
+      "Pluggable Relay: storage + executor + MCP transport; adopt select Gas Town concepts; optional graphify plugin",
+    state: "AWAITING_APPROVAL",
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    channelId,
+    classification,
+    plan: null,
+    ticketPlan: {
+      version: 1,
+      task: {
+        title: "Pluggable Relay refactor",
+        featureRequest:
+          "Pluggable Relay: storage + executor + MCP transport; adopt select Gas Town concepts; optional graphify plugin",
+        repoRoot: REPO
+      },
+      classification,
+      tickets,
+      finalVerification: { commands: ["pnpm build", "pnpm test"] },
+      docsToUpdate: ["README.md"]
+    },
+    events: [],
+    evidence: [],
+    artifacts: [],
+    phaseLedger: [],
+    phaseLedgerPath: null,
+    ticketLedger,
+    ticketLedgerPath: null,
+    runIndexPath: null
+  };
+
+  // Per-run snapshot (immutable decomposition record).
+  await artifactStore.saveRunSnapshot(run);
+  await artifactStore.saveTicketLedger({ runId, ticketLedger });
+
+  // Runs index entry.
+  await artifactStore.saveRunsIndex({
+    entry: {
+      runId,
+      featureRequest: run.featureRequest,
+      state: run.state,
+      channelId,
+      startedAt: now,
+      updatedAt: now,
+      completedAt: null,
+      phaseLedgerPath: null,
+      artifactsRoot: join(artifactsDir, runId)
+    }
+  });
+
+  // Unified live ticket board — rly board + GUI both read this.
+  await channelStore.writeChannelTickets(channelId, ticketLedger);
+  await channelStore.linkRun(channelId, runId, workspace.workspaceId);
+
+  console.log(
+    JSON.stringify(
+      {
+        runId,
+        channelId,
+        workspaceId: workspace.workspaceId,
+        ticketCount: tickets.length,
+        artifactsDir: join(artifactsDir, runId)
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/channels/board-resolver.ts
+++ b/src/channels/board-resolver.ts
@@ -1,0 +1,63 @@
+import type { ChannelStore } from "./channel-store.js";
+import type { TicketLedgerEntry } from "../domain/ticket.js";
+
+/**
+ * Tickets as they appear on a channel board, paired with the runId of the
+ * originating orchestrator run when known. runId is null for chat-created
+ * entries and for legacy-fallback entries whose workspace could not be
+ * resolved.
+ */
+export interface BoardTicket {
+  entry: TicketLedgerEntry;
+  runId: string | null;
+}
+
+/**
+ * Loader for per-run ticket ledgers, injected by callers that want the
+ * fallback path. The MCP tool and the CLI both need this; unit tests can
+ * supply a fake to exercise the fallback without a real filesystem.
+ */
+export type RunLedgerLoader = (
+  workspaceId: string,
+  runId: string
+) => Promise<TicketLedgerEntry[] | null>;
+
+/**
+ * Resolve the canonical ticket list for a channel board. The channel file
+ * (`channels/<id>/tickets.json`) is the live, unified source for both chat-
+ * created and orchestrator-generated tickets; when it's empty, we fall back
+ * to traversing the channel's linked runs and reading their per-run ledgers
+ * (legacy data written before PR #10's unification).
+ *
+ * Remove the fallback branch once all workspaces have a non-empty channel
+ * board — this helper is the single place to do that.
+ */
+export async function resolveBoardTickets(
+  channelStore: ChannelStore,
+  channelId: string,
+  loadRunLedger?: RunLedgerLoader
+): Promise<BoardTicket[]> {
+  const channelTickets = await channelStore.readChannelTickets(channelId);
+
+  if (channelTickets.length > 0) {
+    return channelTickets.map((entry) => ({
+      entry,
+      runId: entry.runId ?? null
+    }));
+  }
+
+  if (!loadRunLedger) return [];
+
+  const runLinks = await channelStore.readRunLinks(channelId);
+  const out: BoardTicket[] = [];
+
+  for (const link of runLinks) {
+    const tickets = await loadRunLedger(link.workspaceId, link.runId);
+    if (!tickets) continue;
+    for (const entry of tickets) {
+      out.push({ entry, runId: link.runId });
+    }
+  }
+
+  return out;
+}

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -16,6 +16,7 @@ import {
   type RepoAssignment
 } from "../domain/channel.js";
 import { buildDecisionId, type Decision } from "../domain/decision.js";
+import type { TicketLedgerEntry } from "../domain/ticket.js";
 
 export class ChannelStore {
   private readonly channelsDir: string;
@@ -321,6 +322,93 @@ export class ChannelStore {
     } catch {
       return [];
     }
+  }
+
+  // --- Ticket board (channel-scoped, unified across chat + orchestrator) ---
+
+  async readChannelTickets(channelId: string): Promise<TicketLedgerEntry[]> {
+    try {
+      const raw = JSON.parse(
+        await readFile(
+          join(this.channelsDir, channelId, "tickets.json"),
+          "utf8"
+        )
+      ) as { tickets?: TicketLedgerEntry[] };
+      return raw.tickets ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Replace the full ticket list on the channel board. Callers that only
+   * want to add/update a subset should use `upsertChannelTickets` — this
+   * method is primarily for seeders and full-board rewrites.
+   */
+  async writeChannelTickets(
+    channelId: string,
+    tickets: TicketLedgerEntry[]
+  ): Promise<void> {
+    const channelDir = join(this.channelsDir, channelId);
+    await mkdir(channelDir, { recursive: true });
+
+    const path = join(channelDir, "tickets.json");
+    const tmpPath = `${path}.tmp.${process.pid}`;
+
+    await writeFile(
+      tmpPath,
+      JSON.stringify(
+        {
+          updatedAt: new Date().toISOString(),
+          tickets
+        },
+        null,
+        2
+      )
+    );
+    await rename(tmpPath, path);
+  }
+
+  /**
+   * Merge `incoming` into the existing channel board by `ticketId`. Entries
+   * already present are replaced wholesale by the incoming version (so the
+   * caller owns the full shape, not just a patch). New ticketIds are
+   * appended in the order they appear in `incoming`. Existing entries
+   * absent from `incoming` are preserved unchanged.
+   */
+  async upsertChannelTickets(
+    channelId: string,
+    incoming: TicketLedgerEntry[]
+  ): Promise<TicketLedgerEntry[]> {
+    const existing = await this.readChannelTickets(channelId);
+    const byId = new Map(existing.map((t) => [t.ticketId, t]));
+
+    for (const entry of incoming) {
+      byId.set(entry.ticketId, entry);
+    }
+
+    // Preserve original ordering: existing entries keep their slot; new
+    // entries append at the end in the order supplied by `incoming`.
+    const merged: TicketLedgerEntry[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of existing) {
+      const current = byId.get(entry.ticketId);
+      if (current) {
+        merged.push(current);
+        seen.add(entry.ticketId);
+      }
+    }
+
+    for (const entry of incoming) {
+      if (!seen.has(entry.ticketId)) {
+        merged.push(entry);
+        seen.add(entry.ticketId);
+      }
+    }
+
+    await this.writeChannelTickets(channelId, merged);
+    return merged;
   }
 
   // --- Decisions ---

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -18,6 +18,16 @@ import {
 import { buildDecisionId, type Decision } from "../domain/decision.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
 
+// Per-channel serialization so concurrent upsertChannelTickets calls for the
+// same channel don't race on read-modify-write. Keyed by channelId; the value
+// is a tail promise callers queue behind. Entries self-cleanup when no one is
+// queued. In-process only — cross-process coordination comes with T-101.
+const channelTicketLocks: Map<string, Promise<void>> = new Map();
+
+// Monotonic suffix so two concurrent writers in the same process never
+// collide on the tmp file used by writeChannelTickets.
+let channelTicketsTmpCounter = 0;
+
 export class ChannelStore {
   private readonly channelsDir: string;
 
@@ -326,24 +336,51 @@ export class ChannelStore {
 
   // --- Ticket board (channel-scoped, unified across chat + orchestrator) ---
 
+  /**
+   * Read the unified ticket board for a channel. Returns `[]` only when the
+   * file legitimately does not exist yet (ENOENT). Any other error — parse
+   * failure, permission denied, malformed JSON — is rethrown so callers
+   * don't silently overwrite real data via `upsertChannelTickets`.
+   */
   async readChannelTickets(channelId: string): Promise<TicketLedgerEntry[]> {
+    const path = join(this.channelsDir, channelId, "tickets.json");
+    let content: string;
+
     try {
-      const raw = JSON.parse(
-        await readFile(
-          join(this.channelsDir, channelId, "tickets.json"),
-          "utf8"
-        )
-      ) as { tickets?: TicketLedgerEntry[] };
-      return raw.tickets ?? [];
-    } catch {
-      return [];
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw new Error(
+        `Failed to read channel ticket board at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
+      const raw = JSON.parse(content) as { tickets?: TicketLedgerEntry[] };
+      const tickets = raw?.tickets;
+      if (tickets !== undefined && !Array.isArray(tickets)) {
+        throw new Error(`tickets field is not an array`);
+      }
+      return tickets ?? [];
+    } catch (err) {
+      throw new Error(
+        `Corrupt channel ticket board at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 
   /**
-   * Replace the full ticket list on the channel board. Callers that only
-   * want to add/update a subset should use `upsertChannelTickets` — this
-   * method is primarily for seeders and full-board rewrites.
+   * Replace the full ticket list on the channel board. Write is atomic via
+   * tmp-file + rename, so readers never observe a partial file even on
+   * crash. Callers that only want to add/update a subset should use
+   * `upsertChannelTickets` — this method is primarily for seeders and
+   * full-board rewrites.
    */
   async writeChannelTickets(
     channelId: string,
@@ -353,7 +390,9 @@ export class ChannelStore {
     await mkdir(channelDir, { recursive: true });
 
     const path = join(channelDir, "tickets.json");
-    const tmpPath = `${path}.tmp.${process.pid}`;
+    // Include a monotonic suffix alongside the PID so two concurrent writes
+    // in the same process don't collide on the tmp file.
+    const tmpPath = `${path}.tmp.${process.pid}.${channelTicketsTmpCounter++}`;
 
     await writeFile(
       tmpPath,
@@ -375,40 +414,70 @@ export class ChannelStore {
    * caller owns the full shape, not just a patch). New ticketIds are
    * appended in the order they appear in `incoming`. Existing entries
    * absent from `incoming` are preserved unchanged.
+   *
+   * Concurrent calls for the same channel are serialized through an
+   * in-memory per-channel mutex so a read-modify-write cycle cannot lose
+   * updates when multiple schedulers (or a scheduler + chat session) write
+   * at once. The mutex is in-process only; cross-process coordination is
+   * deferred to the HarnessStore migration (T-101).
    */
   async upsertChannelTickets(
     channelId: string,
     incoming: TicketLedgerEntry[]
   ): Promise<TicketLedgerEntry[]> {
-    const existing = await this.readChannelTickets(channelId);
-    const byId = new Map(existing.map((t) => [t.ticketId, t]));
+    return this.withChannelLock(channelId, async () => {
+      const existing = await this.readChannelTickets(channelId);
+      const byId = new Map(existing.map((t) => [t.ticketId, t]));
 
-    for (const entry of incoming) {
-      byId.set(entry.ticketId, entry);
-    }
+      for (const entry of incoming) {
+        byId.set(entry.ticketId, entry);
+      }
 
-    // Preserve original ordering: existing entries keep their slot; new
-    // entries append at the end in the order supplied by `incoming`.
-    const merged: TicketLedgerEntry[] = [];
-    const seen = new Set<string>();
+      const merged: TicketLedgerEntry[] = [];
+      const seen = new Set<string>();
 
-    for (const entry of existing) {
-      const current = byId.get(entry.ticketId);
-      if (current) {
-        merged.push(current);
-        seen.add(entry.ticketId);
+      for (const entry of existing) {
+        const current = byId.get(entry.ticketId);
+        if (current) {
+          merged.push(current);
+          seen.add(entry.ticketId);
+        }
+      }
+
+      for (const entry of incoming) {
+        if (!seen.has(entry.ticketId)) {
+          merged.push(entry);
+          seen.add(entry.ticketId);
+        }
+      }
+
+      await this.writeChannelTickets(channelId, merged);
+      return merged;
+    });
+  }
+
+  private async withChannelLock<T>(
+    channelId: string,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    const prev = channelTicketLocks.get(channelId) ?? Promise.resolve();
+    let resolveCurrent!: () => void;
+    const current = new Promise<void>((resolve) => {
+      resolveCurrent = resolve;
+    });
+    const next = prev.then(() => current);
+    channelTicketLocks.set(channelId, next);
+
+    try {
+      await prev;
+      return await fn();
+    } finally {
+      resolveCurrent();
+      // If nobody queued behind us, clean up so the map doesn't grow unbounded.
+      if (channelTicketLocks.get(channelId) === next) {
+        channelTicketLocks.delete(channelId);
       }
     }
-
-    for (const entry of incoming) {
-      if (!seen.has(entry.ticketId)) {
-        merged.push(entry);
-        seen.add(entry.ticketId);
-      }
-    }
-
-    await this.writeChannelTickets(channelId, merged);
-    return merged;
   }
 
   // --- Decisions ---

--- a/src/cli/chat-context.ts
+++ b/src/cli/chat-context.ts
@@ -31,12 +31,20 @@ export function buildSystemPrompt(input: {
     `Decisions dir: \`${decisionsDir}/\`\n\n` +
     `IMPORTANT: When asked about tickets, always READ \`${ticketsPath}\` first. ` +
     `Do not guess or say tickets don't exist without checking the file.\n\n` +
-    `When creating tickets, write them to \`${ticketsPath}\` as a JSON object with a \`tickets\` array. ` +
-    `Each ticket: {"ticketId": "T-1", "title": "...", "specialty": "...", "status": "pending", ` +
-    `"dependsOn": [], "assignedAgentId": null, "assignedAgentName": null, "verification": "...", "attempt": 0}\n\n` +
-    `Status values: \`pending\` | \`blocked\` | \`executing\` | \`completed\` | \`failed\`\n` +
-    `When starting a ticket set \`executing\`, when done set \`completed\`/\`failed\`. ` +
-    `Always read-modify-write the whole file.\n\n` +
+    `This file is the unified board shared by chat and orchestrator runs. ` +
+    `When creating tickets, write to \`${ticketsPath}\` as JSON: ` +
+    `\`{"updatedAt": "<ISO-8601>", "tickets": [<TicketLedgerEntry>...]}\`. ` +
+    `Each ticket must use the full TicketLedgerEntry shape: ` +
+    `\`{"ticketId": "T-1", "title": "...", "specialty": "general"|"ui"|"business_logic"|"api_crud"|"devops"|"testing", ` +
+    `"status": "pending"|"blocked"|"ready"|"executing"|"verifying"|"retry"|"completed"|"failed", ` +
+    `"dependsOn": [], "assignedAgentId": null, "assignedAgentName": null, "crosslinkSessionId": null, ` +
+    `"verification": "pending"|"running"|"passed"|"failed_recoverable"|"failed_terminal", ` +
+    `"lastClassification": null, "chosenNextAction": null, "attempt": 0, ` +
+    `"startedAt": null, "completedAt": null, "updatedAt": "<ISO-8601>", "runId": null}\`.\n\n` +
+    `Set \`runId\` to null for chat-created tickets; the orchestrator fills it for run-decomposed tickets. ` +
+    `When starting a ticket set \`status\` to \`executing\` and \`startedAt\` to now; ` +
+    `when done set \`completed\`/\`failed\` and populate \`completedAt\`. ` +
+    `Always read-modify-write the whole file and refresh \`updatedAt\` on every write.\n\n` +
     `Decisions: write as JSON files in \`${decisionsDir}/\` with ` +
     `decisionId, title, description, rationale, alternatives, decidedByName, createdAt.`
   );

--- a/src/domain/ticket.ts
+++ b/src/domain/ticket.ts
@@ -75,9 +75,14 @@ export interface TicketLedgerEntry {
   startedAt: string | null;
   completedAt: string | null;
   updatedAt: string;
+  /** Orchestrator run this ticket was decomposed from, or null for chat-created. */
+  runId: string | null;
 }
 
-export function initializeTicketLedger(tickets: TicketDefinition[]): TicketLedgerEntry[] {
+export function initializeTicketLedger(
+  tickets: TicketDefinition[],
+  runId: string | null = null
+): TicketLedgerEntry[] {
   const now = new Date().toISOString();
 
   return tickets.map((ticket) => ({
@@ -95,7 +100,8 @@ export function initializeTicketLedger(tickets: TicketDefinition[]): TicketLedge
     attempt: 0,
     startedAt: null,
     completedAt: null,
-    updatedAt: now
+    updatedAt: now,
+    runId
   }));
 }
 

--- a/src/domain/ticket.ts
+++ b/src/domain/ticket.ts
@@ -75,7 +75,13 @@ export interface TicketLedgerEntry {
   startedAt: string | null;
   completedAt: string | null;
   updatedAt: string;
-  /** Orchestrator run this ticket was decomposed from, or null for chat-created. */
+  /**
+   * ID of the orchestrator run that produced this entry; null when the
+   * ticket was created directly via chat rather than run decomposition.
+   * Set at `initializeTicketLedger` and not rewritten afterward — `upsert`
+   * replaces the full entry, so downstream stages that stamp a new runId
+   * must do so by re-initializing, not by patching this field in place.
+   */
   runId: string | null;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -847,7 +847,9 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
 
   // Unified ticket board: channel-scoped file is the live source for both
   // chat-created and orchestrator-generated tickets. Fall back to the per-run
-  // ledgers only if the channel board is empty (legacy data).
+  // ledgers only if the channel board is empty (legacy data written before
+  // the unification in PR #10). Remove the fallback once all workspaces have
+  // a non-empty channel board.
   const board: Record<string, Array<{ ticketId: string; title: string }>> = {};
   const channelTickets = await store.readChannelTickets(channelId);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -845,30 +845,46 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
     return;
   }
 
-  const runLinks = await store.readRunLinks(channelId);
-
-  if (runLinks.length === 0) {
-    console.log("No runs linked to this channel.");
-    return;
-  }
-
+  // Unified ticket board: channel-scoped file is the live source for both
+  // chat-created and orchestrator-generated tickets. Fall back to the per-run
+  // ledgers only if the channel board is empty (legacy data).
   const board: Record<string, Array<{ ticketId: string; title: string }>> = {};
+  const channelTickets = await store.readChannelTickets(channelId);
 
-  for (const link of runLinks) {
-    const wsStore = new LocalArtifactStore(
-      `${getGlobalRoot()}/workspaces/${link.workspaceId}/artifacts`
-    );
-    const tickets = await wsStore.readTicketLedger(link.runId);
-    if (!tickets) continue;
-
-    for (const ticket of tickets) {
+  if (channelTickets.length > 0) {
+    for (const ticket of channelTickets) {
       if (!board[ticket.status]) board[ticket.status] = [];
       board[ticket.status].push({ ticketId: ticket.ticketId, title: ticket.title });
+    }
+  } else {
+    const runLinks = await store.readRunLinks(channelId);
+
+    if (runLinks.length === 0) {
+      console.log("No tickets on this channel and no runs linked.");
+      return;
+    }
+
+    for (const link of runLinks) {
+      const wsStore = new LocalArtifactStore(
+        `${getGlobalRoot()}/workspaces/${link.workspaceId}/artifacts`
+      );
+      const tickets = await wsStore.readTicketLedger(link.runId);
+      if (!tickets) continue;
+
+      for (const ticket of tickets) {
+        if (!board[ticket.status]) board[ticket.status] = [];
+        board[ticket.status].push({ ticketId: ticket.ticketId, title: ticket.title });
+      }
     }
   }
 
   if (args.includes("--json")) {
     jsonOut(board);
+    return;
+  }
+
+  if (Object.keys(board).length === 0) {
+    console.log("No tickets on this channel.");
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { Orchestrator } from "./orchestrator/orchestrator.js";
 import { OrchestratorV2 } from "./orchestrator/orchestrator-v2.js";
 import { ScriptedInvoker } from "./simulation/scripted-invoker.js";
 import { ChannelStore } from "./channels/channel-store.js";
+import { resolveBoardTickets } from "./channels/board-resolver.js";
 import {
   createPrWatcherFactory,
   getActiveWatcher
@@ -845,39 +846,22 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
     return;
   }
 
-  // Unified ticket board: channel-scoped file is the live source for both
-  // chat-created and orchestrator-generated tickets. Fall back to the per-run
-  // ledgers only if the channel board is empty (legacy data written before
-  // the unification in PR #10). Remove the fallback once all workspaces have
-  // a non-empty channel board.
+  // Delegates to resolveBoardTickets so CLI + MCP tool + GUI all read the
+  // channel board through the same unified-then-fallback policy.
   const board: Record<string, Array<{ ticketId: string; title: string }>> = {};
-  const channelTickets = await store.readChannelTickets(channelId);
+  const resolved = await resolveBoardTickets(store, channelId, async (
+    workspaceId,
+    runId
+  ) => {
+    const wsStore = new LocalArtifactStore(
+      `${getGlobalRoot()}/workspaces/${workspaceId}/artifacts`
+    );
+    return wsStore.readTicketLedger(runId);
+  });
 
-  if (channelTickets.length > 0) {
-    for (const ticket of channelTickets) {
-      if (!board[ticket.status]) board[ticket.status] = [];
-      board[ticket.status].push({ ticketId: ticket.ticketId, title: ticket.title });
-    }
-  } else {
-    const runLinks = await store.readRunLinks(channelId);
-
-    if (runLinks.length === 0) {
-      console.log("No tickets on this channel and no runs linked.");
-      return;
-    }
-
-    for (const link of runLinks) {
-      const wsStore = new LocalArtifactStore(
-        `${getGlobalRoot()}/workspaces/${link.workspaceId}/artifacts`
-      );
-      const tickets = await wsStore.readTicketLedger(link.runId);
-      if (!tickets) continue;
-
-      for (const ticket of tickets) {
-        if (!board[ticket.status]) board[ticket.status] = [];
-        board[ticket.status].push({ ticketId: ticket.ticketId, title: ticket.title });
-      }
-    }
+  for (const { entry } of resolved) {
+    if (!board[entry.status]) board[entry.status] = [];
+    board[entry.status].push({ ticketId: entry.ticketId, title: entry.title });
   }
 
   if (args.includes("--json")) {

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -1,5 +1,6 @@
 import { getAgentName } from "../domain/agent-names.js";
 import { ChannelStore } from "../channels/channel-store.js";
+import { resolveBoardTickets } from "../channels/board-resolver.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
 import {
   getGlobalRoot,
@@ -176,40 +177,21 @@ export async function callChannelTool(
       const channelId = String(args.channelId ?? "");
       const board: Record<string, Array<{ ticketId: string; title: string; runId: string | null }>> = {};
 
-      // Unified ticket board: channel-scoped file is the live source for both
-      // chat-created and orchestrator-generated tickets. Fall back to the
-      // per-run ledgers only if the channel board is empty (legacy data
-      // written before the unification in PR #10). Remove the fallback once
-      // all workspaces have a non-empty channel board.
-      const channelTickets = await store.readChannelTickets(channelId);
+      const tickets = await resolveBoardTickets(store, channelId, async (
+        workspaceId,
+        runId
+      ) => {
+        const artifactStore = buildArtifactStoreForWorkspace(workspaceId);
+        return artifactStore.readTicketLedger(runId);
+      });
 
-      if (channelTickets.length > 0) {
-        for (const ticket of channelTickets) {
-          if (!board[ticket.status]) board[ticket.status] = [];
-          board[ticket.status].push({
-            ticketId: ticket.ticketId,
-            title: ticket.title,
-            runId: ticket.runId ?? null
-          });
-        }
-        return { channelId, board };
-      }
-
-      // Legacy fallback: traverse run links.
-      const runLinks = await store.readRunLinks(channelId);
-      for (const link of runLinks) {
-        const artifactStore = buildArtifactStoreForWorkspace(link.workspaceId);
-        const tickets = await artifactStore.readTicketLedger(link.runId);
-        if (!tickets) continue;
-
-        for (const ticket of tickets) {
-          if (!board[ticket.status]) board[ticket.status] = [];
-          board[ticket.status].push({
-            ticketId: ticket.ticketId,
-            title: ticket.title,
-            runId: link.runId
-          });
-        }
+      for (const { entry, runId } of tickets) {
+        if (!board[entry.status]) board[entry.status] = [];
+        board[entry.status].push({
+          ticketId: entry.ticketId,
+          title: entry.title,
+          runId
+        });
       }
 
       return { channelId, board };

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -174,9 +174,28 @@ export async function callChannelTool(
 
     case "channel_task_board": {
       const channelId = String(args.channelId ?? "");
-      const runLinks = await store.readRunLinks(channelId);
-      const board: Record<string, Array<{ ticketId: string; title: string; runId: string }>> = {};
+      const board: Record<string, Array<{ ticketId: string; title: string; runId: string | null }>> = {};
 
+      // Unified ticket board: channel-scoped file is the live source for both
+      // chat-created and orchestrator-generated tickets. Fall back to the
+      // per-run ledgers only if the channel board is empty (legacy data
+      // written before unification).
+      const channelTickets = await store.readChannelTickets(channelId);
+
+      if (channelTickets.length > 0) {
+        for (const ticket of channelTickets) {
+          if (!board[ticket.status]) board[ticket.status] = [];
+          board[ticket.status].push({
+            ticketId: ticket.ticketId,
+            title: ticket.title,
+            runId: ticket.runId ?? null
+          });
+        }
+        return { channelId, board };
+      }
+
+      // Legacy fallback: traverse run links.
+      const runLinks = await store.readRunLinks(channelId);
       for (const link of runLinks) {
         const artifactStore = buildArtifactStoreForWorkspace(link.workspaceId);
         const tickets = await artifactStore.readTicketLedger(link.runId);

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -179,7 +179,8 @@ export async function callChannelTool(
       // Unified ticket board: channel-scoped file is the live source for both
       // chat-created and orchestrator-generated tickets. Fall back to the
       // per-run ledgers only if the channel board is empty (legacy data
-      // written before unification).
+      // written before the unification in PR #10). Remove the fallback once
+      // all workspaces have a non-empty channel board.
       const channelTickets = await store.readChannelTickets(channelId);
 
       if (channelTickets.length > 0) {

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -111,8 +111,14 @@ export class OrchestratorV2 {
           content: `Run started: ${featureRequest}`,
           metadata: { runId: run.id, state: run.state }
         });
-      } catch {
-        // Channel creation is non-critical — continue without it
+      } catch (err) {
+        // Channel creation is non-critical — continue without it, but don't
+        // swallow silently. A logged warning lets operators see why a run
+        // has no channel without having to trace through the code.
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[orchestrator] channel creation failed (runId=${run.id}): ${message}`
+        );
       }
     }
 
@@ -219,9 +225,9 @@ export class OrchestratorV2 {
 
     // Channel board is the live, unified ticket view across chat + orchestrator.
     // Per-run ticket-ledger.json remains as an immutable decomposition snapshot.
-    if (run.channelId && this.channelStore) {
-      await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
-    }
+    // Log-and-continue on failure: a filesystem blip on the channel board must
+    // not abort the run after planning and ledger persistence have succeeded.
+    await this.mirrorToChannelBoard(run);
 
     // Step 6: Approval gate or direct ticket execution
     if (tierNeedsApproval(classification.tier)) {
@@ -264,8 +270,7 @@ export class OrchestratorV2 {
       this.registry,
       (r, req) => this.dispatch(r, req),
       (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details),
-      undefined,
-      this.channelStore
+      { channelStore: this.channelStore }
     );
 
     const poller = this.startPoller(run, scheduler);
@@ -288,13 +293,15 @@ export class OrchestratorV2 {
     await this.persistRunIndex(run);
 
     if (run.channelId && this.channelStore) {
-      await this.channelStore.postEntry(run.channelId, {
-        type: "run_completed",
-        fromAgentId: null,
-        fromDisplayName: "Orchestrator",
-        content: `Run completed: ${run.state}`,
-        metadata: { runId: run.id, state: run.state }
-      }).catch(() => {});
+      await this.channelStore
+        .postEntry(run.channelId, {
+          type: "run_completed",
+          fromAgentId: null,
+          fromDisplayName: "Orchestrator",
+          content: `Run completed: ${run.state}`,
+          metadata: { runId: run.id, state: run.state }
+        })
+        .catch((err: unknown) => this.warnChannelPostFailed(run, err));
     }
 
     return run;
@@ -322,8 +329,11 @@ export class OrchestratorV2 {
           content: `Run started (trivial): ${featureRequest}`,
           metadata: { runId: run.id, state: run.state }
         });
-      } catch {
-        // non-critical
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[orchestrator] trivial channel setup failed (runId=${run.id}): ${message}`
+        );
       }
     }
 
@@ -334,9 +344,8 @@ export class OrchestratorV2 {
     run.ticketPlan = ticketPlan;
     run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id);
 
-    if (run.channelId && this.channelStore) {
-      await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
-    }
+    // Same log-and-continue policy as the regular decomposition path.
+    await this.mirrorToChannelBoard(run);
 
     // Fast-track: plan generated, then straight to tickets
     await this.transition(run, "PlanGenerated", "phase_00");
@@ -354,8 +363,7 @@ export class OrchestratorV2 {
       this.registry,
       (r, req) => this.dispatch(r, req),
       (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details),
-      undefined,
-      this.channelStore
+      { channelStore: this.channelStore }
     );
 
     const poller = this.startPoller(run, scheduler);
@@ -370,13 +378,15 @@ export class OrchestratorV2 {
     await this.persistRunIndex(run);
 
     if (run.channelId && this.channelStore) {
-      await this.channelStore.postEntry(run.channelId, {
-        type: "run_completed",
-        fromAgentId: null,
-        fromDisplayName: "Orchestrator",
-        content: `Run completed: ${run.state}`,
-        metadata: { runId: run.id, state: run.state }
-      }).catch(() => {});
+      await this.channelStore
+        .postEntry(run.channelId, {
+          type: "run_completed",
+          fromAgentId: null,
+          fromDisplayName: "Orchestrator",
+          content: `Run completed: ${run.state}`,
+          metadata: { runId: run.id, state: run.state }
+        })
+        .catch((err: unknown) => this.warnChannelPostFailed(run, err));
     }
 
     return run;
@@ -391,7 +401,11 @@ export class OrchestratorV2 {
       const poller = this.pollerFactory({ run, scheduler });
       poller?.start();
       return poller;
-    } catch {
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[orchestrator] poller start failed (runId=${run.id}): ${message}`
+      );
       return null;
     }
   }
@@ -414,13 +428,15 @@ export class OrchestratorV2 {
       });
 
       if (run.channelId && this.channelStore) {
-        this.channelStore.postEntry(run.channelId, {
-          type: "message",
-          fromAgentId: agent.id,
-          fromDisplayName: agent.name,
-          content: `Dispatched for ${input.kind}: ${input.title}`,
-          metadata: { attempt: String(attempt) }
-        }).catch(() => {});
+        this.channelStore
+          .postEntry(run.channelId, {
+            type: "message",
+            fromAgentId: agent.id,
+            fromDisplayName: agent.name,
+            content: `Dispatched for ${input.kind}: ${input.title}`,
+            metadata: { attempt: String(attempt) }
+          })
+          .catch((err: unknown) => this.warnChannelPostFailed(run, err));
       }
 
       try {
@@ -485,13 +501,15 @@ export class OrchestratorV2 {
     await this.persistRunIndex(run);
 
     if (run.channelId && this.channelStore) {
-      this.channelStore.postEntry(run.channelId, {
-        type: "status_update",
-        fromAgentId: null,
-        fromDisplayName: "Orchestrator",
-        content: `${eventType} → ${run.state}`,
-        metadata: { runId: run.id, state: run.state, event: eventType }
-      }).catch(() => {});
+      this.channelStore
+        .postEntry(run.channelId, {
+          type: "status_update",
+          fromAgentId: null,
+          fromDisplayName: "Orchestrator",
+          content: `${eventType} → ${run.state}`,
+          metadata: { runId: run.id, state: run.state, event: eventType }
+        })
+        .catch((err: unknown) => this.warnChannelPostFailed(run, err));
     }
   }
 
@@ -509,7 +527,12 @@ export class OrchestratorV2 {
     };
 
     run.events.push(event);
-    this.artifactStore.appendEvent(run.id, event).catch(() => {});
+    this.artifactStore.appendEvent(run.id, event).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[orchestrator] appendEvent failed (runId=${run.id} type=${type}): ${message}`
+      );
+    });
   }
 
   private recordEvidence(run: HarnessRun, record: EvidenceRecord): void {
@@ -533,6 +556,30 @@ export class OrchestratorV2 {
       }
     });
     await this.artifactStore.saveRunSnapshot(run);
+  }
+
+  /**
+   * Mirror the run's current ticket ledger onto the channel's unified board.
+   * Best-effort but logged: a mirror failure must not abort the run (the
+   * per-run ledger is already persisted), but it also must not be silent.
+   */
+  private async mirrorToChannelBoard(run: HarnessRun): Promise<void> {
+    if (!run.channelId || !this.channelStore) return;
+    try {
+      await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[orchestrator] channel board mirror failed (runId=${run.id} channelId=${run.channelId}): ${message}`
+      );
+    }
+  }
+
+  private warnChannelPostFailed(run: HarnessRun, err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[orchestrator] channel post failed (runId=${run.id} channelId=${run.channelId}): ${message}`
+    );
   }
 }
 

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -210,12 +210,18 @@ export class OrchestratorV2 {
     });
 
     run.ticketPlan = ticketPlan;
-    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets);
+    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id);
 
     await this.artifactStore.saveTicketLedger({
       runId: run.id,
       ticketLedger: run.ticketLedger
     });
+
+    // Channel board is the live, unified ticket view across chat + orchestrator.
+    // Per-run ticket-ledger.json remains as an immutable decomposition snapshot.
+    if (run.channelId && this.channelStore) {
+      await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
+    }
 
     // Step 6: Approval gate or direct ticket execution
     if (tierNeedsApproval(classification.tier)) {
@@ -257,7 +263,9 @@ export class OrchestratorV2 {
       this.verificationRunner,
       this.registry,
       (r, req) => this.dispatch(r, req),
-      (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details)
+      (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details),
+      undefined,
+      this.channelStore
     );
 
     const poller = this.startPoller(run, scheduler);
@@ -324,7 +332,11 @@ export class OrchestratorV2 {
 
     const ticketPlan = buildTicketPlanFromPhases(trivialPlan, classification);
     run.ticketPlan = ticketPlan;
-    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets);
+    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id);
+
+    if (run.channelId && this.channelStore) {
+      await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
+    }
 
     // Fast-track: plan generated, then straight to tickets
     await this.transition(run, "PlanGenerated", "phase_00");
@@ -341,7 +353,9 @@ export class OrchestratorV2 {
       this.verificationRunner,
       this.registry,
       (r, req) => this.dispatch(r, req),
-      (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details)
+      (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details),
+      undefined,
+      this.channelStore
     );
 
     const poller = this.startPoller(run, scheduler);

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -24,9 +24,16 @@ import {
 
 export interface TicketSchedulerOptions {
   maxConcurrency: number;
+  /**
+   * Optional ChannelStore. When present, scheduler mirrors ticket status
+   * changes to the channel's unified ticket board. Living in options (not a
+   * positional ctor arg) prevents the "positional-after-optional" foot-gun
+   * where a caller supplying options silently drops the store.
+   */
+  channelStore?: ChannelStore;
 }
 
-const DEFAULT_OPTIONS: TicketSchedulerOptions = {
+const DEFAULT_OPTIONS: Required<Pick<TicketSchedulerOptions, "maxConcurrency">> = {
   maxConcurrency: 3
 };
 
@@ -39,7 +46,7 @@ type RaceResult =
   | { ticketId: "__wake__"; success: false; wake: true };
 
 export class TicketScheduler {
-  private readonly options: TicketSchedulerOptions;
+  private readonly options: { maxConcurrency: number };
 
   /** The run that the active `executeAll` is driving, if any. */
   private activeRun: HarnessRun | null = null;
@@ -49,6 +56,8 @@ export class TicketScheduler {
 
   /** Tail of queued single-ticket executions after `executeAll` resolved. */
   private enqueueTail: Promise<void> = Promise.resolve();
+
+  private readonly channelStore: ChannelStore | undefined;
 
   constructor(
     private readonly repoRoot: string,
@@ -65,10 +74,10 @@ export class TicketScheduler {
       phaseId: string,
       details: Record<string, string>
     ) => void,
-    options?: Partial<TicketSchedulerOptions>,
-    private readonly channelStore?: ChannelStore
+    options?: Partial<TicketSchedulerOptions>
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.channelStore = options?.channelStore;
   }
 
   async executeAll(run: HarnessRun): Promise<boolean> {
@@ -525,13 +534,29 @@ export class TicketScheduler {
 
     // Mirror status changes onto the channel's unified ticket board so chat
     // and orchestrator tickets share a single live view. The per-run ledger
-    // above remains as the immutable decomposition snapshot.
+    // above is the immutable decomposition snapshot and is already written.
+    //
+    // The mirror is best-effort — a mirror failure must not halt the
+    // scheduler loop — but it is NEVER silent. We log and record a run
+    // event so operators can see drift between the per-run ledger and the
+    // channel board without debugging the filesystem.
     if (run.channelId && this.channelStore) {
       try {
         await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
-      } catch {
-        // Channel board mirror is best-effort; a transient write failure must
-        // not halt the scheduler loop. The per-run ledger is still persisted.
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[scheduler] channel board mirror failed (runId=${run.id} channelId=${run.channelId}): ${message}`
+        );
+        try {
+          this.recordEvent(run, "TicketFailed", "__channel_mirror__", {
+            runId: run.id,
+            channelId: run.channelId,
+            error: message
+          });
+        } catch {
+          // recordEvent itself must never break the scheduler loop.
+        }
       }
     }
   }

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -12,6 +12,7 @@ import {
   initializeTicketLedger
 } from "../domain/ticket.js";
 import type { ArtifactStore } from "../execution/artifact-store.js";
+import type { ChannelStore } from "../channels/channel-store.js";
 import type { VerificationRunner } from "../execution/verification-runner.js";
 import { selectVerificationCommands } from "../execution/verification-runner.js";
 import {
@@ -64,7 +65,8 @@ export class TicketScheduler {
       phaseId: string,
       details: Record<string, string>
     ) => void,
-    options?: Partial<TicketSchedulerOptions>
+    options?: Partial<TicketSchedulerOptions>,
+    private readonly channelStore?: ChannelStore
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
   }
@@ -520,5 +522,17 @@ export class TicketScheduler {
       runId: run.id,
       ticketLedger: run.ticketLedger
     });
+
+    // Mirror status changes onto the channel's unified ticket board so chat
+    // and orchestrator tickets share a single live view. The per-run ledger
+    // above remains as the immutable decomposition snapshot.
+    if (run.channelId && this.channelStore) {
+      try {
+        await this.channelStore.upsertChannelTickets(run.channelId, run.ticketLedger);
+      } catch {
+        // Channel board mirror is best-effort; a transient write failure must
+        // not halt the scheduler loop. The per-run ledger is still persisted.
+      }
+    }
   }
 }

--- a/test/channel-task-board-fallback.test.ts
+++ b/test/channel-task-board-fallback.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../src/channels/channel-store.js";
+import { callChannelTool, type ChannelToolState } from "../src/mcp/channel-tools.js";
+import { initializeTicketLedger } from "../src/domain/ticket.js";
+import type { TicketDefinition, TicketLedgerEntry } from "../src/domain/ticket.js";
+
+function makeTicket(
+  id: string,
+  overrides: Partial<TicketDefinition> = {}
+): TicketDefinition {
+  return {
+    id,
+    title: `Ticket ${id}`,
+    objective: `Objective ${id}`,
+    specialty: "general",
+    acceptanceCriteria: [`AC for ${id}`],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    dependsOn: [],
+    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
+    ...overrides
+  };
+}
+
+interface BoardResult {
+  channelId: string;
+  board: Record<
+    string,
+    Array<{ ticketId: string; title: string; runId: string | null }>
+  >;
+}
+
+describe("channel_task_board MCP tool — unified + fallback", () => {
+  it("returns an empty board when the channel has neither tickets.json nor runs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ctb-empty-"));
+    const channelStore = new ChannelStore(dir);
+    const channel = await channelStore.createChannel({
+      name: "#empty",
+      description: ""
+    });
+
+    try {
+      const state: ChannelToolState = { sessionId: null, channelStore };
+      const result = (await callChannelTool(
+        "channel_task_board",
+        { channelId: channel.channelId },
+        state
+      )) as BoardResult;
+
+      expect(result.channelId).toBe(channel.channelId);
+      expect(result.board).toEqual({});
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads from the channel file when it is populated and skips the run-link fallback", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ctb-populated-"));
+    const channelStore = new ChannelStore(dir);
+    const channel = await channelStore.createChannel({
+      name: "#populated",
+      description: ""
+    });
+
+    try {
+      // Populate the channel file with a mix of chat (runId=null) + orchestrator (runId set).
+      const ledger: TicketLedgerEntry[] = [
+        ...initializeTicketLedger([makeTicket("T-chat")], null),
+        ...initializeTicketLedger([makeTicket("T-run")], "run-alpha")
+      ];
+      await channelStore.writeChannelTickets(channel.channelId, ledger);
+
+      // Deliberately also link a run that does NOT have a real artifact store —
+      // if the fallback ever activates, we'd see a crash or missing ticket.
+      // The unified-read path must ignore the run link entirely when the
+      // channel file is non-empty.
+      await channelStore.linkRun(
+        channel.channelId,
+        "ghost-run",
+        "ghost-workspace"
+      );
+
+      const state: ChannelToolState = { sessionId: null, channelStore };
+      const result = (await callChannelTool(
+        "channel_task_board",
+        { channelId: channel.channelId },
+        state
+      )) as BoardResult;
+
+      // Both tickets should be in the ready bucket (no deps, status initialized
+      // to "ready"). runId nulls and strings both preserved.
+      const readyBucket = result.board.ready ?? [];
+      const ids = readyBucket.map((t) => t.ticketId).sort();
+      expect(ids).toEqual(["T-chat", "T-run"]);
+      const byId = new Map(readyBucket.map((t) => [t.ticketId, t]));
+      expect(byId.get("T-chat")?.runId).toBeNull();
+      expect(byId.get("T-run")?.runId).toBe("run-alpha");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates corruption from readChannelTickets instead of silently falling back", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ctb-corrupt-"));
+    const channelStore = new ChannelStore(dir);
+    const channel = await channelStore.createChannel({
+      name: "#corrupt",
+      description: ""
+    });
+
+    try {
+      // Write a malformed file — this should surface as an error, not an
+      // empty array that would erase data via downstream upsert.
+      const { writeFile, mkdir } = await import("node:fs/promises");
+      const chanDir = join(dir, channel.channelId);
+      await mkdir(chanDir, { recursive: true });
+      await writeFile(join(chanDir, "tickets.json"), "{this is not json");
+
+      const state: ChannelToolState = { sessionId: null, channelStore };
+      await expect(
+        callChannelTool(
+          "channel_task_board",
+          { channelId: channel.channelId },
+          state
+        )
+      ).rejects.toThrow(/Corrupt channel ticket board/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/channel-ticket-board.test.ts
+++ b/test/channel-ticket-board.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../src/channels/channel-store.js";
+import { initializeTicketLedger } from "../src/domain/ticket.js";
+import type { TicketDefinition, TicketLedgerEntry } from "../src/domain/ticket.js";
+
+function makeTicket(
+  id: string,
+  overrides: Partial<TicketDefinition> = {}
+): TicketDefinition {
+  return {
+    id,
+    title: `Ticket ${id}`,
+    objective: `Objective ${id}`,
+    specialty: "general",
+    acceptanceCriteria: [`AC for ${id}`],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    dependsOn: [],
+    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
+    ...overrides
+  };
+}
+
+describe("channel ticket board (unified)", () => {
+  it("returns [] when no tickets.json exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ticket-board-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const channel = await store.createChannel({ name: "#empty", description: "" });
+      const tickets = await store.readChannelTickets(channel.channelId);
+      expect(tickets).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips a full ledger via writeChannelTickets", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ticket-board-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const channel = await store.createChannel({ name: "#rt", description: "" });
+      const ledger = initializeTicketLedger(
+        [makeTicket("T-1"), makeTicket("T-2", { dependsOn: ["T-1"] })],
+        "run-alpha"
+      );
+
+      await store.writeChannelTickets(channel.channelId, ledger);
+      const read = await store.readChannelTickets(channel.channelId);
+
+      expect(read).toHaveLength(2);
+      expect(read[0].ticketId).toBe("T-1");
+      expect(read[0].runId).toBe("run-alpha");
+      expect(read[1].status).toBe("blocked");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("upsert replaces existing ticketIds and preserves order", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ticket-board-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const channel = await store.createChannel({ name: "#upsert", description: "" });
+
+      // Initial: T-1 ready, T-2 blocked
+      const initial = initializeTicketLedger(
+        [makeTicket("T-1"), makeTicket("T-2", { dependsOn: ["T-1"] })],
+        "run-alpha"
+      );
+      await store.writeChannelTickets(channel.channelId, initial);
+
+      // Scheduler-style update: T-1 completed
+      const completedT1: TicketLedgerEntry = {
+        ...initial[0],
+        status: "completed",
+        completedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      const merged = await store.upsertChannelTickets(channel.channelId, [completedT1]);
+
+      expect(merged).toHaveLength(2);
+      expect(merged[0].ticketId).toBe("T-1");
+      expect(merged[0].status).toBe("completed");
+      // T-2 untouched, still in place after T-1
+      expect(merged[1].ticketId).toBe("T-2");
+      expect(merged[1].status).toBe("blocked");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("upsert appends new tickets in supplied order", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ticket-board-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const channel = await store.createChannel({ name: "#append", description: "" });
+
+      // Start with a chat-created ticket (runId=null).
+      const chatTickets = initializeTicketLedger([makeTicket("T-chat")], null);
+      await store.writeChannelTickets(channel.channelId, chatTickets);
+
+      // Orchestrator run adds two more.
+      const runTickets = initializeTicketLedger(
+        [makeTicket("T-1"), makeTicket("T-2", { dependsOn: ["T-1"] })],
+        "run-beta"
+      );
+      const merged = await store.upsertChannelTickets(channel.channelId, runTickets);
+
+      expect(merged.map((t) => t.ticketId)).toEqual(["T-chat", "T-1", "T-2"]);
+      expect(merged[0].runId).toBeNull();
+      expect(merged[1].runId).toBe("run-beta");
+      expect(merged[2].runId).toBe("run-beta");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/orchestrator-v2.test.ts
+++ b/test/orchestrator-v2.test.ts
@@ -7,12 +7,17 @@ import { describe, expect, it } from "vitest";
 import { AgentRegistry } from "../src/agents/registry.js";
 import { createLiveAgents } from "../src/agents/factory.js";
 import { NodeCommandInvoker } from "../src/agents/command-invoker.js";
+import { ChannelStore } from "../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { VerificationRunner } from "../src/execution/verification-runner.js";
 import { OrchestratorV2 } from "../src/orchestrator/orchestrator-v2.js";
 import { ScriptedInvoker } from "../src/simulation/scripted-invoker.js";
 
-function buildOrchestrator(cwd: string, artifactsDir: string) {
+function buildOrchestrator(
+  cwd: string,
+  artifactsDir: string,
+  opts: { channelStore?: ChannelStore; workspaceId?: string } = {}
+) {
   const registry = new AgentRegistry();
   const agents = createLiveAgents({
     cwd,
@@ -34,7 +39,9 @@ function buildOrchestrator(cwd: string, artifactsDir: string) {
     cwd,
     verificationRunner,
     artifactStore,
-    artifactsDir
+    artifactsDir,
+    opts.channelStore,
+    opts.workspaceId
   );
 }
 
@@ -140,6 +147,91 @@ describe("OrchestratorV2 integration", () => {
       // Verify runs index
       const runs = await artifactStore.readRunsIndex();
       expect(runs.some((r) => r.runId === run.id)).toBe(true);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("mirrors ticket ledger to the channel board on the regular decomposition path", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "orch-v2-test-"));
+    const artifactsDir = join(tmpDir, "artifacts");
+    const channelsDir = join(tmpDir, "channels");
+
+    try {
+      const channelStore = new ChannelStore(channelsDir);
+      const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
+        channelStore,
+        workspaceId: "ws-test"
+      });
+      const run = await orchestrator.run(
+        "Implement a new authentication system with JWT tokens and session management"
+      );
+
+      expect(run.channelId).not.toBeNull();
+      const boardTickets = await channelStore.readChannelTickets(run.channelId!);
+      expect(boardTickets.length).toBe(run.ticketLedger.length);
+      for (const entry of boardTickets) {
+        expect(entry.runId).toBe(run.id);
+      }
+      const boardIds = boardTickets.map((t) => t.ticketId).sort();
+      const ledgerIds = run.ticketLedger.map((t) => t.ticketId).sort();
+      expect(boardIds).toEqual(ledgerIds);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("mirrors ticket ledger to the channel board on the trivial fast-track path", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "orch-v2-test-"));
+    const artifactsDir = join(tmpDir, "artifacts");
+    const channelsDir = join(tmpDir, "channels");
+
+    try {
+      const channelStore = new ChannelStore(channelsDir);
+      const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
+        channelStore,
+        workspaceId: "ws-test"
+      });
+      const run = await orchestrator.run("Fix typo in README");
+
+      expect(run.classification!.tier).toBe("trivial");
+      expect(run.channelId).not.toBeNull();
+      const boardTickets = await channelStore.readChannelTickets(run.channelId!);
+      expect(boardTickets.length).toBeGreaterThan(0);
+      expect(boardTickets[0].runId).toBe(run.id);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("continues the run when the channel store mirror throws", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "orch-v2-test-"));
+    const artifactsDir = join(tmpDir, "artifacts");
+    const channelsDir = join(tmpDir, "channels");
+
+    try {
+      const channelStore = new ChannelStore(channelsDir);
+      // Force upsert to fail for the duration of the run.
+      const originalUpsert = channelStore.upsertChannelTickets.bind(channelStore);
+      channelStore.upsertChannelTickets = async () => {
+        throw new Error("simulated write failure");
+      };
+
+      const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
+        channelStore,
+        workspaceId: "ws-test"
+      });
+      const run = await orchestrator.run(
+        "Implement a new authentication system with JWT tokens and session management"
+      );
+
+      // Run still completes the per-run ledger even though the mirror failed.
+      expect(run.ticketLedger.length).toBeGreaterThan(0);
+
+      // Restore and verify the channel board is empty as expected.
+      channelStore.upsertChannelTickets = originalUpsert;
+      const boardTickets = await channelStore.readChannelTickets(run.channelId!);
+      expect(boardTickets).toEqual([]);
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/test/orchestrator/ticket-scheduler-enqueue.test.ts
+++ b/test/orchestrator/ticket-scheduler-enqueue.test.ts
@@ -17,6 +17,7 @@ import {
   parseTicketPlan,
   type TicketDefinition
 } from "../../src/domain/ticket.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
 import { VerificationRunner } from "../../src/execution/verification-runner.js";
 import { TicketScheduler } from "../../src/orchestrator/ticket-scheduler.js";
@@ -95,6 +96,7 @@ interface BuildSchedulerOptions {
     req: Omit<WorkRequest, "runId">
   ) => Promise<AgentResult>;
   onRecordEvent?: (event: RecordedEvent) => void;
+  channelStore?: ChannelStore;
 }
 
 /**
@@ -157,7 +159,7 @@ async function buildScheduler(
       events.push(event);
       options.onRecordEvent?.(event);
     },
-    { maxConcurrency: 2 }
+    { maxConcurrency: 2, channelStore: options.channelStore }
   );
 
   return { scheduler, dispatched, events, artifactStore };
@@ -350,6 +352,103 @@ describe("TicketScheduler.enqueue", () => {
       await scheduler.enqueue(run, ticket("t_after"));
       const after = run.ticketLedger.find((t) => t.ticketId === "t_after");
       expect(after?.status).toBe("completed");
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("TicketScheduler channel board mirror", () => {
+  it("mirrors every persistTicketLedger to the channel board", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-mirror-"));
+    try {
+      const channelStore = new ChannelStore(join(tmp, "channels"));
+      const channel = await channelStore.createChannel({
+        name: "#mirror",
+        description: "mirror test"
+      });
+
+      const run = buildRun(tmp, [ticket("t_a"), ticket("t_b")]);
+      run.channelId = channel.channelId;
+
+      const { scheduler } = await buildScheduler(tmp, { channelStore });
+      const ok = await scheduler.executeAll(run);
+      expect(ok).toBe(true);
+
+      const boardTickets = await channelStore.readChannelTickets(channel.channelId);
+      expect(boardTickets).toHaveLength(2);
+      const byId = new Map(boardTickets.map((t) => [t.ticketId, t]));
+      expect(byId.get("t_a")?.status).toBe("completed");
+      expect(byId.get("t_b")?.status).toBe("completed");
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("keeps the scheduler loop alive when the mirror throws", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-mirror-fail-"));
+    const warnCalls: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args.map((a) => String(a)).join(" "));
+    };
+
+    try {
+      const channelStore = new ChannelStore(join(tmp, "channels"));
+      const channel = await channelStore.createChannel({
+        name: "#mirror-fail",
+        description: "mirror failure test"
+      });
+      channelStore.upsertChannelTickets = async () => {
+        throw new Error("simulated mirror failure");
+      };
+
+      const run = buildRun(tmp, [ticket("t_a")]);
+      run.channelId = channel.channelId;
+
+      const { scheduler, events } = await buildScheduler(tmp, { channelStore });
+      const ok = await scheduler.executeAll(run);
+
+      expect(ok).toBe(true);
+      const entry = run.ticketLedger.find((t) => t.ticketId === "t_a");
+      expect(entry?.status).toBe("completed");
+
+      const mirrorWarn = warnCalls.find((w) =>
+        w.includes("[scheduler] channel board mirror failed")
+      );
+      const mirrorEvent = events.find(
+        (e) => e.phaseId === "__channel_mirror__"
+      );
+      expect(mirrorWarn || mirrorEvent).toBeTruthy();
+    } finally {
+      console.warn = originalWarn;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("serializes concurrent upserts on the same channel (no lost updates)", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "ts-mirror-concurrent-"));
+    try {
+      const channelStore = new ChannelStore(join(tmp, "channels"));
+      const channel = await channelStore.createChannel({
+        name: "#concurrent",
+        description: "concurrency test"
+      });
+
+      // Two disjoint upserts fired at once. If upsert read-modified-wrote
+      // without a mutex, one would clobber the other (both read empty, both
+      // write their single ticket). With the mutex, both survive.
+      const [a] = initializeTicketLedger([ticket("t_a")], "run-a");
+      const [b] = initializeTicketLedger([ticket("t_b")], "run-b");
+
+      await Promise.all([
+        channelStore.upsertChannelTickets(channel.channelId, [a]),
+        channelStore.upsertChannelTickets(channel.channelId, [b])
+      ]);
+
+      const board = await channelStore.readChannelTickets(channel.channelId);
+      const ids = board.map((t) => t.ticketId).sort();
+      expect(ids).toEqual(["t_a", "t_b"]);
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/test/ticket.test.ts
+++ b/test/ticket.test.ts
@@ -121,4 +121,15 @@ describe("initializeTicketLedger", () => {
     expect(ledger[1].status).toBe("blocked");
     expect(ledger[2].status).toBe("ready");
   });
+
+  it("defaults runId to null for chat-created ledgers", () => {
+    const ledger = initializeTicketLedger([ticket("a")]);
+    expect(ledger[0].runId).toBeNull();
+  });
+
+  it("tags every entry with the supplied runId", () => {
+    const ledger = initializeTicketLedger([ticket("a"), ticket("b")], "run-abc");
+    expect(ledger[0].runId).toBe("run-abc");
+    expect(ledger[1].runId).toBe("run-abc");
+  });
 });


### PR DESCRIPTION
## Summary

- Collapse the two parallel ticket tracks into one: chat-created and orchestrator-generated tickets both live at `channels/<id>/tickets.json`, with an optional `runId` on every entry.
- `rly board` and the Tauri GUI's Board tab now read the same file. Per-run `ticket-ledger.json` stays as an immutable decomposition snapshot — status updates are mirrored to the channel board by the scheduler.
- Chat system prompt updated to emit the full `TicketLedgerEntry` shape so chat-written tickets are indistinguishable from orchestrator-written ones.

## Why

Before this, `rly board` traversed run links and read `artifacts/<runId>/ticket-ledger.json`, while the GUI's Board tab read `channels/<id>/tickets.json`. Chat tickets were visible only in the GUI; orchestrator tickets only in the CLI. Same feature, two disjoint views.

## Shape change

`TicketLedgerEntry` gains `runId: string | null`:
- `null` — chat-created
- populated — decomposed by an orchestrator run

`initializeTicketLedger(tickets, runId?)` threads it. Existing callers default to `null`, which is the chat-created semantic.

`ChannelStore` gains:
- `readChannelTickets(channelId)`
- `writeChannelTickets(channelId, tickets)` — full replace, atomic rename
- `upsertChannelTickets(channelId, incoming)` — merge by ticketId, append new entries in supplied order, preserve pre-existing entries not mentioned

## Wiring

- `orchestrator-v2.ts`: on both decomposition paths (regular + fast-track), upsert to channel board after `initializeTicketLedger`.
- `ticket-scheduler.ts`: new optional `channelStore` ctor arg. `persistTicketLedger` mirrors to channel board best-effort (failure does not halt the scheduler loop).
- `channel_task_board` MCP tool + `rly board` CLI: prefer channel file; fall back to run-link traversal only when the channel file is empty (legacy data compatibility).
- `scripts/seed-plan-tickets.ts`: writes the channel board directly via `writeChannelTickets`, defaults run state to `AWAITING_APPROVAL`, tags `runId` on every entry.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 143 tests pass, 1 skipped (pre-existing)
- [x] New `test/channel-ticket-board.test.ts` covers: empty read, write/read round-trip, upsert replace + preserve ordering, mixed chat + run ticket append
- [x] `test/ticket.test.ts` extended with `runId` default-null and explicit-run cases
- [ ] Manual: re-run `scripts/seed-plan-tickets.ts` against the planning channel and verify both `rly board` and the GUI render the 23 tickets identically
- [ ] Manual: kick off a real `rly run` and confirm tickets land on the channel board as the scheduler transitions them through ready → executing → completed

## Migration notes

- No schema migration required. Legacy channels with no `tickets.json` keep working via the run-link fallback path.
- Rust `harness-data` crate's `TicketLedgerEntry` struct doesn't currently deserialize `runId` — unknown fields are dropped silently (no `deny_unknown_fields`), so this is forward-compatible. A follow-up can surface `runId` in the Rust types once the GUI needs to display it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)