### PR TITLE
T-003: AgentExecutor + SandboxProvider interfaces

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -29,18 +29,67 @@ export type ExecutionEventKind =
 export interface ExecutionEvent {
   kind: ExecutionEventKind;
   at: string; // ISO-8601
-  data?: string;
+  /**
+   * Event payload. Shape varies by `kind`:
+   *   - `stdout` / `stderr`: string (line or chunk)
+   *   - `tool_use`: structured record (tool name, args, id)
+   *   - `exit`: string exit code or small summary object
+   *   - `start` / `heartbeat`: typically omitted
+   * Kept as `unknown` so structured payloads don't need to be stringified at
+   * the event boundary; consumers narrow on `kind`.
+   */
+  data?: unknown;
 }
+
+/**
+ * Lifecycle state of an ExecutionHandle.
+ * - `running`: handle is live; wait() has not resolved and kill() has not been called.
+ * - `exited`:  wait() has resolved with the process's own exit code.
+ * - `killed`:  kill() was called before wait() resolved; next wait() yields exitCode 137.
+ */
+export type ExecutionStatus = "running" | "exited" | "killed";
 
 export interface ExecutionHandle {
   readonly id: string;
   readonly sandbox: SandboxRef;
+  /**
+   * Observational status of the handle. Callers may poll it between awaits
+   * (e.g. for dashboards or scheduler decisions), but it is only authoritative
+   * once {@link ExecutionHandle.wait} has resolved — before that it is a best-
+   * effort snapshot that can race with in-flight I/O in real executor impls.
+   */
+  readonly status: ExecutionStatus;
   wait(): Promise<ExecutionResult>;
-  // Async so remote executors (pod, VM) can make a network call to terminate.
+  /**
+   * Terminate the underlying execution.
+   *
+   * Idempotent. Calling `kill()` after `wait()` has resolved is a no-op — the
+   * exit code is already cached and the handle's `status` stays `exited`.
+   * Calling `kill()` before `wait()` transitions the handle to `killed`; the
+   * next `wait()` resolves with `exitCode: 137` (128 + SIGKILL). Double-kill
+   * is safe: the second call is a no-op.
+   *
+   * Async so remote executors (pod, VM) can make a network call to terminate.
+   */
   kill(signal?: "SIGTERM" | "SIGKILL"): Promise<void>;
-  // Pull-based so the scheduler can back-pressure and the executor can bridge
-  // to SSE/WebSocket later without redesigning the surface. Separate from
-  // wait() so a consumer can take either independently.
+  /**
+   * Live, single-consumer event stream.
+   *
+   * Iteration begins at subscribe time — there is **no replay** of events
+   * emitted before subscription. For a handle that has already completed,
+   * `stream()` yields the terminal events (`start`, `exit`) synthesized from
+   * cached state so late subscribers still see a coherent begin/end pair.
+   *
+   * Calling `stream()` twice is supported: each call returns an independent
+   * iterator. Do **not** rely on identical ordering across calls on a
+   * still-running handle — the two iterators race each other against a live
+   * producer. On a completed handle both iterators yield the same synthesized
+   * start+exit pair.
+   *
+   * Pull-based so the scheduler can back-pressure and the executor can bridge
+   * to SSE/WebSocket later without redesigning the surface. Separate from
+   * wait() so a consumer can take either independently.
+   */
   stream(): AsyncIterable<ExecutionEvent>;
 }
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -1,0 +1,50 @@
+import type { TicketDefinition } from "../domain/ticket.js";
+import type { SandboxRef } from "./sandbox.js";
+
+export interface ExecutorStartOptions {
+  runId: string;
+  repoRoot: string;
+  sandbox: SandboxRef;
+  /** Optional per-invocation timeout, in ms. Executors enforce via kill(). */
+  timeoutMs?: number;
+  /** Forwarded to the process environment where applicable. */
+  env?: Record<string, string | undefined>;
+}
+
+export interface ExecutionResult {
+  exitCode: number;
+  summary?: string;
+  stdout: string;
+  stderr: string;
+}
+
+export type ExecutionEventKind =
+  | "start"
+  | "stdout"
+  | "stderr"
+  | "tool_use"
+  | "heartbeat"
+  | "exit";
+
+export interface ExecutionEvent {
+  kind: ExecutionEventKind;
+  at: string; // ISO-8601
+  data?: string;
+}
+
+export interface ExecutionHandle {
+  readonly id: string;
+  readonly sandbox: SandboxRef;
+  wait(): Promise<ExecutionResult>;
+  // Async so remote executors (pod, VM) can make a network call to terminate.
+  kill(signal?: "SIGTERM" | "SIGKILL"): Promise<void>;
+  // Pull-based so the scheduler can back-pressure and the executor can bridge
+  // to SSE/WebSocket later without redesigning the surface. Separate from
+  // wait() so a consumer can take either independently.
+  stream(): AsyncIterable<ExecutionEvent>;
+}
+
+export interface AgentExecutor {
+  /** Start work on a ticket. Returns a handle the scheduler can wait/kill/stream on. */
+  start(ticket: TicketDefinition, opts: ExecutorStartOptions): Promise<ExecutionHandle>;
+}

