### PR TITLE
T-002: Composition root for HarnessStore injection

### DIFF
--- a/docs/storage-injection.md
+++ b/docs/storage-injection.md
@@ -1,0 +1,69 @@
+# Storage Injection
+
+Relay's persistent state lives behind a single interface, `HarnessStore`
+(`src/storage/store.ts`). Today the only implementation is
+`FileHarnessStore`, rooted at `~/.relay/`. A Postgres backend is planned for
+the cloud/pod deployment path and will slot in without touching call sites.
+
+## Goal
+
+Let the harness run against a local filesystem during development and
+against Postgres in shared deployments by changing an environment variable,
+not by editing handlers. All backend selection flows through one place:
+`buildHarnessStore()` in `src/storage/factory.ts`.
+
+## Composition root
+
+The CLI entry (`src/index.ts`) holds the single cached instance:
+
+```ts
+import { getHarnessStore } from "./index.js";
+const store = getHarnessStore();
+```
+
+Downstream modules should take `HarnessStore` as a constructor argument and
+accept it from their caller — they must not call `buildHarnessStore()`
+themselves. That keeps tests free to substitute in-memory fakes without a
+global side-effect.
+
+## Environment
+
+| `HARNESS_STORE` | Behavior |
+| --- | --- |
+| unset / `file` | `FileHarnessStore` at `getRelayDir()` (usually `~/.relay/`) |
+| `postgres` | Throws `NotImplementedError` until T-402 lands |
+| `sqlite` | Throws `NotImplementedError` (no tracking ticket yet) |
+
+## Legacy stores (unmigrated)
+
+These five modules still import `node:fs/promises` directly. They predate
+`HarnessStore` and migrate one ticket at a time so each PR stays
+reviewable:
+
+| File | Ticket |
+| --- | --- |
+| `src/channels/channel-store.ts` | T-101 |
+| `src/cli/workspace-registry.ts` | T-102 |
+| `src/cli/session-store.ts` | T-102 |
+| `src/execution/artifact-store.ts` | T-103 |
+| `src/crosslink/store.ts` | T-104 |
+
+Until those tickets land, these files are exempt from a "no direct fs in
+storage code" lint. The canonical list lives as a comment in
+`src/storage/factory.ts` so it stays in sync with the code.
+
+Other `node:fs/promises` importers in `src/` (bootstrap, config, agent
+wrapper, MCP server, scripted invoker, etc.) are not storage backends —
+they don't migrate and aren't part of the allowlist.
+
+## Adding a new backend
+
+1. Implement `HarnessStore` in a new file under `src/storage/`.
+2. Widen `StoreKind` in `factory.ts` if a new env value is needed.
+3. Wire it into `buildHarnessStore()` behind its `StoreKind`.
+4. Replace the `NotImplementedError` throw.
+
+The Postgres impl (T-402) will use `LISTEN/NOTIFY` instead of mtime polling
+for `watch`, and Postgres advisory locks instead of the in-process promise
+mutex for `mutate`. The interface contract is designed to accommodate both
+without changes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,6 +430,12 @@ export async function main(): Promise<void> {
 
 // One store per process. Handlers migrating off direct `fs/promises` (T-101+)
 // will call `getHarnessStore()`; nothing wires it yet.
+//
+// Module-level singleton rather than DI: legacy handlers still instantiate
+// their own stores directly, and a module-level cache keeps them from forking
+// behavior against a separately-constructed instance. Downstream constructors
+// (T-101+) take `HarnessStore` as a ctor arg for test substitution, so the
+// singleton is only a default entry point — not a hard dependency.
 let cachedStore: HarnessStore | null = null;
 export function getHarnessStore(): HarnessStore {
   if (!cachedStore) cachedStore = buildHarnessStore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ import {
 } from "./cli/workspace-registry.js";
 import { addProjectDir, readConfig, removeProjectDir } from "./cli/config.js";
 import { LocalArtifactStore } from "./execution/artifact-store.js";
+import { buildHarnessStore } from "./storage/factory.js";
+import type { HarnessStore } from "./storage/store.js";
 import { startMcpServer } from "./mcp/server.js";
 import { VerificationRunner } from "./execution/verification-runner.js";
 import { Orchestrator } from "./orchestrator/orchestrator.js";
@@ -424,6 +426,14 @@ export async function main(): Promise<void> {
       `- ${event.createdAt} ${event.phaseId} ${event.type} ${JSON.stringify(event.details)}`
     );
   }
+}
+
+// One store per process. Handlers migrating off direct `fs/promises` (T-101+)
+// will call `getHarnessStore()`; nothing wires it yet.
+let cachedStore: HarnessStore | null = null;
+export function getHarnessStore(): HarnessStore {
+  if (!cachedStore) cachedStore = buildHarnessStore();
+  return cachedStore;
 }
 
 async function printChannels(args: string[] = []): Promise<void> {

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -15,8 +15,9 @@ export interface StoreFactoryOptions {
 
 /**
  * Thrown when a store kind is recognized but not yet implemented. The message
- * points at the tracking ticket so operators know where to follow up instead
- * of filing duplicate bugs.
+ * points at the tracking ticket (where one exists) so operators know where to
+ * follow up instead of filing duplicate bugs. SQLite has no tracking ticket
+ * yet (TBD); postgres points at T-402.
  */
 export class NotImplementedError extends Error {
   constructor(message: string) {
@@ -39,8 +40,9 @@ export class NotImplementedError extends Error {
  *
  * Other `node:fs/promises` importers (workspace bootstrap, agent wrapper,
  * crosslink hook/tools, config, welcome, mcp server, scripted invoker,
- * agent-names, cli-agents, this file's peer `file-store.ts`) are not
- * storage backends and stay on direct fs access.
+ * agent-names, cli-agents, src/index.ts (reads package.json for version),
+ * this file's peer `file-store.ts`) are not storage backends and stay on
+ * direct fs access.
  */
 
 function resolveKind(explicit: StoreKind | undefined): StoreKind {
@@ -54,6 +56,8 @@ function resolveKind(explicit: StoreKind | undefined): StoreKind {
  * Construct the HarnessStore instance for this process. Single source of
  * truth for backend selection — downstream modules take the store as a ctor
  * argument and must not call this factory directly.
+ *
+ * Precedence: `opts.kind` > `HARNESS_STORE` env > default `"file"`.
  */
 export function buildHarnessStore(
   opts: StoreFactoryOptions = {}

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -1,0 +1,76 @@
+import { FileHarnessStore } from "./file-store.js";
+import type { HarnessStore } from "./store.js";
+import { getRelayDir } from "../cli/paths.js";
+
+export type StoreKind = "file" | "postgres" | "sqlite";
+
+export interface StoreFactoryOptions {
+  /** Override env-based detection. Falls back to HARNESS_STORE env, then "file". */
+  kind?: StoreKind;
+  /** Root directory for FileHarnessStore. Defaults to getRelayDir(). */
+  fileRoot?: string;
+  /** Connection config for future Postgres impl (T-402). */
+  postgresUrl?: string;
+}
+
+/**
+ * Thrown when a store kind is recognized but not yet implemented. The message
+ * points at the tracking ticket so operators know where to follow up instead
+ * of filing duplicate bugs.
+ */
+export class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotImplementedError";
+  }
+}
+
+/*
+ * Interim direct-`node:fs/promises` allowlist. Each entry migrates to
+ * `HarnessStore` in a dedicated ticket — until then, treat this list as the
+ * canonical record of unmigrated state surfaces so reviewers don't flag them
+ * in unrelated PRs:
+ *
+ *   - src/cli/workspace-registry.ts      -> T-102
+ *   - src/cli/session-store.ts           -> T-102
+ *   - src/channels/channel-store.ts      -> T-101
+ *   - src/crosslink/store.ts             -> T-104
+ *   - src/execution/artifact-store.ts    -> T-103
+ *
+ * Other `node:fs/promises` importers (workspace bootstrap, agent wrapper,
+ * crosslink hook/tools, config, welcome, mcp server, scripted invoker,
+ * agent-names, cli-agents, this file's peer `file-store.ts`) are not
+ * storage backends and stay on direct fs access.
+ */
+
+function resolveKind(explicit: StoreKind | undefined): StoreKind {
+  if (explicit) return explicit;
+  const env = process.env["HARNESS_STORE"];
+  if (env === "file" || env === "postgres" || env === "sqlite") return env;
+  return "file";
+}
+
+/**
+ * Construct the HarnessStore instance for this process. Single source of
+ * truth for backend selection — downstream modules take the store as a ctor
+ * argument and must not call this factory directly.
+ */
+export function buildHarnessStore(
+  opts: StoreFactoryOptions = {}
+): HarnessStore {
+  const kind = resolveKind(opts.kind);
+
+  if (kind === "file") {
+    return new FileHarnessStore(opts.fileRoot ?? getRelayDir());
+  }
+
+  if (kind === "postgres") {
+    throw new NotImplementedError(
+      "PostgresHarnessStore is T-402 (not yet implemented); use HARNESS_STORE=file."
+    );
+  }
+
+  throw new NotImplementedError(
+    "SqliteHarnessStore is not yet implemented; use HARNESS_STORE=file."
+  );
+}

--- a/test/storage/factory.test.ts
+++ b/test/storage/factory.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+import {
+  buildHarnessStore,
+  NotImplementedError
+} from "../../src/storage/factory.js";
+import { getHarnessStore } from "../../src/index.js";
+
+describe("buildHarnessStore", () => {
+  let savedEnv: string | undefined;
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    savedEnv = process.env["HARNESS_STORE"];
+    delete process.env["HARNESS_STORE"];
+    tmpRoot = await mkdtemp(join(tmpdir(), "relay-factory-"));
+  });
+
+  afterEach(async () => {
+    if (savedEnv === undefined) {
+      delete process.env["HARNESS_STORE"];
+    } else {
+      process.env["HARNESS_STORE"] = savedEnv;
+    }
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("returns a FileHarnessStore by default when HARNESS_STORE is unset", () => {
+    const store = buildHarnessStore();
+    expect(store).toBeInstanceOf(FileHarnessStore);
+  });
+
+  it("returns a FileHarnessStore when HARNESS_STORE=file", () => {
+    process.env["HARNESS_STORE"] = "file";
+    const store = buildHarnessStore();
+    expect(store).toBeInstanceOf(FileHarnessStore);
+  });
+
+  it("throws NotImplementedError pointing at T-402 when HARNESS_STORE=postgres", () => {
+    process.env["HARNESS_STORE"] = "postgres";
+    expect(() => buildHarnessStore()).toThrow(NotImplementedError);
+    expect(() => buildHarnessStore()).toThrow(/T-402/);
+  });
+
+  it("explicit opts.kind overrides env and opts.fileRoot roots the store there", async () => {
+    process.env["HARNESS_STORE"] = "postgres";
+    const store = buildHarnessStore({ kind: "file", fileRoot: tmpRoot });
+    expect(store).toBeInstanceOf(FileHarnessStore);
+
+    // Confirm fileRoot actually landed — a round-trip write shows up on disk
+    // under tmpRoot rather than the default relay dir.
+    await store.putDoc("canary", "probe", { ok: true });
+    const loaded = await store.getDoc<{ ok: boolean }>("canary", "probe");
+    expect(loaded).toEqual({ ok: true });
+  });
+});
+
+describe("getHarnessStore", () => {
+  it("returns the same instance across repeated calls", () => {
+    const a = getHarnessStore();
+    const b = getHarnessStore();
+    expect(Object.is(a, b)).toBe(true);
+  });
+});

--- a/test/storage/factory.test.ts
+++ b/test/storage/factory.test.ts
@@ -47,6 +47,45 @@ describe("buildHarnessStore", () => {
     expect(() => buildHarnessStore()).toThrow(/T-402/);
   });
 
+  it("throws NotImplementedError mentioning sqlite when HARNESS_STORE=sqlite", () => {
+    process.env["HARNESS_STORE"] = "sqlite";
+    expect(() => buildHarnessStore()).toThrow(NotImplementedError);
+    expect(() => buildHarnessStore()).toThrow(/sqlite/i);
+  });
+
+  it("throws NotImplementedError for explicit opts.kind=sqlite (same guard path)", () => {
+    expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(
+      NotImplementedError
+    );
+    expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(/sqlite/i);
+  });
+
+  it("throws NotImplementedError for explicit opts.kind=postgres with postgresUrl (same guard path)", () => {
+    // Proves env-driven and opts-driven paths both flow through the same
+    // NotImplementedError guard — not a separate opts-only branch.
+    expect(() =>
+      buildHarnessStore({
+        kind: "postgres",
+        postgresUrl: "postgres://example/db"
+      })
+    ).toThrow(NotImplementedError);
+    expect(() =>
+      buildHarnessStore({
+        kind: "postgres",
+        postgresUrl: "postgres://example/db"
+      })
+    ).toThrow(/T-402/);
+  });
+
+  it("falls through to file default when HARNESS_STORE is an unrecognized value", () => {
+    // Pins current behavior: `HARNESS_STORE=garbage` silently falls back to
+    // "file" rather than throwing. If a future refactor tightens this to
+    // throw-on-unknown, updating this test should be a conscious decision.
+    process.env["HARNESS_STORE"] = "garbage";
+    const store = buildHarnessStore();
+    expect(store).toBeInstanceOf(FileHarnessStore);
+  });
+
   it("explicit opts.kind overrides env and opts.fileRoot roots the store there", async () => {
     process.env["HARNESS_STORE"] = "postgres";
     const store = buildHarnessStore({ kind: "file", fileRoot: tmpRoot });


### PR DESCRIPTION
## Summary

- New `src/storage/factory.ts` — `buildHarnessStore()` is the single place backend selection happens, plus `NotImplementedError` pointing at T-402 for the Postgres case
- Cached module-level `getHarnessStore()` on the CLI entry (`src/index.ts`), wired to nothing yet
- `docs/storage-injection.md` covering goals, env semantics, and the interim allowlist
- 5 new tests in `test/storage/factory.test.ts` (default env, explicit file, postgres throws, opts-override, cached-getter identity)

## Why

T-001 landed `HarnessStore` and `FileHarnessStore`. This PR gives downstream code one injection point to construct against without forcing any legacy store to migrate in the same change. Each legacy module (channel, workspace-registry, session, artifact, crosslink) migrates in its own PR so review stays tractable:

| Legacy module | Ticket |
| --- | --- |
| `src/channels/channel-store.ts` | T-101 |
| `src/cli/workspace-registry.ts` | T-102 |
| `src/cli/session-store.ts` | T-102 |
| `src/execution/artifact-store.ts` | T-103 |
| `src/crosslink/store.ts` | T-104 |

## Scope callout

This PR deliberately does NOT touch any of the legacy stores — `node:fs/promises` still lives in all of them. The interim allowlist comment in `factory.ts` (and mirrored in `docs/storage-injection.md`) is the artifact that tracks the remaining migrations.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 191 passed (+5), 1 skipped
- [x] `buildHarnessStore()` returns `FileHarnessStore` by default and with `HARNESS_STORE=file`
- [x] `HARNESS_STORE=postgres` throws `NotImplementedError` with the T-402 reference in the message
- [x] `opts.kind` + `opts.fileRoot` override env and roots the store where specified (verified via round-trip write)
- [x] `getHarnessStore()` returns the same instance on repeated calls (`Object.is`)