### PR TITLE
T-402: PostgresHarnessStore + SQL migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node -e \"require('fs').cpSync('src/storage/migrations','dist/storage/migrations',{recursive:true,filter:(p)=>!p.endsWith('.ts')})\"",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-migrations.mjs",
     "demo": "tsx src/cli.ts",
     "demo:live": "HARNESS_LIVE=1 tsx src/cli.ts",
     "list-runs": "tsx src/cli.ts list-runs",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node -e \"require('fs').cpSync('src/storage/migrations','dist/storage/migrations',{recursive:true,filter:(p)=>!p.endsWith('.ts')})\"",
     "demo": "tsx src/cli.ts",
     "demo:live": "HARNESS_LIVE=1 tsx src/cli.ts",
     "list-runs": "tsx src/cli.ts list-runs",
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.30",
+    "@types/pg": "^8.20.0",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "zod": "^3.24.4"
@@ -39,6 +40,7 @@
     "@aoagents/ao-plugin-scm-github": "0.2.5",
     "@aoagents/ao-plugin-tracker-github": "0.2.5",
     "@aoagents/ao-plugin-tracker-linear": "0.2.5",
+    "pg": "^8.20.0",
     "tsx": "^4.20.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@aoagents/ao-plugin-tracker-linear':
         specifier: 0.2.5
         version: 0.2.5
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
@@ -27,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^22.15.30
         version: 22.19.15
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -351,6 +357,9 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -465,6 +474,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -475,6 +518,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -490,6 +549,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -612,6 +675,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -808,6 +875,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -934,6 +1007,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -943,6 +1051,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -980,6 +1098,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -1095,6 +1215,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xtend@4.0.2: {}
 
   yaml@2.8.3: {}
 

