### PR TITLE
Global auto-approve for unattended runs + per-column board scroll fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,5 +207,6 @@ Tokens are read from the environment:
 ## Flags
 
 - `HARNESS_LIVE=1` — use real Claude/Codex adapters instead of scripted simulation
+- `RELAY_AUTO_APPROVE=1` (or `--auto-approve` / `--yolo` on the CLI) — run fully unattended: Claude launches with `--dangerously-skip-permissions`, Codex with `--full-auto` + workspace-write sandbox + `--ask-for-approval never`, and internal scheduler-dispatched agents inherit. Required for multi-hour runs where you don't want permission prompts. Only use when you trust the tasks you're dispatching.
 - `--sequential` — use v1 sequential orchestrator instead of v2 ticket-based
 - `--no-harness-mcp` — launch Claude/Codex without attaching the Relay MCP server

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -182,7 +182,10 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 12px;
-  height: 100%;
+  /* Fill the board-content flex track without `height: 100%`, which resolves
+     to auto inside a flex parent in some browsers and lets the columns grow
+     to natural content height. */
+  flex: 1 1 auto;
   min-height: 0;
   align-items: stretch;
 }
@@ -190,6 +193,9 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Without overflow hidden, the column's natural content height wins and
+     board-column-body's overflow-y has nothing to scroll against. */
+  overflow: hidden;
 }
 .board-column h4 {
   font-size: 11px;

--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,13 @@ cat > "$TEMPLATE" <<'ENVEOF'
 
 # Set to 1 to use the real Claude/Codex adapters instead of the scripted demo.
 # export HARNESS_LIVE=1
+
+# Set to 1 to run Claude / Codex fully unattended — no permission prompts.
+# Claude launches with --dangerously-skip-permissions; Codex with --full-auto
+# (workspace-write sandbox, --ask-for-approval never). Internal scheduler
+# agents inherit. Use only when you trust the tasks being dispatched — this
+# lets the harness run for hours without intervention.
+# export RELAY_AUTO_APPROVE=1
 ENVEOF
 
 CONFIG="${RELAY_DIR}/config.env"

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -90,6 +90,14 @@ export class CodexCliAgent extends CliAgentBase {
 
     await writeFile(schemaPath, JSON.stringify(agentResultJsonSchema, null, 2));
 
+    // When RELAY_AUTO_APPROVE is set, drop the read-only sandbox so the
+    // dispatched codex agent can actually make changes unattended. Stays
+    // read-only by default so nothing surprising happens on a casual run.
+    const autoApprove =
+      process.env.RELAY_AUTO_APPROVE === "1" ||
+      process.env.RELAY_AUTO_APPROVE === "true" ||
+      process.env.RELAY_AUTO_APPROVE === "yes";
+
     try {
       const args = [
         "exec",
@@ -97,12 +105,16 @@ export class CodexCliAgent extends CliAgentBase {
         this.cwd,
         "--skip-git-repo-check",
         "--sandbox",
-        "read-only",
+        autoApprove ? "workspace-write" : "read-only",
         "--output-schema",
         schemaPath,
         "-o",
         outputPath
       ];
+
+      if (autoApprove) {
+        args.push("--ask-for-approval", "never");
+      }
 
       if (this.model) {
         args.push("--model", this.model);
@@ -138,15 +150,27 @@ export class CodexCliAgent extends CliAgentBase {
 
 export class ClaudeCliAgent extends CliAgentBase {
   protected async invokeProvider(prompt: string): Promise<ParsedProviderResult> {
+    // When the user sets RELAY_AUTO_APPROVE=1 (or launched with --auto-approve
+    // / --yolo), internal dispatched agents run fully unattended. Otherwise
+    // we stay on the default permission mode and users will be prompted.
+    const autoApprove =
+      process.env.RELAY_AUTO_APPROVE === "1" ||
+      process.env.RELAY_AUTO_APPROVE === "true" ||
+      process.env.RELAY_AUTO_APPROVE === "yes";
+
     const args = [
       "-p",
       "--output-format",
       "json",
       "--json-schema",
-      JSON.stringify(agentResultJsonSchema),
-      "--permission-mode",
-      "default"
+      JSON.stringify(agentResultJsonSchema)
     ];
+
+    if (autoApprove) {
+      args.push("--dangerously-skip-permissions");
+    } else {
+      args.push("--permission-mode", "default");
+    }
 
     if (this.model) {
       args.push("--model", this.model);

--- a/src/cli/agent-wrapper.ts
+++ b/src/cli/agent-wrapper.ts
@@ -52,25 +52,49 @@ const HARNESS_SYSTEM_PROMPT = [
   "If you need information from another repo, use crosslink_discover to find the right session, then crosslink_send to ask."
 ].join("\n");
 
+/**
+ * Auto-approve is enabled when RELAY_AUTO_APPROVE=1 OR the user passed
+ * --auto-approve / --yolo. Reads from env so children inherit.
+ */
+export function isAutoApproveEnabled(args: string[] = []): boolean {
+  if (args.includes("--auto-approve") || args.includes("--yolo")) return true;
+  const env = process.env.RELAY_AUTO_APPROVE;
+  return env === "1" || env === "true" || env === "yes";
+}
+
+/**
+ * Strip our own auto-approve flags so they don't get passed through to the
+ * underlying CLI (which wouldn't recognise them).
+ */
+export function stripAutoApproveFlags(args: string[]): string[] {
+  return args.filter((arg) => arg !== "--auto-approve" && arg !== "--yolo");
+}
+
 export function buildClaudeLaunchArgs(input: {
   userArgs: string[];
   mcpConfigPath: string;
+  autoApprove?: boolean;
 }): string[] {
-  return [
+  const base = [
     "--mcp-config",
     input.mcpConfigPath,
     "--append-system-prompt",
-    HARNESS_SYSTEM_PROMPT,
-    ...input.userArgs
+    HARNESS_SYSTEM_PROMPT
   ];
+  if (input.autoApprove) {
+    // Claude Code's flag for unattended runs. No per-tool prompts.
+    base.push("--dangerously-skip-permissions");
+  }
+  return [...base, ...input.userArgs];
 }
 
 export function buildCodexLaunchArgs(input: {
   userArgs: string[];
   cwd: string;
   cliEntrypoint: string;
+  autoApprove?: boolean;
 }): string[] {
-  return [
+  const base = [
     "-c",
     `mcp_servers.relay.command=${tomlString(process.execPath)}`,
     "-c",
@@ -81,9 +105,14 @@ export function buildCodexLaunchArgs(input: {
       input.cwd
     ])}`,
     "-c",
-    `mcp_servers.relay.env.AGENT_HARNESS_PROVIDER=${tomlString("codex")}`,
-    ...input.userArgs
+    `mcp_servers.relay.env.AGENT_HARNESS_PROVIDER=${tomlString("codex")}`
   ];
+  if (input.autoApprove) {
+    // Codex CLI's unattended mode. If your codex version rejects this flag,
+    // drop auto-approve or set --approval-policy never manually.
+    base.push("--full-auto");
+  }
+  return [...base, ...input.userArgs];
 }
 
 function tomlString(value: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import {
   buildCodexLaunchArgs,
   ensureClaudeMcpConfig,
   hasHarnessMcpOptOut,
+  isAutoApproveEnabled,
+  stripAutoApproveFlags,
   stripHarnessMcpOptOut
 } from "./cli/agent-wrapper.js";
 import { AgentRegistry } from "./agents/registry.js";
@@ -169,7 +171,8 @@ export async function main(): Promise<void> {
   if (command === "claude" || command === "codex" || command.startsWith("claude-") || command.startsWith("codex-")) {
     const cliEntrypoint = resolveCliEntrypoint();
     const attachHarnessMcp = !hasHarnessMcpOptOut(args);
-    const userArgs = stripHarnessMcpOptOut(args);
+    const autoApprove = isAutoApproveEnabled(args);
+    const userArgs = stripAutoApproveFlags(stripHarnessMcpOptOut(args));
 
     // For claude-* variants (e.g. claude-turingon), use the base binary
     // with CLAUDE_CONFIG_DIR set to ~/.claude-<variant>
@@ -188,7 +191,8 @@ export async function main(): Promise<void> {
           cwd,
           cliEntrypoint,
           userArgs,
-          workspace
+          workspace,
+          autoApprove
         })
       : userArgs;
     const exitCode = await launchInteractiveCommand({
@@ -199,7 +203,9 @@ export async function main(): Promise<void> {
         ...variantEnv,
         AGENT_HARNESS_HOME: workspace.paths.rootDir,
         AGENT_HARNESS_ARTIFACTS_DIR: workspace.paths.artifactsDir,
-        AGENT_HARNESS_RUNS_INDEX: workspace.paths.runsIndexPath
+        AGENT_HARNESS_RUNS_INDEX: workspace.paths.runsIndexPath,
+        // Propagate to children (dispatched agents) so they inherit.
+        ...(autoApprove ? { RELAY_AUTO_APPROVE: "1" } : {})
       }
     });
 
@@ -1307,7 +1313,10 @@ async function inspectMcp(input: {
             cwd: input.cwd,
             cliEntrypoint,
             userArgs: ["mcp", "list"],
-            workspace: input.workspace
+            workspace: input.workspace,
+            // `mcp list` is a probe, no approvals needed and no spawning of
+            // long-running agents. Skip auto-approve propagation here.
+            autoApprove: false
           })
         : ["mcp", "list"],
       cwd: input.cwd,
@@ -1417,6 +1426,7 @@ async function buildWrappedAgentLaunchArgs(input: {
   workspace: {
     paths: HarnessWorkspacePaths;
   };
+  autoApprove: boolean;
 }): Promise<string[]> {
   // claude-* variants use the same MCP config as claude
   if (input.command === "claude" || input.command.startsWith("claude-")) {
@@ -1426,14 +1436,16 @@ async function buildWrappedAgentLaunchArgs(input: {
         cwd: input.cwd,
         cliEntrypoint: input.cliEntrypoint,
         paths: input.workspace.paths
-      })
+      }),
+      autoApprove: input.autoApprove
     });
   }
 
   return buildCodexLaunchArgs({
     userArgs: input.userArgs,
     cwd: input.cwd,
-    cliEntrypoint: input.cliEntrypoint
+    cliEntrypoint: input.cliEntrypoint,
+    autoApprove: input.autoApprove
   });
 }
 


### PR DESCRIPTION
Two unrelated but both user-reported fixes.

## 1. Auto-approve (unattended mode)

One switch turns off every permission prompt across every Relay-dispatched Claude/Codex invocation, so multi-hour runs don't stall on "Allow read?" dialogs.

**Enable:**
- \`RELAY_AUTO_APPROVE=1\` in \`~/.relay/config.env\` (sourced by your shell), or
- \`--auto-approve\` / \`--yolo\` flag on \`rly claude\` / \`rly codex\`.

**What changes under the hood:**
- \`buildClaudeLaunchArgs\` adds \`--dangerously-skip-permissions\`.
- \`buildCodexLaunchArgs\` adds \`--full-auto\`.
- \`ClaudeCliAgent\` (internal scheduler dispatch) switches \`--permission-mode default\` → \`--dangerously-skip-permissions\`.
- \`CodexCliAgent\` (internal scheduler dispatch) drops \`--sandbox read-only\` for \`--sandbox workspace-write\` and adds \`--ask-for-approval never\`.
- \`src/index.ts\` propagates \`RELAY_AUTO_APPROVE\` into the child's env so every subsequently dispatched agent inherits — your "allow" doesn't reset between tickets.

The existing TUI / GUI auto-approve toggles keep working as before; this change is about the CLI + scheduler paths that previously had no way to opt in.

**Safety note**: \`--dangerously-skip-permissions\` lives up to its name. Use this only when you trust the tasks you're dispatching (bug-fix loop on your own repo, not running untrusted prompts).

## 2. Board scroll — actually works now

The PR #8 attempt used \`height: 100%\` on \`.board-columns\` inside a column-flex parent, which some browsers resolve to auto and let columns grow to natural content height (so 21 tickets in Blocked overflowed the pane with no scrollbar).

**Fix:** switch to \`flex: 1 1 auto; min-height: 0\` for \`.board-columns\`, and add \`overflow: hidden\` on \`.board-column\` so the column body's \`overflow-y: auto\` has something to scroll against.

Rebuild the GUI to see it: \`rly gui --rebuild\`.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 137/137 + 1 skipped
- [x] \`pnpm build\` clean
- [x] \`cd gui && pnpm build\` clean
- [ ] Manual: \`export RELAY_AUTO_APPROVE=1 && rly claude\` → no permission prompt fires on a read/write.
- [ ] Manual: \`rly gui --rebuild\` → open a channel with many blocked tickets, confirm Blocked column scrolls internally without pushing other columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)