### PR TITLE
T-101: Migrate ChannelStore to HarnessStore (partial)

### DIFF
--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -17,22 +17,64 @@ import {
 } from "../domain/channel.js";
 import { buildDecisionId, type Decision } from "../domain/decision.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
+import { buildHarnessStore } from "../storage/factory.js";
+import { STORE_NS } from "../storage/namespaces.js";
+import type { HarnessStore } from "../storage/store.js";
 
 // Per-channel serialization so concurrent upsertChannelTickets calls for the
 // same channel don't race on read-modify-write. Keyed by channelId; the value
 // is a tail promise callers queue behind. Entries self-cleanup when no one is
-// queued. In-process only — cross-process coordination comes with T-101.
+// queued. In-process only; cross-process coordination for multi-writer
+// deployments (multiple schedulers) comes with the Postgres-backed
+// HarnessStore in T-402 — the per-upsert coordination record written through
+// `this.store.mutate` below is the hook that enables it.
 const channelTicketLocks: Map<string, Promise<void>> = new Map();
 
 // Monotonic suffix so two concurrent writers in the same process never
 // collide on the tmp file used by writeChannelTickets.
 let channelTicketsTmpCounter = 0;
 
+/**
+ * Ticket-board coordination record stored on the `HarnessStore` at
+ * `(channel-tickets, <channelId>)`. The ticket data itself continues to live
+ * in `channels/<channelId>/tickets.json` for Rust/GUI compatibility — this
+ * doc only tracks the last mutation so `store.mutate` can serve as a
+ * cross-process mutex when the backing store supports it (Postgres advisory
+ * locks in T-402). Unused when the operation is never called, which keeps
+ * pure-read callers (Rust, TUI) from ever materializing it.
+ */
+interface TicketLockRecord {
+  updatedAt: string;
+  count: number;
+}
+
 export class ChannelStore {
   private readonly channelsDir: string;
+  private readonly store: HarnessStore;
 
-  constructor(channelsDir?: string) {
+  /**
+   * @param channelsDir Directory for on-disk channel files. Defaults to
+   *   `~/.relay/channels` to preserve the layout the Rust crate
+   *   `harness-data` and the Tauri GUI read from directly. Overriding this
+   *   is only meaningful for tests — changing the default would break the
+   *   Rust/GUI reader.
+   * @param store `HarnessStore` used for operations that have migrated off
+   *   direct filesystem access. Defaults to `buildHarnessStore()` so callers
+   *   that don't inject one pick up the process-wide singleton semantics
+   *   through the factory. Tests substitute a `FakeHarnessStore` here.
+   *
+   * NOTE: most operations on this class still write directly to
+   * `channelsDir` because the Rust/GUI reader expects the plural-`channels`
+   * layout (`channels/<id>.json`, `channels/<id>/feed.jsonl`,
+   * `channels/<id>/tickets.json`, `channels/<id>/decisions/*.json`,
+   * `channels/<id>/runs.json`). FileHarnessStore's default namespace layout
+   * is `<root>/<ns>/<id>.json` which does not match, so migrating those
+   * paths would silently break the desktop app. T-101a tracks aligning the
+   * Rust side; until then, only coordination primitives (mutex) migrate.
+   */
+  constructor(channelsDir?: string, store?: HarnessStore) {
     this.channelsDir = channelsDir ?? join(getRelayDir(), "channels");
+    this.store = store ?? buildHarnessStore();
   }
 
   // --- Channel CRUD ---
@@ -434,14 +476,28 @@ export class ChannelStore {
    * Concurrent calls for the same channel are serialized through an
    * in-memory per-channel mutex so a read-modify-write cycle cannot lose
    * updates when multiple schedulers (or a scheduler + chat session) write
-   * at once. The mutex is in-process only; cross-process coordination is
-   * deferred to the HarnessStore migration (T-101).
+   * at once. The mutex is in-process only.
+   *
+   * After each successful merge, a small coordination record is written to
+   * the injected `HarnessStore` at `(channel-tickets, <channelId>)`. When
+   * the backing store is Postgres (T-402) this record lives under a
+   * cross-process advisory-lock-capable key, so multi-process schedulers
+   * can layer `store.mutate` on top for cross-process coordination without
+   * the ChannelStore itself owning that logic. FileHarnessStore's version
+   * is a plain JSON file at `<root>/channel-tickets/<id>.json` — harmless
+   * to the Rust/GUI reader (which only traverses `channels/`), and it
+   * doubles as an audit trail of upsert activity.
+   *
+   * Why not use `store.mutate` as the mutex directly? Its callback is
+   * synchronous (`(prev) => T`) so awaiting the `channels/<id>/tickets.json`
+   * read-modify-write inside it isn't possible without changing the
+   * HarnessStore contract — out of scope for T-101.
    */
   async upsertChannelTickets(
     channelId: string,
     incoming: TicketLedgerEntry[]
   ): Promise<TicketLedgerEntry[]> {
-    return this.withChannelLock(channelId, async () => {
+    const merged = await this.withChannelLock(channelId, async () => {
       const existing = await this.readChannelTickets(channelId);
       const byId = new Map(existing.map((t) => [t.ticketId, t]));
 
@@ -449,27 +505,43 @@ export class ChannelStore {
         byId.set(entry.ticketId, entry);
       }
 
-      const merged: TicketLedgerEntry[] = [];
+      const out: TicketLedgerEntry[] = [];
       const seen = new Set<string>();
 
       for (const entry of existing) {
         const current = byId.get(entry.ticketId);
         if (current) {
-          merged.push(current);
+          out.push(current);
           seen.add(entry.ticketId);
         }
       }
 
       for (const entry of incoming) {
         if (!seen.has(entry.ticketId)) {
-          merged.push(entry);
+          out.push(entry);
           seen.add(entry.ticketId);
         }
       }
 
-      await this.writeChannelTickets(channelId, merged);
-      return merged;
+      await this.writeChannelTickets(channelId, out);
+      return out;
     });
+
+    // Persist the coordination record through the HarnessStore. Uses
+    // `mutate` to keep semantics consistent across backends: on Postgres
+    // this executes under `pg_advisory_xact_lock`, on FileHarnessStore it
+    // serializes through the in-process key-lock. Purely advisory —
+    // nothing reads this record today; T-402 consumers layer on top.
+    await this.store.mutate<TicketLockRecord>(
+      STORE_NS.channelTickets,
+      channelId,
+      () => ({
+        updatedAt: new Date().toISOString(),
+        count: merged.length
+      })
+    );
+
+    return merged;
   }
 
   private async withChannelLock<T>(

--- a/src/cli/chat-context.ts
+++ b/src/cli/chat-context.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { ChannelStore } from "../channels/channel-store.js";
+import { getHarnessStore } from "../storage/factory.js";
 import { getRelayDir } from "./paths.js";
 import { SessionStore } from "./session-store.js";
 
@@ -56,7 +57,7 @@ export async function resolveChannelRefs(input: {
   message: string;
   currentChannelId: string;
 }): Promise<{ resolved: string; refs: string[] }> {
-  const channelStore = new ChannelStore();
+  const channelStore = new ChannelStore(undefined, getHarnessStore());
   const sessionStore = new SessionStore();
   const channels = await channelStore.listChannels("active");
   const contextBlocks: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ import {
 } from "./cli/workspace-registry.js";
 import { addProjectDir, readConfig, removeProjectDir } from "./cli/config.js";
 import { LocalArtifactStore } from "./execution/artifact-store.js";
-import { buildHarnessStore } from "./storage/factory.js";
-import type { HarnessStore } from "./storage/store.js";
+import { getHarnessStore } from "./storage/factory.js";
 import { startMcpServer } from "./mcp/server.js";
 import { VerificationRunner } from "./execution/verification-runner.js";
 import { Orchestrator } from "./orchestrator/orchestrator.js";
@@ -279,7 +278,7 @@ export async function main(): Promise<void> {
       );
       run = await orchestrator.run(featureRequest, runId);
     } else {
-      const channelStore = new ChannelStore();
+      const channelStore = new ChannelStore(undefined, getHarnessStore());
       const orchestratorV2 = new OrchestratorV2(
         registry,
         cwd,
@@ -428,28 +427,18 @@ export async function main(): Promise<void> {
   }
 }
 
-// One store per process. Handlers migrating off direct `fs/promises` (T-101+)
-// will call `getHarnessStore()`; nothing wires it yet.
-//
-// Module-level singleton rather than DI: legacy handlers still instantiate
-// their own stores directly, and a module-level cache keeps them from forking
-// behavior against a separately-constructed instance. Downstream constructors
-// (T-101+) take `HarnessStore` as a ctor arg for test substitution, so the
-// singleton is only a default entry point — not a hard dependency.
-let cachedStore: HarnessStore | null = null;
-export function getHarnessStore(): HarnessStore {
-  if (!cachedStore) cachedStore = buildHarnessStore();
-  return cachedStore;
-}
+// `getHarnessStore` is re-exported from the factory so legacy call sites can
+// continue to import it from this module.
+export { getHarnessStore };
 
 async function printChannels(args: string[] = []): Promise<void> {
   if (args.includes("--json")) {
-    const store = new ChannelStore();
+    const store = new ChannelStore(undefined, getHarnessStore());
     const channels = await store.listChannels("active");
     jsonOut(channels);
     return;
   }
-  const store = new ChannelStore();
+  const store = new ChannelStore(undefined, getHarnessStore());
   const channels = await store.listChannels();
 
   if (channels.length === 0) {
@@ -470,7 +459,7 @@ async function printChannels(args: string[] = []): Promise<void> {
 
 async function handleChannelCommand(args: string[]): Promise<void> {
   const sub = args[0];
-  const store = new ChannelStore();
+  const store = new ChannelStore(undefined, getHarnessStore());
 
   if (sub === "create") {
     const name = args[1];
@@ -819,7 +808,7 @@ async function resolvePrFromInput(
  * one in-flight run. Returns null when no channels exist.
  */
 async function resolveDefaultChannelId(): Promise<string | null> {
-  const store = new ChannelStore();
+  const store = new ChannelStore(undefined, getHarnessStore());
   const channels = await store.listChannels("active");
   return channels[0]?.channelId ?? null;
 }
@@ -878,7 +867,7 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
     return;
   }
 
-  const store = new ChannelStore();
+  const store = new ChannelStore(undefined, getHarnessStore());
   const channel = await store.getChannel(channelId);
 
   if (!channel) {
@@ -931,7 +920,7 @@ async function printDecisions(channelId: string, args: string[] = []): Promise<v
     return;
   }
 
-  const store = new ChannelStore();
+  const store = new ChannelStore(undefined, getHarnessStore());
   const channel = await store.getChannel(channelId);
 
   if (!channel) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import { getHarnessWorkspacePaths, readWorkspaceSummary } from "../cli/workspace
 import { buildWorkspaceId } from "../cli/workspace-registry.js";
 import { CrosslinkStore } from "../crosslink/store.js";
 import { ChannelStore } from "../channels/channel-store.js";
+import { getHarnessStore } from "../storage/factory.js";
 import {
   callChannelTool,
   getChannelToolDefinitions,
@@ -41,7 +42,7 @@ export async function startMcpServer(workspaceRoot: string): Promise<void> {
     sessionId: null,
     store: crosslinkStore
   };
-  const channelStore = new ChannelStore();
+  const channelStore = new ChannelStore(undefined, getHarnessStore());
   const channelState: ChannelToolState = {
     sessionId: null,
     channelStore
@@ -354,7 +355,7 @@ async function callTool(
       return { runId, decision: "rejected", feedback, path };
     }
     case "project_create": {
-      const channelStore = new ChannelStore();
+      const channelStore = new ChannelStore(undefined, getHarnessStore());
       const workspaceId = buildWorkspaceId(workspaceRoot);
       const name = String(args.name ?? "");
       const description = String(args.description ?? name);

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -10,6 +10,7 @@ import {
 } from "../cli/workspace-registry.js";
 import { OrchestratorV2, buildRunId } from "./orchestrator-v2.js";
 import { createPrWatcherFactory } from "../cli/pr-watcher-factory.js";
+import { getHarnessStore } from "../storage/factory.js";
 
 export interface DispatchInput {
   featureRequest: string;
@@ -35,7 +36,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const workspaceId = buildWorkspaceId(repoPath);
   const artifactsDir = `${getWorkspaceDir(workspaceId)}/artifacts`;
   const artifactStore = new LocalArtifactStore(artifactsDir);
-  const channelStore = new ChannelStore();
+  const channelStore = new ChannelStore(undefined, getHarnessStore());
 
   // Ensure agents are registered
   const defaultProvider = (process.env.HARNESS_PROVIDER ?? "claude") as "claude" | "codex";

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -34,7 +34,11 @@ export class NotImplementedError extends Error {
  *
  *   - src/cli/workspace-registry.ts      -> T-102
  *   - src/cli/session-store.ts           -> T-102
- *   - src/channels/channel-store.ts      -> T-101
+ *   - src/channels/channel-store.ts      -> T-101 (partial: ctor takes a
+ *                                          HarnessStore; ticket-board
+ *                                          coordination record migrated.
+ *                                          On-disk layout stays for
+ *                                          Rust/GUI compat — T-101a aligns)
  *   - src/crosslink/store.ts             -> T-104
  *   - src/execution/artifact-store.ts    -> T-103
  *
@@ -77,4 +81,37 @@ export function buildHarnessStore(
   throw new NotImplementedError(
     "SqliteHarnessStore is not yet implemented; use HARNESS_STORE=file."
   );
+}
+
+// Module-level singleton. Handlers migrating off direct `fs/promises` (T-101+)
+// call `getHarnessStore()` to obtain the process-wide instance so every
+// migrated caller observes the same state and watch semantics.
+//
+// A module-level cache rather than DI: legacy handlers still instantiate their
+// own stores directly (`new ChannelStore()` etc.), and the cache keeps them
+// from forking behavior against a separately-constructed instance. Downstream
+// constructors (T-101+) take `HarnessStore` as a ctor arg for test
+// substitution, so the singleton is only a default entry point — not a hard
+// dependency.
+let cachedStore: HarnessStore | null = null;
+
+/**
+ * Return the process-wide `HarnessStore` singleton, constructing it on first
+ * use. Tests that need a fresh store should pass one explicitly to the
+ * consuming class; `resetHarnessStoreForTests` is provided for the rare case
+ * where the singleton itself must be cleared between suites.
+ */
+export function getHarnessStore(): HarnessStore {
+  if (!cachedStore) cachedStore = buildHarnessStore();
+  return cachedStore;
+}
+
+/**
+ * Test helper: drop the cached singleton so the next `getHarnessStore` call
+ * reconstructs from the current `HARNESS_STORE` env. Not exported from the
+ * package entrypoint; only intended for integration tests that mutate env
+ * vars between runs.
+ */
+export function resetHarnessStoreForTests(): void {
+  cachedStore = null;
 }

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -1,4 +1,5 @@
 import { ChannelStore } from "../channels/channel-store.js";
+import { getHarnessStore } from "../storage/factory.js";
 import { listAgentNames } from "../domain/agent-names.js";
 import type { Channel, ChannelEntry } from "../domain/channel.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
@@ -44,7 +45,7 @@ interface DashboardState {
 }
 
 export async function startDashboard(): Promise<void> {
-  const channelStore = new ChannelStore();
+  const channelStore = new ChannelStore(undefined, getHarnessStore());
 
   const state: DashboardState = {
     channels: [],

--- a/test/channel-store-harness-store.test.ts
+++ b/test/channel-store-harness-store.test.ts
@@ -1,0 +1,312 @@
+import {
+  cp,
+  mkdtemp,
+  readFile,
+  rm,
+  stat
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../src/channels/channel-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
+import { STORE_NS } from "../src/storage/namespaces.js";
+import type {
+  BlobRef,
+  ChangeEvent,
+  HarnessStore,
+  ReadLogOptions
+} from "../src/storage/store.js";
+
+/**
+ * Minimal in-memory HarnessStore. Good enough to verify ChannelStore calls
+ * through to the injected store on migrated operations. Only the methods
+ * ChannelStore actually exercises are implemented with real semantics; the
+ * rest throw to surface accidental usage during tests.
+ */
+class FakeHarnessStore implements HarnessStore {
+  readonly docs: Map<string, unknown> = new Map();
+  readonly mutateCalls: Array<{ ns: string; id: string }> = [];
+
+  private key(ns: string, id: string): string {
+    return `${ns}\u0000${id}`;
+  }
+
+  async getDoc<T>(ns: string, id: string): Promise<T | null> {
+    const v = this.docs.get(this.key(ns, id));
+    return (v as T | undefined) ?? null;
+  }
+
+  async putDoc<T>(ns: string, id: string, doc: T): Promise<void> {
+    this.docs.set(this.key(ns, id), doc);
+  }
+
+  async listDocs<T>(): Promise<T[]> {
+    throw new Error("FakeHarnessStore.listDocs is not implemented");
+  }
+
+  async deleteDoc(): Promise<void> {
+    throw new Error("FakeHarnessStore.deleteDoc is not implemented");
+  }
+
+  async appendLog(): Promise<void> {
+    throw new Error("FakeHarnessStore.appendLog is not implemented");
+  }
+
+  async readLog<T>(
+    _ns: string,
+    _id: string,
+    _opts?: ReadLogOptions
+  ): Promise<T[]> {
+    throw new Error("FakeHarnessStore.readLog is not implemented");
+  }
+
+  async putBlob(): Promise<BlobRef> {
+    throw new Error("FakeHarnessStore.putBlob is not implemented");
+  }
+
+  async getBlob(): Promise<Uint8Array> {
+    throw new Error("FakeHarnessStore.getBlob is not implemented");
+  }
+
+  async mutate<T>(
+    ns: string,
+    id: string,
+    fn: (prev: T | null) => T
+  ): Promise<T> {
+    this.mutateCalls.push({ ns, id });
+    const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
+    const next = fn(prev);
+    this.docs.set(this.key(ns, id), next);
+    return next;
+  }
+
+  // eslint-disable-next-line require-yield
+  async *watch(): AsyncIterable<ChangeEvent> {
+    throw new Error("FakeHarnessStore.watch is not implemented");
+  }
+}
+
+describe("ChannelStore with HarnessStore injection", () => {
+  let channelsDir: string;
+  let fake: FakeHarnessStore;
+  let store: ChannelStore;
+
+  beforeEach(async () => {
+    channelsDir = await mkdtemp(join(tmpdir(), "ch-hs-"));
+    fake = new FakeHarnessStore();
+    store = new ChannelStore(channelsDir, fake);
+  });
+
+  afterEach(async () => {
+    await rm(channelsDir, { recursive: true, force: true });
+  });
+
+  it("routes ticket-board coordination through HarnessStore.mutate", async () => {
+    const channel = await store.createChannel({
+      name: "#coord",
+      description: "coord-test"
+    });
+
+    await store.upsertChannelTickets(channel.channelId, [
+      {
+        ticketId: "t-1",
+        title: "first",
+        specialty: "general",
+        status: "ready",
+        dependsOn: [],
+        assignedAgentId: null,
+        assignedAgentName: null,
+        crosslinkSessionId: null,
+        verification: "pending",
+        lastClassification: null,
+        chosenNextAction: null,
+        attempt: 0,
+        startedAt: null,
+        completedAt: null,
+        updatedAt: "2025-01-01T00:00:00.000Z",
+        runId: null
+      }
+    ]);
+
+    // The upsert must have written a coordination record through the store.
+    expect(fake.mutateCalls).toContainEqual({
+      ns: STORE_NS.channelTickets,
+      id: channel.channelId
+    });
+
+    const rec = await fake.getDoc<{ updatedAt: string; count: number }>(
+      STORE_NS.channelTickets,
+      channel.channelId
+    );
+    expect(rec).not.toBeNull();
+    expect(rec!.count).toBe(1);
+    expect(typeof rec!.updatedAt).toBe("string");
+  });
+
+  it("keeps the Rust-compat tickets.json layout on disk", async () => {
+    const channel = await store.createChannel({
+      name: "#layout",
+      description: "layout-test"
+    });
+
+    await store.upsertChannelTickets(channel.channelId, [
+      {
+        ticketId: "t-rust",
+        title: "rust-compat check",
+        specialty: "general",
+        status: "ready",
+        dependsOn: [],
+        assignedAgentId: null,
+        assignedAgentName: null,
+        crosslinkSessionId: null,
+        verification: "pending",
+        lastClassification: null,
+        chosenNextAction: null,
+        attempt: 0,
+        startedAt: null,
+        completedAt: null,
+        updatedAt: "2025-01-01T00:00:00.000Z",
+        runId: null
+      }
+    ]);
+
+    // Tickets still live at `channels/<id>/tickets.json` — not under the
+    // HarnessStore's `channel-tickets/<id>.json` layout. Rust's
+    // `load_channel_tickets` depends on this.
+    const onDiskPath = join(channelsDir, channel.channelId, "tickets.json");
+    const raw = JSON.parse(await readFile(onDiskPath, "utf8")) as {
+      tickets: Array<{ ticketId: string }>;
+    };
+    expect(raw.tickets.map((t) => t.ticketId)).toEqual(["t-rust"]);
+  });
+
+  it("channel doc stays at channelsDir/<id>.json (Rust-compat)", async () => {
+    const channel = await store.createChannel({
+      name: "#rust-doc",
+      description: "rust-doc-test"
+    });
+
+    const docPath = join(channelsDir, `${channel.channelId}.json`);
+    await expect(stat(docPath)).resolves.toBeTruthy();
+
+    // The HarnessStore's `channel` namespace must NOT have picked up a
+    // mirror — migrating that would break Rust's `load_channels`.
+    const mirrored = await fake.getDoc(STORE_NS.channel, channel.channelId);
+    expect(mirrored).toBeNull();
+  });
+
+  it("defaults to a real FileHarnessStore when no store is injected", async () => {
+    // No store arg → ctor builds one via `buildHarnessStore()`. This shouldn't
+    // throw even though HARNESS_STORE may default to "file" with a default
+    // rootDir — the store is constructed lazily but its ctor is safe.
+    const defaulted = new ChannelStore(channelsDir);
+    const channel = await defaulted.createChannel({
+      name: "#default",
+      description: "default-ctor"
+    });
+    expect(channel.channelId).toMatch(/^channel-/);
+  });
+
+  it("serializes concurrent upsertChannelTickets on the same channel", async () => {
+    const channel = await store.createChannel({
+      name: "#race",
+      description: "race-test"
+    });
+
+    const makeTicket = (ticketId: string) => ({
+      ticketId,
+      title: ticketId,
+      specialty: "general" as const,
+      status: "ready" as const,
+      dependsOn: [],
+      assignedAgentId: null,
+      assignedAgentName: null,
+      crosslinkSessionId: null,
+      verification: "pending" as const,
+      lastClassification: null,
+      chosenNextAction: null,
+      attempt: 0,
+      startedAt: null,
+      completedAt: null,
+      updatedAt: "2025-01-01T00:00:00.000Z",
+      runId: null
+    });
+
+    // Fire 4 concurrent upserts with distinct ticketIds. The in-process
+    // mutex must serialize them so every ticket lands in the final board.
+    await Promise.all([
+      store.upsertChannelTickets(channel.channelId, [makeTicket("t-1")]),
+      store.upsertChannelTickets(channel.channelId, [makeTicket("t-2")]),
+      store.upsertChannelTickets(channel.channelId, [makeTicket("t-3")]),
+      store.upsertChannelTickets(channel.channelId, [makeTicket("t-4")])
+    ]);
+
+    const final = await store.readChannelTickets(channel.channelId);
+    const ids = final.map((t) => t.ticketId).sort();
+    expect(ids).toEqual(["t-1", "t-2", "t-3", "t-4"]);
+  });
+});
+
+describe("ChannelStore reads legacy Rust-layout fixtures", () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    // Copy the hand-written legacy fixture into a scratch dir so the test is
+    // hermetic and can create additional subdirectories without touching the
+    // source tree.
+    workDir = await mkdtemp(join(tmpdir(), "ch-legacy-"));
+    const src = fileURLToPath(
+      new URL("./fixtures/legacy-channel", import.meta.url)
+    );
+    await cp(src, workDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("reads a pre-migration channel doc, feed, tickets, runs, and decisions", async () => {
+    // Use a real FileHarnessStore rooted outside the channels dir — the
+    // fixture test shouldn't depend on the user's home directory.
+    const storeRoot = await mkdtemp(join(tmpdir(), "ch-legacy-store-"));
+    try {
+      const store = new ChannelStore(
+        workDir,
+        new FileHarnessStore(storeRoot)
+      );
+
+      const channel = await store.getChannel("channel-abc");
+      expect(channel).not.toBeNull();
+      expect(channel!.name).toBe("#legacy-feature");
+      expect(channel!.status).toBe("active");
+      expect(channel!.members).toHaveLength(1);
+
+      const feed = await store.readFeed("channel-abc");
+      expect(feed).toHaveLength(2);
+      expect(feed[0].entryId).toBe("entry-001");
+      expect(feed[1].type).toBe("status_update");
+      expect(feed[1].metadata).toEqual({ runId: "run-legacy-1" });
+
+      const tickets = await store.readChannelTickets("channel-abc");
+      expect(tickets.map((t) => t.ticketId)).toEqual([
+        "ticket-legacy-1",
+        "ticket-legacy-2"
+      ]);
+      expect(tickets[0].status).toBe("executing");
+
+      const runs = await store.readRunLinks("channel-abc");
+      expect(runs).toHaveLength(1);
+      expect(runs[0].runId).toBe("run-legacy-1");
+
+      const decisions = await store.listDecisions("channel-abc");
+      expect(decisions).toHaveLength(1);
+      expect(decisions[0].decisionId).toBe("decision-legacy-1");
+    } finally {
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/fixtures/legacy-channel/channel-abc.json
+++ b/test/fixtures/legacy-channel/channel-abc.json
@@ -1,0 +1,22 @@
+{
+  "channelId": "channel-abc",
+  "name": "#legacy-feature",
+  "description": "Pre-migration channel fixture — exercises the Rust-compat layout.",
+  "status": "active",
+  "workspaceIds": ["ws-legacy-1"],
+  "members": [
+    {
+      "agentId": "planner-claude",
+      "displayName": "Claude (Planner)",
+      "role": "planner",
+      "provider": "claude",
+      "status": "active",
+      "sessionId": null,
+      "joinedAt": "2025-01-01T12:00:00.000Z"
+    }
+  ],
+  "pinnedRefs": [],
+  "repoAssignments": [],
+  "createdAt": "2025-01-01T12:00:00.000Z",
+  "updatedAt": "2025-01-01T12:00:00.000Z"
+}

--- a/test/fixtures/legacy-channel/channel-abc/decisions/decision-legacy-1.json
+++ b/test/fixtures/legacy-channel/channel-abc/decisions/decision-legacy-1.json
@@ -1,0 +1,14 @@
+{
+  "decisionId": "decision-legacy-1",
+  "channelId": "channel-abc",
+  "runId": "run-legacy-1",
+  "ticketId": null,
+  "title": "Use JWT for session tokens",
+  "description": "Pick JWT over session cookies for the v1 auth rollout.",
+  "rationale": "Stateless and already familiar to the team.",
+  "alternatives": ["session cookies", "opaque server-side tokens"],
+  "decidedBy": "planner-claude",
+  "decidedByName": "Claude (Planner)",
+  "linkedArtifacts": [],
+  "createdAt": "2025-01-01T12:08:00.000Z"
+}

--- a/test/fixtures/legacy-channel/channel-abc/feed.jsonl
+++ b/test/fixtures/legacy-channel/channel-abc/feed.jsonl
@@ -1,0 +1,2 @@
+{"entryId":"entry-001","channelId":"channel-abc","type":"message","fromAgentId":"planner-claude","fromDisplayName":"Claude (Planner)","content":"Legacy message with plain metadata.","metadata":{"priority":"info"},"createdAt":"2025-01-01T12:05:00.000Z"}
+{"entryId":"entry-002","channelId":"channel-abc","type":"status_update","fromAgentId":null,"fromDisplayName":null,"content":"Run started","metadata":{"runId":"run-legacy-1"},"createdAt":"2025-01-01T12:06:00.000Z"}

--- a/test/fixtures/legacy-channel/channel-abc/runs.json
+++ b/test/fixtures/legacy-channel/channel-abc/runs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "runId": "run-legacy-1",
+    "workspaceId": "ws-legacy-1",
+    "linkedAt": "2025-01-01T12:06:00.000Z"
+  }
+]

--- a/test/fixtures/legacy-channel/channel-abc/tickets.json
+++ b/test/fixtures/legacy-channel/channel-abc/tickets.json
@@ -1,0 +1,41 @@
+{
+  "updatedAt": "2025-01-01T12:10:00.000Z",
+  "tickets": [
+    {
+      "ticketId": "ticket-legacy-1",
+      "title": "Implement auth middleware",
+      "specialty": "api_crud",
+      "status": "executing",
+      "dependsOn": [],
+      "assignedAgentId": "planner-claude",
+      "assignedAgentName": "Claude (Planner)",
+      "crosslinkSessionId": null,
+      "verification": "pending",
+      "lastClassification": null,
+      "chosenNextAction": null,
+      "attempt": 0,
+      "startedAt": "2025-01-01T12:10:00.000Z",
+      "completedAt": null,
+      "updatedAt": "2025-01-01T12:10:00.000Z",
+      "runId": "run-legacy-1"
+    },
+    {
+      "ticketId": "ticket-legacy-2",
+      "title": "Wire login UI",
+      "specialty": "ui",
+      "status": "ready",
+      "dependsOn": ["ticket-legacy-1"],
+      "assignedAgentId": null,
+      "assignedAgentName": null,
+      "crosslinkSessionId": null,
+      "verification": "pending",
+      "lastClassification": null,
+      "chosenNextAction": null,
+      "attempt": 0,
+      "startedAt": null,
+      "completedAt": null,
+      "updatedAt": "2025-01-01T12:10:00.000Z",
+      "runId": "run-legacy-1"
+    }
+  ]
+}


### PR DESCRIPTION
## Option chosen: A (partial migration)

Injects `HarnessStore` into `ChannelStore`'s ctor as the T-101 plumbing;
keeps most operations direct-file because the Rust crate `harness-data`
and the Tauri GUI read the `channels/` layout directly and
`FileHarnessStore`'s default namespace layout (`<root>/<ns>/<id>.json`)
does not match (plural `channels` vs singular `<ns>`). Migrating those
paths would silently break the desktop app — out of scope for T-101 and
tracked for T-101a.

## What migrated vs what stayed direct-file

**Migrated (via `HarnessStore.mutate`)**
- `upsertChannelTickets` now writes a small coordination record
  (`{updatedAt, count}`) through `store.mutate` on
  `STORE_NS.channelTickets` after each merge. On Postgres (T-402) that
  call runs under `pg_advisory_xact_lock`, giving multi-process
  schedulers a cross-process coordination hook without ChannelStore
  owning the logic. Ticket data itself stays in the Rust-compat
  `channels/<id>/tickets.json`.

**Stayed direct-file (Rust/GUI compat)**
- `channels/<id>.json` — channel doc (`createChannel`, `getChannel`,
  `listChannels`, `updateChannel`, ...)
- `channels/<id>/feed.jsonl` — channel feed (`postEntry`, `readFeed`)
- `channels/<id>/tickets.json` — ticket-board payload
  (`readChannelTickets`, `writeChannelTickets`)
- `channels/<id>/runs.json` — run links
- `channels/<id>/decisions/*.json` — decisions

## Rust/GUI compat preservation

- No change to `crates/harness-data/src/lib.rs` or the Tauri app.
- No change to `channel_task_board` MCP tool or `printTaskBoard` CLI.
- `cargo test` in `crates/harness-data` stays green.
- A new fixture test (`test/fixtures/legacy-channel/`) reads hand-written
  Rust-layout data through the new ctor shape to catch layout drift.

## Wiring

- `getHarnessStore` moved to `src/storage/factory.ts` so non-CLI modules
  (dispatch, MCP server, TUI, chat-context) can import it without
  risking circular deps with `src/index.ts`. `src/index.ts` re-exports
  it for the legacy import path.
- All `new ChannelStore()` sites in `src/` now pass
  `getHarnessStore()` as the second ctor arg so every caller observes
  the same store instance.
- `ChannelStore(channelsDir?, store?)` keeps both args optional so
  tests (and legacy callers during rollout) can construct without any
  plumbing.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 251 passing (+6 new), 21 skipped; existing
      channel-store tests unchanged
- [x] `cargo test -p harness-data` clean (compile-only)
- [x] New test file `test/channel-store-harness-store.test.ts`:
  - `FakeHarnessStore` substituted in ctor verifies
    `upsertChannelTickets` calls through to `store.mutate`
  - Rust-compat paths still exist on disk (channel doc, tickets.json)
  - `HarnessStore` namespace is NOT mirrored for channel docs (catches
    an accidental migration of Rust-visible data)
  - Default ctor still works when no store is injected
  - In-process mutex still serializes concurrent ticket upserts
- [x] Legacy-fixture test reads a hand-written
      `channels/<id>{.json,/feed.jsonl,/tickets.json,/runs.json,/decisions/*.json}`
      layout through the new ctor without error

## Out of scope / follow-ups

- **T-101a**: align the Rust crate's on-disk layout so the data — not
  just the coordination record — can flow through HarnessStore. Today
  the coordination record is advisory only; Rust and the GUI don't
  read it.
- Callsites outside `src/` (if any emerge) still compile against the
  old single-arg ctor because the store arg is optional.