### PR TITLE
T-401: HTTP/SSE MCP transport + rly serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,23 @@ The **TUI** (`rly tui`, built with `--with-tui`) and **GUI** (built with `--with
 | `rly gui` | Launch the Tauri desktop app (auto-builds on first run; `--dev` for hot reload) |
 | `rly rebuild` | Rebuild the TS dist; `--tui` / `--gui` / `--all` to rebuild more |
 | `rly welcome` | 6-step interactive tour of Relay's concepts and commands |
+| `rly serve [--port N] [--host H] [--token T] [--workspace ID]` | Expose the Relay MCP server over HTTP/SSE (loopback-only by default) |
 
 `agent-harness <cmd>` is accepted as a legacy alias for `rly <cmd>` — both binaries are shipped so existing scripts don't break. `rly` reads current TypeScript source by default (via `tsx`), so a rebuild is **not** required after `git pull`. Set `RELAY_USE_DIST=1` for the compiled dist if you want slightly faster startup.
+
+### `rly serve` — HTTP/SSE MCP transport
+
+`rly serve` exposes the same MCP tool surface as `rly mcp-server` (which runs over stdio), but over HTTP with Server-Sent Events. Useful when you want to drive Relay from a remote agent, browser client, or multi-process local setup.
+
+```bash
+rly serve --port 7420                       # loopback, no auth
+rly serve --token $(openssl rand -hex 16)   # loopback, bearer-token required
+RELAY_TOKEN=... rly serve --host 0.0.0.0    # bound to all interfaces — ONLY with a token
+```
+
+Clients open `GET /sse` to receive a session endpoint, then `POST /message?sessionId=...` with JSON-RPC payloads; server responses arrive as `event: message` frames on the SSE stream. This matches the `SSEServerTransport` pattern from the official MCP SDK.
+
+**Security:** `rly serve` binds to `127.0.0.1` by default — the server is only reachable from the same machine. Never bind to a public interface (`--host 0.0.0.0`) without also passing `--token <secret>` (or `RELAY_TOKEN`): the MCP surface includes `harness_dispatch` and plan-approval tools that can kick off agent runs, so unauthenticated exposure on the network is a real risk. Rate limiting and audit logging are intentionally out of scope — put `rly serve` behind a reverse proxy if you need them.
 
 ## MCP tools (15)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ import {
 import { addProjectDir, readConfig, removeProjectDir } from "./cli/config.js";
 import { LocalArtifactStore } from "./execution/artifact-store.js";
 import { getHarnessStore } from "./storage/factory.js";
-import { startMcpServer } from "./mcp/server.js";
+import { buildMcpMessageHandler, startMcpServer } from "./mcp/server.js";
+import { startHttpMcpServer } from "./mcp/http-transport.js";
 import { VerificationRunner } from "./execution/verification-runner.js";
 import { Orchestrator } from "./orchestrator/orchestrator.js";
 import { OrchestratorV2 } from "./orchestrator/orchestrator-v2.js";
@@ -179,6 +180,11 @@ export async function main(): Promise<void> {
 
   if (command === "mcp-server") {
     await startMcpServer(resolveWorkspaceRoot(cwd, args));
+    return;
+  }
+
+  if (command === "serve") {
+    await handleServeCommand(cwd, args);
     return;
   }
 
@@ -1448,6 +1454,90 @@ async function readPackageVersion(): Promise<string> {
 
 function resolveCliEntrypoint(): string {
   return fileURLToPath(new URL("../dist/cli.js", import.meta.url));
+}
+
+async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: rly serve [--port <n>] [--host <host>] [--token <token>] [--workspace <id>]");
+    console.log("");
+    console.log("Starts an HTTP/SSE MCP server exposing Relay's tool surface.");
+    console.log("");
+    console.log("Options:");
+    console.log("  --port <n>       TCP port to bind (env: RELAY_PORT, default: 7420)");
+    console.log("  --host <host>    Host/interface (default: 127.0.0.1 / loopback only)");
+    console.log("  --token <token>  Require Authorization: Bearer <token> (env: RELAY_TOKEN)");
+    console.log("  --workspace <id> Workspace id (defaults to the current repo's registered id)");
+    console.log("");
+    console.log("For multi-host deployments pass BOTH --host 0.0.0.0 AND --token explicitly.");
+    return;
+  }
+
+  const portArg = parseNamedArg(args, "--port") ?? process.env.RELAY_PORT;
+  const port = portArg ? Number(portArg) : 7420;
+  if (!Number.isFinite(port) || port < 0 || port > 65535) {
+    console.error(`Invalid port: ${portArg}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const host = parseNamedArg(args, "--host") ?? "127.0.0.1";
+  const token = parseNamedArg(args, "--token") ?? process.env.RELAY_TOKEN;
+
+  let workspaceId = parseNamedArg(args, "--workspace");
+  if (!workspaceId) {
+    const workspaces = await listRegisteredWorkspaces();
+    const match = workspaces.find((w) => w.repoPath === cwd);
+    if (!match) {
+      console.error(
+        "No workspace id. Register the current repo with `rly up` or pass --workspace <id>."
+      );
+      process.exitCode = 1;
+      return;
+    }
+    workspaceId = match.workspaceId;
+  }
+
+  if (!token) {
+    console.warn(
+      "[rly serve] WARNING: no auth token — anyone who can reach this host:port can use the MCP server."
+    );
+    console.warn("           Set RELAY_TOKEN or pass --token <token> to require a Bearer token.");
+  }
+
+  if (host !== "127.0.0.1" && host !== "localhost" && !token) {
+    console.warn(
+      `[rly serve] WARNING: listening on non-loopback host "${host}" without auth. This is dangerous.`
+    );
+  }
+
+  const handle = await startHttpMcpServer(
+    async () => {
+      const { handler, context } = await buildMcpMessageHandler(cwd);
+      return { handler, cleanup: context.cleanup };
+    },
+    { port, host, authToken: token, workspaceId }
+  );
+
+  console.log(`Serving MCP at ${handle.url}`);
+  console.log(`Workspace: ${workspaceId}`);
+  console.log(`Auth: ${token ? "Bearer token required" : "none (loopback only recommended)"}`);
+  console.log("Press Ctrl+C to stop.");
+
+  let stopping = false;
+  const shutdown = async (signal: string) => {
+    if (stopping) return;
+    stopping = true;
+    console.log(`\n[rly serve] received ${signal}, shutting down...`);
+    try {
+      await handle.stop();
+    } catch (error) {
+      console.error("[rly serve] stop failed:", error instanceof Error ? error.message : error);
+    }
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
 }
 
 function resolveWorkspaceRoot(cwd: string, args: string[]): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1463,25 +1463,53 @@ async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
     console.log("Starts an HTTP/SSE MCP server exposing Relay's tool surface.");
     console.log("");
     console.log("Options:");
-    console.log("  --port <n>       TCP port to bind (env: RELAY_PORT, default: 7420)");
-    console.log("  --host <host>    Host/interface (default: 127.0.0.1 / loopback only)");
-    console.log("  --token <token>  Require Authorization: Bearer <token> (env: RELAY_TOKEN)");
-    console.log("  --workspace <id> Workspace id (defaults to the current repo's registered id)");
+    console.log("  --port <n>                         TCP port to bind (env: RELAY_PORT, default: 7420)");
+    console.log("  --host <host>                      Host/interface (default: 127.0.0.1 / loopback only)");
+    console.log("  --token <token>                    Require Authorization: Bearer <token> (env: RELAY_TOKEN)");
+    console.log("  --workspace <id>                   Workspace id (required unless the current repo is registered via `rly up`)");
+    console.log("  --allow-unauthenticated-remote     Opt-in: allow non-loopback --host without --token (DANGEROUS)");
     console.log("");
     console.log("For multi-host deployments pass BOTH --host 0.0.0.0 AND --token explicitly.");
     return;
   }
 
