### PR TITLE
T-001: HarnessStore interface + file impl

### DIFF
--- a/src/storage/file-store.ts
+++ b/src/storage/file-store.ts
@@ -9,7 +9,7 @@ import {
   writeFile
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import type {
   BlobRef,
@@ -44,6 +44,27 @@ const keyLocks: Map<string, Promise<void>> = new Map();
 // collide on a tmp-file name.
 let tmpCounter = 0;
 
+/**
+ * Reject path segments that could escape `rootDir` via traversal (`..`),
+ * collapse to the parent (`.`), pierce a directory boundary (`/`, `\`), or
+ * trip the kernel's null-byte guard. Called on every `ns` and `id` at the
+ * entry of every public method — a malicious caller controlling either
+ * would otherwise be able to read/write arbitrary files under the process's
+ * uid.
+ */
+function assertSafeSegment(segment: string, kind: "ns" | "id"): void {
+  if (
+    segment === "" ||
+    segment === "." ||
+    segment === ".." ||
+    segment.includes("/") ||
+    segment.includes("\\") ||
+    segment.includes("\0")
+  ) {
+    throw new Error(`Unsafe path segment in ${kind}: ${segment}`);
+  }
+}
+
 export class FileHarnessStore implements HarnessStore {
   private readonly rootDir: string;
 
@@ -52,6 +73,8 @@ export class FileHarnessStore implements HarnessStore {
   }
 
   async getDoc<T>(ns: string, id: string): Promise<T | null> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const path = this.docPath(ns, id);
     let content: string;
 
@@ -72,7 +95,8 @@ export class FileHarnessStore implements HarnessStore {
       return JSON.parse(content) as T;
     } catch (err) {
       // Surface corruption so callers don't silently overwrite via putDoc.
-      // Mirrors the pattern `readChannelTickets` uses on the ticket board.
+      // Callers rely on corrupt→throw to avoid overwriting real data via a
+      // subsequent putDoc.
       throw new Error(
         `Corrupt doc at ${path}: ${
           err instanceof Error ? err.message : String(err)
@@ -82,11 +106,14 @@ export class FileHarnessStore implements HarnessStore {
   }
 
   async putDoc<T>(ns: string, id: string, doc: T): Promise<void> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const path = this.docPath(ns, id);
     await this.writeJsonAtomic(path, doc);
   }
 
   async listDocs<T>(ns: string, prefix?: string): Promise<T[]> {
+    assertSafeSegment(ns, "ns");
     const dir = this.nsDir(ns);
     const files = await safeReaddir(dir);
     const ids = files
@@ -104,6 +131,8 @@ export class FileHarnessStore implements HarnessStore {
   }
 
   async deleteDoc(ns: string, id: string): Promise<void> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const path = this.docPath(ns, id);
     try {
       await rm(path);
@@ -114,6 +143,8 @@ export class FileHarnessStore implements HarnessStore {
   }
 
   async appendLog(ns: string, id: string, entry: unknown): Promise<void> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const path = this.logPath(ns, id);
     await mkdir(this.nsDir(ns), { recursive: true });
     await appendFile(path, JSON.stringify(entry) + "\n");
@@ -124,6 +155,8 @@ export class FileHarnessStore implements HarnessStore {
     id: string,
     opts?: ReadLogOptions
   ): Promise<T[]> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const path = this.logPath(ns, id);
     let raw: string;
 
@@ -134,10 +167,23 @@ export class FileHarnessStore implements HarnessStore {
       throw err;
     }
 
-    const entries = raw
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as T);
+    const lines = raw.split("\n").filter(Boolean);
+    const entries: T[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      try {
+        entries.push(JSON.parse(line) as T);
+      } catch (err) {
+        // Match `getDoc`'s corruption posture: surface with file + line so
+        // operators can repair instead of silently dropping the bad record.
+        throw new Error(
+          `Corrupt log at ${path} line ${i}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { cause: err }
+        );
+      }
+    }
 
     let filtered = entries;
     if (opts?.after !== undefined) {
@@ -145,7 +191,10 @@ export class FileHarnessStore implements HarnessStore {
       const idx = filtered.findIndex(
         (e) => cursorKey(e) !== undefined && cursorKey(e) === cursor
       );
-      filtered = idx >= 0 ? filtered.slice(idx + 1) : filtered;
+      // Cursor not found → return []. Returning the full log would cause
+      // duplicate delivery on resume; the contract is documented on
+      // `ReadLogOptions.after`.
+      filtered = idx >= 0 ? filtered.slice(idx + 1) : [];
     }
     if (opts?.limit !== undefined && opts.limit < filtered.length) {
       filtered = filtered.slice(-opts.limit);
@@ -160,28 +209,63 @@ export class FileHarnessStore implements HarnessStore {
     bytes: Uint8Array,
     meta?: Record<string, string>
   ): Promise<BlobRef> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const path = this.blobPath(ns, id);
+    const metaPath = `${path}.meta.json`;
     await mkdir(this.nsDir(ns), { recursive: true });
 
-    const tmpPath = `${path}.tmp.${process.pid}.${tmpCounter++}`;
-    await writeFile(tmpPath, bytes);
-    await rename(tmpPath, path);
+    const hasMeta = meta !== undefined && Object.keys(meta).length > 0;
+    const blobTmp = `${path}.tmp.${process.pid}.${tmpCounter++}`;
+    const metaTmp = hasMeta
+      ? `${metaPath}.tmp.${process.pid}.${tmpCounter++}`
+      : null;
 
-    let contentType: string | undefined;
-    if (meta && Object.keys(meta).length > 0) {
-      await this.writeJsonAtomic(`${path}.meta.json`, meta);
-      contentType = meta["contentType"];
+    // Stage both tmp files BEFORE either rename so we never end up with a
+    // durable blob that's missing its sidecar metadata.
+    await writeFile(blobTmp, bytes);
+    if (metaTmp !== null && meta !== undefined) {
+      await writeFile(metaTmp, JSON.stringify(meta, null, 2));
+    }
+
+    try {
+      await rename(blobTmp, path);
+    } catch (err) {
+      await rm(blobTmp, { force: true }).catch(() => {});
+      if (metaTmp !== null) {
+        await rm(metaTmp, { force: true }).catch(() => {});
+      }
+      throw err;
+    }
+
+    if (metaTmp !== null) {
+      try {
+        await rename(metaTmp, metaPath);
+      } catch (err) {
+        // Blob is already durable; roll it back so the caller isn't left
+        // holding a blob without its declared contentType.
+        await rm(path, { force: true }).catch(() => {});
+        await rm(metaTmp, { force: true }).catch(() => {});
+        throw new Error(
+          `Failed to commit blob meta sidecar at ${metaPath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { cause: err }
+        );
+      }
     }
 
     return {
       ns,
       id,
       size: bytes.byteLength,
-      contentType
+      contentType: hasMeta ? meta?.["contentType"] : undefined
     };
   }
 
   async getBlob(ref: BlobRef): Promise<Uint8Array> {
+    assertSafeSegment(ref.ns, "ns");
+    assertSafeSegment(ref.id, "id");
     const path = this.blobPath(ref.ns, ref.id);
     const buf = await readFile(path);
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
@@ -192,6 +276,8 @@ export class FileHarnessStore implements HarnessStore {
     id: string,
     fn: (prev: T | null) => T
   ): Promise<T> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     return withKeyLock(ns, id, async () => {
       const prev = await this.getDoc<T>(ns, id);
       const next = fn(prev);
@@ -206,8 +292,22 @@ export class FileHarnessStore implements HarnessStore {
    * coalesce across rapid writes, no cross-namespace ordering. Cleans up
    * when the iterator is returned (break out of `for await`) so callers
    * don't leak the polling interval.
+   *
+   * Poll interval is 250ms — balances promptness vs CPU and matches the
+   * at-least-once coalescing contract consumers already need to tolerate
+   * for the Postgres `LISTEN/NOTIFY` implementation (T-402). `fs.watch` was
+   * rejected due to platform-specific quirks (macOS coalescing, Linux
+   * non-recursive behavior on subdir creation).
+   *
+   * Error semantics: if `stat` on a tracked path fails with anything other
+   * than `ENOENT` (e.g. `EACCES` after a `chmod`), the iterator throws
+   * from its next iteration and terminates. A silent watch that stops
+   * emitting was considered worse than a loud failure — callers can
+   * observe the throw and decide whether to retry.
    */
   async *watch(ns: string, id: string): AsyncIterable<ChangeEvent> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
     const pollIntervalMs = 250;
     const candidates = [
       this.docPath(ns, id),
@@ -250,20 +350,27 @@ export class FileHarnessStore implements HarnessStore {
   }
 
   private async writeJsonAtomic(path: string, doc: unknown): Promise<void> {
-    const dir = path.slice(0, path.lastIndexOf("/"));
+    const dir = dirname(path);
     await mkdir(dir, { recursive: true });
 
     const tmpPath = `${path}.tmp.${process.pid}.${tmpCounter++}`;
     await writeFile(tmpPath, JSON.stringify(doc, null, 2));
-    await rename(tmpPath, path);
+    try {
+      await rename(tmpPath, path);
+    } catch (err) {
+      // Legitimately best-effort — we're already in an error path and the
+      // caller needs to see the original rename failure, not a cleanup one.
+      await rm(tmpPath, { force: true }).catch(() => {});
+      throw err;
+    }
   }
 }
 
 /**
  * Serialize work keyed by (ns, id) through an in-process Promise-chain
- * mutex. Matches the shape of `withChannelLock` in `channel-store.ts`: the
- * tail promise in the map is what the next caller awaits, and the entry
- * self-cleans when no successor has queued behind it. In-process only.
+ * mutex. Chain of tail promises per key; each caller awaits the previous
+ * tail and installs its own. Self-cleans when no successor is queued.
+ * In-process only.
  */
 async function withKeyLock<T>(
   ns: string,
@@ -293,8 +400,9 @@ async function withKeyLock<T>(
 async function safeReaddir(dir: string): Promise<string[]> {
   try {
     return await readdir(dir);
-  } catch {
-    return [];
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
   }
 }
 
@@ -304,8 +412,12 @@ async function readMtimes(paths: string[]): Promise<Map<string, number>> {
     try {
       const s = await stat(p);
       out.set(p, s.mtimeMs);
-    } catch {
-      // Missing file is fine; we'll detect creation on the next poll.
+    } catch (err) {
+      // Missing file is fine — we'll detect creation on the next poll.
+      // Any other error (permissions, I/O) is surfaced so the watch
+      // iterator throws instead of going silent.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
     }
   }
   return out;

--- a/src/storage/file-store.ts
+++ b/src/storage/file-store.ts
@@ -1,0 +1,357 @@
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type {
+  BlobRef,
+  ChangeEvent,
+  HarnessStore,
+  ReadLogOptions
+} from "./store.js";
+
+/**
+ * Filesystem-backed implementation of `HarnessStore`. Layout under `rootDir`:
+ *
+ *   ${root}/${ns}/${id}.json          docs
+ *   ${root}/${ns}/${id}.jsonl         logs
+ *   ${root}/${ns}/${id}.blob          blob bytes
+ *   ${root}/${ns}/${id}.blob.meta.json optional sidecar metadata
+ *
+ * Doc and blob writes are atomic via tmp-file + rename. `mutate` serializes
+ * per (ns, id) through an in-process Promise-chain mutex so concurrent
+ * callers in the same process can't lose updates on a read-modify-write.
+ *
+ * Single-process only: cross-process coordination (flock, Postgres advisory
+ * locks, etc.) is explicitly out of scope here — use `PgHarnessStore` from
+ * T-402 when multiple processes need to share the same state.
+ */
+
+// Per-key mutex shared across all store instances. Keyed by "${ns}\0${id}"
+// so the same key in two FileHarnessStore instances in the same process
+// still serializes (they back to the same file on disk).
+const keyLocks: Map<string, Promise<void>> = new Map();
+
+// Monotonic suffix so two concurrent writers in the same process never
+// collide on a tmp-file name.
+let tmpCounter = 0;
+
+export class FileHarnessStore implements HarnessStore {
+  private readonly rootDir: string;
+
+  constructor(rootDir?: string) {
+    this.rootDir = rootDir ?? join(homedir(), ".relay");
+  }
+
+  async getDoc<T>(ns: string, id: string): Promise<T | null> {
+    const path = this.docPath(ns, id);
+    let content: string;
+
+    try {
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw new Error(
+        `Failed to read doc at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
+      return JSON.parse(content) as T;
+    } catch (err) {
+      // Surface corruption so callers don't silently overwrite via putDoc.
+      // Mirrors the pattern `readChannelTickets` uses on the ticket board.
+      throw new Error(
+        `Corrupt doc at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  async putDoc<T>(ns: string, id: string, doc: T): Promise<void> {
+    const path = this.docPath(ns, id);
+    await this.writeJsonAtomic(path, doc);
+  }
+
+  async listDocs<T>(ns: string, prefix?: string): Promise<T[]> {
+    const dir = this.nsDir(ns);
+    const files = await safeReaddir(dir);
+    const ids = files
+      .filter((f) => f.endsWith(".json") && !f.endsWith(".blob.meta.json"))
+      .map((f) => f.slice(0, -".json".length))
+      .filter((stem) => !prefix || stem.startsWith(prefix))
+      .sort();
+
+    const out: T[] = [];
+    for (const stem of ids) {
+      const doc = await this.getDoc<T>(ns, stem);
+      if (doc !== null) out.push(doc);
+    }
+    return out;
+  }
+
+  async deleteDoc(ns: string, id: string): Promise<void> {
+    const path = this.docPath(ns, id);
+    try {
+      await rm(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+  }
+
+  async appendLog(ns: string, id: string, entry: unknown): Promise<void> {
+    const path = this.logPath(ns, id);
+    await mkdir(this.nsDir(ns), { recursive: true });
+    await appendFile(path, JSON.stringify(entry) + "\n");
+  }
+
+  async readLog<T>(
+    ns: string,
+    id: string,
+    opts?: ReadLogOptions
+  ): Promise<T[]> {
+    const path = this.logPath(ns, id);
+    let raw: string;
+
+    try {
+      raw = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+
+    const entries = raw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as T);
+
+    let filtered = entries;
+    if (opts?.after !== undefined) {
+      const cursor = opts.after;
+      const idx = filtered.findIndex(
+        (e) => cursorKey(e) !== undefined && cursorKey(e) === cursor
+      );
+      filtered = idx >= 0 ? filtered.slice(idx + 1) : filtered;
+    }
+    if (opts?.limit !== undefined && opts.limit < filtered.length) {
+      filtered = filtered.slice(-opts.limit);
+    }
+
+    return filtered;
+  }
+
+  async putBlob(
+    ns: string,
+    id: string,
+    bytes: Uint8Array,
+    meta?: Record<string, string>
+  ): Promise<BlobRef> {
+    const path = this.blobPath(ns, id);
+    await mkdir(this.nsDir(ns), { recursive: true });
+
+    const tmpPath = `${path}.tmp.${process.pid}.${tmpCounter++}`;
+    await writeFile(tmpPath, bytes);
+    await rename(tmpPath, path);
+
+    let contentType: string | undefined;
+    if (meta && Object.keys(meta).length > 0) {
+      await this.writeJsonAtomic(`${path}.meta.json`, meta);
+      contentType = meta["contentType"];
+    }
+
+    return {
+      ns,
+      id,
+      size: bytes.byteLength,
+      contentType
+    };
+  }
+
+  async getBlob(ref: BlobRef): Promise<Uint8Array> {
+    const path = this.blobPath(ref.ns, ref.id);
+    const buf = await readFile(path);
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+
+  async mutate<T>(
+    ns: string,
+    id: string,
+    fn: (prev: T | null) => T
+  ): Promise<T> {
+    return withKeyLock(ns, id, async () => {
+      const prev = await this.getDoc<T>(ns, id);
+      const next = fn(prev);
+      await this.putDoc<T>(ns, id, next);
+      return next;
+    });
+  }
+
+  /**
+   * Poll the doc/log/blob file on disk for mtime changes and yield a
+   * `ChangeEvent` each time one is observed. At-least-once delivery, may
+   * coalesce across rapid writes, no cross-namespace ordering. Cleans up
+   * when the iterator is returned (break out of `for await`) so callers
+   * don't leak the polling interval.
+   */
+  async *watch(ns: string, id: string): AsyncIterable<ChangeEvent> {
+    const pollIntervalMs = 250;
+    const candidates = [
+      this.docPath(ns, id),
+      this.logPath(ns, id),
+      this.blobPath(ns, id)
+    ];
+
+    let lastMtimes = await readMtimes(candidates);
+    let closed = false;
+
+    try {
+      while (!closed) {
+        await sleep(pollIntervalMs);
+        if (closed) break;
+
+        const next = await readMtimes(candidates);
+        const event = diffMtimes(lastMtimes, next, ns, id);
+        lastMtimes = next;
+        if (event) yield event;
+      }
+    } finally {
+      closed = true;
+    }
+  }
+
+  private nsDir(ns: string): string {
+    return join(this.rootDir, ns);
+  }
+
+  private docPath(ns: string, id: string): string {
+    return join(this.nsDir(ns), `${id}.json`);
+  }
+
+  private logPath(ns: string, id: string): string {
+    return join(this.nsDir(ns), `${id}.jsonl`);
+  }
+
+  private blobPath(ns: string, id: string): string {
+    return join(this.nsDir(ns), `${id}.blob`);
+  }
+
+  private async writeJsonAtomic(path: string, doc: unknown): Promise<void> {
+    const dir = path.slice(0, path.lastIndexOf("/"));
+    await mkdir(dir, { recursive: true });
+
+    const tmpPath = `${path}.tmp.${process.pid}.${tmpCounter++}`;
+    await writeFile(tmpPath, JSON.stringify(doc, null, 2));
+    await rename(tmpPath, path);
+  }
+}
+
+/**
+ * Serialize work keyed by (ns, id) through an in-process Promise-chain
+ * mutex. Matches the shape of `withChannelLock` in `channel-store.ts`: the
+ * tail promise in the map is what the next caller awaits, and the entry
+ * self-cleans when no successor has queued behind it. In-process only.
+ */
+async function withKeyLock<T>(
+  ns: string,
+  id: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const key = `${ns}\u0000${id}`;
+  const prev = keyLocks.get(key) ?? Promise.resolve();
+  let resolveCurrent!: () => void;
+  const current = new Promise<void>((resolve) => {
+    resolveCurrent = resolve;
+  });
+  const next = prev.then(() => current);
+  keyLocks.set(key, next);
+
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    resolveCurrent();
+    if (keyLocks.get(key) === next) {
+      keyLocks.delete(key);
+    }
+  }
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir);
+  } catch {
+    return [];
+  }
+}
+
+async function readMtimes(paths: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  for (const p of paths) {
+    try {
+      const s = await stat(p);
+      out.set(p, s.mtimeMs);
+    } catch {
+      // Missing file is fine; we'll detect creation on the next poll.
+    }
+  }
+  return out;
+}
+
+function diffMtimes(
+  prev: Map<string, number>,
+  next: Map<string, number>,
+  ns: string,
+  id: string
+): ChangeEvent | null {
+  for (const [path, mtime] of next) {
+    const before = prev.get(path);
+    if (before === undefined) {
+      return { ns, id, kind: path.endsWith(".jsonl") ? "append" : "put" };
+    }
+    if (before !== mtime) {
+      return { ns, id, kind: path.endsWith(".jsonl") ? "append" : "put" };
+    }
+  }
+  for (const path of prev.keys()) {
+    if (!next.has(path)) {
+      return { ns, id, kind: "delete" };
+    }
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Extract a cursor key from a log entry for `ReadLogOptions.after`. We try
+ * common id/timestamp field names so the primitive is useful without
+ * forcing every log writer to conform to one shape; callers that need a
+ * stricter contract can pass `limit` only.
+ */
+function cursorKey(entry: unknown): string | undefined {
+  if (typeof entry !== "object" || entry === null) return undefined;
+  const e = entry as Record<string, unknown>;
+  for (const field of ["id", "entryId", "eventId", "timestamp", "createdAt"]) {
+    const v = e[field];
+    if (typeof v === "string") return v;
+  }
+  return undefined;
+}

--- a/src/storage/namespaces.ts
+++ b/src/storage/namespaces.ts
@@ -1,0 +1,23 @@
+/**
+ * Central namespace constants for `HarnessStore`. Referencing these rather
+ * than inline string literals lets the Postgres impl (T-402) map each ns to
+ * a dedicated table without a mass string-find across callers, and keeps
+ * typos from silently partitioning data.
+ */
+
+export const STORE_NS = {
+  workspace: "workspace",
+  channel: "channel",
+  channelFeed: "channel-feed",
+  channelTickets: "channel-tickets",
+  run: "run",
+  runEvents: "run-events",
+  runArtifacts: "run-artifacts",
+  agentName: "agent-name",
+  session: "session",
+  decision: "decision",
+  crosslinkSession: "crosslink-session",
+  crosslinkMailbox: "crosslink-mailbox"
+} as const;
+
+export type StoreNamespace = (typeof STORE_NS)[keyof typeof STORE_NS];

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -29,29 +29,116 @@ export interface ChangeEvent {
 }
 
 export interface ReadLogOptions {
+  /**
+   * Exclusive cursor. The implementation extracts a string key from each
+   * entry (tries `id`, `entryId`, `eventId`, `timestamp`, `createdAt` in
+   * that order) and returns entries strictly after the one whose key
+   * matches `after`. If no entry matches the cursor, `readLog` returns
+   * `[]` — never the full log — to avoid duplicate delivery on resume.
+   */
   after?: string;
+  /**
+   * Tail limit. When set, the last N entries (after `after` filtering)
+   * are returned.
+   */
   limit?: number;
 }
 
 export interface HarnessStore {
+  /**
+   * Read a namespaced JSON document. Returns `null` when the file does
+   * not exist (`ENOENT`). Throws on parse errors with a `Corrupt doc`
+   * prefix so callers can't silently overwrite bad data via a follow-up
+   * `putDoc`. Throws on permission or other I/O errors with the original
+   * cause wrapped. Throws `Unsafe path segment` if `ns` or `id` contains
+   * traversal (`..`, `.`), separators (`/`, `\`), or a null byte.
+   */
   getDoc<T>(ns: string, id: string): Promise<T | null>;
+  /**
+   * Write a JSON document with full-overwrite semantics. Atomic via
+   * tmp-file + rename: observers of the final path see the old bytes or
+   * the new bytes, never a torn write. Creates the namespace directory
+   * if missing. Throws `Unsafe path segment` for unsafe `ns` or `id`.
+   */
   putDoc<T>(ns: string, id: string, doc: T): Promise<void>;
+  /**
+   * Enumerate documents in a namespace. Results are stably ordered by
+   * id (alphabetical). When `prefix` is provided, only ids whose stem
+   * (filename without `.json`) starts with `prefix` are returned.
+   * Returns `[]` when the namespace directory does not exist.
+   */
   listDocs<T>(ns: string, prefix?: string): Promise<T[]>;
+  /**
+   * Remove a document. No-op (resolves quietly) when the document is
+   * missing, so callers can `deleteDoc` idempotently without pre-checking.
+   * Throws `Unsafe path segment` for unsafe `ns` or `id`.
+   */
   deleteDoc(ns: string, id: string): Promise<void>;
 
+  /**
+   * Append one JSON-serialized entry to an append-only log. Append-only
+   * by contract, but single-writer-per-(ns, id) is NOT enforced — if
+   * two callers append concurrently, entries may interleave. Readers
+   * may see a torn last line after a process crash mid-write; `readLog`
+   * will throw `Corrupt log` in that case. Throws `Unsafe path segment`
+   * for unsafe `ns` or `id`.
+   */
   appendLog(ns: string, id: string, entry: unknown): Promise<void>;
+  /**
+   * Read log entries. `limit` returns the tail (last N). `after` is an
+   * exclusive cursor — returns entries after the match, or `[]` if the
+   * cursor doesn't appear in the log (deliberate, to avoid duplicate
+   * delivery). Throws `Corrupt log at <path> line <n>` on a per-line
+   * parse failure so operators can repair. Throws `Unsafe path segment`
+   * for unsafe `ns` or `id`.
+   */
   readLog<T>(ns: string, id: string, opts?: ReadLogOptions): Promise<T[]>;
 
+  /**
+   * Store opaque bytes. Bytes round-trip exactly through `getBlob`. When
+   * `meta` is provided, it's persisted in a sidecar (`${id}.blob.meta.json`)
+   * and `BlobRef.contentType` is populated from `meta.contentType`. Blob
+   * and sidecar are committed atomically — on sidecar write failure the
+   * blob is rolled back so callers don't end up with bytes missing their
+   * declared `contentType`. Throws `Unsafe path segment` for unsafe
+   * `ns` or `id`.
+   */
   putBlob(
     ns: string,
     id: string,
     bytes: Uint8Array,
     meta?: Record<string, string>
   ): Promise<BlobRef>;
+  /**
+   * Fetch bytes by ref. Bytes are returned exactly as written by
+   * `putBlob`. Throws `ENOENT` if the blob was deleted or never written.
+   * Throws `Unsafe path segment` if `ref.ns` or `ref.id` is unsafe.
+   */
   getBlob(ref: BlobRef): Promise<Uint8Array>;
 
+  /**
+   * Atomic read-modify-write on a doc. Calls `fn(prev)` with the current
+   * value (or `null` when missing) and persists the return value via
+   * `putDoc`. Serialized per (ns, id) within a single process — concurrent
+   * `mutate` calls against the same key queue on a shared Promise-chain
+   * mutex, so no caller's update is lost. `fn` may throw; the lock is
+   * released and the error propagates to the caller. Single-process only:
+   * cross-process coordination is out of scope (use `PgHarnessStore`
+   * when it lands in T-402). Throws `Unsafe path segment` for unsafe
+   * `ns` or `id`.
+   */
   mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T>;
 
+  /**
+   * Observe changes to a (ns, id) as an async iterable of `ChangeEvent`.
+   * At-least-once delivery — consumers may see duplicate events for the
+   * same underlying change, and rapid bursts of writes may coalesce into
+   * a single yield. No ordering guarantees across namespaces. Close by
+   * calling `iterator.return()` (or `break` out of `for await`) — this
+   * cleans up the polling loop. Throws `Unsafe path segment` for unsafe
+   * `ns` or `id`. See the impl-level doc on error propagation (file impl
+   * surfaces `stat` errors by throwing from the next iteration).
+   */
   watch(ns: string, id: string): AsyncIterable<ChangeEvent>;
 }
 

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -1,0 +1,59 @@
+/**
+ * Pluggable storage surface for the harness. All persistent state the
+ * orchestrator, chat channels, crosslink, and run history write today flows
+ * through one of these four primitives:
+ *
+ *   - docs: namespaced JSON documents with full-overwrite semantics
+ *   - logs: append-only event streams (events.jsonl, feed.jsonl, mailboxes)
+ *   - blobs: opaque bytes (command stdout/stderr, design docs, uploads)
+ *   - mutate: atomic read-modify-write for counters and indexes
+ *
+ * Callers use `watch` to observe downstream changes; the file impl polls,
+ * the Postgres impl (T-402) will use `LISTEN/NOTIFY`. Semantics are
+ * deliberately weak — at-least-once delivery, may coalesce, no ordering
+ * guarantees across namespaces — so implementations can diverge on strategy
+ * without breaking callers.
+ */
+
+export interface BlobRef {
+  ns: string;
+  id: string;
+  size: number;
+  contentType?: string;
+}
+
+export interface ChangeEvent {
+  ns: string;
+  id: string;
+  kind: "put" | "delete" | "append";
+}
+
+export interface ReadLogOptions {
+  after?: string;
+  limit?: number;
+}
+
+export interface HarnessStore {
+  getDoc<T>(ns: string, id: string): Promise<T | null>;
+  putDoc<T>(ns: string, id: string, doc: T): Promise<void>;
+  listDocs<T>(ns: string, prefix?: string): Promise<T[]>;
+  deleteDoc(ns: string, id: string): Promise<void>;
+
+  appendLog(ns: string, id: string, entry: unknown): Promise<void>;
+  readLog<T>(ns: string, id: string, opts?: ReadLogOptions): Promise<T[]>;
+
+  putBlob(
+    ns: string,
+    id: string,
+    bytes: Uint8Array,
+    meta?: Record<string, string>
+  ): Promise<BlobRef>;
+  getBlob(ref: BlobRef): Promise<Uint8Array>;
+
+  mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T>;
+
+  watch(ns: string, id: string): AsyncIterable<ChangeEvent>;
+}
+
+// TODO(T-402): second impl backed by Postgres (`PgHarnessStore`) for the
+// cloud/pod deployment path. Same interface, different durability + fanout.

--- a/test/storage/file-store.test.ts
+++ b/test/storage/file-store.test.ts
@@ -1,0 +1,248 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+import type { BlobRef, ChangeEvent } from "../../src/storage/store.js";
+
+interface Widget {
+  id: string;
+  label: string;
+  count: number;
+}
+
+describe("FileHarnessStore", () => {
+  let root: string;
+  let store: FileHarnessStore;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-file-store-"));
+    store = new FileHarnessStore(root);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe("docs", () => {
+    it("round-trips a typed doc via putDoc / getDoc", async () => {
+      const widget: Widget = { id: "w1", label: "alpha", count: 3 };
+      await store.putDoc<Widget>("widgets", "w1", widget);
+
+      const loaded = await store.getDoc<Widget>("widgets", "w1");
+      expect(loaded).toEqual(widget);
+    });
+
+    it("returns null for a missing id", async () => {
+      const loaded = await store.getDoc<Widget>("widgets", "does-not-exist");
+      expect(loaded).toBeNull();
+    });
+
+    it("throws with a clear error on corrupt JSON", async () => {
+      await mkdir(join(root, "widgets"), { recursive: true });
+      await writeFile(join(root, "widgets", "bad.json"), "{ not valid json");
+
+      await expect(store.getDoc<Widget>("widgets", "bad")).rejects.toThrow(
+        /Corrupt doc at .*bad\.json/
+      );
+    });
+
+    it("listDocs returns alphabetically-stable results and honors prefix", async () => {
+      await store.putDoc<Widget>("widgets", "beta-2", {
+        id: "beta-2",
+        label: "b2",
+        count: 0
+      });
+      await store.putDoc<Widget>("widgets", "alpha-1", {
+        id: "alpha-1",
+        label: "a1",
+        count: 0
+      });
+      await store.putDoc<Widget>("widgets", "alpha-2", {
+        id: "alpha-2",
+        label: "a2",
+        count: 0
+      });
+
+      const all = await store.listDocs<Widget>("widgets");
+      expect(all.map((w) => w.id)).toEqual(["alpha-1", "alpha-2", "beta-2"]);
+
+      const alphas = await store.listDocs<Widget>("widgets", "alpha-");
+      expect(alphas.map((w) => w.id)).toEqual(["alpha-1", "alpha-2"]);
+    });
+
+    it("deleteDoc removes the file and subsequent getDoc returns null", async () => {
+      await store.putDoc<Widget>("widgets", "w1", {
+        id: "w1",
+        label: "a",
+        count: 1
+      });
+      expect(await store.getDoc<Widget>("widgets", "w1")).not.toBeNull();
+
+      await store.deleteDoc("widgets", "w1");
+      expect(await store.getDoc<Widget>("widgets", "w1")).toBeNull();
+
+      // Idempotent: second delete is a no-op.
+      await expect(store.deleteDoc("widgets", "w1")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("logs", () => {
+    it("round-trips entries via appendLog / readLog", async () => {
+      await store.appendLog("events", "run-1", { id: "a", v: 1 });
+      await store.appendLog("events", "run-1", { id: "b", v: 2 });
+      await store.appendLog("events", "run-1", { id: "c", v: 3 });
+
+      const entries = await store.readLog<{ id: string; v: number }>(
+        "events",
+        "run-1"
+      );
+      expect(entries.map((e) => e.id)).toEqual(["a", "b", "c"]);
+    });
+
+    it("readLog honors `limit` by returning the last N entries", async () => {
+      for (const n of [1, 2, 3, 4, 5]) {
+        await store.appendLog("events", "run-2", { id: `e${n}`, v: n });
+      }
+      const tail = await store.readLog<{ id: string; v: number }>(
+        "events",
+        "run-2",
+        { limit: 2 }
+      );
+      expect(tail.map((e) => e.id)).toEqual(["e4", "e5"]);
+    });
+
+    it("readLog honors `after` as an exclusive cursor", async () => {
+      for (const n of [1, 2, 3, 4]) {
+        await store.appendLog("events", "run-3", { id: `e${n}`, v: n });
+      }
+      const after = await store.readLog<{ id: string; v: number }>(
+        "events",
+        "run-3",
+        { after: "e2" }
+      );
+      expect(after.map((e) => e.id)).toEqual(["e3", "e4"]);
+    });
+
+    it("readLog returns [] when the log doesn't exist", async () => {
+      const entries = await store.readLog("events", "never-written");
+      expect(entries).toEqual([]);
+    });
+  });
+
+  describe("blobs", () => {
+    it("round-trips binary bytes exactly", async () => {
+      const bytes = new Uint8Array(256);
+      for (let i = 0; i < 256; i++) bytes[i] = i;
+
+      const ref = await store.putBlob("artifacts", "bin-1", bytes, {
+        contentType: "application/octet-stream"
+      });
+
+      expect(ref).toMatchObject({
+        ns: "artifacts",
+        id: "bin-1",
+        size: 256,
+        contentType: "application/octet-stream"
+      });
+
+      const loaded = await store.getBlob(ref);
+      expect(loaded.length).toBe(256);
+      for (let i = 0; i < 256; i++) {
+        expect(loaded[i]).toBe(i);
+      }
+    });
+
+    it("getBlob works on a ref constructed from primitive fields", async () => {
+      const payload = new TextEncoder().encode("hello world");
+      await store.putBlob("artifacts", "txt-1", payload);
+
+      const manual: BlobRef = {
+        ns: "artifacts",
+        id: "txt-1",
+        size: payload.byteLength
+      };
+      const loaded = await store.getBlob(manual);
+      expect(new TextDecoder().decode(loaded)).toBe("hello world");
+    });
+  });
+
+  describe("mutate", () => {
+    it("creates the doc when prev is null", async () => {
+      const result = await store.mutate<Widget>(
+        "widgets",
+        "new",
+        (prev) => prev ?? { id: "new", label: "fresh", count: 1 }
+      );
+      expect(result).toEqual({ id: "new", label: "fresh", count: 1 });
+      expect(await store.getDoc<Widget>("widgets", "new")).toEqual(result);
+    });
+
+    it("serializes 100 concurrent increments on the same (ns, id)", async () => {
+      await store.putDoc<Widget>("widgets", "ctr", {
+        id: "ctr",
+        label: "counter",
+        count: 0
+      });
+
+      const ops: Promise<Widget>[] = [];
+      for (let i = 0; i < 100; i++) {
+        ops.push(
+          store.mutate<Widget>("widgets", "ctr", (prev) => ({
+            id: "ctr",
+            label: "counter",
+            count: (prev?.count ?? 0) + 1
+          }))
+        );
+      }
+      await Promise.all(ops);
+
+      const final = await store.getDoc<Widget>("widgets", "ctr");
+      expect(final?.count).toBe(100);
+    });
+  });
+
+  describe("watch", () => {
+    it("yields a ChangeEvent when putDoc writes to the watched key, and closes cleanly", async () => {
+      const events: ChangeEvent[] = [];
+
+      const iterator = store.watch("widgets", "watched")[Symbol.asyncIterator]();
+      const nextEvent = iterator.next();
+
+      // Wait long enough for the watcher's baseline poll, then trigger a write.
+      // 300ms > 250ms poll interval + small margin for mtime resolution.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await store.putDoc<Widget>("widgets", "watched", {
+        id: "watched",
+        label: "hi",
+        count: 1
+      });
+
+      const result = await Promise.race<
+        IteratorResult<ChangeEvent> | "timeout"
+      >([
+        nextEvent,
+        new Promise<"timeout">((resolve) =>
+          setTimeout(() => resolve("timeout"), 2000)
+        )
+      ]);
+
+      expect(result).not.toBe("timeout");
+      if (result !== "timeout" && !result.done) {
+        events.push(result.value);
+      }
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0]).toMatchObject({
+        ns: "widgets",
+        id: "watched",
+        kind: "put"
+      });
+
+      // Return closes the async generator; the polling loop should exit.
+      await iterator.return?.();
+    });
+  });
+});

--- a/test/storage/file-store.test.ts
+++ b/test/storage/file-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -211,8 +211,9 @@ describe("FileHarnessStore", () => {
       const iterator = store.watch("widgets", "watched")[Symbol.asyncIterator]();
       const nextEvent = iterator.next();
 
-      // Wait long enough for the watcher's baseline poll, then trigger a write.
-      // 300ms > 250ms poll interval + small margin for mtime resolution.
+      // Brief sleep so the watcher has a chance to capture baseline mtimes
+      // before we trigger a write. The 250ms poll interval still governs
+      // when the first event is observed; 50ms here just orders the setup.
       await new Promise((resolve) => setTimeout(resolve, 50));
       await store.putDoc<Widget>("widgets", "watched", {
         id: "watched",
@@ -243,6 +244,148 @@ describe("FileHarnessStore", () => {
 
       // Return closes the async generator; the polling loop should exit.
       await iterator.return?.();
+    });
+
+    it("surfaces non-ENOENT errors from stat instead of going silent", async () => {
+      // Platform guard: chmod 000 is only reliable on POSIX. On Windows we
+      // skip because the permission model doesn't map cleanly.
+      if (process.platform === "win32") return;
+      // Root on unix can read anything regardless of perms — the chmod path
+      // won't trigger EACCES. Skip so we don't green a broken test.
+      if (typeof process.getuid === "function" && process.getuid() === 0) {
+        return;
+      }
+
+      // Seed the watched doc so stat() succeeds on the first poll and the
+      // watcher captures a baseline mtime for it.
+      await store.putDoc<Widget>("watch-errs", "w1", {
+        id: "w1",
+        label: "seed",
+        count: 0
+      });
+
+      const iterator = store
+        .watch("watch-errs", "w1")
+        [Symbol.asyncIterator]();
+      const nextEvent = iterator.next();
+
+      // Deny read on the namespace dir so stat() throws EACCES on the next
+      // poll. The iterator should throw rather than silently coalescing
+      // into a no-event stream.
+      const nsDir = join(root, "watch-errs");
+      await chmod(nsDir, 0o000);
+
+      try {
+        await expect(
+          Promise.race<IteratorResult<ChangeEvent> | "timeout">([
+            nextEvent,
+            new Promise<"timeout">((resolve) =>
+              setTimeout(() => resolve("timeout"), 2000)
+            )
+          ])
+        ).rejects.toThrow();
+      } finally {
+        // Restore perms so afterEach cleanup can rm -rf the tmpdir.
+        await chmod(nsDir, 0o700).catch(() => {});
+        await iterator.return?.().catch(() => {});
+      }
+    });
+  });
+
+  describe("concurrency", () => {
+    it("50 concurrent putDoc writes on one key never yield a torn JSON file", async () => {
+      const ops: Promise<void>[] = [];
+      for (let i = 0; i < 50; i++) {
+        ops.push(
+          store.putDoc<Widget>("widgets", "concurrent", {
+            id: "concurrent",
+            label: `write-${i}`,
+            count: i
+          })
+        );
+      }
+      await Promise.all(ops);
+
+      // Without tmp-file + atomic rename this would sometimes throw
+      // "Unexpected token" from a half-written doc.
+      const final = await store.getDoc<Widget>("widgets", "concurrent");
+      expect(final).not.toBeNull();
+      expect(final?.id).toBe("concurrent");
+      // Final count must be one of the 50 writes — the specific winner is
+      // a race and we don't care which, only that it's internally
+      // consistent.
+      expect(final?.count).toBeGreaterThanOrEqual(0);
+      expect(final?.count).toBeLessThan(50);
+      expect(final?.label).toBe(`write-${final?.count}`);
+    });
+  });
+
+  describe("path traversal rejection", () => {
+    const unsafeNs = "..";
+    const unsafeId = "../x";
+
+    it("getDoc rejects unsafe ns and id", async () => {
+      await expect(store.getDoc("valid", unsafeId)).rejects.toThrow(
+        /Unsafe path segment/
+      );
+      await expect(store.getDoc(unsafeNs, "valid")).rejects.toThrow(
+        /Unsafe path segment/
+      );
+    });
+
+    it("putDoc rejects unsafe ns and id", async () => {
+      const widget: Widget = { id: "x", label: "a", count: 0 };
+      await expect(store.putDoc("valid", unsafeId, widget)).rejects.toThrow(
+        /Unsafe path segment/
+      );
+      await expect(store.putDoc(unsafeNs, "valid", widget)).rejects.toThrow(
+        /Unsafe path segment/
+      );
+    });
+
+    it("deleteDoc rejects unsafe ns and id", async () => {
+      await expect(store.deleteDoc("valid", unsafeId)).rejects.toThrow(
+        /Unsafe path segment/
+      );
+      await expect(store.deleteDoc(unsafeNs, "valid")).rejects.toThrow(
+        /Unsafe path segment/
+      );
+    });
+
+    it("appendLog rejects unsafe ns and id", async () => {
+      await expect(store.appendLog("valid", unsafeId, { v: 1 })).rejects.toThrow(
+        /Unsafe path segment/
+      );
+      await expect(store.appendLog(unsafeNs, "valid", { v: 1 })).rejects.toThrow(
+        /Unsafe path segment/
+      );
+    });
+
+    it("putBlob rejects unsafe ns and id", async () => {
+      const bytes = new Uint8Array([0, 1, 2]);
+      await expect(store.putBlob("valid", unsafeId, bytes)).rejects.toThrow(
+        /Unsafe path segment/
+      );
+      await expect(store.putBlob(unsafeNs, "valid", bytes)).rejects.toThrow(
+        /Unsafe path segment/
+      );
+    });
+  });
+
+  describe("readLog cursor semantics", () => {
+    it("returns [] when the `after` cursor isn't in the log", async () => {
+      await store.appendLog("events", "run-x", { id: "e1", v: 1 });
+      await store.appendLog("events", "run-x", { id: "e2", v: 2 });
+      await store.appendLog("events", "run-x", { id: "e3", v: 3 });
+
+      // Contract: unknown cursor → []. Returning the full log would cause
+      // duplicate delivery on resume.
+      const out = await store.readLog<{ id: string; v: number }>(
+        "events",
+        "run-x",
+        { after: "does-not-exist" }
+      );
+      expect(out).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Defines `HarnessStore`, the single pluggable storage surface the harness will route all persistent state through: namespaced JSON docs, append-only logs, blobs, atomic `mutate`, and a `watch` change stream.
- Ships `FileHarnessStore`, a filesystem implementation under `~/.relay` by default (configurable). Atomic writes via tmp-file + rename; per-`(ns, id)` mutex for `mutate` follows the `withChannelLock` pattern already landed in `channel-store.ts`; `watch` is a lightweight 250ms mtime poll that cleans up when the iterator returns.
- Adds `STORE_NS` constants so callers don't spread namespace-string typos once migration lands.

## Why
Today every persistence path (artifact-store, channel-store, workspace-registry, crosslink mailbox) writes directly to the local filesystem. That blocks multi-process and cloud/pod deployments. T-001 is the unblock: once T-101 through T-104 migrate each existing store onto this interface, T-402 can land a Postgres-backed `PgHarnessStore` without touching any caller. This PR is pure capability — no production code is modified.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 166 passed (was 152 on main, +14 new tests in `test/storage/file-store.test.ts`)
- [x] Doc round-trip (typed shape), missing-id null, corrupt-JSON raises with path in message
- [x] `listDocs` alphabetical stability; prefix filter
- [x] `deleteDoc` idempotent
- [x] Log round-trip; `limit` returns last N; `after` is an exclusive cursor
- [x] Blob round-trip preserves arbitrary byte values (0..255, not just UTF-8)
- [x] `mutate` serializes 100 concurrent increments on the same key → final count is exactly 100 (test would fail without the per-key lock)
- [x] `mutate` handles the `prev === null` path
- [x] `watch` emits a `put` event on `putDoc` and closes cleanly via iterator `return()`

## Notes
- No production code modified in this PR; callers migrate in T-101–T-104 and the Postgres impl lands in T-402. A single `TODO(T-402)` breadcrumb sits at the bottom of `store.ts`.
- `watch` design choice: polling beat `fs.watch` here because `fs.watch` is platform-quirky (macOS coalesces rapidly; Linux recursive mode is non-portable), and the Postgres impl will use `LISTEN/NOTIFY` anyway — consumers should already tolerate coalesced at-least-once delivery.
- Mutex is explicitly in-process only. Cross-process coordination arrives with the Postgres impl; `FileHarnessStore` docs call this out.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>