--- a/src/execution/noop-executor.ts
+++ b/src/execution/noop-executor.ts
@@ -1,0 +1,87 @@
+import type { TicketDefinition } from "../domain/ticket.js";
+import type {
+  AgentExecutor,
+  ExecutionEvent,
+  ExecutionHandle,
+  ExecutionResult,
+  ExecutorStartOptions
+} from "./executor.js";
+import type { RepoRef, SandboxProvider, SandboxRef } from "./sandbox.js";
+
+export class NoopSandboxProvider implements SandboxProvider {
+  private counter = 0;
+  private readonly paths = new Map<string, string>();
+
+  async create(repo: RepoRef, base: string): Promise<SandboxRef> {
+    const id = `noop-sandbox-${++this.counter}`;
+    this.paths.set(id, repo.root);
+
+    return {
+      id,
+      workdir: repo.root,
+      meta: { base }
+    };
+  }
+
+  async destroy(ref: SandboxRef): Promise<void> {
+    // Idempotent: missing entries are a silent no-op so callers can retry
+    // destroy without guarding on existence.
+    this.paths.delete(ref.id);
+  }
+
+  resolvePath(ref: SandboxRef): string | null {
+    return this.paths.get(ref.id) ?? null;
+  }
+}
+
+class NoopExecutionHandle implements ExecutionHandle {
+  readonly id: string;
+  readonly sandbox: SandboxRef;
+
+  private killed = false;
+  private cachedResult: ExecutionResult | null = null;
+
+  constructor(id: string, sandbox: SandboxRef) {
+    this.id = id;
+    this.sandbox = sandbox;
+  }
+
+  async wait(): Promise<ExecutionResult> {
+    if (this.cachedResult) {
+      return this.cachedResult;
+    }
+
+    this.cachedResult = this.killed
+      ? { exitCode: 137, summary: "killed", stdout: "", stderr: "" }
+      : { exitCode: 0, summary: "noop", stdout: "", stderr: "" };
+
+    return this.cachedResult;
+  }
+
+  async kill(_signal?: "SIGTERM" | "SIGKILL"): Promise<void> {
+    this.killed = true;
+  }
+
+  async *stream(): AsyncIterable<ExecutionEvent> {
+    yield { kind: "start", at: new Date().toISOString() };
+    const result = await this.wait();
+    yield {
+      kind: "exit",
+      at: new Date().toISOString(),
+      data: String(result.exitCode)
+    };
+  }
+}
+
+export class NoopExecutor implements AgentExecutor {
+  private counter = 0;
+
+  async start(
+    _ticket: TicketDefinition,
+    opts: ExecutorStartOptions
+  ): Promise<ExecutionHandle> {
+    const id = `noop-exec-${++this.counter}`;
+
+    return new NoopExecutionHandle(id, opts.sandbox);
+  }
+}

--- a/src/execution/noop-executor.ts
+++ b/src/execution/noop-executor.ts
@@ -4,21 +4,23 @@ import type {
   ExecutionEvent,
   ExecutionHandle,
   ExecutionResult,
+  ExecutionStatus,
   ExecutorStartOptions
 } from "./executor.js";
 import type { RepoRef, SandboxProvider, SandboxRef } from "./sandbox.js";
