### PR TITLE
Fix chat content pollution, create-channel failure, friendlier streaming UI, repo context

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -130,6 +130,7 @@ fn run_cli(args: Vec<String>) -> CliResult {
 }
 
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RepoAssignmentInput {
     pub alias: String,
     pub workspace_id: String,
@@ -455,6 +456,31 @@ fn start_chat(
                                             text: describe_tool_use(name, input),
                                         },
                                     );
+                                }
+                                Some("thinking") => {
+                                    // Claude extended-thinking content blocks —
+                                    // surface a trimmed preview as activity so
+                                    // the UI shows something other than "…"
+                                    // while the model is reasoning.
+                                    if let Some(text) = block
+                                        .get("thinking")
+                                        .and_then(|v| v.as_str())
+                                    {
+                                        let preview = text
+                                            .split_whitespace()
+                                            .take(16)
+                                            .collect::<Vec<_>>()
+                                            .join(" ");
+                                        if !preview.is_empty() {
+                                            let _ = app_handle.emit(
+                                                "chat-event",
+                                                ChatEvent::Activity {
+                                                    stream_id,
+                                                    text: format!("thinking: {}…", preview),
+                                                },
+                                            );
+                                        }
+                                    }
                                 }
                                 _ => {}
                             }

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -196,21 +196,31 @@ function ChatView({
           <FeedView entries={feed} />
         )}
         {stream && (
-          <div className={`feed-entry role-assistant`}>
+          <div className={`feed-entry role-assistant streaming`}>
             <div className="feed-header">
               <span className="feed-author">
                 {stream.alias ? `@${stream.alias}` : "assistant"}
               </span>
-              <span>streaming…</span>
+              <span className="stream-status">
+                <span className="stream-dot" /> streaming
+              </span>
             </div>
-            {stream.activity.length > 0 && (
-              <div className="stream-activity">
-                {stream.activity.slice(-4).map((a, i) => (
-                  <div key={i}>· {a}</div>
-                ))}
-              </div>
+            <div className="stream-activity">
+              {stream.activity.length === 0 ? (
+                <div className="stream-activity-empty">
+                  {stream.accum ? "writing response…" : "thinking…"}
+                </div>
+              ) : (
+                stream.activity.slice(-5).map((a, i) => (
+                  <div key={i} className="stream-activity-line">
+                    · {a}
+                  </div>
+                ))
+              )}
+            </div>
+            {stream.accum && (
+              <div className="feed-content">{stream.accum}</div>
             )}
-            <div className="feed-content">{stream.accum || "…"}</div>
           </div>
         )}
       </div>

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -357,9 +357,44 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   font-size: 11px;
   color: var(--text-dim);
   font-style: italic;
-  margin-bottom: 6px;
+  margin: 4px 0 8px;
   border-left: 2px solid var(--activity);
-  padding-left: 8px;
+  padding: 4px 8px;
+  background: rgba(250, 179, 135, 0.04);
+  border-radius: 0 3px 3px 0;
+}
+.stream-activity-line {
+  line-height: 1.5;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.stream-activity-empty {
+  color: var(--text-muted);
+}
+.feed-entry.streaming {
+  border: 1px solid var(--accent-dim);
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: rgba(116, 199, 236, 0.04);
+}
+.stream-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-dim);
+  font-size: 11px;
+}
+.stream-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: stream-pulse 1.2s ease-in-out infinite;
+}
+@keyframes stream-pulse {
+  0%, 100% { opacity: 0.3; transform: scale(0.85); }
+  50%      { opacity: 1;   transform: scale(1.1); }
 }
 
 /* Sessions panel */

--- a/src/cli/chat-context.ts
+++ b/src/cli/chat-context.ts
@@ -1,9 +1,59 @@
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { ChannelStore } from "../channels/channel-store.js";
 import { getRelayDir } from "./paths.js";
 import { SessionStore } from "./session-store.js";
