### PR TITLE
T-201: GitWorktreeSandbox provider

### DIFF
--- a/src/execution/noop-executor.ts
+++ b/src/execution/noop-executor.ts
@@ -7,7 +7,12 @@ import type {
   ExecutionStatus,
   ExecutorStartOptions
 } from "./executor.js";
-import type { RepoRef, SandboxProvider, SandboxRef } from "./sandbox.js";
+import type {
+  DestroyResult,
+  RepoRef,
+  SandboxProvider,
+  SandboxRef
+} from "./sandbox.js";
 import { resolveLocalPath } from "./sandbox.js";
 
 export class NoopSandboxProvider implements SandboxProvider {
@@ -25,10 +30,12 @@ export class NoopSandboxProvider implements SandboxProvider {
     };
   }
 
-  async destroy(ref: SandboxRef): Promise<void> {
-    // Idempotent: missing entries are a silent no-op so callers can retry
-    // destroy without guarding on existence.
-    this.refs.delete(ref.id);
+  async destroy(ref: SandboxRef): Promise<DestroyResult> {
+    // Idempotent: `Set#delete` already reports whether the id was present;
+    // surface that as the discriminated result so callers (and tests) can
+    // tell a real removal from a no-op retry.
+    const hadRef = this.refs.delete(ref.id);
+    return hadRef ? { kind: "removed" } : { kind: "missing" };
   }
 }
 

--- a/src/execution/sandbox.ts
+++ b/src/execution/sandbox.ts
@@ -27,11 +27,34 @@ export interface RepoRef {
   remoteUrl?: string;
 }
 
