### PR TITLE
Sort GUI channel sidebar by most-recent activity

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -80,6 +80,12 @@ pub struct Channel {
     pub pinned_refs: Vec<ChannelRef>,
     #[serde(default)]
     pub repo_assignments: Vec<RepoAssignment>,
+    /// ISO 8601 timestamps. Optional for back-compat with channel files
+    /// written before these fields were tracked.
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -7,7 +7,28 @@ type Props = {
   onNewChannel: () => void;
 };
 
+/**
+ * Sort by most-recent activity (updatedAt desc) so the channel you're
+ * actively working in — or last worked in — stays at the top. Falls back to
+ * createdAt, then name. Channels missing both timestamps sink to the bottom.
+ * Pure, safe to call every render.
+ */
+function sortByActivity(channels: Channel[]): Channel[] {
+  const activityTs = (c: Channel): number => {
+    const raw = c.updatedAt ?? c.createdAt;
+    if (!raw) return 0;
+    const parsed = Date.parse(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+  return [...channels].sort((a, b) => {
+    const diff = activityTs(b) - activityTs(a);
+    if (diff !== 0) return diff;
+    return a.name.localeCompare(b.name);
+  });
+}
+
 export function Sidebar({ channels, selectedId, onSelect, onNewChannel }: Props) {
+  const sorted = sortByActivity(channels);
   return (
     <div className="panel">
       <div className="panel-header">
@@ -17,8 +38,8 @@ export function Sidebar({ channels, selectedId, onSelect, onNewChannel }: Props)
         </button>
       </div>
       <div className="list">
-        {channels.length === 0 && <div className="empty">No active channels</div>}
-        {channels.map((c) => (
+        {sorted.length === 0 && <div className="empty">No active channels</div>}
+        {sorted.map((c) => (
           <div
             key={c.channelId}
             className={`list-item ${c.channelId === selectedId ? "active" : ""}`}

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -33,6 +33,9 @@ export type Channel = {
   members: ChannelMember[];
   pinnedRefs: ChannelRef[];
   repoAssignments: RepoAssignment[];
+  // ISO 8601; optional for back-compat with older channel files.
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 export type ChannelEntry = {

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -110,6 +110,19 @@ export class ChannelStore {
     return this.updateChannel(channelId, { status: "archived" });
   }
 
+  /**
+   * Bump a channel's `updatedAt` without patching any user-visible field.
+   * Called from activity writes (postEntry, recordDecision) so the sidebar
+   * can sort channels by most-recent activity. Silently no-ops if the
+   * channel is missing so activity on orphan feeds doesn't throw.
+   */
+  private async touchChannel(channelId: string): Promise<void> {
+    const channel = await this.getChannel(channelId);
+    if (!channel) return;
+    channel.updatedAt = new Date().toISOString();
+    await this.writeChannel(channel);
+  }
+
   // --- Members ---
 
   async joinChannel(channelId: string, member: Omit<ChannelMember, "joinedAt" | "status">): Promise<Channel | null> {
@@ -197,6 +210,9 @@ export class ChannelStore {
       join(feedDir, "feed.jsonl"),
       JSON.stringify(entry) + "\n"
     );
+
+    // Bump channel-level activity so sorts by updatedAt reflect feed writes.
+    await this.touchChannel(channelId);
 
     return entry;
   }


### PR DESCRIPTION
The channel you were actively working in used to drift mid-list because the sidebar rendered in backend order (roughly channel-id). Now it floats to the top on every write.

## Changes
- **Sidebar**: local sort by \`updatedAt\` desc → \`createdAt\` desc → name. Undated channels (very old data) sink to the bottom. Pure function, safe per render.
- **ChannelStore.postEntry**: now bumps \`updatedAt\` via a private \`touchChannel\` helper so feed writes — not just \`updateChannel\`/\`archiveChannel\` — count as activity. \`recordDecision\` transitively inherits via its \`postEntry\` call.
- **Rust Channel struct** + **gui/src/types.ts Channel**: added optional \`created_at\` / \`updated_at\` fields with \`#[serde(default)]\` for back-compat. Old channel files without these fields deserialize fine and end up at the bottom.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 137/137 + 1 skipped
- [x] \`cd gui && pnpm build\` clean
- [ ] Manual: \`rly gui --rebuild\`, post to a channel, confirm it floats to the top of the sidebar. Post to a different channel, confirm the previous one drops below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)