+
+/**
+ * Best-effort repo context: git remote + branch + top-level tree + README
+ * head. Returns an empty string when anything fails so we never block chat
+ * startup on a git hiccup (repo deleted, not a git repo, etc.).
+ */
+function collectRepoContext(repoPath: string): string {
+  const lines: string[] = [];
+  const tryGit = (args: string[]): string | null => {
+    try {
+      return execFileSync("git", ["-C", repoPath, ...args], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 2000
+      }).trim();
+    } catch {
+      return null;
+    }
+  };
+
+  const remote = tryGit(["remote", "get-url", "origin"]);
+  if (remote) lines.push(`Git remote: ${remote}`);
+  const branch = tryGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (branch) lines.push(`Current branch: ${branch}`);
+
+  try {
+    const entries = readdirSync(repoPath, { withFileTypes: true })
+      .filter((e) => !e.name.startsWith("."))
+      .slice(0, 20)
+      .map((e) => (e.isDirectory() ? `${e.name}/` : e.name))
+      .join(" ");
+    if (entries) lines.push(`Top-level entries: ${entries}`);
+  } catch {
+    /* skip */
+  }
+
+  const readme = ["README.md", "README", "Readme.md", "readme.md"]
+    .map((name) => join(repoPath, name))
+    .find((p) => existsSync(p));
+  if (readme) {
+    try {
+      const head = readFileSync(readme, "utf8").split("\n").slice(0, 10).join("\n").trim();
+      if (head) lines.push(`README head:\n${head}`);
+    } catch {
+      /* skip */
+    }
+  }
+  return lines.length > 0 ? lines.join("\n") : "";
+}
 
 export function buildSystemPrompt(input: {
   channelId: string;
@@ -19,6 +69,18 @@ export function buildSystemPrompt(input: {
       `Your working directory is already set to this repo — do NOT search for it elsewhere. ` +
       `All file operations should be relative to this directory.`
     );
+    const repoContext = collectRepoContext(input.repoPath);
+    if (repoContext) {
+      parts.push(
+        "\nRepo context (read at session start — may be stale after long runs):\n" +
+          repoContext
+      );
+    }
+  } else if (input.repoPath) {
+    const repoContext = collectRepoContext(input.repoPath);
+    if (repoContext) {
+      parts.push("Current repo context:\n" + repoContext);
+    }
   }
 
   const channelDir = join(getRelayDir(), "channels", input.channelId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1047,6 +1047,28 @@ function parseNamedArg(args: string[], name: string): string | undefined {
   return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : undefined;
 }
 
+/**
+ * Extract positional arguments: strip `--flag` entries AND the values that
+ * follow them, unless the next entry is itself a flag (boolean flag case).
+ * Replaces the naive `args.filter(a => !a.startsWith("--"))` pattern, which
+ * leaked flag values (channel ids, session ids, role) into content fields —
+ * visible in chat history as "ch-... sess-... user <message>".
+ */
+function extractPositionals(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        i++;
+      }
+      continue;
+    }
+    result.push(arg);
+  }
+  return result;
+}
+
 async function handleSessionCommand(args: string[]): Promise<void> {
   const sub = args[0];
   const store = new SessionStore();
@@ -1117,7 +1139,7 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     const sessionId = parseNamedArg(args, "--session");
     const role = parseNamedArg(args, "--role") ?? "user";
     const alias = parseNamedArg(args, "--alias") ?? null;
-    const content = args.filter((a) => !a.startsWith("--")).slice(1).join(" ");
+    const content = extractPositionals(args).slice(1).join(" ");
 
     if (!channelId || !sessionId || !content) {
       console.error("Usage: rly session append --channel <id> --session <id> --role <role> [--alias <name>] <content>");
@@ -1141,7 +1163,7 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     const sessionId = parseNamedArg(args, "--session");
     const role = parseNamedArg(args, "--role") ?? "assistant";
     const alias = parseNamedArg(args, "--alias") ?? null;
-    const content = args.filter((a) => !a.startsWith("--")).slice(1).join(" ");
+    const content = extractPositionals(args).slice(1).join(" ");
 
     if (!channelId || !sessionId || !content) {
       console.error("Usage: rly session update-last --channel <id> --session <id> <content>");
@@ -1220,7 +1242,7 @@ async function handleChatCommand(
 
   if (sub === "resolve-refs") {
     const channelId = parseNamedArg(args, "--channel");
-    const message = args.filter((a) => !a.startsWith("--")).slice(1).join(" ");
+    const message = extractPositionals(args).slice(1).join(" ");
 
     if (!channelId || !message) {
       console.error("Usage: rly chat resolve-refs --channel <id> <message>");


### PR DESCRIPTION
Four fixes in one PR — two hard bugs you hit directly plus two UX improvements that came out of the same feedback.

## 1. \`create_channel\` with repos no longer fails
**Symptom:** \"invalid args \`repos\` for command \`create_channel\`: missing field \`workspace_id\`\"

**Cause:** The Tauri command's \`RepoAssignmentInput\` struct was missing \`#[serde(rename_all = \"camelCase\")]\`, so camelCase JSON from the TS side (\`workspaceId\`, \`repoPath\`) couldn't deserialize into the snake_case Rust fields. Fix is one attribute.

## 2. Chat content no longer polluted with \"ch-... sess-... user\" prefix
**Symptom:** User messages stored and rendered as \`ch-1775623896124 sess-1776723441725 user Pull the latest tickets...\`.

**Cause:** \`handleSessionCommand\` / \`handleChatCommand\` used \`args.filter(a => !a.startsWith(\"--\")).slice(1).join(\" \")\` to extract positional content. That leaves the VALUES of the --flag pairs in the positional stream, so the channel id, session id, and role all got prepended.

**Fix:** New \`extractPositionals(args)\` helper that properly skips \`--flag\` AND its following value (unless the next token is itself a flag — boolean case). Applied to all three broken call sites: \`session append\`, \`session update-last\`, \`chat resolve-refs\`.

## 3. Streaming UI shows real progress instead of \"...\"
- **Rust parser**: new arm for Claude's extended-thinking content blocks. Emits a 16-word preview as an Activity event so you see reasoning rather than a silent \"...\".
- **Stream panel**: always visible during a stream. Shows a pulsing accent-blue dot, an activity rail of the last 5 tool calls / thinking previews, and a clear \"thinking...\" or \"writing response...\" placeholder when the rail is empty. Streaming entry gets a subtle accent border + tint so it reads as live.

## 4. Agent gets repo context on session start
\`buildSystemPrompt\` now calls \`collectRepoContext(repoPath)\` which shells out for \`git remote get-url origin\` + \`git rev-parse --abbrev-ref HEAD\`, reads the top-level directory listing (up to 20 entries), and grabs the first 10 lines of README.md. Appended to the system prompt under a \"Repo context (read at session start)\" header.

Best-effort: each probe is individually try/catched, so a non-git dir, missing origin, or missing README won't block chat startup. Timeouts capped at 2s.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 245/245 + 21 skipped (no baseline regression)
- [x] \`pnpm build\` clean
- [x] \`cd gui && pnpm build\` clean
- [ ] Manual: \`rly gui --rebuild\`, create a channel with a repo, confirm no \"missing field workspace_id\" error.
- [ ] Manual: send a chat message, confirm the stored content is the message text only, no ID prefix.
- [ ] Manual: ask the agent a reasoning question — \"thinking...\" / thinking previews show in the activity rail instead of silent \"...\".
- [ ] Manual: ask the agent \"what repo are we in?\" — answer should reference the git remote + branch + top-level tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)