### PR TITLE
GUI bundle: app-only by default, skip flaky DMG build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,33 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agent-harness-gui"
-version = "0.1.0"
-dependencies = [
- "harness-data",
- "notify",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-shell",
-]
-
-[[package]]
-name = "agent-harness-tui"
-version = "0.1.0"
-dependencies = [
- "arboard",
- "chrono",
- "crossterm",
- "dirs",
- "harness-data",
- "ratatui",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3119,33 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relay-gui"
+version = "0.1.0"
+dependencies = [
+ "harness-data",
+ "notify",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-shell",
+]
+
+[[package]]
+name = "relay-tui"
+version = "0.1.0"
+dependencies = [
+ "arboard",
+ "chrono",
+ "crossterm",
+ "dirs",
+ "harness-data",
+ "ratatui",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "reqwest"

--- a/README.md
+++ b/README.md
@@ -182,7 +182,13 @@ Direct `pnpm` scripts (useful when hacking on the GUI from the repo):
 
 ```bash
 pnpm gui:dev      # launch dev window (Vite + Tauri)
-pnpm gui:build    # produce a release .app/.dmg
+pnpm gui:build    # produce a release .app bundle
+```
+
+Default bundle target is `app` only — the DMG bundler (`bundle_dmg.sh`) is flaky on macOS (osascript/hdiutil permissions, leftover mounts) and isn't needed for local use. To produce a DMG for distribution, run:
+
+```bash
+cd gui && pnpm tauri build --bundles app,dmg
 ```
 
 The Rust backend in `gui/src-tauri/` shares `crates/harness-data` with the TUI, so both read the same `~/.relay/` files. Prereqs: `cargo` (rustup) and Xcode command-line tools on macOS.

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
**Symptom:** \`rly rebuild --gui\` was failing at the very end:
\`\`\`
Bundling Relay_0.1.0_aarch64.dmg (…)
 Running bundle_dmg.sh
failed to bundle project error running bundle_dmg.sh
\`\`\`

**Cause:** Tauri's DMG bundler shells out to \`bundle_dmg.sh\` which drives \`osascript\` + \`hdiutil\`. That pipeline is notoriously brittle on macOS — Accessibility permission prompts that never arrive in headless-ish sessions, leftover mounted DMGs from a previous run, \`hdiutil attach\` failing when disk pressure is high, etc. The .app bundled fine above it.

**Fix:** \`bundle.targets\` goes from \`\"all\"\` → \`[\"app\"]\`. \`rly gui\` only ever opens the .app; skipping DMG gets us a clean success path for local dev.

**Distribution**: when you actually want a DMG to ship, one-liner escape hatch:
\`\`\`bash
cd gui && pnpm tauri build --bundles app,dmg
\`\`\`

README updated with the note.

## Test plan
- [x] \`pnpm gui:build\` completes cleanly — 1 bundle (Relay.app) at \`target/release/bundle/macos/Relay.app\`.
- [ ] Manual: \`rly gui --rebuild\` no longer fails, \`rly gui\` opens the refreshed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)