+/**
+ * Discriminated outcome of {@link SandboxProvider.destroy}.
+ *
+ * Callers (and crash-recovery tooling) must be able to tell these three cases
+ * apart — a bare `void` collapses them into an apparent success and hides the
+ * "preserved" case where uncommitted work is sitting on disk, waiting to be
+ * salvaged.
+ *
+ * - `removed` — the sandbox was torn down successfully.
+ * - `preserved` — the backing store refused to delete (e.g. a git worktree
+ *   reported modified/untracked files) and the provider deliberately did NOT
+ *   force-delete; on-disk state is intact for recovery.
+ * - `missing` — nothing to remove. Either the sandbox was never created, or
+ *   a previous `destroy` already removed it (idempotent retry).
+ */
+export type DestroyResult =
+  | { kind: "removed" }
+  | { kind: "preserved"; reason: "dirty"; stderr: string }
+  | { kind: "missing" };
+
 export interface SandboxProvider {
   /** Create a sandbox rooted at `base` (typically a branch or commit ref). */
   create(repo: RepoRef, base: string): Promise<SandboxRef>;
-  /** Destroy the sandbox. Idempotent — calling on a missing sandbox is a no-op. */
-  destroy(ref: SandboxRef): Promise<void>;
+  /**
+   * Destroy the sandbox. Idempotent — calling on a missing sandbox resolves
+   * to `{ kind: "missing" }` rather than throwing. See {@link DestroyResult}.
+   */
+  destroy(ref: SandboxRef): Promise<DestroyResult>;
 }
 
 /**

--- a/src/execution/sandboxes/git-worktree.ts
+++ b/src/execution/sandboxes/git-worktree.ts
@@ -1,0 +1,235 @@
+import { execFile } from "node:child_process";
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import { getRelayDir } from "../../cli/paths.js";
+import type {
+  RepoRef,
+  SandboxProvider,
+  SandboxRef
+} from "../sandbox.js";
+
+// argv-based runner (no shell) keeps repo paths safe from shell expansion.
+const runGitChild = promisify(execFile);
+
+export interface RunGitResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/**
+ * Shell runner for git invocations. The default spawns git as a child
+ * process with argv (no shell). Tests inject a mock so the provider is
+ * unit-testable without a real git repo on disk.
+ */
+export type RunGit = (
+  args: string[],
+  cwd: string
+) => Promise<RunGitResult>;
+
+export interface GitWorktreeSandboxOptions {
+  /** Parent dir holding all sandboxes for this harness. */
+  baseDir?: string;
+  /** Shell runner for git. Default spawns a child process; tests inject a mock. */
+  runGit?: RunGit;
+}
+
+export interface GitWorktreeStateFile {
+  runId: string;
+  ticketId: string;
+  createdAt: string;
+  base: string;
+  branch: string;
+}
+
+export interface CreateOptions {
+  runId: string;
+  ticketId: string;
+}
+
+export interface DestroyOptions {
+  force?: boolean;
+}
+
+// Matches stderr emitted by `git worktree remove` when the worktree has
+// uncommitted changes — we read these fragments to decide whether to preserve
+// the worktree for crash-recovery inspection instead of deleting work.
+const DIRTY_STDERR_FRAGMENTS = [
+  "contains modified or untracked files",
+  "is dirty",
+  "has modifications",
+  "use --force to delete it"
+];
+
+const defaultRunGit: RunGit = async (args, cwd) => {
+  try {
+    const { stdout, stderr } = await runGitChild("git", args, { cwd });
+    return { stdout, stderr, code: 0 };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+    };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? String(err),
+      code: typeof e.code === "number" ? e.code : 1
+    };
+  }
+};
+
+/**
+ * SandboxProvider backed by `git worktree`. One worktree per active ticket,
+ * keyed by (runId, ticketId), rooted at a configurable base dir.
+ *
+ * Branch naming `sandbox/<runId>/<ticketId>` makes `git worktree list` readable
+ * at a glance — operators can trace each checkout back to its owning run and
+ * ticket without cross-referencing state files.
+ *
+ * The provider writes a `.relay-state.json` stamp inside each worktree so a
+ * future crash-recovery scan can identify orphaned sandboxes (e.g. after the
+ * harness exits without a graceful `destroy`).
+ */
+export class GitWorktreeSandboxProvider implements SandboxProvider {
+  private readonly baseDir: string;
+  private readonly runGit: RunGit;
+  private readonly ownerRepo = new Map<string, string>();
+
+  constructor(options: GitWorktreeSandboxOptions = {}) {
+    this.baseDir = options.baseDir ?? join(getRelayDir(), "sandboxes");
+    this.runGit = options.runGit ?? defaultRunGit;
+  }
+
+  /**
+   * Create a fresh worktree for `(runId, ticketId)` branched from `base`.
+   *
+   * The caller owns the lifecycle. If `destroy` is never called (e.g. harness
+   * crash), the worktree and its `.relay-state.json` remain on disk for T-203
+   * recovery — deletion is never implicit.
+   */
+  async create(
+    repo: RepoRef,
+    base: string,
+    options?: CreateOptions
+  ): Promise<SandboxRef> {
+    const { runId, ticketId } = requireIds(options);
+
+    const sandboxPath = join(this.baseDir, `run-${runId}`, ticketId);
+    const branch = `sandbox/${runId}/${ticketId}`;
+    const id = `runtime-${runId}-${ticketId}`;
+
+    await mkdir(dirname(sandboxPath), { recursive: true });
+
+    const result = await this.runGit(
+      ["worktree", "add", "-b", branch, sandboxPath, base],
+      repo.root
+    );
+
+    if (result.code !== 0) {
+      throw new Error(
+        `git worktree add failed for ${branch} at ${sandboxPath}: ${result.stderr.trim() || "unknown error"}`
+      );
+    }
+
+    const state: GitWorktreeStateFile = {
+      runId,
+      ticketId,
+      createdAt: new Date().toISOString(),
+      base,
+      branch
+    };
+
+    await writeFile(
+      join(sandboxPath, ".relay-state.json"),
+      `${JSON.stringify(state, null, 2)}\n`,
+      "utf8"
+    );
+
+    this.ownerRepo.set(id, repo.root);
+
+    return {
+      id,
+      workdir: { kind: "local", path: sandboxPath },
+      meta: { branch, base, runId, ticketId }
+    };
+  }
+
+  /**
+   * Remove a worktree. Idempotent: a missing path is a silent no-op.
+   *
+   * When `git worktree remove` reports uncommitted changes, the worktree is
+   * preserved (we do NOT add `--force` implicitly). This lets T-203 crash
+   * recovery inspect stale sandboxes without destroying unflushed work.
+   * Pass `{ force: true }` to force deletion.
+   */
+  async destroy(ref: SandboxRef, opts: DestroyOptions = {}): Promise<void> {
+    if (ref.workdir.kind !== "local") {
+      return;
+    }
+
+    const path = ref.workdir.path;
+
+    if (!(await pathExists(path))) {
+      // Missing path — nothing to remove. Logged at debug only so normal
+      // re-entrancy (retry / resume) doesn't spam the console.
+      // eslint-disable-next-line no-console
+      console.debug?.(`[git-worktree] destroy: path ${path} missing, no-op`);
+      return;
+    }
+
+    const cwd = this.ownerRepo.get(ref.id) ?? ref.meta?.repoRoot;
+    if (!cwd) {
+      // Without the origin repo we cannot run `git worktree remove`. This
+      // should only happen on a ref from a different provider instance; leave
+      // the worktree in place for manual / T-203 cleanup.
+      return;
+    }
+
+    const args = ["worktree", "remove"];
+    if (opts.force) args.push("--force");
+    args.push(path);
+
+    const result = await this.runGit(args, cwd);
+
+    if (result.code === 0) {
+      this.ownerRepo.delete(ref.id);
+      return;
+    }
+
+    if (!opts.force && isDirtyWorktreeError(result.stderr)) {
+      // Preserve on-disk state so recovery tooling (T-203) can inspect the
+      // dirty worktree and decide manually. This is the key safety property.
+      return;
+    }
+
+    throw new Error(
+      `git worktree remove failed for ${path}: ${result.stderr.trim() || "unknown error"}`
+    );
+  }
+}
+
+function requireIds(options: CreateOptions | undefined): CreateOptions {
+  if (!options?.runId || !options.ticketId) {
+    throw new Error(
+      "GitWorktreeSandboxProvider.create requires { runId, ticketId }"
+    );
+  }
+  return options;
+}
+
+function isDirtyWorktreeError(stderr: string): boolean {
+  const lower = stderr.toLowerCase();
+  return DIRTY_STDERR_FRAGMENTS.some((f) => lower.includes(f));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/execution/sandboxes/git-worktree.ts
+++ b/src/execution/sandboxes/git-worktree.ts
@@ -5,10 +5,12 @@ import { promisify } from "node:util";
 
 import { getRelayDir } from "../../cli/paths.js";
 import type {
+  DestroyResult,
   RepoRef,
   SandboxProvider,
   SandboxRef
 } from "../sandbox.js";
+export type { DestroyResult } from "../sandbox.js";
 
 // argv-based runner (no shell) keeps repo paths safe from shell expansion.
 const runGitChild = promisify(execFile);
@@ -17,6 +19,14 @@ export interface RunGitResult {
   stdout: string;
   stderr: string;
   code: number;
+  /**
+   * Set when the spawn itself fails (e.g. `git` isn't on PATH) rather than git
+   * exiting non-zero. Callers can distinguish "git not found" (spawnCode
+   * `ENOENT`) from "git exited 128" (plain `code: 128`). Preserved as a string
+   * because Node's spawn errors surface string codes (ENOENT, EACCES, …),
+   * not numeric ones.
+   */
+  spawnCode?: string;
 }
 
 /**
@@ -63,6 +73,33 @@ const DIRTY_STDERR_FRAGMENTS = [
   "use --force to delete it"
 ];
 
+/**
+ * Reject path segments that could escape the sandbox base dir via traversal
+ * (`..`), collapse to the parent (`.`), pierce a directory boundary (`/`,
+ * `\`), trip the kernel's null-byte guard, or carry whitespace that could
+ * confuse downstream argv handling.
+ *
+ * Intentionally duplicated (with a narrower `kind` type) from
+ * {@link ../../storage/file-store.ts} — see the PR review: a tiny local copy
+ * is preferable to extracting a shared helper during a review-response commit.
+ */
+function assertSafeSegment(
+  segment: string,
+  kind: "runId" | "ticketId"
+): void {
+  if (
+    segment === "" ||
+    segment === "." ||
+    segment === ".." ||
+    segment.includes("/") ||
+    segment.includes("\\") ||
+    segment.includes("\0") ||
+    /\s/.test(segment)
+  ) {
+    throw new Error(`Unsafe path segment in ${kind}: ${segment}`);
+  }
+}
+
 const defaultRunGit: RunGit = async (args, cwd) => {
   try {
     const { stdout, stderr } = await runGitChild("git", args, { cwd });
@@ -73,6 +110,18 @@ const defaultRunGit: RunGit = async (args, cwd) => {
       stderr?: string;
       code?: number | string;
     };
+    // Spawn-level errors (git missing, permission denied, …) surface as
+    // string codes on the thrown error. Preserve them separately from the
+    // process exit code so callers can distinguish "git not installed"
+    // (spawnCode=ENOENT) from "git exited non-zero" (code=128).
+    if (typeof e.code === "string") {
+      return {
+        stdout: e.stdout ?? "",
+        stderr: e.stderr ?? String(err),
+        code: 1,
+        spawnCode: e.code
+      };
+    }
     return {
       stdout: e.stdout ?? "",
       stderr: e.stderr ?? String(err),
@@ -115,6 +164,17 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
     base: string,
     options?: CreateOptions
   ): Promise<SandboxRef> {
+    if (!options) {
+      throw new Error(
+        "GitWorktreeSandboxProvider.create requires { runId, ticketId }"
+      );
+    }
+    // Validate BEFORE the non-null coerce in requireIds — an empty string
+    // should surface as "Unsafe path segment" (not as the lower-priority
+    // "requires { runId, ticketId }" message) so callers get a uniform
+    // signal for path-injection attempts regardless of the bad value.
+    assertSafeSegment(options.runId ?? "", "runId");
+    assertSafeSegment(options.ticketId ?? "", "ticketId");
     const { runId, ticketId } = requireIds(options);
 
     const sandboxPath = join(this.baseDir, `run-${runId}`, ticketId);
@@ -123,6 +183,17 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
 
     await mkdir(dirname(sandboxPath), { recursive: true });
 
+    // A pre-existing target path almost always means a resumed run or crash
+    // recovery — conditions T-203 is meant to handle. Fail loudly with a
+    // distinguishable error instead of letting `git worktree add` return a
+    // generic "directory already exists" that's harder for callers to reason
+    // about.
+    if (await pathExists(sandboxPath)) {
+      throw new Error(
+        `Sandbox path ${sandboxPath} already exists (runId=${runId}, ticketId=${ticketId}); T-203 recovery should handle resume`
+      );
+    }
+
     const result = await this.runGit(
       ["worktree", "add", "-b", branch, sandboxPath, base],
       repo.root
@@ -130,7 +201,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
 
     if (result.code !== 0) {
       throw new Error(
-        `git worktree add failed for ${branch} at ${sandboxPath}: ${result.stderr.trim() || "unknown error"}`
+        `git worktree add failed for ${branch} at ${sandboxPath} (exit ${result.code}): ${result.stderr.trim() || "unknown error"}${result.stdout ? ` | stdout: ${result.stdout.trim()}` : ""}${result.spawnCode ? ` | spawnCode: ${result.spawnCode}` : ""}`
       );
     }
 
@@ -142,11 +213,35 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
       branch
     };
 
-    await writeFile(
-      join(sandboxPath, ".relay-state.json"),
-      `${JSON.stringify(state, null, 2)}\n`,
-      "utf8"
-    );
+    try {
+      await writeFile(
+        join(sandboxPath, ".relay-state.json"),
+        `${JSON.stringify(state, null, 2)}\n`,
+        "utf8"
+      );
+    } catch (err) {
+      // The worktree exists on disk without its stamp — an orphan that T-203
+      // can't identify. Best-effort roll back the `git worktree add`, then
+      // rethrow with context so the caller sees both failures.
+      // eslint-disable-next-line no-console
+      console.debug(
+        `[git-worktree] state-file write failed at ${sandboxPath}; attempting rollback`
+      );
+      const rollback = await this.runGit(
+        ["worktree", "remove", "--force", sandboxPath],
+        repo.root
+      );
+      if (rollback.code !== 0) {
+        // eslint-disable-next-line no-console
+        console.debug(
+          `[git-worktree] rollback failed for ${sandboxPath} (exit ${rollback.code}): ${rollback.stderr.trim() || "unknown error"}`
+        );
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed to write .relay-state.json at ${sandboxPath}: ${message}`
+      );
+    }
 
     this.ownerRepo.set(id, repo.root);
 
@@ -158,34 +253,57 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * Remove a worktree. Idempotent: a missing path is a silent no-op.
+   * Remove a worktree. Idempotent: a missing path resolves to
+   * `{ kind: "missing" }`.
    *
-   * When `git worktree remove` reports uncommitted changes, the worktree is
-   * preserved (we do NOT add `--force` implicitly). This lets T-203 crash
-   * recovery inspect stale sandboxes without destroying unflushed work.
-   * Pass `{ force: true }` to force deletion.
+   * When `git worktree remove` reports uncommitted changes — matched against
+   * {@link DIRTY_STDERR_FRAGMENTS} (currently:
+   * "contains modified or untracked files", "is dirty", "has modifications",
+   * "use --force to delete it") — the worktree is preserved and the call
+   * resolves with `{ kind: "preserved", reason: "dirty" }`. We do NOT add
+   * `--force` implicitly: doing so would destroy uncommitted agent output
+   * that a T-203 recovery sweep is expected to salvage. Pass
+   * `{ force: true }` to override.
    */
-  async destroy(ref: SandboxRef, opts: DestroyOptions = {}): Promise<void> {
+  async destroy(
+    ref: SandboxRef,
+    opts: DestroyOptions = {}
+  ): Promise<DestroyResult> {
     if (ref.workdir.kind !== "local") {
-      return;
+      return { kind: "missing" };
+    }
+
+    // Validate the ids embedded in the ref before we act on them — a ref
+    // fabricated with `ticketId="../escape"` must not steer us to a path
+    // outside `baseDir`.
+    const runIdFromRef = ref.meta?.runId;
+    const ticketIdFromRef = ref.meta?.ticketId;
+    if (runIdFromRef !== undefined) assertSafeSegment(runIdFromRef, "runId");
+    if (ticketIdFromRef !== undefined) {
+      assertSafeSegment(ticketIdFromRef, "ticketId");
     }
 
     const path = ref.workdir.path;
 
     if (!(await pathExists(path))) {
       // Missing path — nothing to remove. Logged at debug only so normal
-      // re-entrancy (retry / resume) doesn't spam the console.
+      // re-entrancy (retry / resume) doesn't spam the console. TODO: swap
+      // for a project-wide logger once one exists; `console.debug` is
+      // intentional and temporary.
       // eslint-disable-next-line no-console
-      console.debug?.(`[git-worktree] destroy: path ${path} missing, no-op`);
-      return;
+      console.debug(`[git-worktree] destroy: path ${path} missing, no-op`);
+      return { kind: "missing" };
     }
 
     const cwd = this.ownerRepo.get(ref.id) ?? ref.meta?.repoRoot;
     if (!cwd) {
-      // Without the origin repo we cannot run `git worktree remove`. This
-      // should only happen on a ref from a different provider instance; leave
-      // the worktree in place for manual / T-203 cleanup.
-      return;
+      // Without the origin repo we cannot run `git worktree remove`. Rather
+      // than silently returning (which looks like success), surface the
+      // problem so callers can either pass `ref.meta.repoRoot` or use the
+      // same provider instance that created the ref.
+      throw new Error(
+        `Cannot destroy sandbox ${ref.id}: owner repo unknown and ref.meta.repoRoot is missing`
+      );
     }
 
     const args = ["worktree", "remove"];
@@ -196,17 +314,17 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
 
     if (result.code === 0) {
       this.ownerRepo.delete(ref.id);
-      return;
+      return { kind: "removed" };
     }
 
     if (!opts.force && isDirtyWorktreeError(result.stderr)) {
       // Preserve on-disk state so recovery tooling (T-203) can inspect the
       // dirty worktree and decide manually. This is the key safety property.
-      return;
+      return { kind: "preserved", reason: "dirty", stderr: result.stderr };
     }
 
     throw new Error(
-      `git worktree remove failed for ${path}: ${result.stderr.trim() || "unknown error"}`
+      `git worktree remove failed for ${path} (exit ${result.code}): ${result.stderr.trim() || "unknown error"}${result.stdout ? ` | stdout: ${result.stdout.trim()}` : ""}${result.spawnCode ? ` | spawnCode: ${result.spawnCode}` : ""}`
     );
   }
 }
@@ -229,7 +347,8 @@ async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
   }
 }

--- a/test/execution/git-worktree-sandbox.test.ts
+++ b/test/execution/git-worktree-sandbox.test.ts
@@ -1,0 +1,375 @@
+import { execFile as execFileCb } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import type { RepoRef } from "../../src/execution/sandbox.js";
+import { resolveLocalPath } from "../../src/execution/sandbox.js";
+import {
+  GitWorktreeSandboxProvider,
+  type RunGit,
+  type RunGitResult
+} from "../../src/execution/sandboxes/git-worktree.js";
+
+const runRealGit = promisify(execFileCb);
+
+interface RecordedCall {
+  args: string[];
+  cwd: string;
+}
+
+// Mocked runGit: mirrors the side effects a real `git worktree add` would
+// produce on the filesystem (creating the target dir) so the provider's
+// subsequent `.relay-state.json` write lands on a real path.
+function makeRecordingRunGit(
+  responder: (call: RecordedCall) => RunGitResult | Promise<RunGitResult> = () => ({
+    stdout: "",
+    stderr: "",
+    code: 0
+  })
+): { runGit: RunGit; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const runGit: RunGit = async (args, cwd) => {
+    calls.push({ args, cwd });
+    const result = await responder({ args, cwd });
+    if (
+      result.code === 0 &&
+      args[0] === "worktree" &&
+      args[1] === "add"
+    ) {
+      // `-b <branch> <path> <base>` — the path is the 4th positional arg.
+      const path = args[4];
+      if (path) {
+        await mkdir(path, { recursive: true });
+      }
+    }
+    if (
+      result.code === 0 &&
+      args[0] === "worktree" &&
+      args[1] === "remove"
+    ) {
+      const path = args[args.length - 1];
+      if (path) {
+        await rm(path, { recursive: true, force: true });
+      }
+    }
+    return result;
+  };
+  return { runGit, calls };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const repo: RepoRef = { root: "/tmp/fake-repo" };
+
+describe("GitWorktreeSandboxProvider.create", () => {
+  it("invokes git worktree add with the expected args", async () => {
+    const { runGit, calls } = makeRecordingRunGit();
+    const baseDir = "/tmp/relay-sandboxes-unit";
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const ref = await provider.create(repo, "main", {
+      runId: "run-abc",
+      ticketId: "T-042"
+    });
+
+    expect(calls).toHaveLength(1);
+    const expectedPath = join(baseDir, "run-run-abc", "T-042");
+    expect(calls[0]).toEqual({
+      args: [
+        "worktree",
+        "add",
+        "-b",
+        "sandbox/run-abc/T-042",
+        expectedPath,
+        "main"
+      ],
+      cwd: repo.root
+    });
+
+    expect(ref.id).toBe("runtime-run-abc-T-042");
+    expect(ref.workdir.kind).toBe("local");
+    expect(resolveLocalPath(ref)).toBe(expectedPath);
+    expect(ref.meta?.branch).toBe("sandbox/run-abc/T-042");
+    expect(ref.meta?.base).toBe("main");
+    expect(ref.meta?.runId).toBe("run-abc");
+    expect(ref.meta?.ticketId).toBe("T-042");
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("writes .relay-state.json with the expected shape", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-state-"));
+    const { runGit } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const ref = await provider.create(repo, "develop", {
+      runId: "run-xyz",
+      ticketId: "T-007"
+    });
+
+    const statePath = join(
+      resolveLocalPath(ref) ?? "/missing",
+      ".relay-state.json"
+    );
+    const raw = JSON.parse(await readFile(statePath, "utf8"));
+
+    expect(raw).toMatchObject({
+      runId: "run-xyz",
+      ticketId: "T-007",
+      base: "develop",
+      branch: "sandbox/run-xyz/T-007"
+    });
+    expect(typeof raw.createdAt).toBe("string");
+    expect(Number.isNaN(Date.parse(raw.createdAt))).toBe(false);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("returns a ref with workdir.kind=local and expected meta.branch", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-ref-"));
+    const { runGit } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const ref = await provider.create(repo, "main", {
+      runId: "r1",
+      ticketId: "T-1"
+    });
+
+    expect(ref.workdir).toEqual({
+      kind: "local",
+      path: join(baseDir, "run-r1", "T-1")
+    });
+    expect(ref.meta?.branch).toBe("sandbox/r1/T-1");
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("throws with descriptive error when git worktree add fails", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-fail-"));
+    const { runGit } = makeRecordingRunGit(() => ({
+      stdout: "",
+      stderr: "fatal: invalid reference: nope",
+      code: 128
+    }));
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    await expect(
+      provider.create(repo, "nope", { runId: "r", ticketId: "T" })
+    ).rejects.toThrow(/invalid reference/);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("yields distinct paths and refs for two concurrent creates", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-conc-"));
+    const { runGit } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const [a, b] = await Promise.all([
+      provider.create(repo, "main", { runId: "run-a", ticketId: "T-1" }),
+      provider.create(repo, "main", { runId: "run-b", ticketId: "T-2" })
+    ]);
+
+    expect(a.id).not.toBe(b.id);
+    expect(resolveLocalPath(a)).not.toBe(resolveLocalPath(b));
+    expect(resolveLocalPath(a)).toBe(join(baseDir, "run-run-a", "T-1"));
+    expect(resolveLocalPath(b)).toBe(join(baseDir, "run-run-b", "T-2"));
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+});
+
+describe("GitWorktreeSandboxProvider.destroy", () => {
+  it("invokes git worktree remove without --force by default", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-rm-"));
+    const { runGit, calls } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const ref = await provider.create(repo, "main", {
+      runId: "r",
+      ticketId: "T"
+    });
+
+    await provider.destroy(ref);
+
+    const removeCall = calls.find((c) => c.args[1] === "remove");
+    expect(removeCall).toBeDefined();
+    expect(removeCall!.args).toEqual([
+      "worktree",
+      "remove",
+      resolveLocalPath(ref)
+    ]);
+    expect(removeCall!.args).not.toContain("--force");
+    expect(removeCall!.cwd).toBe(repo.root);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("adds --force when destroy is called with { force: true }", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-force-"));
+    const { runGit, calls } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const ref = await provider.create(repo, "main", {
+      runId: "r",
+      ticketId: "T"
+    });
+
+    await provider.destroy(ref, { force: true });
+
+    const removeCall = calls.find((c) => c.args[1] === "remove");
+    expect(removeCall).toBeDefined();
+    expect(removeCall!.args).toEqual([
+      "worktree",
+      "remove",
+      "--force",
+      resolveLocalPath(ref)
+    ]);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("is idempotent when the worktree path does not exist", async () => {
+    const { runGit, calls } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({
+      baseDir: "/tmp/relay-gwt-missing-never-created",
+      runGit
+    });
+
+    // Build a ref for a path that was never created on disk.
+    const phantom = {
+      id: "runtime-ghost-T-0",
+      workdir: {
+        kind: "local" as const,
+        path: "/tmp/relay-gwt-missing-never-created/run-ghost/T-0"
+      },
+      meta: { branch: "sandbox/ghost/T-0" }
+    };
+
+    await expect(provider.destroy(phantom)).resolves.toBeUndefined();
+    // No git invocation should happen when the path is missing.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("preserves the worktree when remove fails due to uncommitted changes", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-dirty-"));
+    let failNextRemove = false;
+
+    const runGit: RunGit = async (args) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        const path = args[4];
+        if (path) await mkdir(path, { recursive: true });
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (failNextRemove && args[1] === "remove") {
+        return {
+          stdout: "",
+          stderr:
+            "fatal: '...' contains modified or untracked files, use --force to delete it",
+          code: 128
+        };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+    const ref = await provider.create(repo, "main", {
+      runId: "r",
+      ticketId: "T-dirty"
+    });
+
+    const path = resolveLocalPath(ref)!;
+    expect(await exists(path)).toBe(true);
+
+    failNextRemove = true;
+    // The provider must NOT throw; it preserves the worktree.
+    await expect(provider.destroy(ref)).resolves.toBeUndefined();
+
+    // On-disk state intact for T-203 recovery.
+    expect(await exists(path)).toBe(true);
+    expect(await exists(join(path, ".relay-state.json"))).toBe(true);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("rejects on a non-dirty, non-missing failure", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-err-"));
+    let phase: "add" | "remove" = "add";
+
+    const runGit: RunGit = async (args) => {
+      if (phase === "add") {
+        const path = args[4];
+        if (path) await mkdir(path, { recursive: true });
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (args[1] === "remove") {
+        return {
+          stdout: "",
+          stderr: "fatal: catastrophic failure",
+          code: 128
+        };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+    const ref = await provider.create(repo, "main", {
+      runId: "r",
+      ticketId: "T-err"
+    });
+
+    phase = "remove";
+    await expect(provider.destroy(ref)).rejects.toThrow(
+      /catastrophic failure/
+    );
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+});
+
+// Integration test gated behind RELAY_TEST_REAL_GIT=1. Uses a real git repo in
+// a temp dir so CI stays fast and hermetic by default.
+const realGitSuite =
+  process.env.RELAY_TEST_REAL_GIT === "1" ? describe : describe.skip;
+
+realGitSuite("GitWorktreeSandboxProvider — real git integration", () => {
+  it("creates and destroys a real worktree", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "relay-gwt-repo-"));
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-real-"));
+
+    await runRealGit("git", ["init", "-b", "main"], { cwd: repoRoot });
+    await runRealGit(
+      "git",
+      ["-c", "user.email=a@b.c", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],
+      { cwd: repoRoot }
+    );
+
+    const provider = new GitWorktreeSandboxProvider({ baseDir });
+    const ref = await provider.create(
+      { root: repoRoot },
+      "main",
+      { runId: "real", ticketId: "T-real" }
+    );
+
+    const path = resolveLocalPath(ref)!;
+    expect(await exists(path)).toBe(true);
+    expect(await exists(join(path, ".relay-state.json"))).toBe(true);
+
+    await provider.destroy(ref);
+    expect(await exists(path)).toBe(false);
+
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(baseDir, { recursive: true, force: true });
+  });
+});

--- a/test/execution/git-worktree-sandbox.test.ts
+++ b/test/execution/git-worktree-sandbox.test.ts
@@ -75,7 +75,7 @@ const repo: RepoRef = { root: "/tmp/fake-repo" };
 describe("GitWorktreeSandboxProvider.create", () => {
   it("invokes git worktree add with the expected args", async () => {
     const { runGit, calls } = makeRecordingRunGit();
-    const baseDir = "/tmp/relay-sandboxes-unit";
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-"));
     const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
 
     const ref = await provider.create(repo, "main", {
@@ -171,6 +171,26 @@ describe("GitWorktreeSandboxProvider.create", () => {
     await rm(baseDir, { recursive: true, force: true });
   });
 
+  it("surfaces exit code and stdout in create-failure errors", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-exitcode-"));
+    const { runGit } = makeRecordingRunGit(() => ({
+      stdout: "progress: cloning",
+      stderr: "fatal: boom",
+      code: 128
+    }));
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    // Error message should include the exit code (128) and the stdout
+    // snippet, not just the stderr — without those, an operator staring at
+    // the thrown error has no way to tell a non-zero git exit from a random
+    // JS runtime failure.
+    await expect(
+      provider.create(repo, "main", { runId: "r", ticketId: "T" })
+    ).rejects.toThrow(/exit 128.*boom.*stdout: progress: cloning/);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
   it("yields distinct paths and refs for two concurrent creates", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-conc-"));
     const { runGit } = makeRecordingRunGit();
@@ -188,6 +208,132 @@ describe("GitWorktreeSandboxProvider.create", () => {
 
     await rm(baseDir, { recursive: true, force: true });
   });
+
+  it("throws path-already-exists when the same (runId, ticketId) is created twice", async () => {
+    // Pins the behavior for resumed runs / crash recovery: a pre-existing
+    // sandbox dir should raise a distinguishable error so callers can route
+    // to T-203 recovery rather than interpreting a generic git failure.
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-dup-"));
+    const { runGit } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    await provider.create(repo, "main", { runId: "r", ticketId: "T-dup" });
+
+    await expect(
+      provider.create(repo, "main", { runId: "r", ticketId: "T-dup" })
+    ).rejects.toThrow(/already exists.*T-203 recovery should handle resume/);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("rolls back the worktree when the state-file write fails", async () => {
+    // Simulate a write failure after `git worktree add` succeeds. The
+    // provider must best-effort call `git worktree remove --force` so we
+    // don't leave an unstamped orphan that T-203 can't identify.
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-rollback-"));
+    const calls: RecordedCall[] = [];
+    const runGit: RunGit = async (args, cwd) => {
+      calls.push({ args, cwd });
+      if (args[0] === "worktree" && args[1] === "add") {
+        // Do NOT create the directory on disk — that forces the subsequent
+        // writeFile to fail with ENOENT, exercising the rollback branch.
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    await expect(
+      provider.create(repo, "main", { runId: "r", ticketId: "T" })
+    ).rejects.toThrow(/Failed to write \.relay-state\.json/);
+
+    // Rollback = a second invocation with `--force` on the target path.
+    const rollback = calls.find(
+      (c) => c.args[1] === "remove" && c.args.includes("--force")
+    );
+    expect(rollback).toBeDefined();
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  describe("rejects unsafe path segments", () => {
+    const unsafeValues = [
+      { label: "dot-dot", value: ".." },
+      { label: "slash", value: "/foo" },
+      { label: "backslash", value: "\\x" },
+      { label: "empty string", value: "" },
+      { label: "leading space", value: " space" },
+      { label: "null byte", value: "null\0byte" }
+    ];
+
+    for (const { label, value } of unsafeValues) {
+      it(`create rejects unsafe runId (${label})`, async () => {
+        const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-"));
+        const { runGit } = makeRecordingRunGit();
+        const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+        await expect(
+          provider.create(repo, "main", { runId: value, ticketId: "T-1" })
+        ).rejects.toThrow(/Unsafe path segment/);
+
+        await rm(baseDir, { recursive: true, force: true });
+      });
+
+      it(`create rejects unsafe ticketId (${label})`, async () => {
+        const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-"));
+        const { runGit } = makeRecordingRunGit();
+        const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+        await expect(
+          provider.create(repo, "main", { runId: "r", ticketId: value })
+        ).rejects.toThrow(/Unsafe path segment/);
+
+        await rm(baseDir, { recursive: true, force: true });
+      });
+
+      it(`destroy rejects ref with unsafe runId (${label})`, async () => {
+        const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-"));
+        const { runGit } = makeRecordingRunGit();
+        const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+        const forgedRef = {
+          id: `runtime-${value}-T-1`,
+          workdir: {
+            kind: "local" as const,
+            path: join(baseDir, `run-${value}`, "T-1")
+          },
+          meta: { runId: value, ticketId: "T-1" }
+        };
+
+        await expect(provider.destroy(forgedRef)).rejects.toThrow(
+          /Unsafe path segment/
+        );
+
+        await rm(baseDir, { recursive: true, force: true });
+      });
+
+      it(`destroy rejects ref with unsafe ticketId (${label})`, async () => {
+        const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-"));
+        const { runGit } = makeRecordingRunGit();
+        const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+        const forgedRef = {
+          id: `runtime-r-${value}`,
+          workdir: {
+            kind: "local" as const,
+            path: join(baseDir, "run-r", value)
+          },
+          meta: { runId: "r", ticketId: value }
+        };
+
+        await expect(provider.destroy(forgedRef)).rejects.toThrow(
+          /Unsafe path segment/
+        );
+
+        await rm(baseDir, { recursive: true, force: true });
+      });
+    }
+  });
 });
 
 describe("GitWorktreeSandboxProvider.destroy", () => {
@@ -201,7 +347,8 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       ticketId: "T"
     });
 
-    await provider.destroy(ref);
+    const outcome = await provider.destroy(ref);
+    expect(outcome).toEqual({ kind: "removed" });
 
     const removeCall = calls.find((c) => c.args[1] === "remove");
     expect(removeCall).toBeDefined();
@@ -226,7 +373,8 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       ticketId: "T"
     });
 
-    await provider.destroy(ref, { force: true });
+    const outcome = await provider.destroy(ref, { force: true });
+    expect(outcome).toEqual({ kind: "removed" });
 
     const removeCall = calls.find((c) => c.args[1] === "remove");
     expect(removeCall).toBeDefined();
@@ -240,10 +388,11 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     await rm(baseDir, { recursive: true, force: true });
   });
 
-  it("is idempotent when the worktree path does not exist", async () => {
+  it("returns { kind: 'missing' } when the worktree path does not exist", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-missing-"));
     const { runGit, calls } = makeRecordingRunGit();
     const provider = new GitWorktreeSandboxProvider({
-      baseDir: "/tmp/relay-gwt-missing-never-created",
+      baseDir,
       runGit
     });
 
@@ -252,17 +401,49 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       id: "runtime-ghost-T-0",
       workdir: {
         kind: "local" as const,
-        path: "/tmp/relay-gwt-missing-never-created/run-ghost/T-0"
+        path: join(baseDir, "run-ghost", "T-0")
       },
-      meta: { branch: "sandbox/ghost/T-0" }
+      meta: { branch: "sandbox/ghost/T-0", runId: "ghost", ticketId: "T-0" }
     };
 
-    await expect(provider.destroy(phantom)).resolves.toBeUndefined();
+    await expect(provider.destroy(phantom)).resolves.toEqual({
+      kind: "missing"
+    });
     // No git invocation should happen when the path is missing.
     expect(calls).toHaveLength(0);
+
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("throws when destroy can't locate an owner repo for the ref", async () => {
+    // Ref fabricated by a caller using a different provider instance. With
+    // no `meta.repoRoot` fallback we can't run `git worktree remove` — so
+    // we surface that loudly instead of silently returning.
+    const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-noowner-"));
+    const existingPath = join(baseDir, "run-orphan", "T-0");
+    await mkdir(existingPath, { recursive: true });
+
+    const { runGit } = makeRecordingRunGit();
+    const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
+
+    const orphanRef = {
+      id: "runtime-orphan-T-0",
+      workdir: { kind: "local" as const, path: existingPath },
+      meta: { branch: "sandbox/orphan/T-0", runId: "orphan", ticketId: "T-0" }
+    };
+
+    await expect(provider.destroy(orphanRef)).rejects.toThrow(
+      /owner repo unknown and ref\.meta\.repoRoot is missing/
+    );
+
+    await rm(baseDir, { recursive: true, force: true });
   });
 
   it("preserves the worktree when remove fails due to uncommitted changes", async () => {
+    // WHY: A dirty worktree may hold uncommitted agent output. Implicit
+    // `--force` here would destroy work that a T-203 recovery sweep is
+    // expected to salvage. The provider must refuse to delete and return
+    // a "preserved" result so callers know the on-disk state is intact.
     const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-dirty-"));
     let failNextRemove = false;
 
@@ -293,8 +474,14 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     expect(await exists(path)).toBe(true);
 
     failNextRemove = true;
-    // The provider must NOT throw; it preserves the worktree.
-    await expect(provider.destroy(ref)).resolves.toBeUndefined();
+    // The provider must NOT throw; it preserves the worktree and signals
+    // the preservation via the discriminated result.
+    const outcome = await provider.destroy(ref);
+    expect(outcome.kind).toBe("preserved");
+    if (outcome.kind === "preserved") {
+      expect(outcome.reason).toBe("dirty");
+      expect(outcome.stderr).toMatch(/contains modified or untracked files/);
+    }
 
     // On-disk state intact for T-203 recovery.
     expect(await exists(path)).toBe(true);
@@ -303,7 +490,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     await rm(baseDir, { recursive: true, force: true });
   });
 
-  it("rejects on a non-dirty, non-missing failure", async () => {
+  it("rejects on a non-dirty, non-missing failure with exit code + stdout", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "relay-gwt-err-"));
     let phase: "add" | "remove" = "add";
 
@@ -315,7 +502,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       }
       if (args[1] === "remove") {
         return {
-          stdout: "",
+          stdout: "last-line: help",
           stderr: "fatal: catastrophic failure",
           code: 128
         };
@@ -331,7 +518,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
 
     phase = "remove";
     await expect(provider.destroy(ref)).rejects.toThrow(
-      /catastrophic failure/
+      /exit 128.*catastrophic failure.*stdout: last-line: help/
     );
 
     await rm(baseDir, { recursive: true, force: true });
@@ -366,7 +553,8 @@ realGitSuite("GitWorktreeSandboxProvider — real git integration", () => {
     expect(await exists(path)).toBe(true);
     expect(await exists(join(path, ".relay-state.json"))).toBe(true);
 
-    await provider.destroy(ref);
+    const outcome = await provider.destroy(ref);
+    expect(outcome).toEqual({ kind: "removed" });
     expect(await exists(path)).toBe(false);
 
     await rm(repoRoot, { recursive: true, force: true });

--- a/test/execution/noop-executor.test.ts
+++ b/test/execution/noop-executor.test.ts
@@ -60,12 +60,15 @@ describe("NoopSandboxProvider", () => {
     expect(a.id).not.toBe(b.id);
   });
 
-  it("destroy is idempotent", async () => {
+  it("destroy is idempotent and reports removed/missing via the discriminated result", async () => {
     const provider = new NoopSandboxProvider();
     const ref = await provider.create(repo, "main");
 
-    await provider.destroy(ref);
-    await expect(provider.destroy(ref)).resolves.toBeUndefined();
+    await expect(provider.destroy(ref)).resolves.toEqual({ kind: "removed" });
+    // Second call: the id is gone from the internal set, so it resolves to
+    // `missing` rather than silently succeeding. Callers (and T-203) need
+    // this distinction to tell a real teardown from a redundant retry.
+    await expect(provider.destroy(ref)).resolves.toEqual({ kind: "missing" });
     // resolveLocalPath is a pure function of the ref — it stays valid even
     // after destroy. The destroyed-ness lives in the provider's own state;
     // that's intentional for the free-function design.


### PR DESCRIPTION
## Summary

First local `SandboxProvider` implementation, backed by `git worktree`. Creates one worktree per `(runId, ticketId)` under a configurable base dir (default `~/.relay/sandboxes`), with branch `sandbox/<runId>/<ticketId>` and a `.relay-state.json` stamp inside each worktree for crash-recovery scans.

## Why

- Paves the path for `LocalChildProcessExecutor` in T-202 (that executor needs a real on-disk workdir, and this provides it).
- Ownership of each checkout is visible from `git worktree list` via the branch name — no cross-referencing state files to figure out which run a worktree belongs to.
- `.relay-state.json` gives T-203 crash recovery a well-known place to identify orphaned sandboxes after a harness crash.

## Design notes

- **`runGit` injection.** The provider takes an optional `runGit: (args, cwd) => Promise<{stdout,stderr,code}>` in its ctor. Default impl spawns git as a child process with argv (no shell). Tests inject a mock so the unit suite doesn't need a real git repo on disk.
- **Crash-preserve behavior.** `destroy()` never implicitly forces. When `git worktree remove` reports a dirty worktree (stderr contains "modified or untracked files" / "is dirty" / etc.), `destroy()` returns without throwing and without deleting anything — T-203 callers inspect. `{ force: true }` opts into `--force`. Missing paths are a silent no-op.
- **Deterministic id.** `id = runtime-<runId>-<ticketId>` so callers can look up sandboxes across restarts without a separate index.
- **Out of scope.** No scheduler wiring (T-202) and no "list orphans" CLI / recovery scan (T-203).

## Test plan

- [x] 10 unit tests pass with mocked `runGit` (no real git required).
- [x] Coverage: create args, state-file shape, ref shape (`workdir.kind === "local"`, `meta.branch`), destroy args (with/without `--force`), destroy idempotency on missing path, dirty-worktree preservation, non-dirty failures rethrow, distinct refs for concurrent creates with different ids.
- [x] 1 integration test gated behind `RELAY_TEST_REAL_GIT=1` — uses `git init` in a temp dir, real `git worktree add`/`remove`. Skipped on CI by default.
- [x] `pnpm typecheck`, `pnpm build`, `pnpm test` all clean (196 passed, 2 skipped — one the new real-git test, one pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)