### PR TITLE
Run rly from TS source by default + rly rebuild command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ The **TUI** (`rly tui`, built with `--with-tui`) and **GUI** (built with `--with
 | `rly pr-status` | List PRs currently tracked by the watcher |
 | `rly tui` | Launch the ratatui dashboard (auto-builds on first run) |
 | `rly gui` | Launch the Tauri desktop app (auto-builds on first run; `--dev` for hot reload) |
+| `rly rebuild` | Rebuild the TS dist; `--tui` / `--gui` / `--all` to rebuild more |
 
-`agent-harness <cmd>` is accepted as a legacy alias for `rly <cmd>` — both binaries are shipped so existing scripts don't break.
+`agent-harness <cmd>` is accepted as a legacy alias for `rly <cmd>` — both binaries are shipped so existing scripts don't break. `rly` reads current TypeScript source by default (via `tsx`), so a rebuild is **not** required after `git pull`. Set `RELAY_USE_DIST=1` for the compiled dist if you want slightly faster startup.
 
 ## MCP tools (15)
 
@@ -208,5 +209,6 @@ Tokens are read from the environment:
 
 - `HARNESS_LIVE=1` — use real Claude/Codex adapters instead of scripted simulation
 - `RELAY_AUTO_APPROVE=1` (or `--auto-approve` / `--yolo` on the CLI) — run fully unattended: Claude launches with `--dangerously-skip-permissions`, Codex with `--full-auto` + workspace-write sandbox + `--ask-for-approval never`, and internal scheduler-dispatched agents inherit. Required for multi-hour runs where you don't want permission prompts. Only use when you trust the tasks you're dispatching.
+- `RELAY_USE_DIST=1` — run the pre-built `dist/cli.js` in-process instead of launching TypeScript source via `tsx`. Slightly faster startup (~80 ms), but stale if you haven't run `rly rebuild` since the last source change. Default behavior reads source, so no rebuild is required after `git pull`.
 - `--sequential` — use v1 sequential orchestrator instead of v2 ticket-based
 - `--no-harness-mcp` — launch Claude/Codex without attaching the Relay MCP server

--- a/bin/rly.mjs
+++ b/bin/rly.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// rly — Relay CLI launcher.
+//
+// Default path: run the current TypeScript source via tsx, so the CLI always
+// picks up edits without a rebuild. A single child-process hop (~80 ms) keeps
+// startup snappy while giving zero-maintenance development.
+//
+// Fast path: set `RELAY_USE_DIST=1` to run the pre-built `dist/cli.js` in
+// the same process. Stale if you haven't `rly rebuild` / `pnpm build` since
+// the last source change, but avoids the tsx subprocess.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = fileURLToPath(import.meta.url);
+const root = resolve(dirname(here), "..");
+const srcEntry = resolve(root, "src/cli.ts");
+const distEntry = resolve(root, "dist/cli.js");
+
+if (process.env.RELAY_USE_DIST === "1" && existsSync(distEntry)) {
+  await import(pathToFileURL(distEntry).href);
+  process.exit(process.exitCode ?? 0);
+}
+
+// tsx must be loaded with --import, not the deprecated --loader hook, so we
+// run it as a child process. Resolving the binary from node_modules/.bin
+// keeps us from depending on the user's PATH.
+const tsxBin = resolve(root, "node_modules/.bin/tsx");
+if (!existsSync(tsxBin)) {
+  console.error(
+    "[rly] tsx binary not found at " +
+      tsxBin +
+      ". Run `pnpm install` in " +
+      root +
+      " to restore dependencies, or set RELAY_USE_DIST=1 to use the compiled dist."
+  );
+  process.exit(1);
+}
+
+const child = spawn(tsxBin, [srcEntry, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  env: process.env
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});
+
+child.on("error", (err) => {
+  console.error("[rly] failed to launch tsx: " + err.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "private": false,
   "type": "module",
   "bin": {
-    "rly": "dist/cli.js",
-    "agent-harness": "dist/cli.js"
+    "rly": "bin/rly.mjs",
+    "agent-harness": "bin/rly.mjs"
   },
   "files": [
+    "bin",
     "dist",
+    "src",
     "README.md"
   ],
   "scripts": {
@@ -28,7 +30,6 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.30",
-    "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "zod": "^3.24.4"
@@ -37,6 +38,7 @@
     "@aoagents/ao-core": "0.2.5",
     "@aoagents/ao-plugin-scm-github": "0.2.5",
     "@aoagents/ao-plugin-tracker-github": "0.2.5",
-    "@aoagents/ao-plugin-tracker-linear": "0.2.5"
+    "@aoagents/ao-plugin-tracker-linear": "0.2.5",
+    "tsx": "^4.20.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
       '@aoagents/ao-plugin-tracker-linear':
         specifier: 0.2.5
         version: 0.2.5
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
     devDependencies:
       '@types/node':
         specifier: ^22.15.30
         version: 22.19.15
-      tsx:
-        specifier: ^4.20.6
-        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/src/cli/rebuild.ts
+++ b/src/cli/rebuild.ts
@@ -1,0 +1,98 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Resolve the Relay repo root from this module's location so `rly rebuild`
+ * works from any cwd. Mirrors launch-gui-tui.ts — dist/cli/rebuild.js
+ * → ../.. is the repo root.
+ */
+function resolveRepoRoot(): string {
+  return fileURLToPath(new URL("../..", import.meta.url));
+}
+
+async function runTool(
+  command: string,
+  args: string[],
+  cwd: string
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: "inherit" });
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+}
+
+export interface RebuildOptions {
+  /** Rebuild the TS dist (tsc). Default true when no target flags are set. */
+  dist: boolean;
+  /** Rebuild the Rust TUI via cargo. */
+  tui: boolean;
+  /** Rebuild the Tauri GUI bundle. */
+  gui: boolean;
+}
+
+export function parseRebuildFlags(args: string[]): RebuildOptions {
+  const all = args.includes("--all");
+  const explicitTui = args.includes("--tui");
+  const explicitGui = args.includes("--gui");
+  const explicitDist = args.includes("--dist");
+  const anyExplicit = explicitTui || explicitGui || explicitDist;
+
+  const known = new Set(["--all", "--tui", "--gui", "--dist"]);
+  for (const arg of args) {
+    if (arg.startsWith("--") && !known.has(arg)) {
+      console.warn(
+        `[rly rebuild] ignoring unknown flag ${arg}. Supported: --all, --dist, --tui, --gui.`
+      );
+    }
+  }
+
+  return {
+    dist: all || explicitDist || !anyExplicit,
+    tui: all || explicitTui,
+    gui: all || explicitGui
+  };
+}
+
+/**
+ * Rebuild one or more Relay artifacts. Called from `rly rebuild` in the
+ * main CLI dispatch. Prints progress inline; individual step failures
+ * short-circuit the remaining steps so the user sees the actual error.
+ */
+export async function runRebuild(options: RebuildOptions): Promise<number> {
+  const repoRoot = resolveRepoRoot();
+
+  if (options.dist) {
+    console.log("[rly rebuild] TS dist — pnpm build");
+    const exit = await runTool("pnpm", ["build"], repoRoot);
+    if (exit !== 0) {
+      console.error("[rly rebuild] dist build failed — stopping.");
+      return exit;
+    }
+  }
+
+  if (options.tui) {
+    console.log("[rly rebuild] TUI — cargo build --release -p relay-tui");
+    const exit = await runTool(
+      "cargo",
+      ["build", "--release", "-p", "relay-tui"],
+      repoRoot
+    );
+    if (exit !== 0) {
+      console.error("[rly rebuild] TUI build failed — stopping.");
+      return exit;
+    }
+  }
+
+  if (options.gui) {
+    console.log("[rly rebuild] GUI — pnpm gui:build");
+    const exit = await runTool("pnpm", ["gui:build"], repoRoot);
+    if (exit !== 0) {
+      console.error("[rly rebuild] GUI build failed — stopping.");
+      return exit;
+    }
+  }
+
+  console.log("[rly rebuild] done.");
+  return 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from "./cli/agent-wrapper.js";
 import { AgentRegistry } from "./agents/registry.js";
 import { launchGui, launchTui, parseGuiFlags } from "./cli/launch-gui-tui.js";
+import { parseRebuildFlags, runRebuild } from "./cli/rebuild.js";
 import { launchInteractiveCommand } from "./cli/launcher.js";
 import {
   ensureHarnessWorkspace,
@@ -120,6 +121,11 @@ export async function main(): Promise<void> {
 
   if (command === "gui") {
     process.exitCode = await launchGui(parseGuiFlags(args));
+    return;
+  }
+
+  if (command === "rebuild") {
+    process.exitCode = await runRebuild(parseRebuildFlags(args));
     return;
   }
 


### PR DESCRIPTION
No more "did I \`pnpm build\`?" dance after \`git pull\`.

## A. Always-current source
\`bin/rly.mjs\` is a Node launcher that spawns \`tsx src/cli.ts\` in a child process. Every invocation reads current source, so edits are live immediately. ~80 ms subprocess startup overhead — invisible for interactive CLI use.

Escape hatch: \`RELAY_USE_DIST=1\` runs the compiled \`dist/cli.js\` in-process (faster startup, but stale until you rebuild).

Changes:
- \`bin/rly.mjs\` — new, mode 0755. Resolves \`node_modules/.bin/tsx\` locally so it doesn't depend on the user's PATH. Signals and exit codes propagate from the child. Prints a clean error if \`node_modules\` is missing.
- \`package.json\`: \`bin.rly\` and \`bin.agent-harness\` point at the launcher. \`tsx\` moves from \`devDependencies\` to \`dependencies\` (required at runtime). \`files[]\` adds \`bin\` + \`src\` so published tarballs work without \`dist\`.

## B. \`rly rebuild\`
One command for the three artifacts.
\`\`\`bash
rly rebuild           # TS dist (pnpm build) — default
rly rebuild --tui     # relay-tui binary
rly rebuild --gui     # Tauri .app bundle
rly rebuild --all     # all three
\`\`\`
Unknown flags warn but don't fail. Each step short-circuits on failure so the real error is visible.

Files:
- \`src/cli/rebuild.ts\` (new) — runTool helper + parseRebuildFlags + runRebuild. Same repo-root resolution pattern as \`launch-gui-tui.ts\`.
- \`src/index.ts\` — \`rly rebuild\` dispatch.

## README
- New CLI table row for \`rebuild\`.
- Footer on the CLI table clarifies the tsx-by-default behavior.
- New \`RELAY_USE_DIST\` flag entry.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 137/137 + 1 skipped
- [x] \`pnpm build\` clean
- [x] Live smoke: \`node bin/rly.mjs status\` produces the doctor output against the current worktree (tsx path active).
- [ ] Manual: after \`git pull\`, \`rly status\` reflects the freshly-pulled source without running \`pnpm build\`.
- [ ] Manual: \`RELAY_USE_DIST=1 rly status\` runs the compiled dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)