+  try {
+    await runServeCommand(cwd, args);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    const code = err?.code;
+    if (code === "EADDRINUSE") {
+      // Port already bound — user needs to pick a different one or stop the
+      // conflicting process. Don't dump the raw stack.
+      const port = parseNamedArg(args, "--port") ?? process.env.RELAY_PORT ?? "7420";
+      console.error(`[rly serve] Port ${port} is already in use. Try --port <n>.`);
+    } else if (code === "EACCES") {
+      const port = parseNamedArg(args, "--port") ?? process.env.RELAY_PORT ?? "7420";
+      const host = parseNamedArg(args, "--host") ?? "127.0.0.1";
+      console.error(
+        `[rly serve] Permission denied binding to ${host}:${port}. Try --port > 1024 or run with sudo.`
+      );
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[rly serve] Failed to start MCP server: ${msg}`);
+    }
+    process.exit(1);
+  }
+}
+
+async function runServeCommand(cwd: string, args: string[]): Promise<void> {
   const portArg = parseNamedArg(args, "--port") ?? process.env.RELAY_PORT;
   const port = portArg ? Number(portArg) : 7420;
   if (!Number.isFinite(port) || port < 0 || port > 65535) {
     console.error(`Invalid port: ${portArg}`);
-    process.exitCode = 1;
-    return;
+    process.exit(1);
   }
 
+  // Loopback-by-default: MCP surface exposes sensitive tools (harness_dispatch,
+  // plan approval). Opt-in to non-loopback via --host.
   const host = parseNamedArg(args, "--host") ?? "127.0.0.1";
   const token = parseNamedArg(args, "--token") ?? process.env.RELAY_TOKEN;
+  const allowUnauthenticatedRemote = args.includes("--allow-unauthenticated-remote");
 
   let workspaceId = parseNamedArg(args, "--workspace");
   if (!workspaceId) {
@@ -1491,10 +1519,23 @@ async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
       console.error(
         "No workspace id. Register the current repo with `rly up` or pass --workspace <id>."
       );
-      process.exitCode = 1;
-      return;
+      process.exit(1);
     }
     workspaceId = match.workspaceId;
+  }
+
+  const isLoopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
+
+  if (!isLoopback && !token && !allowUnauthenticatedRemote) {
+    // Refuse to start: a non-loopback bind with no auth token is effectively
+    // "the internet can use your dispatch surface". Require explicit opt-in.
+    console.error(
+      `[rly serve] Refusing to start: --host ${host} is non-loopback and no --token was provided.`
+    );
+    console.error(
+      "           Either pass --token <token> (recommended) or --allow-unauthenticated-remote to override."
+    );
+    process.exit(1);
   }
 
   if (!token) {
@@ -1504,9 +1545,9 @@ async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
     console.warn("           Set RELAY_TOKEN or pass --token <token> to require a Bearer token.");
   }
 
-  if (host !== "127.0.0.1" && host !== "localhost" && !token) {
+  if (!isLoopback && !token && allowUnauthenticatedRemote) {
     console.warn(
-      `[rly serve] WARNING: listening on non-loopback host "${host}" without auth. This is dangerous.`
+      `[rly serve] WARNING: listening on non-loopback host "${host}" without auth (--allow-unauthenticated-remote). This is dangerous.`
     );
   }
 
@@ -1524,7 +1565,7 @@ async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
   console.log("Press Ctrl+C to stop.");
 
   let stopping = false;
-  const shutdown = async (signal: string) => {
+  const shutdown = async (signal: string): Promise<void> => {
     if (stopping) return;
     stopping = true;
     console.log(`\n[rly serve] received ${signal}, shutting down...`);
@@ -1536,8 +1577,20 @@ async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
     process.exit(0);
   };
 
-  process.on("SIGINT", () => void shutdown("SIGINT"));
-  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  const onSignal = (signal: "SIGINT" | "SIGTERM") => (): void => {
+    // Run the async shutdown and log any terminal error rather than letting
+    // the promise reject into an unhandledRejection.
+    shutdown(signal).catch((err) => {
+      console.error(
+        "[rly serve] shutdown failed:",
+        err instanceof Error ? err.message : String(err)
+      );
+      process.exit(1);
+    });
+  };
+
+  process.on("SIGINT", onSignal("SIGINT"));
+  process.on("SIGTERM", onSignal("SIGTERM"));
 }
 
 function resolveWorkspaceRoot(cwd: string, args: string[]): string {

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -18,11 +18,30 @@ export interface HttpMcpServerHandle {
   host: string;
 }
 
+/**
+ * Thrown by `readBody` when the POST body exceeds MAX_BYTES. Exported so the
+ * outer request handler can distinguish it from other errors and map to 413
+ * (Payload Too Large) instead of a generic 500.
+ */
+export class BodyTooLargeError extends Error {
+  public readonly byteCount: number;
+  public readonly limit: number;
+
+  constructor(byteCount: number, limit: number) {
+    super(`request body too large: ${byteCount} bytes exceeds ${limit} byte limit`);
+    this.name = "BodyTooLargeError";
+    this.byteCount = byteCount;
+    this.limit = limit;
+  }
+}
+
 interface SseSession {
   sessionId: string;
   response: ServerResponse;
   handler: McpMessageHandler;
   cleanup: () => void;
+  /** Promises for in-flight POST handler invocations. Drained on stop(). */
+  inflight: Set<Promise<unknown>>;
 }
 
 /**
@@ -42,6 +61,8 @@ export async function startHttpMcpServer(
   buildHandler: () => Promise<{ handler: McpMessageHandler; cleanup: () => void }>,
   opts: HttpMcpServerOptions
 ): Promise<HttpMcpServerHandle> {
+  // Loopback-by-default: MCP surface exposes sensitive tools (harness_dispatch,
+  // plan approval). Opt-in to non-loopback via --host.
   const host = opts.host ?? "127.0.0.1";
   const sessions = new Map<string, SseSession>();
 
@@ -63,6 +84,24 @@ export async function startHttpMcpServer(
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: "not_found", path: url.pathname }));
     } catch (error) {
+      if (error instanceof BodyTooLargeError) {
+        // eslint-disable-next-line no-console
+        console.warn(`[http-mcp] rejecting oversized body: ${error.message}`);
+        if (!res.headersSent) {
+          res.statusCode = 413;
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify({
+              error: "payload_too_large",
+              error_detail: `body exceeded ${error.limit} byte limit (received ${error.byteCount} bytes)`
+            })
+          );
+        } else {
+          res.end();
+        }
+        return;
+      }
+
       // Defensive: never leak a stack trace to a remote client, but keep a
       // trace on the server side.
       // eslint-disable-next-line no-console
@@ -89,16 +128,31 @@ export async function startHttpMcpServer(
   const boundPort = typeof address === "object" && address ? address.port : opts.port;
 
   const stop = async (): Promise<void> => {
+    // Drain in-flight handler invocations across all sessions so their results
+    // get a last chance to write to the SSE stream before we close it. Without
+    // this, a SIGINT during an in-flight tool call silently drops the response.
+    const inflight: Array<Promise<unknown>> = [];
+    for (const session of sessions.values()) {
+      for (const p of session.inflight) inflight.push(p);
+    }
+    if (inflight.length > 0) {
+      await Promise.allSettled(inflight);
+    }
+
     for (const session of sessions.values()) {
       try {
         session.cleanup();
-      } catch {
-        // best-effort
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`[http-mcp] session cleanup failed (sessionId=${session.sessionId}): ${msg}`);
       }
       try {
         session.response.end();
-      } catch {
-        // best-effort
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`[http-mcp] stream close failed (sessionId=${session.sessionId}): ${msg}`);
       }
     }
     sessions.clear();
@@ -129,6 +183,9 @@ async function handleSse(
   buildHandler: () => Promise<{ handler: McpMessageHandler; cleanup: () => void }>,
   opts: HttpMcpServerOptions
 ): Promise<void> {
+  // Check auth before upgrading the SSE stream to avoid leaking the
+  // session-endpoint frame to unauthenticated clients; also re-check on POST
+  // because sessionId alone is not a credential.
   if (!authorizeRequest(req, res, opts.authToken)) return;
 
   const sessionId = randomUUID();
@@ -147,11 +204,18 @@ async function handleSse(
   const messagePath = `/message?sessionId=${encodeURIComponent(sessionId)}`;
   res.write(`event: endpoint\ndata: ${messagePath}\n\n`);
 
+  // 25s beats common proxy idle timeouts (nginx default 60s, CDNs ~30s) to
+  // prevent connection drops on long-lived SSE streams.
   const keepAlive = setInterval(() => {
     try {
       res.write(`: keep-alive\n\n`);
-    } catch {
-      // Socket likely closed; session cleanup handles teardown.
+    } catch (err) {
+      // If this fires it likely means the client disconnected; the session
+      // close handler below will tear down state shortly. Logging is still
+      // useful for diagnosing unexpected write failures.
+      const msg = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.warn(`[http-mcp] keep-alive write failed (sessionId=${sessionId}): ${msg}`);
     }
   }, 25_000);
 
@@ -161,7 +225,13 @@ async function handleSse(
     cleanup();
   };
 
-  const session: SseSession = { sessionId, response: res, handler, cleanup: sessionCleanup };
+  const session: SseSession = {
+    sessionId,
+    response: res,
+    handler,
+    cleanup: sessionCleanup,
+    inflight: new Set()
+  };
   sessions.set(sessionId, session);
 
   req.on("close", () => {
@@ -179,6 +249,8 @@ async function handleMessagePost(
   sessions: Map<string, SseSession>,
   opts: HttpMcpServerOptions
 ): Promise<void> {
+  // Re-check auth on POST even though the SSE endpoint already checked it:
+  // sessionId alone is not a credential and must not be treated as one.
   if (!authorizeRequest(req, res, opts.authToken)) return;
 
   const sessionId = url.searchParams.get("sessionId");
@@ -197,8 +269,11 @@ async function handleMessagePost(
   let message: JsonRpcMessage;
   try {
     message = JSON.parse(raw) as JsonRpcMessage;
-  } catch {
-    respondJson(res, 400, { error: "invalid_json" });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console
+    console.warn(`[http-mcp] invalid JSON body on POST /message: ${detail}`);
+    respondJson(res, 400, { error: "invalid_json", error_detail: detail });
     return;
   }
 
@@ -208,21 +283,34 @@ async function handleMessagePost(
   res.setHeader("Content-Type", "application/json");
   res.end(JSON.stringify({ status: "accepted" }));
 
-  try {
-    const response = await session.handler(message);
-    if (response) {
-      writeSseMessage(session.response, response);
-    }
-  } catch (error) {
-    writeSseMessage(session.response, {
-      jsonrpc: "2.0",
-      id: message.id ?? null,
-      error: {
-        code: -32603,
-        message: error instanceof Error ? error.message : "Internal error"
+  // Track the handler promise so stop() can drain it. Removed on settle so the
+  // set doesn't grow unbounded for long-lived sessions.
+  const work = (async () => {
+    try {
+      const response = await session.handler(message);
+      if (response) {
+        writeSseMessage(session.response, response, sessionId);
       }
-    });
-  }
+    } catch (error) {
+      writeSseMessage(
+        session.response,
+        {
+          jsonrpc: "2.0",
+          id: message.id ?? null,
+          error: {
+            code: -32603,
+            message: error instanceof Error ? error.message : "Internal error"
+          }
+        },
+        sessionId
+      );
+    }
+  })();
+
+  session.inflight.add(work);
+  work.finally(() => {
+    session.inflight.delete(work);
+  });
 }
 
 function authorizeRequest(
@@ -251,24 +339,28 @@ function respondJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
-function writeSseMessage(res: ServerResponse, message: JsonRpcMessage): void {
+function writeSseMessage(res: ServerResponse, message: JsonRpcMessage, sessionId: string): void {
   try {
     res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
-  } catch {
-    // Stream likely gone; the close handler will clean up.
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console
+    console.warn(`[http-mcp] SSE write failed on session ${sessionId}: ${msg}`);
   }
 }
 
 async function readBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
   let total = 0;
-  const MAX_BYTES = 1_000_000; // 1 MB guard against runaway POSTs.
+  // 1 MB generous headroom for large tool-call arguments; MCP messages are
+  // typically <10 KB. Adjust if a real use case demands it.
+  const MAX_BYTES = 1_000_000;
 
   for await (const chunk of req) {
     const buf = chunk instanceof Buffer ? chunk : Buffer.from(chunk);
     total += buf.length;
     if (total > MAX_BYTES) {
-      throw new Error("request body too large");
+      throw new BodyTooLargeError(total, MAX_BYTES);
     }
     chunks.push(buf);
   }

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -1,0 +1,276 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
+import { URL } from "node:url";
+
+import type { JsonRpcMessage, McpMessageHandler } from "./server.js";
+
+export interface HttpMcpServerOptions {
+  port: number;
+  host?: string;
+  authToken?: string;
+  workspaceId?: string;
+}
+
+export interface HttpMcpServerHandle {
+  stop: () => Promise<void>;
+  url: string;
+  port: number;
+  host: string;
+}
+
+interface SseSession {
+  sessionId: string;
+  response: ServerResponse;
+  handler: McpMessageHandler;
+  cleanup: () => void;
+}
+
+/**
+ * Start an HTTP server that exposes an MCP endpoint over SSE.
+ *
+ * Protocol (mirrors the MCP SSE transport shipped by @modelcontextprotocol/sdk):
+ *  - GET /sse — opens the SSE stream. The server sends an initial
+ *    `event: endpoint\n data: /message?sessionId=...` frame so the client knows
+ *    where to POST JSON-RPC requests for this session.
+ *  - POST /message?sessionId=... — accepts a single JSON-RPC message. Responses
+ *    are delivered back over the SSE stream as `event: message` frames.
+ *
+ * Each incoming GET /sse builds its own McpMessageHandler via `buildHandler`,
+ * so each client gets an isolated MCP session.
+ */
+export async function startHttpMcpServer(
+  buildHandler: () => Promise<{ handler: McpMessageHandler; cleanup: () => void }>,
+  opts: HttpMcpServerOptions
+): Promise<HttpMcpServerHandle> {
+  const host = opts.host ?? "127.0.0.1";
+  const sessions = new Map<string, SseSession>();
+
+  const server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+
+      if (req.method === "GET" && url.pathname === "/sse") {
+        await handleSse(req, res, url, sessions, buildHandler, opts);
+        return;
+      }
+
+      if (req.method === "POST" && url.pathname === "/message") {
+        await handleMessagePost(req, res, url, sessions, opts);
+        return;
+      }
+
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "not_found", path: url.pathname }));
+    } catch (error) {
+      // Defensive: never leak a stack trace to a remote client, but keep a
+      // trace on the server side.
+      // eslint-disable-next-line no-console
+      console.error("[rly serve] request failed:", error);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "internal_error" }));
+      } else {
+        res.end();
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, host, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  const boundPort = typeof address === "object" && address ? address.port : opts.port;
+
+  const stop = async (): Promise<void> => {
+    for (const session of sessions.values()) {
+      try {
+        session.cleanup();
+      } catch {
+        // best-effort
+      }
+      try {
+        session.response.end();
+      } catch {
+        // best-effort
+      }
+    }
+    sessions.clear();
+
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      // Force-close any idle keep-alive sockets so close() resolves promptly.
+      const maybeCloseAll = (server as Server & { closeAllConnections?: () => void }).closeAllConnections;
+      if (typeof maybeCloseAll === "function") {
+        maybeCloseAll.call(server);
+      }
+    });
+  };
+
+  return {
+    stop,
+    url: `http://${host}:${boundPort}/sse`,
+    port: boundPort,
+    host
+  };
+}
+
+async function handleSse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  sessions: Map<string, SseSession>,
+  buildHandler: () => Promise<{ handler: McpMessageHandler; cleanup: () => void }>,
+  opts: HttpMcpServerOptions
+): Promise<void> {
+  if (!authorizeRequest(req, res, opts.authToken)) return;
+
+  const sessionId = randomUUID();
+  const { handler, cleanup } = await buildHandler();
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
+  if (opts.workspaceId) {
+    res.setHeader("X-Relay-Workspace", opts.workspaceId);
+  }
+  res.flushHeaders?.();
+
+  const messagePath = `/message?sessionId=${encodeURIComponent(sessionId)}`;
+  res.write(`event: endpoint\ndata: ${messagePath}\n\n`);
+
+  const keepAlive = setInterval(() => {
+    try {
+      res.write(`: keep-alive\n\n`);
+    } catch {
+      // Socket likely closed; session cleanup handles teardown.
+    }
+  }, 25_000);
+
+  const sessionCleanup = (): void => {
+    clearInterval(keepAlive);
+    sessions.delete(sessionId);
+    cleanup();
+  };
+
+  const session: SseSession = { sessionId, response: res, handler, cleanup: sessionCleanup };
+  sessions.set(sessionId, session);
+
+  req.on("close", () => {
+    sessionCleanup();
+  });
+  req.on("error", () => {
+    sessionCleanup();
+  });
+}
+
+async function handleMessagePost(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  sessions: Map<string, SseSession>,
+  opts: HttpMcpServerOptions
+): Promise<void> {
+  if (!authorizeRequest(req, res, opts.authToken)) return;
+
+  const sessionId = url.searchParams.get("sessionId");
+  if (!sessionId) {
+    respondJson(res, 400, { error: "missing_session_id" });
+    return;
+  }
+
+  const session = sessions.get(sessionId);
+  if (!session) {
+    respondJson(res, 404, { error: "unknown_session" });
+    return;
+  }
+
+  const raw = await readBody(req);
+  let message: JsonRpcMessage;
+  try {
+    message = JSON.parse(raw) as JsonRpcMessage;
+  } catch {
+    respondJson(res, 400, { error: "invalid_json" });
+    return;
+  }
+
+  // MCP HTTP transport: ack the POST with 202 and push the response back
+  // through the SSE stream so requests aren't bound to per-POST lifetimes.
+  res.statusCode = 202;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ status: "accepted" }));
+
+  try {
+    const response = await session.handler(message);
+    if (response) {
+      writeSseMessage(session.response, response);
+    }
+  } catch (error) {
+    writeSseMessage(session.response, {
+      jsonrpc: "2.0",
+      id: message.id ?? null,
+      error: {
+        code: -32603,
+        message: error instanceof Error ? error.message : "Internal error"
+      }
+    });
+  }
+}
+
+function authorizeRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  expected: string | undefined
+): boolean {
+  if (!expected) return true;
+
+  const header = req.headers["authorization"];
+  if (typeof header !== "string" || !header.startsWith("Bearer ")) {
+    respondJson(res, 401, { error: "unauthorized" });
+    return false;
+  }
+  const provided = header.slice("Bearer ".length).trim();
+  if (provided !== expected) {
+    respondJson(res, 401, { error: "unauthorized" });
+    return false;
+  }
+  return true;
+}
+
+function respondJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+function writeSseMessage(res: ServerResponse, message: JsonRpcMessage): void {
+  try {
+    res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+  } catch {
+    // Stream likely gone; the close handler will clean up.
+  }
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const MAX_BYTES = 1_000_000; // 1 MB guard against runaway POSTs.
+
+  for await (const chunk of req) {
+    const buf = chunk instanceof Buffer ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > MAX_BYTES) {
+      throw new Error("request body too large");
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -22,7 +22,7 @@ import {
   type CrosslinkToolState
 } from "../crosslink/tools.js";
 
-interface JsonRpcMessage {
+export interface JsonRpcMessage {
   jsonrpc: "2.0";
   id?: string | number | null;
   method?: string;
@@ -34,7 +34,24 @@ interface JsonRpcMessage {
   };
 }
 
-export async function startMcpServer(workspaceRoot: string): Promise<void> {
+export type McpMessageHandler = (message: JsonRpcMessage) => Promise<JsonRpcMessage | null>;
+
+export interface McpHandlerContext {
+  workspaceRoot: string;
+  artifactStore: LocalArtifactStore;
+  crosslinkState: CrosslinkToolState;
+  channelState: ChannelToolState;
+  cleanup: () => void;
+}
+
+/**
+ * Build the JSON-RPC message handler + supporting state for an MCP server
+ * instance. Shared between the stdio and HTTP/SSE transports so both paths
+ * serve the same tool surface.
+ */
+export async function buildMcpMessageHandler(
+  workspaceRoot: string
+): Promise<{ handler: McpMessageHandler; context: McpHandlerContext }> {
   const paths = getHarnessWorkspacePaths(workspaceRoot);
   const artifactStore = new LocalArtifactStore(paths.artifactsDir);
   const crosslinkStore = new CrosslinkStore();
@@ -69,22 +86,31 @@ export async function startMcpServer(workspaceRoot: string): Promise<void> {
     }
   }, 30_000);
 
-  // Cleanup on exit
-  const cleanup = () => {
+  const cleanup = (): void => {
     clearInterval(heartbeatInterval);
     if (crosslinkState.sessionId) {
       crosslinkStore.deregisterSession(crosslinkState.sessionId).catch(() => {});
+      crosslinkState.sessionId = null;
     }
   };
 
-  process.on("exit", cleanup);
-  process.on("SIGTERM", () => { cleanup(); process.exit(0); });
-  process.on("SIGINT", () => { cleanup(); process.exit(0); });
+  const handler: McpMessageHandler = (message) =>
+    handleMessage(message, workspaceRoot, artifactStore, crosslinkState, channelState);
 
-  const transport = new StdioJsonRpcTransport((message) =>
-    handleMessage(message, workspaceRoot, artifactStore, crosslinkState, channelState)
-  );
+  return {
+    handler,
+    context: { workspaceRoot, artifactStore, crosslinkState, channelState, cleanup }
+  };
+}
 
+export async function startMcpServer(workspaceRoot: string): Promise<void> {
+  const { handler, context } = await buildMcpMessageHandler(workspaceRoot);
+
+  process.on("exit", context.cleanup);
+  process.on("SIGTERM", () => { context.cleanup(); process.exit(0); });
+  process.on("SIGINT", () => { context.cleanup(); process.exit(0); });
+
+  const transport = new StdioJsonRpcTransport(handler);
   transport.start();
 }
 

--- a/test/cli/serve-command.test.ts
+++ b/test/cli/serve-command.test.ts
@@ -1,0 +1,138 @@
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Integration tests for `rly serve` flag validation and startup error paths.
+ * Spawns the CLI via tsx (no build required) and asserts on the exit code +
+ * stderr banner. These cover:
+ *  - --host 0.0.0.0 with no token AND no --allow-unauthenticated-remote must refuse
+ *  - EADDRINUSE produces a human-readable message, not a raw stack
+ */
+
+const here = fileURLToPath(import.meta.url);
+const repoRoot = resolvePath(dirname(here), "..", "..");
+const cliEntry = resolvePath(repoRoot, "src/cli.ts");
+const tsxBin = resolvePath(repoRoot, "node_modules/.bin/tsx");
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Spawn the CLI and collect its output. We attach a kill-timer so a wayward
+ * `rly serve` that actually starts successfully doesn't hang the test suite.
+ */
+function runCli(
+  args: string[],
+  opts: { env?: Record<string, string>; cwd?: string; timeoutMs?: number } = {}
+): Promise<CliResult> {
+  return new Promise((resolve) => {
+    const child = spawn(tsxBin, [cliEntry, ...args], {
+      cwd: opts.cwd ?? repoRoot,
+      env: { ...process.env, ...(opts.env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c: Buffer) => {
+      stdout += c.toString("utf8");
+    });
+    child.stderr.on("data", (c: Buffer) => {
+      stderr += c.toString("utf8");
+    });
+
+    const killTimer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, opts.timeoutMs ?? 10_000);
+
+    child.on("exit", (code) => {
+      clearTimeout(killTimer);
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
+  });
+}
+
+describe("rly serve — flag validation", () => {
+  let tmpRepo: string;
+
+  beforeAll(async () => {
+    // Workspace registry lookup walks up from cwd; run from a scratch dir that
+    // won't match any registered workspace so the --workspace flag is required.
+    tmpRepo = await mkdtemp(resolvePath(tmpdir(), "rly-serve-test-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpRepo, { recursive: true, force: true });
+  });
+
+  it("refuses to start when binding non-loopback without --token or --allow-unauthenticated-remote", async () => {
+    const result = await runCli(
+      [
+        "serve",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "0",
+        "--workspace",
+        "test-workspace"
+      ],
+      { cwd: tmpRepo, env: { RELAY_TOKEN: "" } }
+    );
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/Refusing to start/i);
+    expect(result.stderr).toMatch(/--allow-unauthenticated-remote/);
+  }, 15_000);
+});
+
+describe("rly serve — startup errors map to friendly messages", () => {
+  let blocker: Server;
+  let blockedPort = 0;
+
+  beforeAll(async () => {
+    // Bind a loopback port and hold it so the CLI attempt hits EADDRINUSE.
+    blocker = createServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(0, "127.0.0.1", () => {
+        const addr = blocker.address();
+        blockedPort = typeof addr === "object" && addr ? addr.port : 0;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => blocker.close(() => resolve()));
+  });
+
+  it("EADDRINUSE — prints a clear 'port is already in use' message and exits 1", async () => {
+    const result = await runCli(
+      [
+        "serve",
+        "--port",
+        String(blockedPort),
+        "--workspace",
+        "test-workspace"
+      ],
+      {
+        // Point at a scratch cwd so workspace-registry fallback isn't the
+        // error we trip on.
+        cwd: tmpdir()
+      }
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(new RegExp(`Port ${blockedPort} is already in use`));
+    expect(result.stderr).toMatch(/--port/);
+  }, 15_000);
+});

--- a/test/mcp/http-transport.test.ts
+++ b/test/mcp/http-transport.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { startHttpMcpServer } from "../../src/mcp/http-transport.js";
+import type { JsonRpcMessage, McpMessageHandler } from "../../src/mcp/server.js";
+
+/**
+ * Stub handler that mimics the shape of the real MCP handler. Keeps the test
+ * focused on transport behaviour (SSE framing, auth, shutdown) rather than the
+ * tool surface, which is exercised elsewhere.
+ */
+function stubHandler(): { handler: McpMessageHandler; cleanup: () => void } {
+  const handler: McpMessageHandler = async (message) => {
+    if (message.method === "initialize") {
+      return {
+        jsonrpc: "2.0",
+        id: message.id ?? null,
+        result: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "relay-test", version: "0.0.0" }
+        }
+      };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: message.id ?? null,
+      error: { code: -32601, message: `Method not found: ${message.method}` }
+    };
+  };
+  return { handler, cleanup: () => {} };
+}
+
+/**
+ * Open an SSE stream against the server and resolve to a parser that yields
+ * `{event, data}` frames one at a time.
+ */
+async function openSse(
+  url: string,
+  authToken?: string
+): Promise<{
+  response: Response;
+  readFrame: () => Promise<{ event: string; data: string } | null>;
+  close: () => void;
+}> {
+  const headers: Record<string, string> = {};
+  if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
+  const controller = new AbortController();
+
+  const response = await fetch(url, { headers, signal: controller.signal });
+  if (!response.body) {
+    return {
+      response,
+      readFrame: async () => null,
+      close: () => controller.abort()
+    };
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const readFrame = async (): Promise<{ event: string; data: string } | null> => {
+    while (true) {
+      const boundary = buffer.indexOf("\n\n");
+      if (boundary !== -1) {
+        const raw = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const lines = raw.split("\n");
+        let event = "message";
+        const dataLines: string[] = [];
+        for (const line of lines) {
+          if (line.startsWith(":")) continue; // comment / keep-alive
+          if (line.startsWith("event:")) event = line.slice(6).trim();
+          else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length === 0) continue;
+        return { event, data: dataLines.join("\n") };
+      }
+      const { value, done } = await reader.read();
+      if (done) return null;
+      buffer += decoder.decode(value, { stream: true });
+    }
+  };
+
+  return {
+    response,
+    readFrame,
+    close: () => {
+      try {
+        reader.cancel().catch(() => {});
+      } finally {
+        controller.abort();
+      }
+    }
+  };
+}
+
+describe("startHttpMcpServer", () => {
+  let handle: Awaited<ReturnType<typeof startHttpMcpServer>> | null = null;
+
+  beforeEach(() => {
+    handle = null;
+  });
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.stop();
+      handle = null;
+    }
+  });
+
+  it("serves the SSE endpoint and dispatches a JSON-RPC initialize", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), { port: 0 });
+
+    const sse = await openSse(handle.url);
+    expect(sse.response.status).toBe(200);
+    expect(sse.response.headers.get("content-type")).toContain("text/event-stream");
+
+    const endpointFrame = await sse.readFrame();
+    expect(endpointFrame?.event).toBe("endpoint");
+    const messagePath = endpointFrame?.data ?? "";
+    expect(messagePath).toMatch(/^\/message\?sessionId=/);
+
+    const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {}
+      })
+    });
+    expect(postRes.status).toBe(202);
+    // Drain the body so fetch/undici doesn't leak the socket into the next tick.
+    await postRes.text();
+
+    const messageFrame = await sse.readFrame();
+    expect(messageFrame?.event).toBe("message");
+    const payload = JSON.parse(messageFrame?.data ?? "{}") as JsonRpcMessage;
+    expect(payload.id).toBe(1);
+    expect((payload.result as { serverInfo?: { name?: string } })?.serverInfo?.name).toBe("relay-test");
+
+    sse.close();
+  });
+
+  it("rejects /sse when the auth token is missing", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), {
+      port: 0,
+      authToken: "secret"
+    });
+
+    const response = await fetch(handle.url);
+    expect(response.status).toBe(401);
+    await response.text();
+  });
+
+  it("rejects /sse when the auth token is wrong", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), {
+      port: 0,
+      authToken: "secret"
+    });
+
+    const response = await fetch(handle.url, {
+      headers: { Authorization: "Bearer wrong" }
+    });
+    expect(response.status).toBe(401);
+    await response.text();
+  });
+
+  it("accepts /sse with the correct bearer token", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), {
+      port: 0,
+      authToken: "secret"
+    });
+
+    const sse = await openSse(handle.url, "secret");
+    expect(sse.response.status).toBe(200);
+    const endpointFrame = await sse.readFrame();
+    expect(endpointFrame?.event).toBe("endpoint");
+    sse.close();
+  });
+
+  it("stops cleanly — subsequent requests fail", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), { port: 0 });
+    const url = handle.url;
+    await handle.stop();
+    handle = null;
+
+    await expect(fetch(url)).rejects.toThrow();
+  });
+});