+import { resolveLocalPath } from "./sandbox.js";
 
 export class NoopSandboxProvider implements SandboxProvider {
   private counter = 0;
-  private readonly paths = new Map<string, string>();
+  private readonly refs = new Set<string>();
 
   async create(repo: RepoRef, base: string): Promise<SandboxRef> {
     const id = `noop-sandbox-${++this.counter}`;
-    this.paths.set(id, repo.root);
+    this.refs.add(id);
 
     return {
       id,
-      workdir: repo.root,
+      workdir: { kind: "local", path: repo.root },
       meta: { base }
     };
   }
@@ -26,11 +28,7 @@ export class NoopSandboxProvider implements SandboxProvider {
   async destroy(ref: SandboxRef): Promise<void> {
     // Idempotent: missing entries are a silent no-op so callers can retry
     // destroy without guarding on existence.
-    this.paths.delete(ref.id);
-  }
-
-  resolvePath(ref: SandboxRef): string | null {
-    return this.paths.get(ref.id) ?? null;
+    this.refs.delete(ref.id);
   }
 }
 
@@ -46,23 +44,42 @@ class NoopExecutionHandle implements ExecutionHandle {
     this.sandbox = sandbox;
   }
 
+  get status(): ExecutionStatus {
+    if (this.cachedResult) {
+      // wait() resolved normally; if kill() fires afterward it's a no-op and
+      // we stay `exited` per the documented contract on ExecutionHandle.kill.
+      return this.killed && this.cachedResult.exitCode === 137
+        ? "killed"
+        : "exited";
+    }
+
+    return this.killed ? "killed" : "running";
+  }
+
   async wait(): Promise<ExecutionResult> {
     if (this.cachedResult) {
       return this.cachedResult;
     }
 
     this.cachedResult = this.killed
-      ? { exitCode: 137, summary: "killed", stdout: "", stderr: "" }
+      ? // 128 + SIGKILL(9); standard Unix convention for a killed process.
+        { exitCode: 137, summary: "killed", stdout: "", stderr: "" }
       : { exitCode: 0, summary: "noop", stdout: "", stderr: "" };
 
     return this.cachedResult;
   }
 
   async kill(_signal?: "SIGTERM" | "SIGKILL"): Promise<void> {
+    // Idempotent. If wait() has already resolved the exit code is cached and
+    // this is a deliberate no-op — the handle's observable status remains
+    // `exited`. Double-kill is likewise safe: the flag is already set.
     this.killed = true;
   }
 
   async *stream(): AsyncIterable<ExecutionEvent> {
+    // Noop handles have no live producer, so stream() just synthesizes a
+    // terminal start+exit pair from cached state — matching the documented
+    // "synthesized from cached state" clause on ExecutionHandle.stream().
     yield { kind: "start", at: new Date().toISOString() };
     const result = await this.wait();
     yield {
@@ -73,6 +90,13 @@ class NoopExecutionHandle implements ExecutionHandle {
   }
 }
 
+/**
+ * Test double implementing {@link AgentExecutor}. Produces a synthetic
+ * success run with no side effects — use for scheduler unit tests and
+ * smoke tests that do not need real process spawning. Not a reference
+ * implementation; see T-202 (LocalChildProcessExecutor) and T-403
+ * (PodExecutor) for production impls.
+ */
 export class NoopExecutor implements AgentExecutor {
   private counter = 0;
 
@@ -85,3 +109,7 @@ export class NoopExecutor implements AgentExecutor {
     return new NoopExecutionHandle(id, opts.sandbox);
   }
 }
+
+// Re-export the free helper so consumers importing from noop-executor for
+// tests don't need a separate sandbox.js import path.
+export { resolveLocalPath };

--- a/src/execution/sandbox.ts
+++ b/src/execution/sandbox.ts
@@ -1,0 +1,27 @@
+export interface SandboxRef {
+  /** Stable id so handlers can look up the same sandbox across restarts. */
+  id: string;
+  /** Where the workdir lives. For local impls, an absolute path. For remote
+   *  impls, an opaque URI like "pod://ns/name:/work" or "vercel-sandbox://…". */
+  workdir: string;
+  /** Free-form metadata the provider chose to stamp (branch, commit, etc.). */
+  meta?: Record<string, string>;
+}
+
+export interface RepoRef {
+  /** Absolute path to the origin repo. Cloud impls may use this as a clone source. */
+  root: string;
+  /** Remote URL (optional) — useful when the sandbox is created from a bare clone. */
+  remoteUrl?: string;
+}
+
+export interface SandboxProvider {
+  /** Create a sandbox rooted at `base` (typically a branch or commit ref). */
+  create(repo: RepoRef, base: string): Promise<SandboxRef>;
+  /** Destroy the sandbox. Idempotent — calling on a missing sandbox is a no-op. */
+  destroy(ref: SandboxRef): Promise<void>;
+  /** Return a local path for the sandbox if one exists, else null. Callers
+   *  that need a local path (e.g. the LocalChildProcessExecutor) will guard
+   *  on null; remote-only providers can return null without breaking. */
+  resolvePath(ref: SandboxRef): string | null;
+}

--- a/src/execution/sandbox.ts
+++ b/src/execution/sandbox.ts
@@ -1,11 +1,23 @@
+/**
+ * Discriminated union describing where a sandbox's working directory lives.
+ *
+ * - `local` — a real, on-disk absolute path. Executors that spawn child
+ *   processes against the filesystem can operate directly on this.
+ * - `remote` — an opaque URI for cloud/remote impls (e.g. "pod://ns/name:/work",
+ *   "vercel-sandbox://…"). Consumers that need a local path should use
+ *   {@link resolveLocalPath} and guard on `null`.
+ */
+export type Workdir =
+  | { readonly kind: "local"; readonly path: string }
+  | { readonly kind: "remote"; readonly uri: string };
+
 export interface SandboxRef {
   /** Stable id so handlers can look up the same sandbox across restarts. */
-  id: string;
-  /** Where the workdir lives. For local impls, an absolute path. For remote
-   *  impls, an opaque URI like "pod://ns/name:/work" or "vercel-sandbox://…". */
-  workdir: string;
+  readonly id: string;
+  /** Discriminated workdir — see {@link Workdir}. */
+  readonly workdir: Workdir;
   /** Free-form metadata the provider chose to stamp (branch, commit, etc.). */
-  meta?: Record<string, string>;
+  readonly meta?: Record<string, string>;
 }
 
 export interface RepoRef {
@@ -20,8 +32,17 @@ export interface SandboxProvider {
   create(repo: RepoRef, base: string): Promise<SandboxRef>;
   /** Destroy the sandbox. Idempotent — calling on a missing sandbox is a no-op. */
   destroy(ref: SandboxRef): Promise<void>;
-  /** Return a local path for the sandbox if one exists, else null. Callers
-   *  that need a local path (e.g. the LocalChildProcessExecutor) will guard
-   *  on null; remote-only providers can return null without breaking. */
-  resolvePath(ref: SandboxRef): string | null;
+}
+
+/**
+ * Return a local filesystem path for the sandbox if one exists, else null.
+ *
+ * Free-function rather than an interface method so every `SandboxProvider`
+ * gets correct behavior for free — the answer is entirely determined by the
+ * ref's discriminant. Callers that need a local path (e.g. the
+ * LocalChildProcessExecutor) should guard on `null`; remote-only providers
+ * naturally return `null` without any per-impl code.
+ */
+export function resolveLocalPath(ref: SandboxRef): string | null {
+  return ref.workdir.kind === "local" ? ref.workdir.path : null;
 }

--- a/test/execution/noop-executor.test.ts
+++ b/test/execution/noop-executor.test.ts
@@ -7,6 +7,7 @@ import {
   NoopSandboxProvider
 } from "../../src/execution/noop-executor.js";
 import type { RepoRef } from "../../src/execution/sandbox.js";
+import { resolveLocalPath } from "../../src/execution/sandbox.js";
 
 const ticket: TicketDefinition = {
   id: "T-noop",
@@ -36,14 +37,19 @@ async function collectStream(
 }
 
 describe("NoopSandboxProvider", () => {
-  it("round-trips create + resolvePath for a local sandbox", async () => {
+  it("round-trips create + resolveLocalPath for a local sandbox", async () => {
     const provider = new NoopSandboxProvider();
     const ref = await provider.create(repo, "main");
 
     expect(ref.id).toBe("noop-sandbox-1");
-    expect(ref.workdir).toBe(repo.root);
+    expect(ref.workdir.kind).toBe("local");
+    // Narrow manually so the kind-specific field is reachable in the assertion.
+    if (ref.workdir.kind !== "local") {
+      throw new Error("expected a local workdir");
+    }
+    expect(ref.workdir.path).toBe(repo.root);
     expect(ref.meta?.base).toBe("main");
-    expect(provider.resolvePath(ref)).toBe(repo.root);
+    expect(resolveLocalPath(ref)).toBe(repo.root);
   });
 
   it("assigns distinct ids across create calls", async () => {
@@ -60,7 +66,19 @@ describe("NoopSandboxProvider", () => {
 
     await provider.destroy(ref);
     await expect(provider.destroy(ref)).resolves.toBeUndefined();
-    expect(provider.resolvePath(ref)).toBeNull();
+    // resolveLocalPath is a pure function of the ref — it stays valid even
+    // after destroy. The destroyed-ness lives in the provider's own state;
+    // that's intentional for the free-function design.
+    expect(resolveLocalPath(ref)).toBe(repo.root);
+  });
+
+  it("resolveLocalPath returns null for a remote workdir ref", () => {
+    const ref = {
+      id: "remote-1",
+      workdir: { kind: "remote" as const, uri: "pod://ns/name:/work" }
+    };
+
+    expect(resolveLocalPath(ref)).toBeNull();
   });
 });
 
@@ -131,5 +149,100 @@ describe("NoopExecutor", () => {
 
     expect(a.id).not.toBe(b.id);
     expect(a.sandbox.id).toBe(sandbox.id);
+  });
+
+  it("wait() then kill() is safe and does not change status", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(0);
+
+    await expect(handle.kill("SIGTERM")).resolves.toBeUndefined();
+    // kill-after-wait is a no-op: exit code stays cached and status stays
+    // `exited`, per the documented ExecutionHandle.kill contract.
+    expect(handle.status).toBe("exited");
+    expect((await handle.wait()).exitCode).toBe(0);
+  });
+
+  it("status transitions correctly: running -> exited", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    expect(handle.status).toBe("running");
+    await handle.wait();
+    expect(handle.status).toBe("exited");
+  });
+
+  it("status transitions correctly: running -> killed (kill before wait)", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    expect(handle.status).toBe("running");
+    await handle.kill("SIGKILL");
+    expect(handle.status).toBe("killed");
+    await handle.wait();
+    expect(handle.status).toBe("killed");
+  });
+
+  it("stream() called twice returns independent iterators with the same sequence", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    // Drive the handle to completion first so both stream() calls operate on
+    // cached state — the documented "synthesized from cached state" path.
+    await handle.wait();
+
+    const firstIter = handle.stream()[Symbol.asyncIterator]();
+    const secondIter = handle.stream()[Symbol.asyncIterator]();
+
+    // Each iterator is independent — reading from one does not drain the other.
+    const firstEvents: ExecutionEvent[] = [];
+    const secondEvents: ExecutionEvent[] = [];
+
+    for (let i = 0; i < 2; i += 1) {
+      const a = await firstIter.next();
+      if (!a.done) {
+        firstEvents.push(a.value);
+      }
+
+      const b = await secondIter.next();
+      if (!b.done) {
+        secondEvents.push(b.value);
+      }
+    }
+
+    // Drain terminators so the generators release their resources cleanly.
+    await firstIter.next();
+    await secondIter.next();
+
+    expect(firstEvents.map((e) => e.kind)).toEqual(["start", "exit"]);
+    expect(secondEvents.map((e) => e.kind)).toEqual(["start", "exit"]);
+    expect(firstEvents[1].data).toBe("0");
+    expect(secondEvents[1].data).toBe("0");
   });
 });

--- a/test/execution/noop-executor.test.ts
+++ b/test/execution/noop-executor.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import type { TicketDefinition } from "../../src/domain/ticket.js";
+import type { ExecutionEvent } from "../../src/execution/executor.js";
+import {
+  NoopExecutor,
+  NoopSandboxProvider
+} from "../../src/execution/noop-executor.js";
+import type { RepoRef } from "../../src/execution/sandbox.js";
+
+const ticket: TicketDefinition = {
+  id: "T-noop",
+  title: "Noop ticket",
+  objective: "Do nothing",
+  specialty: "general",
+  acceptanceCriteria: ["Does nothing"],
+  allowedCommands: [],
+  verificationCommands: [],
+  docsToUpdate: [],
+  dependsOn: [],
+  retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+};
+
+const repo: RepoRef = { root: "/tmp/fake-repo" };
+
+async function collectStream(
+  stream: AsyncIterable<ExecutionEvent>
+): Promise<ExecutionEvent[]> {
+  const events: ExecutionEvent[] = [];
+
+  for await (const event of stream) {
+    events.push(event);
+  }
+
+  return events;
+}
+
+describe("NoopSandboxProvider", () => {
+  it("round-trips create + resolvePath for a local sandbox", async () => {
+    const provider = new NoopSandboxProvider();
+    const ref = await provider.create(repo, "main");
+
+    expect(ref.id).toBe("noop-sandbox-1");
+    expect(ref.workdir).toBe(repo.root);
+    expect(ref.meta?.base).toBe("main");
+    expect(provider.resolvePath(ref)).toBe(repo.root);
+  });
+
+  it("assigns distinct ids across create calls", async () => {
+    const provider = new NoopSandboxProvider();
+    const a = await provider.create(repo, "main");
+    const b = await provider.create(repo, "main");
+
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("destroy is idempotent", async () => {
+    const provider = new NoopSandboxProvider();
+    const ref = await provider.create(repo, "main");
+
+    await provider.destroy(ref);
+    await expect(provider.destroy(ref)).resolves.toBeUndefined();
+    expect(provider.resolvePath(ref)).toBeNull();
+  });
+});
+
+describe("NoopExecutor", () => {
+  it("wait resolves with exitCode 0 and caches the result", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    const first = await handle.wait();
+    const second = await handle.wait();
+
+    expect(first).toEqual({
+      exitCode: 0,
+      summary: "noop",
+      stdout: "",
+      stderr: ""
+    });
+    expect(second).toBe(first);
+  });
+
+  it("stream yields start then exit in order", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    const events = await collectStream(handle.stream());
+
+    expect(events.map((event) => event.kind)).toEqual(["start", "exit"]);
+    expect(events[1].data).toBe("0");
+  });
+
+  it("kill before wait produces exitCode 137", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const handle = await executor.start(ticket, {
+      runId: "run-1",
+      repoRoot: repo.root,
+      sandbox
+    });
+
+    await handle.kill("SIGKILL");
+    const result = await handle.wait();
+
+    expect(result.exitCode).toBe(137);
+    expect(result.summary).toBe("killed");
+  });
+
+  it("assigns distinct ids to concurrent handles", async () => {
+    const provider = new NoopSandboxProvider();
+    const executor = new NoopExecutor();
+    const sandbox = await provider.create(repo, "main");
+    const opts = { runId: "run-1", repoRoot: repo.root, sandbox };
+
+    const a = await executor.start(ticket, opts);
+    const b = await executor.start(ticket, opts);
+
+    expect(a.id).not.toBe(b.id);
+    expect(a.sandbox.id).toBe(sandbox.id);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/execution/sandbox.ts` with `SandboxRef`, `RepoRef`, and `SandboxProvider` — the "where does the agent's workspace live?" boundary.
- Adds `src/execution/executor.ts` with `AgentExecutor`, `ExecutionHandle`, `ExecutionResult`, and `ExecutionEvent` — the "how does an agent run?" boundary.
- Adds `src/execution/noop-executor.ts` — `NoopSandboxProvider` + `NoopExecutor` test double, used by unit tests and future scheduler tests that don't want to spawn processes.
- Adds `test/execution/noop-executor.test.ts` covering sandbox round-trip, idempotent destroy, cached `wait()`, ordered `stream()`, kill-before-wait exit code 137, and distinct handle ids.

## Why

Decouples "what an agent does" from "where it runs," so T-202 (`LocalChildProcessExecutor`) and T-403 (`PodExecutor`) can plug in without changing the scheduler. Streaming is pull-based (`AsyncIterable`) so the scheduler can back-pressure and bridge to SSE/WebSocket later; `kill` is async so remote executors can make a network call; `wait()` is separate from `stream()` so consumers can take either independently.

## Scope boundary

- Interface-only + test double. Scheduler wiring is T-202.
- No sandbox/executor implementations (git worktree, child process, pod) in this PR.
- No changes to `ticket-scheduler.ts` or any orchestrator code.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` green (159 passing, +7 vs main; 1 skipped unchanged)
- [x] `NoopSandboxProvider.create` + `resolvePath` round-trips for the local case
- [x] `NoopSandboxProvider.destroy` is idempotent
- [x] `NoopExecutor.wait()` resolves once and caches the result
- [x] `stream()` yields start then exit in order
- [x] `kill()` before `wait()` produces exitCode 137
- [x] Two concurrent `start()` calls yield distinct handle ids