--- a/scripts/copy-migrations.mjs
+++ b/scripts/copy-migrations.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * copy-migrations.mjs
+ *
+ * The SQL files under `src/storage/migrations/NNN_*.sql` are runtime
+ * artifacts, not TypeScript — `tsc` won't emit them into `dist/`. This
+ * script copies every non-`.ts` file from the source migrations dir into
+ * the matching `dist/` path so the published package can locate them at
+ * runtime via `fileURLToPath(import.meta.url)`.
+ *
+ * Invoked from the `build` script in package.json after `tsc`. Kept out of
+ * the build script itself because a one-line `cpSync` in package.json is
+ * hostile to read and easy to break silently.
+ */
+import { cpSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+const src = join(repoRoot, "src/storage/migrations");
+const dst = join(repoRoot, "dist/storage/migrations");
+
+cpSync(src, dst, {
+  recursive: true,
+  filter: (path) => !path.endsWith(".ts")
+});

--- a/src/storage/file-store.ts
+++ b/src/storage/file-store.ts
@@ -31,8 +31,8 @@ import type {
  * callers in the same process can't lose updates on a read-modify-write.
  *
  * Single-process only: cross-process coordination (flock, Postgres advisory
- * locks, etc.) is explicitly out of scope here — use `PgHarnessStore` from
- * T-402 when multiple processes need to share the same state.
+ * locks, etc.) is explicitly out of scope here — use `PostgresHarnessStore`
+ * when multiple processes need to share the same state.
  */
 
 // Per-key mutex shared across all store instances. Keyed by "${ns}\0${id}"
@@ -295,7 +295,7 @@ export class FileHarnessStore implements HarnessStore {
    *
    * Poll interval is 250ms — balances promptness vs CPU and matches the
    * at-least-once coalescing contract consumers already need to tolerate
-   * for the Postgres `LISTEN/NOTIFY` implementation (T-402). `fs.watch` was
+   * for the Postgres `LISTEN/NOTIFY` implementation. `fs.watch` was
    * rejected due to platform-specific quirks (macOS coalescing, Linux
    * non-recursive behavior on subdir creation).
    *

--- a/src/storage/file-store.ts
+++ b/src/storage/file-store.ts
@@ -52,7 +52,7 @@ let tmpCounter = 0;
  * would otherwise be able to read/write arbitrary files under the process's
  * uid.
  */
-function assertSafeSegment(segment: string, kind: "ns" | "id"): void {
+export function assertSafeSegment(segment: string, kind: "ns" | "id"): void {
   if (
     segment === "" ||
     segment === "." ||

--- a/src/storage/migrations/001_init.sql
+++ b/src/storage/migrations/001_init.sql
@@ -39,6 +39,11 @@ CREATE TABLE IF NOT EXISTS harness_blobs (
 -- pg_notify from triggers instead of call sites so a future caller that
 -- inserts directly (e.g. an admin SQL session) still emits the event and
 -- watchers don't silently go stale.
+--
+-- Channel name cap: Postgres identifiers truncate at 63 bytes. The prefix
+-- `harness_change_` is 15 chars, leaving 48 for `ns`. The application layer
+-- (`postgres-store.ts` `watch()` guard and `MAX_WATCH_NS_LENGTH`) rejects
+-- any `ns` longer than 48 so LISTEN and NOTIFY agree on the same identifier.
 CREATE OR REPLACE FUNCTION harness_notify_change() RETURNS TRIGGER AS $$
 DECLARE
   change_kind TEXT;

--- a/src/storage/migrations/001_init.sql
+++ b/src/storage/migrations/001_init.sql
@@ -1,0 +1,76 @@
+-- Three primitives behind HarnessStore: docs (JSONB key-value), logs
+-- (BIGSERIAL-ordered append-only), blobs (BYTEA). The (ns, id) composite
+-- primary key mirrors the filesystem layout so the contract stays identical
+-- across backends.
+
+CREATE TABLE IF NOT EXISTS harness_docs (
+  ns TEXT NOT NULL,
+  id TEXT NOT NULL,
+  doc JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (ns, id)
+);
+
+-- text_pattern_ops lets LIKE 'prefix%' use this index regardless of the
+-- database's default collation.
+CREATE INDEX IF NOT EXISTS idx_harness_docs_ns_id_prefix
+  ON harness_docs (ns, id text_pattern_ops);
+
+CREATE TABLE IF NOT EXISTS harness_logs (
+  ns TEXT NOT NULL,
+  id TEXT NOT NULL,
+  seq BIGSERIAL NOT NULL,
+  entry JSONB NOT NULL,
+  entry_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (ns, id, seq)
+);
+
+CREATE TABLE IF NOT EXISTS harness_blobs (
+  ns TEXT NOT NULL,
+  id TEXT NOT NULL,
+  bytes BYTEA NOT NULL,
+  meta JSONB NOT NULL DEFAULT '{}'::jsonb,
+  size BIGINT NOT NULL,
+  content_type TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (ns, id)
+);
+
+-- pg_notify from triggers instead of call sites so a future caller that
+-- inserts directly (e.g. an admin SQL session) still emits the event and
+-- watchers don't silently go stale.
+CREATE OR REPLACE FUNCTION harness_notify_change() RETURNS TRIGGER AS $$
+DECLARE
+  change_kind TEXT;
+  ns_val TEXT;
+  id_val TEXT;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    ns_val := OLD.ns; id_val := OLD.id; change_kind := 'delete';
+  ELSIF TG_OP = 'INSERT' AND TG_TABLE_NAME = 'harness_logs' THEN
+    ns_val := NEW.ns; id_val := NEW.id; change_kind := 'append';
+  ELSE
+    ns_val := NEW.ns; id_val := NEW.id; change_kind := 'put';
+  END IF;
+  PERFORM pg_notify(
+    'harness_change_' || ns_val,
+    json_build_object('id', id_val, 'kind', change_kind)::text
+  );
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS harness_docs_notify ON harness_docs;
+CREATE TRIGGER harness_docs_notify
+  AFTER INSERT OR UPDATE OR DELETE ON harness_docs
+  FOR EACH ROW EXECUTE FUNCTION harness_notify_change();
+
+DROP TRIGGER IF EXISTS harness_logs_notify ON harness_logs;
+CREATE TRIGGER harness_logs_notify
+  AFTER INSERT ON harness_logs
+  FOR EACH ROW EXECUTE FUNCTION harness_notify_change();
+
+DROP TRIGGER IF EXISTS harness_blobs_notify ON harness_blobs;
+CREATE TRIGGER harness_blobs_notify
+  AFTER INSERT OR UPDATE OR DELETE ON harness_blobs
+  FOR EACH ROW EXECUTE FUNCTION harness_notify_change();

--- a/src/storage/migrations/runner.ts
+++ b/src/storage/migrations/runner.ts
@@ -68,7 +68,11 @@ export async function migrate(
         await client.query("COMMIT");
         applied.push({ version, alreadyApplied: false });
       } catch (err) {
-        await client.query("ROLLBACK").catch(() => {});
+        await client.query("ROLLBACK").catch((rollbackErr) => {
+          console.warn(
+            `[migration] ROLLBACK failed after ${version} error: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`
+          );
+        });
         throw err;
       } finally {
         client.release();

--- a/src/storage/migrations/runner.ts
+++ b/src/storage/migrations/runner.ts
@@ -1,0 +1,122 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import pg from "pg";
+
+/**
+ * Tiny forward-only migration runner. Reads `NNN_*.sql` files from this
+ * directory in lexical order, runs each inside a transaction, and records the
+ * version in `harness_schema_migrations`. Re-running is a no-op.
+ *
+ * Deliberately minimal — we don't need down migrations, checksums, or
+ * branching histories. A separate library adds weight we don't earn back at
+ * this scale.
+ */
+
+export interface MigrateOptions {
+  pool?: pg.Pool;
+  connectionString?: string;
+  migrationsDir?: string;
+}
+
+export interface AppliedMigration {
+  version: string;
+  alreadyApplied: boolean;
+}
+
+const SCHEMA_TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS harness_schema_migrations (
+  version TEXT PRIMARY KEY,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)
+`;
+
+export async function migrate(
+  opts: MigrateOptions = {}
+): Promise<AppliedMigration[]> {
+  const { pool, ownsPool } = resolvePool(opts);
+  const dir = opts.migrationsDir ?? defaultMigrationsDir();
+
+  try {
+    await pool.query(SCHEMA_TABLE_DDL);
+    const files = (await readdir(dir))
+      .filter((f) => /^\d+_.*\.sql$/.test(f))
+      .sort();
+
+    const applied: AppliedMigration[] = [];
+    for (const file of files) {
+      const version = file.replace(/\.sql$/, "");
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        const { rowCount } = await client.query(
+          "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
+          [version]
+        );
+        if (rowCount && rowCount > 0) {
+          await client.query("COMMIT");
+          applied.push({ version, alreadyApplied: true });
+          continue;
+        }
+        const sql = await readFile(join(dir, file), "utf8");
+        await client.query(sql);
+        await client.query(
+          "INSERT INTO harness_schema_migrations (version) VALUES ($1)",
+          [version]
+        );
+        await client.query("COMMIT");
+        applied.push({ version, alreadyApplied: false });
+      } catch (err) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+    return applied;
+  } finally {
+    if (ownsPool) await pool.end();
+  }
+}
+
+function resolvePool(opts: MigrateOptions): {
+  pool: pg.Pool;
+  ownsPool: boolean;
+} {
+  if (opts.pool) return { pool: opts.pool, ownsPool: false };
+  const connectionString =
+    opts.connectionString ?? process.env["HARNESS_POSTGRES_URL"];
+  if (!connectionString) {
+    throw new Error(
+      "migrate(): pass { pool } or { connectionString }, or set HARNESS_POSTGRES_URL"
+    );
+  }
+  return { pool: new pg.Pool({ connectionString }), ownsPool: true };
+}
+
+function defaultMigrationsDir(): string {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+// CLI entry: `tsx src/storage/migrations/runner.ts migrate`
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("runner.ts") === true ||
+  process.argv[1]?.endsWith("runner.js") === true;
+
+if (isMain && process.argv[2] === "migrate") {
+  migrate()
+    .then((results) => {
+      for (const r of results) {
+        const tag = r.alreadyApplied ? "skip" : "apply";
+        process.stdout.write(`${tag} ${r.version}\n`);
+      }
+    })
+    .catch((err) => {
+      process.stderr.write(
+        `migrate failed: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      process.exit(1);
+    });
+}

--- a/src/storage/namespaces.ts
+++ b/src/storage/namespaces.ts
@@ -1,8 +1,8 @@
 /**
  * Central namespace constants for `HarnessStore`. Referencing these rather
- * than inline string literals lets the Postgres impl (T-402) map each ns to
- * a dedicated table without a mass string-find across callers, and keeps
- * typos from silently partitioning data.
+ * than inline string literals lets the Postgres impl map each ns to a
+ * dedicated table (or filter on `ns`) without a mass string-find across
+ * callers, and keeps typos from silently partitioning data.
  */
 
 export const STORE_NS = {

--- a/src/storage/postgres-store.ts
+++ b/src/storage/postgres-store.ts
@@ -9,6 +9,15 @@ import type {
 } from "./store.js";
 
 /**
+ * Postgres channel names truncate at 63 bytes. The prefix `harness_change_`
+ * is 15 characters, leaving 48 for the `ns`. Callers that violate this would
+ * silently LISTEN on one identifier and NOTIFY from a different (truncated)
+ * identifier — events would never land. The trigger in `001_init.sql` emits
+ * the untruncated string; both sides of the contract rely on this cap.
+ */
+const MAX_WATCH_NS_LENGTH = 48;
+
+/**
  * Postgres-backed `HarnessStore`. Same contract as `FileHarnessStore`, with
  * durability and cross-process coordination earned via the database:
  *
@@ -34,7 +43,9 @@ interface WatchSubscription {
   expectedId: string;
   queue: ChangeEvent[];
   resolveWaiter: ((event: ChangeEvent | null) => void) | null;
+  rejectWaiter: ((err: unknown) => void) | null;
   closed: boolean;
+  error: unknown;
 }
 
 export class PostgresHarnessStore implements HarnessStore {
@@ -77,11 +88,19 @@ export class PostgresHarnessStore implements HarnessStore {
         sub.closed = true;
         sub.resolveWaiter?.(null);
       }
-      await entry.client.end().catch(() => {});
+      await entry.client.end().catch((err) => {
+        console.warn(
+          `[postgres-store] LISTEN client.end() failed during close(): ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     }
     this.listenClients.clear();
     if (this.ownsPool) {
-      await this.pool.end().catch(() => {});
+      await this.pool.end().catch((err) => {
+        console.warn(
+          `[postgres-store] pool.end() failed during close(): ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     }
   }
 
@@ -110,12 +129,18 @@ export class PostgresHarnessStore implements HarnessStore {
 
   async listDocs<T>(ns: string, prefix?: string): Promise<T[]> {
     assertSafeSegment(ns, "ns");
+    // Escape LIKE metacharacters so a prefix containing `_` or `%` matches
+    // literally, mirroring FileHarnessStore.listDocs which uses
+    // `String.startsWith`. Without this, a prefix of `a_b` would match
+    // `axb`, `aab`, etc., diverging from the contract.
+    const escapedPrefix =
+      prefix !== undefined ? prefix.replace(/[\\%_]/g, "\\$&") : null;
     const result = await this.pool.query<{ doc: T }>(
       `SELECT doc FROM harness_docs
        WHERE ns = $1
-         AND ($2::text IS NULL OR id LIKE $2 || '%')
+         AND ($2::text IS NULL OR id LIKE $2 || '%' ESCAPE '\\')
        ORDER BY id`,
-      [ns, prefix ?? null]
+      [ns, escapedPrefix]
     );
     return result.rows.map((r) => r.doc);
   }
@@ -238,6 +263,20 @@ export class PostgresHarnessStore implements HarnessStore {
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
 
+  /**
+   * Atomic read-modify-write keyed on `(ns, id)`. Cross-process serialization
+   * is enforced by a transaction-scoped Postgres advisory lock derived from
+   * `hashtextextended(ns || '\0' || id, 0)`. Two callers racing on a fresh
+   * key therefore queue on the same advisory slot and see consistent `prev`
+   * values — `SELECT ... FOR UPDATE` alone is insufficient because it
+   * returns zero rows for a non-existent key, so both callers would see
+   * `prev=null` and both would compute `next` from stale state.
+   *
+   * The transaction also holds a row-level `FOR UPDATE` lock once the row
+   * exists. `fn` runs inside the transaction; if it throws the transaction
+   * is rolled back and no row is modified. `fn` itself should be pure and
+   * fast — the row lock is held for its entire runtime.
+   */
   async mutate<T>(
     ns: string,
     id: string,
@@ -248,6 +287,19 @@ export class PostgresHarnessStore implements HarnessStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
+      // Advisory lock serializes concurrent mutate() callers on the same
+      // (ns, id), including when the row does not yet exist. The lock key
+      // is derived server-side from the composite identifier so all
+      // processes hash to the same slot. `/` is a safe separator because
+      // `assertSafeSegment` already bans it from both `ns` and `id`, so no
+      // two distinct pairs can collide in the concatenated form. A null
+      // byte (`E'\0'`) is rejected by Postgres's UTF8 input at parse time
+      // so we deliberately avoid it even though it would be a more obvious
+      // delimiter.
+      await client.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1 || '/' || $2, 0))",
+        [ns, id]
+      );
       const existing = await client.query<{ doc: T }>(
         "SELECT doc FROM harness_docs WHERE ns = $1 AND id = $2 FOR UPDATE",
         [ns, id]
@@ -267,7 +319,11 @@ export class PostgresHarnessStore implements HarnessStore {
       await client.query("COMMIT");
       return next;
     } catch (err) {
-      await client.query("ROLLBACK").catch(() => {});
+      await client.query("ROLLBACK").catch((rollbackErr) => {
+        console.warn(
+          `[postgres-store] ROLLBACK failed in mutate(${ns}/${id}): ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`
+        );
+      });
       throw err;
     } finally {
       client.release();
@@ -277,6 +333,14 @@ export class PostgresHarnessStore implements HarnessStore {
   watch(ns: string, id: string): AsyncIterable<ChangeEvent> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
+    if (ns.length > MAX_WATCH_NS_LENGTH) {
+      // Postgres identifiers truncate at 63 bytes. `harness_change_` is 15
+      // chars, leaving 48 for the ns. Reject early rather than silently
+      // LISTEN on the truncated channel (and miss events).
+      throw new Error(
+        `watch(): ns exceeds ${MAX_WATCH_NS_LENGTH} chars (would truncate Postgres LISTEN channel): ${ns}`
+      );
+    }
 
     // Manual AsyncIterator so `return()` can wake a pending waiter and run
     // cleanup synchronously. An async generator would deadlock — the pending
@@ -288,12 +352,20 @@ export class PostgresHarnessStore implements HarnessStore {
     const iterator: AsyncIterator<ChangeEvent> = {
       async next(): Promise<IteratorResult<ChangeEvent>> {
         const sub = await subPromise;
+        if (sub.error) {
+          const err = sub.error;
+          sub.error = null;
+          throw err;
+        }
         if (sub.closed) return { value: undefined, done: true };
         const queued = sub.queue.shift();
         if (queued) return { value: queued, done: false };
-        const event = await new Promise<ChangeEvent | null>((resolve) => {
-          sub.resolveWaiter = resolve;
-        });
+        const event = await new Promise<ChangeEvent | null>(
+          (resolve, reject) => {
+            sub.resolveWaiter = resolve;
+            sub.rejectWaiter = reject;
+          }
+        );
         if (event === null) return { value: undefined, done: true };
         return { value: event, done: false };
       },
@@ -323,7 +395,9 @@ export class PostgresHarnessStore implements HarnessStore {
       expectedId: id,
       queue: [],
       resolveWaiter: null,
-      closed: false
+      rejectWaiter: null,
+      closed: false,
+      error: null
     };
 
     let entry = this.listenClients.get(ns);
@@ -340,10 +414,14 @@ export class PostgresHarnessStore implements HarnessStore {
 
       client.on("notification", (msg) => {
         if (!msg.payload) return;
+        const channel = msg.channel;
         let parsed: { id?: string; kind?: string };
         try {
           parsed = JSON.parse(msg.payload) as { id?: string; kind?: string };
-        } catch {
+        } catch (err) {
+          console.warn(
+            `[postgres-store] malformed watch payload on channel ${channel}: ${err instanceof Error ? err.message : String(err)}`
+          );
           return;
         }
         const kind = parsed.kind;
@@ -352,12 +430,17 @@ export class PostgresHarnessStore implements HarnessStore {
         const target = this.listenClients.get(ns);
         if (!target) return;
         for (const s of target.subscribers) {
+          // A subscriber may have been unsubscribed between NOTIFY arrival
+          // and the handler running; skip closed subs so we never push into
+          // a queue nobody will read.
+          if (s.closed) continue;
           // Filter at the subscriber so one LISTEN connection can fan out to
           // many watchers on the same ns keyed by different ids.
           if (event.id !== s.expectedId) continue;
           if (s.resolveWaiter) {
             const r = s.resolveWaiter;
             s.resolveWaiter = null;
+            s.rejectWaiter = null;
             r(event);
           } else {
             s.queue.push(event);
@@ -365,12 +448,18 @@ export class PostgresHarnessStore implements HarnessStore {
         }
       });
 
-      client.on("error", () => {
+      client.on("error", (err) => {
         const target = this.listenClients.get(ns);
         if (!target) return;
         for (const s of target.subscribers) {
+          s.error = err;
           s.closed = true;
-          if (s.resolveWaiter) {
+          if (s.rejectWaiter) {
+            const reject = s.rejectWaiter;
+            s.rejectWaiter = null;
+            s.resolveWaiter = null;
+            reject(err);
+          } else if (s.resolveWaiter) {
             const r = s.resolveWaiter;
             s.resolveWaiter = null;
             r(null);
@@ -394,6 +483,7 @@ export class PostgresHarnessStore implements HarnessStore {
     if (sub.resolveWaiter) {
       const r = sub.resolveWaiter;
       sub.resolveWaiter = null;
+      sub.rejectWaiter = null;
       r(null);
     }
     const entry = this.listenClients.get(ns);
@@ -402,10 +492,16 @@ export class PostgresHarnessStore implements HarnessStore {
     entry.refCount--;
     if (entry.refCount <= 0) {
       this.listenClients.delete(ns);
-      await entry.client
-        .query(`UNLISTEN ${quoteChannel(ns)}`)
-        .catch(() => {});
-      await entry.client.end().catch(() => {});
+      await entry.client.query(`UNLISTEN ${quoteChannel(ns)}`).catch((err) => {
+        console.warn(
+          `[postgres-store] UNLISTEN failed for ns ${ns}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
+      await entry.client.end().catch((err) => {
+        console.warn(
+          `[postgres-store] LISTEN client.end() failed during unsubscribe(${ns}): ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     }
   }
 

--- a/src/storage/postgres-store.ts
+++ b/src/storage/postgres-store.ts
@@ -1,0 +1,431 @@
+import pg from "pg";
+
+import { assertSafeSegment } from "./file-store.js";
+import type {
+  BlobRef,
+  ChangeEvent,
+  HarnessStore,
+  ReadLogOptions
+} from "./store.js";
+
+/**
+ * Postgres-backed `HarnessStore`. Same contract as `FileHarnessStore`, with
+ * durability and cross-process coordination earned via the database:
+ *
+ *   - docs:  `harness_docs` (JSONB, keyed on `(ns, id)`)
+ *   - logs:  `harness_logs` (BIGSERIAL `seq` per row, ordered reads)
+ *   - blobs: `harness_blobs` (BYTEA + optional meta JSON)
+ *   - mutate: `SELECT ... FOR UPDATE` inside a transaction — cross-process
+ *     safe without an in-memory mutex
+ *   - watch:  `LISTEN harness_change_<ns>` with notify fired from triggers
+ *     so direct SQL writes still surface to watchers
+ *
+ * The caller usually owns the `pg.Pool` so lifecycle and tuning sit at the
+ * app boundary, but a connection string is accepted for scripts.
+ */
+
+export interface PostgresHarnessStoreOptions {
+  pool?: pg.Pool;
+  connectionString?: string;
+}
+
+interface WatchSubscription {
+  ns: string;
+  expectedId: string;
+  queue: ChangeEvent[];
+  resolveWaiter: ((event: ChangeEvent | null) => void) | null;
+  closed: boolean;
+}
+
+export class PostgresHarnessStore implements HarnessStore {
+  private readonly pool: pg.Pool;
+  private readonly ownsPool: boolean;
+  private readonly connectionString: string | undefined;
+
+  // One dedicated LISTEN client per namespace, shared across all watchers on
+  // that ns. Refcounted so the connection returns to the pool once the last
+  // watcher exits.
+  private readonly listenClients: Map<
+    string,
+    { client: pg.Client; refCount: number; subscribers: Set<WatchSubscription> }
+  > = new Map();
+
+  constructor(opts: PostgresHarnessStoreOptions) {
+    if (opts.pool) {
+      this.pool = opts.pool;
+      this.ownsPool = false;
+      this.connectionString = opts.connectionString;
+    } else if (opts.connectionString) {
+      this.pool = new pg.Pool({ connectionString: opts.connectionString });
+      this.ownsPool = true;
+      this.connectionString = opts.connectionString;
+    } else {
+      throw new Error(
+        "PostgresHarnessStore requires `pool` or `connectionString`"
+      );
+    }
+  }
+
+  /**
+   * Release resources this store owns. Safe to call multiple times. Only
+   * ends the pool if the store created it; a caller-supplied pool is left
+   * untouched so other consumers aren't kicked off mid-flight.
+   */
+  async close(): Promise<void> {
+    for (const [, entry] of this.listenClients) {
+      for (const sub of entry.subscribers) {
+        sub.closed = true;
+        sub.resolveWaiter?.(null);
+      }
+      await entry.client.end().catch(() => {});
+    }
+    this.listenClients.clear();
+    if (this.ownsPool) {
+      await this.pool.end().catch(() => {});
+    }
+  }
+
+  async getDoc<T>(ns: string, id: string): Promise<T | null> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+    const result = await this.pool.query<{ doc: T }>(
+      "SELECT doc FROM harness_docs WHERE ns = $1 AND id = $2",
+      [ns, id]
+    );
+    if (result.rowCount === 0) return null;
+    return result.rows[0]?.doc ?? null;
+  }
+
+  async putDoc<T>(ns: string, id: string, doc: T): Promise<void> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+    await this.pool.query(
+      `INSERT INTO harness_docs (ns, id, doc, updated_at)
+       VALUES ($1, $2, $3::jsonb, NOW())
+       ON CONFLICT (ns, id)
+       DO UPDATE SET doc = EXCLUDED.doc, updated_at = NOW()`,
+      [ns, id, JSON.stringify(doc)]
+    );
+  }
+
+  async listDocs<T>(ns: string, prefix?: string): Promise<T[]> {
+    assertSafeSegment(ns, "ns");
+    const result = await this.pool.query<{ doc: T }>(
+      `SELECT doc FROM harness_docs
+       WHERE ns = $1
+         AND ($2::text IS NULL OR id LIKE $2 || '%')
+       ORDER BY id`,
+      [ns, prefix ?? null]
+    );
+    return result.rows.map((r) => r.doc);
+  }
+
+  async deleteDoc(ns: string, id: string): Promise<void> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+    await this.pool.query(
+      "DELETE FROM harness_docs WHERE ns = $1 AND id = $2",
+      [ns, id]
+    );
+  }
+
+  async appendLog(ns: string, id: string, entry: unknown): Promise<void> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+    await this.pool.query(
+      "INSERT INTO harness_logs (ns, id, entry) VALUES ($1, $2, $3::jsonb)",
+      [ns, id, JSON.stringify(entry)]
+    );
+  }
+
+  async readLog<T>(
+    ns: string,
+    id: string,
+    opts?: ReadLogOptions
+  ): Promise<T[]> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+
+    // Resolve `after` (an entry-level cursor from ReadLogOptions) to a `seq`.
+    // If the cursor doesn't match any entry, mirror FileHarnessStore and
+    // return []. Returning the full log would cause duplicate delivery on
+    // resume — the contract is documented on ReadLogOptions.after.
+    let afterSeq: number | null = null;
+    if (opts?.after !== undefined) {
+      const cursor = opts.after;
+      const match = await this.pool.query<{ seq: string }>(
+        `SELECT seq FROM harness_logs
+         WHERE ns = $1 AND id = $2
+           AND (
+             entry->>'id' = $3
+             OR entry->>'entryId' = $3
+             OR entry->>'eventId' = $3
+             OR entry->>'timestamp' = $3
+             OR entry->>'createdAt' = $3
+           )
+         ORDER BY seq
+         LIMIT 1`,
+        [ns, id, cursor]
+      );
+      if (match.rowCount === 0) return [];
+      afterSeq = Number(match.rows[0]?.seq ?? 0);
+    }
+
+    const rows = await this.pool.query<{ entry: T; seq: string }>(
+      `SELECT entry, seq FROM harness_logs
+       WHERE ns = $1 AND id = $2
+         AND ($3::bigint IS NULL OR seq > $3)
+       ORDER BY seq`,
+      [ns, id, afterSeq]
+    );
+
+    let entries = rows.rows.map((r) => r.entry);
+    if (opts?.limit !== undefined && opts.limit < entries.length) {
+      entries = entries.slice(-opts.limit);
+    }
+    return entries;
+  }
+
+  async putBlob(
+    ns: string,
+    id: string,
+    bytes: Uint8Array,
+    meta?: Record<string, string>
+  ): Promise<BlobRef> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+    const contentType = meta?.["contentType"];
+    const metaJson = meta ? JSON.stringify(meta) : "{}";
+    const buf = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+    await this.pool.query(
+      `INSERT INTO harness_blobs (ns, id, bytes, meta, size, content_type, updated_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5, $6, NOW())
+       ON CONFLICT (ns, id)
+       DO UPDATE SET
+         bytes = EXCLUDED.bytes,
+         meta = EXCLUDED.meta,
+         size = EXCLUDED.size,
+         content_type = EXCLUDED.content_type,
+         updated_at = NOW()`,
+      [ns, id, buf, metaJson, bytes.byteLength, contentType ?? null]
+    );
+
+    const hasMeta = meta !== undefined && Object.keys(meta).length > 0;
+    return {
+      ns,
+      id,
+      size: bytes.byteLength,
+      contentType: hasMeta ? contentType : undefined
+    };
+  }
+
+  async getBlob(ref: BlobRef): Promise<Uint8Array> {
+    assertSafeSegment(ref.ns, "ns");
+    assertSafeSegment(ref.id, "id");
+    const result = await this.pool.query<{ bytes: Buffer }>(
+      "SELECT bytes FROM harness_blobs WHERE ns = $1 AND id = $2",
+      [ref.ns, ref.id]
+    );
+    if (result.rowCount === 0) {
+      const err: NodeJS.ErrnoException = new Error(
+        `Blob not found: ${ref.ns}/${ref.id}`
+      );
+      err.code = "ENOENT";
+      throw err;
+    }
+    const buf = result.rows[0]!.bytes;
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+
+  async mutate<T>(
+    ns: string,
+    id: string,
+    fn: (prev: T | null) => T
+  ): Promise<T> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const existing = await client.query<{ doc: T }>(
+        "SELECT doc FROM harness_docs WHERE ns = $1 AND id = $2 FOR UPDATE",
+        [ns, id]
+      );
+      const prev: T | null =
+        existing.rowCount && existing.rowCount > 0
+          ? existing.rows[0]!.doc
+          : null;
+      const next = fn(prev);
+      await client.query(
+        `INSERT INTO harness_docs (ns, id, doc, updated_at)
+         VALUES ($1, $2, $3::jsonb, NOW())
+         ON CONFLICT (ns, id)
+         DO UPDATE SET doc = EXCLUDED.doc, updated_at = NOW()`,
+        [ns, id, JSON.stringify(next)]
+      );
+      await client.query("COMMIT");
+      return next;
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  watch(ns: string, id: string): AsyncIterable<ChangeEvent> {
+    assertSafeSegment(ns, "ns");
+    assertSafeSegment(id, "id");
+
+    // Manual AsyncIterator so `return()` can wake a pending waiter and run
+    // cleanup synchronously. An async generator would deadlock — the pending
+    // Promise we await on for the next event has no external resolver, so
+    // `iterator.return()` would hang forever.
+    const store = this;
+    const subPromise = this.subscribe(ns, id);
+
+    const iterator: AsyncIterator<ChangeEvent> = {
+      async next(): Promise<IteratorResult<ChangeEvent>> {
+        const sub = await subPromise;
+        if (sub.closed) return { value: undefined, done: true };
+        const queued = sub.queue.shift();
+        if (queued) return { value: queued, done: false };
+        const event = await new Promise<ChangeEvent | null>((resolve) => {
+          sub.resolveWaiter = resolve;
+        });
+        if (event === null) return { value: undefined, done: true };
+        return { value: event, done: false };
+      },
+      async return(): Promise<IteratorResult<ChangeEvent>> {
+        const sub = await subPromise;
+        await store.unsubscribe(ns, sub);
+        return { value: undefined, done: true };
+      },
+      async throw(err: unknown): Promise<IteratorResult<ChangeEvent>> {
+        const sub = await subPromise;
+        await store.unsubscribe(ns, sub);
+        throw err;
+      }
+    };
+
+    return {
+      [Symbol.asyncIterator]: () => iterator
+    };
+  }
+
+  private async subscribe(
+    ns: string,
+    id: string
+  ): Promise<WatchSubscription> {
+    const sub: WatchSubscription = {
+      ns,
+      expectedId: id,
+      queue: [],
+      resolveWaiter: null,
+      closed: false
+    };
+
+    let entry = this.listenClients.get(ns);
+    if (!entry) {
+      const client = new pg.Client({
+        connectionString: this.connectionStringForClient()
+      });
+      // A Pool client can't hold a long-lived LISTEN because the pool will
+      // rotate it back into the free list. Dedicated Client instead.
+      await client.connect();
+      await client.query(`LISTEN ${quoteChannel(ns)}`);
+      entry = { client, refCount: 0, subscribers: new Set() };
+      this.listenClients.set(ns, entry);
+
+      client.on("notification", (msg) => {
+        if (!msg.payload) return;
+        let parsed: { id?: string; kind?: string };
+        try {
+          parsed = JSON.parse(msg.payload) as { id?: string; kind?: string };
+        } catch {
+          return;
+        }
+        const kind = parsed.kind;
+        if (kind !== "put" && kind !== "delete" && kind !== "append") return;
+        const event: ChangeEvent = { ns, id: parsed.id ?? "", kind };
+        const target = this.listenClients.get(ns);
+        if (!target) return;
+        for (const s of target.subscribers) {
+          // Filter at the subscriber so one LISTEN connection can fan out to
+          // many watchers on the same ns keyed by different ids.
+          if (event.id !== s.expectedId) continue;
+          if (s.resolveWaiter) {
+            const r = s.resolveWaiter;
+            s.resolveWaiter = null;
+            r(event);
+          } else {
+            s.queue.push(event);
+          }
+        }
+      });
+
+      client.on("error", () => {
+        const target = this.listenClients.get(ns);
+        if (!target) return;
+        for (const s of target.subscribers) {
+          s.closed = true;
+          if (s.resolveWaiter) {
+            const r = s.resolveWaiter;
+            s.resolveWaiter = null;
+            r(null);
+          }
+        }
+      });
+    }
+
+    entry.subscribers.add(sub);
+    entry.refCount++;
+    return sub;
+  }
+
+  private async unsubscribe(
+    ns: string,
+    sub: WatchSubscription
+  ): Promise<void> {
+    sub.closed = true;
+    // Wake any pending waiter so the generator's finally can run; otherwise
+    // iterator.return() awaits a promise that will never resolve.
+    if (sub.resolveWaiter) {
+      const r = sub.resolveWaiter;
+      sub.resolveWaiter = null;
+      r(null);
+    }
+    const entry = this.listenClients.get(ns);
+    if (!entry) return;
+    entry.subscribers.delete(sub);
+    entry.refCount--;
+    if (entry.refCount <= 0) {
+      this.listenClients.delete(ns);
+      await entry.client
+        .query(`UNLISTEN ${quoteChannel(ns)}`)
+        .catch(() => {});
+      await entry.client.end().catch(() => {});
+    }
+  }
+
+  private connectionStringForClient(): string | undefined {
+    // When the caller passed a bare pool we don't have a connectionString;
+    // pg.Client's ctor falls through to PG* env vars, which is what an
+    // unconfigured pg.Pool would do anyway.
+    return this.connectionString;
+  }
+}
+
+/**
+ * Build a safely-quoted `LISTEN`/`UNLISTEN`/`NOTIFY` channel identifier for a
+ * ns. `assertSafeSegment` already rules out path-breaking characters, so the
+ * sanitize-then-quote below is defense-in-depth — it keeps the identifier
+ * lossless round-tripped against pg's parser and doubles any embedded quotes
+ * per the SQL spec. Must match the string that the trigger emits to
+ * `pg_notify`: `harness_change_<ns>`.
+ */
+function quoteChannel(ns: string): string {
+  const channel = `harness_change_${ns}`;
+  return `"${channel.replace(/"/g, '""')}"`;
+}

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -9,10 +9,10 @@
  *   - mutate: atomic read-modify-write for counters and indexes
  *
  * Callers use `watch` to observe downstream changes; the file impl polls,
- * the Postgres impl (T-402) will use `LISTEN/NOTIFY`. Semantics are
- * deliberately weak — at-least-once delivery, may coalesce, no ordering
- * guarantees across namespaces — so implementations can diverge on strategy
- * without breaking callers.
+ * the Postgres impl uses `LISTEN/NOTIFY`. Semantics are deliberately weak —
+ * at-least-once delivery, may coalesce, no ordering guarantees across
+ * namespaces — so implementations can diverge on strategy without breaking
+ * callers.
  */
 
 export interface BlobRef {
@@ -122,10 +122,10 @@ export interface HarnessStore {
    * `putDoc`. Serialized per (ns, id) within a single process — concurrent
    * `mutate` calls against the same key queue on a shared Promise-chain
    * mutex, so no caller's update is lost. `fn` may throw; the lock is
-   * released and the error propagates to the caller. Single-process only:
-   * cross-process coordination is out of scope (use `PgHarnessStore`
-   * when it lands in T-402). Throws `Unsafe path segment` for unsafe
-   * `ns` or `id`.
+   * released and the error propagates to the caller. Implementations may
+   * extend this to cross-process coordination (the Postgres impl uses a
+   * transaction-scoped advisory lock keyed on the same `(ns, id)`).
+   * Throws `Unsafe path segment` for unsafe `ns` or `id`.
    */
   mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T>;
 
@@ -142,5 +142,3 @@ export interface HarnessStore {
   watch(ns: string, id: string): AsyncIterable<ChangeEvent>;
 }
 
-// TODO(T-402): second impl backed by Postgres (`PgHarnessStore`) for the
-// cloud/pod deployment path. Same interface, different durability + fanout.

--- a/test/storage/postgres-migrations.integration.test.ts
+++ b/test/storage/postgres-migrations.integration.test.ts
@@ -1,0 +1,154 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import pg from "pg";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it
+} from "vitest";
+
+import { migrate } from "../../src/storage/migrations/runner.js";
+
+/**
+ * Integration tests for the forward-only migration runner, gated on
+ * HARNESS_TEST_POSTGRES_URL. The runner is small but load-bearing — a
+ * silent partial apply would poison the store. These tests pin the
+ * rerun-is-noop contract, lexical ordering, and rollback-on-failure.
+ */
+
+const TEST_URL = process.env["HARNESS_TEST_POSTGRES_URL"];
+const skipReason =
+  "requires HARNESS_TEST_POSTGRES_URL; set e.g. postgres://postgres@localhost:5432/relay_test";
+
+const maybeDescribe = TEST_URL ? describe : describe.skip;
+
+maybeDescribe(
+  `migrate() runner (integration, ${TEST_URL ?? skipReason})`,
+  () => {
+    let pool: pg.Pool;
+    let migrationsDir: string;
+    let schemaPrefix: string;
+
+    beforeAll(async () => {
+      if (!TEST_URL) return;
+      pool = new pg.Pool({ connectionString: TEST_URL });
+    });
+
+    afterAll(async () => {
+      if (!pool) return;
+      await pool.end();
+    });
+
+    beforeEach(async () => {
+      if (!TEST_URL) return;
+      // Unique per-test prefix lets multiple migration tests coexist in the
+      // same DB without fighting each other for the same table names. The
+      // SQL written into tmp files below interpolates this prefix so we
+      // never touch the real `harness_*` tables.
+      schemaPrefix = `mig_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+      migrationsDir = await mkdtemp(join(tmpdir(), "relay-mig-"));
+    });
+
+    afterEach(async () => {
+      if (!TEST_URL) return;
+      if (pool) {
+        // Clean up anything these tests created. CASCADE avoids FK noise.
+        await pool.query(
+          `DROP TABLE IF EXISTS ${schemaPrefix}_a, ${schemaPrefix}_b CASCADE`
+        );
+        // Guarded because `harness_schema_migrations` is only created the
+        // first time any migrate() call runs in the DB; the `skip reason`
+        // test doesn't invoke migrate() so the table may not exist yet.
+        await pool
+          .query(
+            `DELETE FROM harness_schema_migrations WHERE version LIKE $1`,
+            [`${schemaPrefix}%`]
+          )
+          .catch(() => undefined);
+      }
+      if (migrationsDir) {
+        await rm(migrationsDir, { recursive: true, force: true });
+      }
+    });
+
+    it("skip reason", () => {
+      if (!TEST_URL) {
+        // eslint-disable-next-line no-console
+        console.log(skipReason);
+      }
+      expect(true).toBe(true);
+    });
+
+    it("applies a single migration, then the second call is a no-op", async () => {
+      if (!TEST_URL) return;
+      const v1 = `001_${schemaPrefix}`;
+      await writeFile(
+        join(migrationsDir, `${v1}.sql`),
+        `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
+      );
+
+      const first = await migrate({ pool, migrationsDir });
+      expect(first).toEqual([{ version: v1, alreadyApplied: false }]);
+
+      const second = await migrate({ pool, migrationsDir });
+      expect(second).toEqual([{ version: v1, alreadyApplied: true }]);
+
+      const row = await pool.query(
+        "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
+        [v1]
+      );
+      expect(row.rowCount).toBe(1);
+    });
+
+    it("applies migrations in lexical order", async () => {
+      if (!TEST_URL) return;
+      const vA = `001_${schemaPrefix}`;
+      const vB = `002_${schemaPrefix}`;
+      await writeFile(
+        join(migrationsDir, `${vB}.sql`),
+        `CREATE TABLE ${schemaPrefix}_b (id INT PRIMARY KEY REFERENCES ${schemaPrefix}_a(id));`
+      );
+      await writeFile(
+        join(migrationsDir, `${vA}.sql`),
+        `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
+      );
+      // The 002 file references 001's table — if the runner applied them
+      // out of order the CREATE TABLE would fail on a missing FK target.
+      const applied = await migrate({ pool, migrationsDir });
+      expect(applied.map((m) => m.version)).toEqual([vA, vB]);
+    });
+
+    it("rolls a failing migration back and leaves harness_schema_migrations untouched", async () => {
+      if (!TEST_URL) return;
+      const vGood = `001_${schemaPrefix}`;
+      const vBad = `002_${schemaPrefix}`;
+      await writeFile(
+        join(migrationsDir, `${vGood}.sql`),
+        `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
+      );
+      await writeFile(
+        join(migrationsDir, `${vBad}.sql`),
+        `THIS IS NOT SQL AT ALL`
+      );
+
+      await expect(migrate({ pool, migrationsDir })).rejects.toThrow();
+
+      const good = await pool.query(
+        "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
+        [vGood]
+      );
+      expect(good.rowCount).toBe(1);
+      const bad = await pool.query(
+        "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
+        [vBad]
+      );
+      expect(bad.rowCount).toBe(0);
+    });
+  }
+);

--- a/test/storage/postgres-store.integration.test.ts
+++ b/test/storage/postgres-store.integration.test.ts
@@ -117,6 +117,39 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     expect(alphas.map((w) => w.id)).toEqual(["alpha-1", "alpha-2"]);
   });
 
+  it("listDocs escapes LIKE metacharacters in prefix (`_`, `%`)", async () => {
+    if (!TEST_URL) return;
+    // Without escaping, `_` matches any single character and `%` matches
+    // any sequence — so the presence of `alphaXb` would leak into a search
+    // for `alpha_b`. Verify parity with FileHarnessStore's String.startsWith.
+    await store.putDoc<Widget>(ns, "alpha_b1", {
+      id: "alpha_b1",
+      label: "u",
+      count: 0
+    });
+    await store.putDoc<Widget>(ns, "alphaXb1", {
+      id: "alphaXb1",
+      label: "x",
+      count: 0
+    });
+    await store.putDoc<Widget>(ns, "pct%tag", {
+      id: "pct%tag",
+      label: "p",
+      count: 0
+    });
+    await store.putDoc<Widget>(ns, "pctZtag", {
+      id: "pctZtag",
+      label: "z",
+      count: 0
+    });
+
+    const underscoreMatches = await store.listDocs<Widget>(ns, "alpha_");
+    expect(underscoreMatches.map((w) => w.id)).toEqual(["alpha_b1"]);
+
+    const percentMatches = await store.listDocs<Widget>(ns, "pct%");
+    expect(percentMatches.map((w) => w.id)).toEqual(["pct%tag"]);
+  });
+
   it("deleteDoc is idempotent and clears the row", async () => {
     if (!TEST_URL) return;
     await store.putDoc<Widget>(ns, "w1", { id: "w1", label: "a", count: 1 });
@@ -190,6 +223,37 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     };
     const loaded = await store.getBlob(manual);
     expect(new TextDecoder().decode(loaded)).toBe("hello postgres");
+  });
+
+  it("mutate creates the row from a null prev on a fresh key", async () => {
+    if (!TEST_URL) return;
+    const created = await store.mutate<Widget>(ns, "fresh", (prev) => {
+      expect(prev).toBeNull();
+      return { id: "fresh", label: "created", count: 7 };
+    });
+    expect(created).toEqual({ id: "fresh", label: "created", count: 7 });
+    const loaded = await store.getDoc<Widget>(ns, "fresh");
+    expect(loaded).toEqual(created);
+  });
+
+  it("mutate serializes 50 concurrent increments on a FRESH key (advisory lock)", async () => {
+    if (!TEST_URL) return;
+    // Critical: no putDoc first. Without advisory-lock serialization each
+    // caller's SELECT ... FOR UPDATE returns 0 rows, prev=null, and the
+    // final count ends at 1. The advisory lock forces strict ordering even
+    // before the row exists.
+    const ops: Promise<{ count: number }>[] = [];
+    for (let i = 0; i < 50; i++) {
+      ops.push(
+        store.mutate<{ count: number }>(ns, "fresh-ctr", (prev) => ({
+          count: (prev?.count ?? 0) + 1
+        }))
+      );
+    }
+    await Promise.all(ops);
+
+    const final = await store.getDoc<{ count: number }>(ns, "fresh-ctr");
+    expect(final?.count).toBe(50);
   });
 
   it("mutate serializes 50 concurrent increments on one key", async () => {

--- a/test/storage/postgres-store.integration.test.ts
+++ b/test/storage/postgres-store.integration.test.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+
+import pg from "pg";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it
+} from "vitest";
+
+import { migrate } from "../../src/storage/migrations/runner.js";
+import { PostgresHarnessStore } from "../../src/storage/postgres-store.js";
+import type { BlobRef, ChangeEvent } from "../../src/storage/store.js";
+
+/**
+ * Integration suite, gated on HARNESS_TEST_POSTGRES_URL. When the env var is
+ * missing every test skips with a clear message. The scenarios mirror the
+ * T-001 FileHarnessStore suite — that's the whole point of having a shared
+ * HarnessStore contract; both implementations should pass the same checks.
+ * T-001's tests are already merged and aren't refactored here to avoid cross-
+ * PR conflict; a follow-up can consolidate into a single conformance helper.
+ */
+
+const TEST_URL = process.env["HARNESS_TEST_POSTGRES_URL"];
+const skipReason =
+  "requires HARNESS_TEST_POSTGRES_URL; set e.g. postgres://postgres@localhost:5432/relay_test";
+
+interface Widget {
+  id: string;
+  label: string;
+  count: number;
+}
+
+const maybeDescribe = TEST_URL ? describe : describe.skip;
+
+maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, () => {
+  let pool: pg.Pool;
+  let store: PostgresHarnessStore;
+  let ns: string;
+
+  beforeAll(async () => {
+    if (!TEST_URL) return;
+    pool = new pg.Pool({ connectionString: TEST_URL });
+    await migrate({ pool });
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.end();
+  });
+
+  beforeEach(() => {
+    store = new PostgresHarnessStore({ pool });
+    ns = `it-${randomUUID()}`;
+  });
+
+  afterEach(async () => {
+    await store.close();
+    // Clean up the ns we used — other tests shouldn't see our rows.
+    if (pool && ns) {
+      await pool.query("DELETE FROM harness_docs WHERE ns = $1", [ns]);
+      await pool.query("DELETE FROM harness_logs WHERE ns = $1", [ns]);
+      await pool.query("DELETE FROM harness_blobs WHERE ns = $1", [ns]);
+    }
+  });
+
+  it("skip reason", () => {
+    // Visible in test output so CI makes it clear why integration tests
+    // didn't actually exercise the database. Always passes; real scenarios
+    // follow when TEST_URL is set.
+    if (!TEST_URL) {
+      // eslint-disable-next-line no-console
+      console.log(skipReason);
+    }
+    expect(true).toBe(true);
+  });
+
+  it("round-trips a typed doc via putDoc / getDoc", async () => {
+    if (!TEST_URL) return;
+    const widget: Widget = { id: "w1", label: "alpha", count: 3 };
+    await store.putDoc<Widget>(ns, "w1", widget);
+    const loaded = await store.getDoc<Widget>(ns, "w1");
+    expect(loaded).toEqual(widget);
+  });
+
+  it("getDoc returns null for a missing id", async () => {
+    if (!TEST_URL) return;
+    const loaded = await store.getDoc<Widget>(ns, "missing");
+    expect(loaded).toBeNull();
+  });
+
+  it("listDocs returns alphabetically-stable results and honors prefix", async () => {
+    if (!TEST_URL) return;
+    await store.putDoc<Widget>(ns, "beta-2", {
+      id: "beta-2",
+      label: "b2",
+      count: 0
+    });
+    await store.putDoc<Widget>(ns, "alpha-1", {
+      id: "alpha-1",
+      label: "a1",
+      count: 0
+    });
+    await store.putDoc<Widget>(ns, "alpha-2", {
+      id: "alpha-2",
+      label: "a2",
+      count: 0
+    });
+
+    const all = await store.listDocs<Widget>(ns);
+    expect(all.map((w) => w.id)).toEqual(["alpha-1", "alpha-2", "beta-2"]);
+
+    const alphas = await store.listDocs<Widget>(ns, "alpha-");
+    expect(alphas.map((w) => w.id)).toEqual(["alpha-1", "alpha-2"]);
+  });
+
+  it("deleteDoc is idempotent and clears the row", async () => {
+    if (!TEST_URL) return;
+    await store.putDoc<Widget>(ns, "w1", { id: "w1", label: "a", count: 1 });
+    await store.deleteDoc(ns, "w1");
+    expect(await store.getDoc<Widget>(ns, "w1")).toBeNull();
+    await expect(store.deleteDoc(ns, "w1")).resolves.toBeUndefined();
+  });
+
+  it("appendLog / readLog round-trip with cursor and limit", async () => {
+    if (!TEST_URL) return;
+    await store.appendLog(ns, "r1", { id: "a", v: 1 });
+    await store.appendLog(ns, "r1", { id: "b", v: 2 });
+    await store.appendLog(ns, "r1", { id: "c", v: 3 });
+    await store.appendLog(ns, "r1", { id: "d", v: 4 });
+
+    const all = await store.readLog<{ id: string; v: number }>(ns, "r1");
+    expect(all.map((e) => e.id)).toEqual(["a", "b", "c", "d"]);
+
+    const tail = await store.readLog<{ id: string; v: number }>(ns, "r1", {
+      limit: 2
+    });
+    expect(tail.map((e) => e.id)).toEqual(["c", "d"]);
+
+    const afterB = await store.readLog<{ id: string; v: number }>(ns, "r1", {
+      after: "b"
+    });
+    expect(afterB.map((e) => e.id)).toEqual(["c", "d"]);
+
+    const unknownCursor = await store.readLog<{ id: string; v: number }>(
+      ns,
+      "r1",
+      { after: "does-not-exist" }
+    );
+    expect(unknownCursor).toEqual([]);
+  });
+
+  it("readLog returns [] for a log with no entries", async () => {
+    if (!TEST_URL) return;
+    const empty = await store.readLog(ns, "never-written");
+    expect(empty).toEqual([]);
+  });
+
+  it("putBlob / getBlob round-trip binary bytes exactly", async () => {
+    if (!TEST_URL) return;
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+
+    const ref = await store.putBlob(ns, "bin-1", bytes, {
+      contentType: "application/octet-stream"
+    });
+    expect(ref).toMatchObject({
+      ns,
+      id: "bin-1",
+      size: 256,
+      contentType: "application/octet-stream"
+    });
+
+    const loaded = await store.getBlob(ref);
+    expect(loaded.length).toBe(256);
+    for (let i = 0; i < 256; i++) expect(loaded[i]).toBe(i);
+  });
+
+  it("getBlob works on a ref constructed from primitive fields", async () => {
+    if (!TEST_URL) return;
+    const payload = new TextEncoder().encode("hello postgres");
+    await store.putBlob(ns, "txt-1", payload);
+    const manual: BlobRef = {
+      ns,
+      id: "txt-1",
+      size: payload.byteLength
+    };
+    const loaded = await store.getBlob(manual);
+    expect(new TextDecoder().decode(loaded)).toBe("hello postgres");
+  });
+
+  it("mutate serializes 50 concurrent increments on one key", async () => {
+    if (!TEST_URL) return;
+    await store.putDoc<Widget>(ns, "ctr", {
+      id: "ctr",
+      label: "counter",
+      count: 0
+    });
+
+    const ops: Promise<Widget>[] = [];
+    for (let i = 0; i < 50; i++) {
+      ops.push(
+        store.mutate<Widget>(ns, "ctr", (prev) => ({
+          id: "ctr",
+          label: "counter",
+          count: (prev?.count ?? 0) + 1
+        }))
+      );
+    }
+    await Promise.all(ops);
+
+    const final = await store.getDoc<Widget>(ns, "ctr");
+    expect(final?.count).toBe(50);
+  });
+
+  it("watch yields a ChangeEvent when putDoc writes to the watched key", async () => {
+    if (!TEST_URL) return;
+    const watcherStore = new PostgresHarnessStore({
+      connectionString: TEST_URL
+    });
+    try {
+      const events: ChangeEvent[] = [];
+      const iterator = watcherStore
+        .watch(ns, "watched")
+        [Symbol.asyncIterator]();
+      const nextEvent = iterator.next();
+
+      // Small delay so the LISTEN is registered before we trigger the write.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      await store.putDoc<Widget>(ns, "watched", {
+        id: "watched",
+        label: "hi",
+        count: 1
+      });
+
+      const result = await Promise.race<
+        IteratorResult<ChangeEvent> | "timeout"
+      >([
+        nextEvent,
+        new Promise<"timeout">((resolve) =>
+          setTimeout(() => resolve("timeout"), 3000)
+        )
+      ]);
+
+      expect(result).not.toBe("timeout");
+      if (result !== "timeout" && !result.done) events.push(result.value);
+      expect(events[0]).toMatchObject({ ns, id: "watched", kind: "put" });
+
+      await iterator.return?.();
+    } finally {
+      await watcherStore.close();
+    }
+  });
+
+  it("watch cleans up on iterator.return()", async () => {
+    if (!TEST_URL) return;
+    const watcherStore = new PostgresHarnessStore({
+      connectionString: TEST_URL
+    });
+    try {
+      const iterator = watcherStore
+        .watch(ns, "watched-cleanup")
+        [Symbol.asyncIterator]();
+      // Prime the subscription and then close immediately.
+      const firstNext = iterator.next();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await iterator.return?.();
+      // Calling .return again is safe, and the pending .next() resolves done.
+      const resolved = await Promise.race<
+        IteratorResult<ChangeEvent> | "timeout"
+      >([
+        firstNext,
+        new Promise<"timeout">((resolve) =>
+          setTimeout(() => resolve("timeout"), 1000)
+        )
+      ]);
+      if (resolved !== "timeout") expect(resolved.done).toBe(true);
+    } finally {
+      await watcherStore.close();
+    }
+  });
+});

--- a/test/storage/postgres-store.unit.test.ts
+++ b/test/storage/postgres-store.unit.test.ts
@@ -1,0 +1,288 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { PostgresHarnessStore } from "../../src/storage/postgres-store.js";
+
+/**
+ * Unit tests drive a mock pg.Pool / pg.Client. They assert the shape of the
+ * SQL issued — parameter order, ON CONFLICT clauses, SELECT ... FOR UPDATE
+ * inside a transaction, LISTEN channel naming. They don't exercise the
+ * database; the integration test file does that.
+ */
+
+interface QueryCall {
+  text: string;
+  values?: unknown[];
+}
+
+function makePoolMock(
+  responses: (
+    text: string,
+    values: unknown[] | undefined
+  ) => { rows: unknown[]; rowCount?: number } = () => ({
+    rows: [],
+    rowCount: 0
+  })
+) {
+  const calls: QueryCall[] = [];
+  const clientCalls: QueryCall[] = [];
+  const released: boolean[] = [];
+
+  const client = {
+    query: vi.fn((text: string, values?: unknown[]) => {
+      clientCalls.push({ text, values });
+      return Promise.resolve(responses(text, values));
+    }),
+    release: vi.fn(() => {
+      released.push(true);
+    })
+  };
+
+  const pool = {
+    query: vi.fn((text: string, values?: unknown[]) => {
+      calls.push({ text, values });
+      return Promise.resolve(responses(text, values));
+    }),
+    connect: vi.fn(() => Promise.resolve(client)),
+    end: vi.fn(() => Promise.resolve())
+  };
+
+  return { pool, client, calls, clientCalls, released };
+}
+
+describe("PostgresHarnessStore (unit, mocked pg)", () => {
+  describe("getDoc", () => {
+    it("issues parameterized SELECT and returns null when no row", async () => {
+      const { pool, calls } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      const result = await store.getDoc("widgets", "w1");
+
+      expect(result).toBeNull();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.text).toMatch(
+        /SELECT doc FROM harness_docs WHERE ns = \$1 AND id = \$2/
+      );
+      expect(calls[0]?.values).toEqual(["widgets", "w1"]);
+    });
+
+    it("returns the row's doc when present", async () => {
+      const { pool } = makePoolMock(() => ({
+        rows: [{ doc: { id: "w1", hello: "world" } }],
+        rowCount: 1
+      }));
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      const result = await store.getDoc<{ id: string; hello: string }>(
+        "widgets",
+        "w1"
+      );
+      expect(result).toEqual({ id: "w1", hello: "world" });
+    });
+  });
+
+  describe("putDoc", () => {
+    it("uses INSERT ... ON CONFLICT DO UPDATE", async () => {
+      const { pool, calls } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      await store.putDoc("widgets", "w1", { v: 1 });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.text).toMatch(/INSERT INTO harness_docs/);
+      expect(calls[0]?.text).toMatch(
+        /ON CONFLICT \(ns, id\)\s+DO UPDATE SET doc = EXCLUDED\.doc/
+      );
+      // doc is serialized to a JSONB string literal — third param.
+      expect(calls[0]?.values?.[0]).toBe("widgets");
+      expect(calls[0]?.values?.[1]).toBe("w1");
+      expect(JSON.parse(String(calls[0]?.values?.[2]))).toEqual({ v: 1 });
+    });
+  });
+
+  describe("listDocs", () => {
+    it("builds a prefix-LIKE query and passes null when no prefix", async () => {
+      const { pool, calls } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      await store.listDocs("widgets");
+      expect(calls[0]?.values).toEqual(["widgets", null]);
+      expect(calls[0]?.text).toMatch(/ORDER BY id/);
+
+      await store.listDocs("widgets", "alpha-");
+      expect(calls[1]?.values).toEqual(["widgets", "alpha-"]);
+    });
+  });
+
+  describe("mutate", () => {
+    it("opens a transaction with SELECT ... FOR UPDATE", async () => {
+      const { pool, clientCalls } = makePoolMock((text) => {
+        if (/SELECT doc FROM harness_docs/.test(text)) {
+          return { rows: [{ doc: { count: 1 } }], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      const next = await store.mutate<{ count: number }>(
+        "widgets",
+        "ctr",
+        (prev) => ({ count: (prev?.count ?? 0) + 1 })
+      );
+
+      expect(next).toEqual({ count: 2 });
+      const texts = clientCalls.map((c) => c.text);
+      expect(texts[0]).toBe("BEGIN");
+      expect(texts[1]).toMatch(/SELECT doc.*FOR UPDATE/);
+      expect(texts.some((t) => /INSERT INTO harness_docs/.test(t))).toBe(true);
+      expect(texts[texts.length - 1]).toBe("COMMIT");
+    });
+
+    it("rolls back the transaction when fn throws", async () => {
+      const { pool, clientCalls } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      await expect(
+        store.mutate("widgets", "ctr", () => {
+          throw new Error("boom");
+        })
+      ).rejects.toThrow("boom");
+
+      const texts = clientCalls.map((c) => c.text);
+      expect(texts).toContain("BEGIN");
+      expect(texts).toContain("ROLLBACK");
+      expect(texts).not.toContain("COMMIT");
+    });
+  });
+
+  describe("watch", () => {
+    it("issues LISTEN on a per-namespace channel", async () => {
+      // pg.Client is constructed inside subscribe(). Patch the imported
+      // default's Client ctor so we observe the LISTEN call without a real
+      // connection. Restored after the test to avoid leaking state.
+      const pg = (await import("pg")).default;
+      const originalClient = pg.Client;
+      const fakeClient = Object.assign(new EventEmitter(), {
+        connect: vi.fn((..._args: unknown[]) => Promise.resolve()),
+        query: vi.fn((..._args: unknown[]) =>
+          Promise.resolve({ rows: [], rowCount: 0 })
+        ),
+        end: vi.fn((..._args: unknown[]) => Promise.resolve())
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (pg as any).Client = vi.fn(() => fakeClient);
+
+      try {
+        const { pool } = makePoolMock();
+        const store = new PostgresHarnessStore({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          pool: pool as any,
+          connectionString: "postgres://x"
+        });
+
+        const iterator = store.watch("my-ns", "id1")[Symbol.asyncIterator]();
+        // Drive the generator past subscribe() so the LISTEN query lands on
+        // our fake client. The iterator blocks once subscribed (no events),
+        // so race it against a close() to free the test.
+        const firstNext = iterator.next();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const listenCalls = fakeClient.query.mock.calls.filter((c) =>
+          String(c[0]).startsWith("LISTEN")
+        );
+        expect(listenCalls.length).toBe(1);
+        const listenSql = String(listenCalls[0]?.[0] ?? "");
+        expect(listenSql).toBe('LISTEN "harness_change_my-ns"');
+
+        await iterator.return?.();
+        await firstNext.catch(() => {});
+      } finally {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (pg as any).Client = originalClient;
+      }
+    });
+  });
+
+  describe("path segment validation", () => {
+    const unsafe = ["..", ".", "a/b", "a\\b", "a\0b", ""];
+
+    it("rejects unsafe ns across every primitive", async () => {
+      const { pool } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      for (const bad of unsafe) {
+        await expect(store.getDoc(bad, "ok")).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.putDoc(bad, "ok", {})).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.deleteDoc(bad, "ok")).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.appendLog(bad, "ok", {})).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(
+          store.putBlob(bad, "ok", new Uint8Array([1]))
+        ).rejects.toThrow(/Unsafe path segment/);
+      }
+    });
+
+    it("rejects unsafe id for getDoc/putDoc/deleteDoc/appendLog/putBlob", async () => {
+      const { pool } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      for (const bad of unsafe) {
+        await expect(store.getDoc("ok", bad)).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.putDoc("ok", bad, {})).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.deleteDoc("ok", bad)).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.appendLog("ok", bad, {})).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(
+          store.putBlob("ok", bad, new Uint8Array([1]))
+        ).rejects.toThrow(/Unsafe path segment/);
+      }
+    });
+  });
+
+  describe("construction", () => {
+    it("requires pool or connectionString", () => {
+      expect(() => new PostgresHarnessStore({})).toThrow(
+        /requires `pool` or `connectionString`/
+      );
+    });
+  });
+});

--- a/test/storage/postgres-store.unit.test.ts
+++ b/test/storage/postgres-store.unit.test.ts
@@ -125,6 +125,21 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       await store.listDocs("widgets", "alpha-");
       expect(calls[1]?.values).toEqual(["widgets", "alpha-"]);
     });
+
+    it("escapes LIKE metacharacters and uses an explicit ESCAPE clause", async () => {
+      const { pool, calls } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any
+      });
+
+      await store.listDocs("widgets", "alpha_b%c\\d");
+
+      expect(calls[0]?.text).toContain("id LIKE $2 || '%' ESCAPE '\\'");
+      // `_`, `%`, and `\` in the caller's prefix should all be backslash-
+      // escaped so Postgres treats them as literal characters.
+      expect(calls[0]?.values).toEqual(["widgets", "alpha\\_b\\%c\\\\d"]);
+    });
   });
 
   describe("mutate", () => {
@@ -149,7 +164,11 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       expect(next).toEqual({ count: 2 });
       const texts = clientCalls.map((c) => c.text);
       expect(texts[0]).toBe("BEGIN");
-      expect(texts[1]).toMatch(/SELECT doc.*FOR UPDATE/);
+      // Advisory lock fires before the row SELECT so concurrent callers
+      // serialize on the same (ns, id) slot even when the row doesn't yet
+      // exist (SELECT ... FOR UPDATE alone returns 0 rows in that case).
+      expect(texts[1]).toMatch(/pg_advisory_xact_lock/);
+      expect(texts[2]).toMatch(/SELECT doc.*FOR UPDATE/);
       expect(texts.some((t) => /INSERT INTO harness_docs/.test(t))).toBe(true);
       expect(texts[texts.length - 1]).toBe("COMMIT");
     });
@@ -282,6 +301,24 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
     it("requires pool or connectionString", () => {
       expect(() => new PostgresHarnessStore({})).toThrow(
         /requires `pool` or `connectionString`/
+      );
+    });
+  });
+
+  describe("watch ns length guard", () => {
+    it("rejects ns longer than 48 chars so LISTEN channel doesn't truncate", () => {
+      const { pool } = makePoolMock();
+      const store = new PostgresHarnessStore({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any,
+        connectionString: "postgres://x"
+      });
+      const tooLong = "x".repeat(49);
+      // Postgres truncates identifiers at 63 bytes. `harness_change_`
+      // (15 chars) + 48-char ns = exactly 63 — anything longer loses
+      // bytes off the tail so LISTEN and NOTIFY would disagree.
+      expect(() => store.watch(tooLong, "id1")).toThrow(
+        /ns exceeds 48 chars/
       );
     });
   });


### PR DESCRIPTION
## Summary

- Adds `PostgresHarnessStore` implementing the `HarnessStore` contract from T-001, plus SQL migrations for `harness_docs` / `harness_logs` / `harness_blobs` and a minimal forward-only migration runner.
- Unblocks cloud/pod deployability — the single-process `FileHarnessStore` can't share state across multiple replicas. Postgres earns durability and cross-process coordination through the database.
- Factory wiring is intentionally **deferred**: T-002 (factory + docs) is a separate PR in flight. A follow-up after both land will register this impl for `HARNESS_STORE=postgres`. Tests in this PR exercise the impl directly.

## Design notes

- **Docs**: `JSONB` keyed on `(ns, id)` with `INSERT ... ON CONFLICT DO UPDATE`. `listDocs` uses a prefix LIKE backed by a `text_pattern_ops` index so it doesn't depend on the DB's default collation.
- **Logs**: `BIGSERIAL seq` per row means the ordering contract falls out for free without needing an application-level counter. `readLog`'s `after` cursor matches the FileHarnessStore field fallback order (`id`, `entryId`, `eventId`, `timestamp`, `createdAt`) inside a single SQL lookup.
- **Blobs**: `BYTEA`. Sufficient for current callers (command stdout/stderr, design docs); S3/GCS backends are a future enhancement per the ticket.
- **mutate**: `BEGIN; SELECT ... FOR UPDATE; UPSERT; COMMIT`. Row-lock serializes per `(ns, id)` across processes — stronger than FileHarnessStore's in-process Promise mutex.
- **watch**: Triggers fire `pg_notify` so direct SQL writes still surface to watchers. One dedicated `pg.Client` per namespace is ref-counted across subscribers; channels are `LISTEN "harness_change_<ns>"`. `watch()` is a **manual async iterator**, not an async generator — `iterator.return()` needs to wake a pending waiter and run cleanup synchronously, which an async generator deadlocks on (the Promise it awaits on for the next event has no external resolver).
- **Path-segment guard**: `assertSafeSegment` exported from `file-store.ts` and reused. Defense-in-depth in Postgres; SQL parameterization already blocks injection.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (also copies `src/storage/migrations/*.sql` into `dist/`)
- [x] `pnpm test` — 196 tests pass, 13 skipped (the integration-tier tests skip cleanly when `HARNESS_TEST_POSTGRES_URL` is unset). Unit tests (10 new) drive a mocked `pg.Pool` to assert SQL shape, `SELECT ... FOR UPDATE`-inside-transaction, LISTEN channel naming, and path-segment rejection.
- [ ] Integration pass against a real Postgres — **not run locally** because Docker Desktop isn't currently running and there's no local PG instance on `:5432`. The integration file is designed to be runnable by a reviewer with:

  ```
  docker run -d --name relay-pg -e POSTGRES_PASSWORD=x -p 5432:5432 postgres:16
  HARNESS_TEST_POSTGRES_URL="postgres://postgres:x@localhost:5432/postgres" pnpm test
  docker rm -f relay-pg
  ```

  Each integration test uses its own UUID-derived `ns` so parallel runs don't collide.

## Docs note

The `docs/storage-injection.md` file from T-002 isn't in main yet. Rather than create it here and risk a merge conflict, the operator notes live in this PR body:

- Run Postgres locally via: `docker run -d --name relay-pg -e POSTGRES_PASSWORD=x -p 5432:5432 postgres:16`
- Point the store at it via `HARNESS_POSTGRES_URL` (store runtime) or `HARNESS_TEST_POSTGRES_URL` (tests)
- Apply migrations: `tsx src/storage/migrations/runner.ts migrate` (reads `HARNESS_POSTGRES_URL` unless `connectionString` is passed programmatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)