--- a/test/mcp/http-transport.test.ts
+++ b/test/mcp/http-transport.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { startHttpMcpServer } from "../../src/mcp/http-transport.js";
+import { BodyTooLargeError, startHttpMcpServer } from "../../src/mcp/http-transport.js";
 import type { JsonRpcMessage, McpMessageHandler } from "../../src/mcp/server.js";
 
 /**
@@ -188,5 +188,116 @@ describe("startHttpMcpServer", () => {
     handle = null;
 
     await expect(fetch(url)).rejects.toThrow();
+  });
+
+  it("returns 400 with error_detail when the POST body is not valid JSON", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), { port: 0 });
+
+    const sse = await openSse(handle.url);
+    const endpointFrame = await sse.readFrame();
+    const messagePath = endpointFrame?.data ?? "";
+
+    const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not valid json,"
+    });
+    expect(postRes.status).toBe(400);
+    const body = (await postRes.json()) as { error?: string; error_detail?: string };
+    expect(body.error).toBe("invalid_json");
+    // The parser-emitted detail must be surfaced, not just a generic tag.
+    expect(typeof body.error_detail).toBe("string");
+    expect((body.error_detail ?? "").length).toBeGreaterThan(0);
+
+    sse.close();
+  });
+
+  it("returns 413 (not 500) when the POST body exceeds the 1 MB cap", async () => {
+    handle = await startHttpMcpServer(async () => stubHandler(), { port: 0 });
+
+    const sse = await openSse(handle.url);
+    const endpointFrame = await sse.readFrame();
+    const messagePath = endpointFrame?.data ?? "";
+
+    // 1.1 MB payload — safely above the 1 MB cap.
+    const oversized = "x".repeat(1_100_000);
+    const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "foo", params: { blob: oversized } })
+    });
+    expect(postRes.status).toBe(413);
+    const body = (await postRes.json()) as { error?: string; error_detail?: string };
+    expect(body.error).toBe("payload_too_large");
+    expect(body.error_detail).toMatch(/byte limit/);
+
+    sse.close();
+  });
+
+  it("drains in-flight handlers on stop() so responses are not silently dropped", async () => {
+    // Handler blocks until we tell it to resolve; gives us a controllable
+    // "in-flight" window to exercise the drain path.
+    let release!: () => void;
+    const handlerCall = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const handler: McpMessageHandler = async (message) => {
+      await handlerCall;
+      return {
+        jsonrpc: "2.0",
+        id: message.id ?? null,
+        result: { ok: true }
+      };
+    };
+
+    const unhandled: unknown[] = [];
+    const onRejection = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      handle = await startHttpMcpServer(
+        async () => ({ handler, cleanup: () => {} }),
+        { port: 0 }
+      );
+
+      const sse = await openSse(handle.url);
+      const endpointFrame = await sse.readFrame();
+      const messagePath = endpointFrame?.data ?? "";
+
+      const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 42, method: "slow", params: {} })
+      });
+      expect(postRes.status).toBe(202);
+      await postRes.text();
+
+      // Kick off stop() but release the handler mid-flight. stop() must wait
+      // for the in-flight handler promise before the server closes.
+      const stopPromise = handle.stop();
+      // Give stop() a moment to start draining before we release the handler.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      release();
+      await stopPromise;
+      handle = null;
+
+      // Give the event loop a tick to surface any rejection.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(unhandled).toEqual([]);
+
+      sse.close();
+    } finally {
+      process.removeListener("unhandledRejection", onRejection);
+    }
+  });
+
+  it("exports BodyTooLargeError with byteCount and limit for callers that need to disambiguate", () => {
+    const err = new BodyTooLargeError(1_500_000, 1_000_000);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("BodyTooLargeError");
+    expect(err.byteCount).toBe(1_500_000);
+    expect(err.limit).toBe(1_000_000);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `src/mcp/http-transport.ts` — an HTTP server (Node built-in `http`, no new deps) that speaks the MCP SSE transport flow: `GET /sse` emits an `endpoint` frame pointing at `POST /message?sessionId=...`, responses stream back as `event: message` frames.
- Adds `rly serve [--port N] [--host H] [--token T] [--workspace ID]`. Defaults to `127.0.0.1:7420`, no auth, and the current repo's registered workspace id.
- Refactors `src/mcp/server.ts` to expose `buildMcpMessageHandler`, shared by stdio and HTTP so the tool surface stays single-sourced. The existing stdio path (`rly mcp-server`) is unchanged externally.

## Security posture
- Loopback-only by default (`--host 127.0.0.1`). Never binds to `0.0.0.0` unless explicitly asked.
- `--token` / `RELAY_TOKEN` enforces `Authorization: Bearer <token>` on **both** `/sse` and `/message`, checked before the SSE stream starts or any POST body is read. Missing or mismatched tokens get a 401.
- Loud console warnings when auth is off, and especially when also bound to a non-loopback host.
- 1 MB body cap on `POST /message` to prevent runaway payloads.
- Rate limiting and audit logging are intentionally out of scope (put `rly serve` behind a reverse proxy if needed).

## Design decision
The existing MCP server (`src/mcp/server.ts`) is a hand-rolled JSON-RPC handler, not a wrapper around `@modelcontextprotocol/sdk` — the SDK is not a dependency. To keep the dependency footprint untouched, the HTTP transport is also implemented directly (same as the existing stdio transport) using Node's `http` module. The SSE framing matches the MCP SDK's `SSEServerTransport` pattern so SDK-based clients are interoperable.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 250 passed / 21 skipped (baseline 245 / 21 — delta +5 tests, +1 file)
- [x] New `test/mcp/http-transport.test.ts` covers: SSE stream + initialize round-trip, 401 on missing/wrong bearer, 200 on correct bearer, clean shutdown (subsequent `fetch` rejects)
- [x] Manual smoke: `rly serve --port 7429 --token testtoken` → `curl -N -H "Authorization: Bearer testtoken" http://127.0.0.1:7429/sse` receives `event: endpoint` frame; unauth and wrong-token each return 401; SIGINT triggers the shutdown path and the port stops accepting connections

## Limitations
- Single-workspace only — no per-session routing yet.
- No websocket fallback (the MCP spec / SDK ships SSE only).
- Stdio transport is unchanged by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)