### PR TITLE
Primary/associated repo model + spawn lifecycle + alias-routed tickets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,6 +3124,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "relay-gui"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "harness-data",
  "notify",
  "serde",

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -56,6 +56,11 @@ pub struct TicketLedgerEntry {
     pub assigned_agent_name: Option<String>,
     pub verification: String,
     pub attempt: u32,
+    /// Alias of the channel repo assignment this ticket should be routed
+    /// to. Optional and `#[serde(default)]`-backed so ticket files written
+    /// before per-repo routing existed still deserialize.
+    #[serde(default)]
+    pub assigned_alias: Option<String>,
 }
 
 // --- Channel ---
@@ -80,6 +85,14 @@ pub struct Channel {
     pub pinned_refs: Vec<ChannelRef>,
     #[serde(default)]
     pub repo_assignments: Vec<RepoAssignment>,
+    /// When set, identifies the `workspace_id` of the entry in
+    /// `repo_assignments` that is this channel's primary repo. Back-compat
+    /// via `#[serde(default)]` — channel files predating the
+    /// primary/associated model omit this field and deserialize with
+    /// `None`, in which case consumers fall back to the first entry in
+    /// `repo_assignments`.
+    #[serde(default)]
+    pub primary_workspace_id: Option<String>,
     /// ISO 8601 timestamps. Optional for back-compat with channel files
     /// written before these fields were tracked.
     #[serde(default)]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -16,4 +16,5 @@ tauri-plugin-shell = "2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "6"
+chrono = "0.4"
 harness-data = { path = "../../crates/harness-data" }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,6 +1,9 @@
 use harness_data as data;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::Emitter;
@@ -150,12 +153,27 @@ fn create_channel(
     name: String,
     description: String,
     repos: Vec<RepoAssignmentInput>,
+    #[allow(non_snake_case)] primaryWorkspaceId: Option<String>,
 ) -> Result<serde_json::Value, String> {
+    // Resolve the primary workspace id (if provided) to the matching alias —
+    // the CLI takes `--primary <alias>` because aliases are user-facing, but
+    // the GUI works with workspace ids. When the id isn't in the repos list
+    // we silently drop it; the CLI would error and that matters less than
+    // the create succeeding with a sensible fallback.
+    let primary_alias = primaryWorkspaceId
+        .as_ref()
+        .and_then(|id| repos.iter().find(|r| &r.workspace_id == id))
+        .map(|r| r.alias.clone());
+
     let repos = repos_arg(&repos);
     let mut args: Vec<&str> = vec!["channel", "create", &name, &description, "--json"];
     if !repos.is_empty() {
         args.push("--repos");
         args.push(&repos);
+    }
+    if let Some(ref alias) = primary_alias {
+        args.push("--primary");
+        args.push(alias);
     }
     cli_json(&args)
 }
@@ -570,6 +588,341 @@ fn start_chat(
     Ok(stream_id)
 }
 
+// --- Terminal.app spawn/kill lifecycle (Task #24) ---
+//
+// Each channel tracks an associated-repo agent spawn in
+// `~/.relay/channels/<channelId>/spawns.json`. On macOS, "spawn" opens a new
+// Terminal.app tab running `rly claude` in the repo; we capture the window/tab
+// ids from the AppleScript return value so we can close them again later.
+//
+// We hardcode STALE_HEARTBEAT_MS here (matching the crosslink store) instead
+// of depending on the TS/crosslink side, so self-heal stays self-contained.
+const STALE_HEARTBEAT_MS: u64 = 120_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Spawn {
+    pub alias: String,
+    pub repo_path: String,
+    pub spawned_at: String,
+    pub terminal_window_id: Option<u32>,
+    pub terminal_tab_id: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct SpawnsFile {
+    #[serde(default = "default_spawns_version")]
+    version: u32,
+    #[serde(default)]
+    spawns: BTreeMap<String, Spawn>,
+}
+
+fn default_spawns_version() -> u32 {
+    1
+}
+
+fn spawns_path(channel_id: &str) -> PathBuf {
+    data::harness_root()
+        .join("channels")
+        .join(channel_id)
+        .join("spawns.json")
+}
+
+fn load_spawns_file(channel_id: &str) -> SpawnsFile {
+    let path = spawns_path(channel_id);
+    match fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str::<SpawnsFile>(&raw).unwrap_or_else(|_| SpawnsFile {
+            version: 1,
+            spawns: BTreeMap::new(),
+        }),
+        Err(_) => SpawnsFile {
+            version: 1,
+            spawns: BTreeMap::new(),
+        },
+    }
+}
+
+fn save_spawns_file(channel_id: &str, file: &SpawnsFile) -> Result<(), String> {
+    let path = spawns_path(channel_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create spawns dir: {}", e))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let content = serde_json::to_string_pretty(file)
+        .map_err(|e| format!("serialize spawns.json: {}", e))?;
+    fs::write(&tmp, content).map_err(|e| format!("write spawns.json tmp: {}", e))?;
+    fs::rename(&tmp, &path).map_err(|e| format!("rename spawns.json: {}", e))
+}
+
+/// Run `osascript -e <script>` and return trimmed stdout, or an error string.
+fn run_osascript(script: &str) -> Result<String, String> {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("osascript failed to launch: {}", e))?;
+    if !output.status.success() {
+        return Err(format!(
+            "osascript error: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Parse the result of `do script` — Terminal returns a reference like
+/// `tab 1 of window id 12345` (the exact wording varies by macOS version
+/// but always includes "window id <N>" and a "tab <N>" index, both as
+/// integers). Returns (window_id, tab_id). Returns None on parse miss so
+/// callers can fall back to a best-effort windowId.
+fn parse_terminal_tab_ref(raw: &str) -> (Option<u32>, Option<u32>) {
+    let window_id = extract_int_after(raw, "window id ");
+    // Terminal's textual form is usually "tab <N> of window id <M>".
+    // Pull the first number after the literal word "tab " for the tab index.
+    let tab_id = extract_int_after(raw, "tab ");
+    (window_id, tab_id)
+}
+
+fn extract_int_after(haystack: &str, needle: &str) -> Option<u32> {
+    let idx = haystack.find(needle)?;
+    let rest = &haystack[idx + needle.len()..];
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse::<u32>().ok()
+    }
+}
+
+/// Best-effort query of Terminal's frontmost window id. Returns None if
+/// Terminal isn't running or AppleScript fails.
+fn frontmost_terminal_window_id() -> Option<u32> {
+    let script = r#"tell application "Terminal" to id of front window"#;
+    run_osascript(script).ok().and_then(|s| s.parse::<u32>().ok())
+}
+
+/// AppleScript single-quote escaping: wrap in single quotes, any inner `'`
+/// becomes `'\''`. Used for shell path interpolation inside the `do script`
+/// command we hand to Terminal.
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// AppleScript string literal escaping: wrap in double quotes, escape inner
+/// backslashes and double quotes.
+fn applescript_string(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{}\"", escaped)
+}
+
+#[tauri::command]
+fn spawn_agent(
+    channel_id: String,
+    alias: String,
+    repo_path: String,
+) -> Result<Spawn, String> {
+    if std::env::consts::OS != "macos" {
+        return Err(
+            "spawn is macOS-only — run `rly claude` in the repo manually on this platform".into(),
+        );
+    }
+
+    // Build the shell command the Terminal tab should run. We single-quote
+    // the path to survive spaces and most shell metacharacters, then wrap
+    // the whole shell command as an AppleScript string literal.
+    let shell_cmd = format!("cd {} && rly claude", shell_single_quote(&repo_path));
+    let script = format!(
+        r#"tell application "Terminal" to do script {}"#,
+        applescript_string(&shell_cmd)
+    );
+
+    let raw = run_osascript(&script)
+        .map_err(|e| format!("failed to open Terminal tab: {}", e))?;
+
+    let (mut window_id, mut tab_id) = parse_terminal_tab_ref(&raw);
+
+    // Fallback: if we couldn't parse window id from the `do script` return,
+    // grab the frontmost Terminal window id. Tab index falls back to 0.
+    if window_id.is_none() {
+        window_id = frontmost_terminal_window_id();
+        if tab_id.is_none() {
+            tab_id = Some(0);
+        }
+    }
+
+    let spawn = Spawn {
+        alias: alias.clone(),
+        repo_path,
+        spawned_at: chrono::Utc::now().to_rfc3339(),
+        terminal_window_id: window_id,
+        terminal_tab_id: tab_id,
+    };
+
+    // Idempotent on alias: overwrite any existing entry.
+    let mut file = load_spawns_file(&channel_id);
+    file.version = 1;
+    file.spawns.insert(alias, spawn.clone());
+    save_spawns_file(&channel_id, &file)?;
+
+    Ok(spawn)
+}
+
+/// Best-effort SIGTERM to a crosslink session whose repoPath matches.
+/// Reads `~/.relay/crosslink/sessions/*.json` and kills the first match.
+/// Any failure is swallowed; this is a fallback when osascript can't find
+/// the tab.
+fn try_sigterm_matching_session(repo_path: &str) {
+    let sessions_dir = data::harness_root().join("crosslink").join("sessions");
+    let Ok(entries) = fs::read_dir(&sessions_dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(session) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        let session_repo = session.get("repoPath").and_then(|v| v.as_str()).unwrap_or("");
+        if session_repo != repo_path {
+            continue;
+        }
+        let Some(pid) = session.get("pid").and_then(|v| v.as_u64()) else {
+            continue;
+        };
+        // Shell out to `kill` — avoids pulling in libc/nix just for SIGTERM.
+        let _ = Command::new("kill")
+            .arg("-TERM")
+            .arg(pid.to_string())
+            .status();
+        break;
+    }
+}
+
+#[tauri::command]
+fn kill_spawned_agent(channel_id: String, alias: String) -> Result<(), String> {
+    let mut file = load_spawns_file(&channel_id);
+    let Some(entry) = file.spawns.remove(&alias) else {
+        // Already gone — treat as success.
+        return Ok(());
+    };
+
+    if std::env::consts::OS == "macos" {
+        if let Some(wid) = entry.terminal_window_id {
+            // Targeted: close the exact tab in the tracked window, if we
+            // have a tab index. Fall back to closing the whole window if
+            // the tab lookup fails.
+            let close_script = if let Some(tid) = entry.terminal_tab_id {
+                format!(
+                    r#"tell application "Terminal"
+                        try
+                            close tab {tid} of window id {wid} saving no
+                        on error
+                            try
+                                close window id {wid} saving no
+                            end try
+                        end try
+                    end tell"#,
+                    tid = tid,
+                    wid = wid,
+                )
+            } else {
+                format!(
+                    r#"tell application "Terminal"
+                        try
+                            close window id {wid} saving no
+                        end try
+                    end tell"#,
+                    wid = wid,
+                )
+            };
+            let _ = run_osascript(&close_script);
+        }
+    }
+
+    // Best-effort SIGTERM to the crosslink session for this repo.
+    try_sigterm_matching_session(&entry.repo_path);
+
+    // Always rewrite spawns.json without this alias, even if osascript
+    // failed — the user may have closed the tab by hand.
+    file.version = 1;
+    save_spawns_file(&channel_id, &file)?;
+    Ok(())
+}
+
+#[tauri::command]
+fn list_spawns(channel_id: String) -> Result<Vec<Spawn>, String> {
+    let mut file = load_spawns_file(&channel_id);
+
+    // Build a lookup of live crosslink sessions keyed by repoPath. A session
+    // is "live" if its lastHeartbeat is newer than STALE_HEARTBEAT_MS.
+    let live_repos = load_live_crosslink_repos();
+
+    let mut survivors: Vec<Spawn> = Vec::new();
+    let mut drop_aliases: Vec<String> = Vec::new();
+
+    for (alias, spawn) in &file.spawns {
+        if live_repos.contains(&spawn.repo_path) {
+            survivors.push(spawn.clone());
+        } else {
+            drop_aliases.push(alias.clone());
+        }
+    }
+
+    if !drop_aliases.is_empty() {
+        for alias in &drop_aliases {
+            file.spawns.remove(alias);
+        }
+        file.version = 1;
+        save_spawns_file(&channel_id, &file)?;
+    }
+
+    Ok(survivors)
+}
+
+fn load_live_crosslink_repos() -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    let sessions_dir = data::harness_root().join("crosslink").join("sessions");
+    let Ok(entries) = fs::read_dir(&sessions_dir) else {
+        return out;
+    };
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(session) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        let Some(repo) = session.get("repoPath").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(hb) = session.get("lastHeartbeat").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(hb) else {
+            continue;
+        };
+        let hb_ms = parsed.timestamp_millis();
+        if (now_ms - hb_ms) <= STALE_HEARTBEAT_MS as i64 {
+            out.insert(repo.to_string());
+        }
+    }
+    out
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -596,6 +949,9 @@ pub fn run() {
             delete_session,
             append_session_message,
             start_chat,
+            spawn_agent,
+            kill_spawned_agent,
+            list_spawns,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -8,6 +8,7 @@ import type {
   Decision,
   PersistedChatMessage,
   RunIndexEntry,
+  Spawn,
   TicketLedgerEntry,
   WorkspaceEntry,
   AgentNameEntry,
@@ -49,11 +50,13 @@ export const api = {
     name: string,
     description: string,
     repos: { alias: string; workspaceId: string; repoPath: string }[],
+    primaryWorkspaceId?: string,
   ) =>
     invoke<{ channelId: string }>("create_channel", {
       name,
       description,
       repos,
+      primaryWorkspaceId,
     }),
   archiveChannel: (channelId: string) =>
     invoke<unknown>("archive_channel", { channelId }),
@@ -102,6 +105,19 @@ export const api = {
     claudeSessionId?: string;
     autoApprove: boolean;
   }) => invoke<number>("start_chat", params),
+
+  // Task #24 contract. These invoke wrappers are thin passthroughs that
+  // assume the Rust side registers `spawn_agent`, `list_spawns`, and
+  // `kill_spawned_agent` commands that accept / return camelCase via
+  // serde rename_all. Until that lands, calls here will reject at runtime
+  // with a "command not found"-style error — which surfaces inline in the
+  // spawn UI rather than crashing the app.
+  spawnAgent: (channelId: string, alias: string, repoPath: string) =>
+    invoke<Spawn>("spawn_agent", { channelId, alias, repoPath }),
+  listSpawns: (channelId: string) =>
+    invoke<Spawn[]>("list_spawns", { channelId }),
+  killSpawnedAgent: (channelId: string, alias: string) =>
+    invoke<void>("kill_spawned_agent", { channelId, alias }),
 };
 
 export type ChatEvent =

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -445,6 +445,9 @@ function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
                   }}
                 >
                   <div>{t.title}</div>
+                  {t.assignedAlias && (
+                    <div className="ticket-alias-chip">@{t.assignedAlias}</div>
+                  )}
                   <div className="ticket-meta">
                     {t.specialty} · attempt {t.attempt}
                     {t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""}
@@ -515,6 +518,12 @@ function TicketDetailModal({
             <div className="detail-row">
               <span className="detail-label">Assigned</span>
               <span>{ticket.assignedAgentName}</span>
+            </div>
+          )}
+          {ticket.assignedAlias && (
+            <div className="detail-row">
+              <span className="detail-label">Assigned to</span>
+              <span>@{ticket.assignedAlias}</span>
             </div>
           )}
           {deps.length > 0 && (

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -12,6 +12,10 @@ type RepoRow = {
   workspace: WorkspaceEntry;
   selected: boolean;
   alias: string;
+  // Only one row can be primary at a time. We track it at the workspace-id
+  // level (see `primaryWorkspaceId` below) rather than on the row so the
+  // invariant "at most one primary" is centrally enforced.
+  spawn: boolean;
 };
 
 export function NewChannelModal({ open, onClose, onCreated }: Props) {
@@ -22,6 +26,16 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
   const [highlightIdx, setHighlightIdx] = useState(0);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Non-fatal warning shown after createChannel succeeds but one or more
+  // spawnAgent calls failed. We still navigate to the channel regardless.
+  const [spawnWarning, setSpawnWarning] = useState<string | null>(null);
+  // Which workspace is flagged primary. Null until the user checks the
+  // first row, at which point we auto-set to that row. If the current
+  // primary is later unchecked, we reassign to the earliest still-
+  // selected row (by master-array order, not visible order).
+  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(
+    null,
+  );
   const filterRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -31,12 +45,15 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
     setFilter("");
     setHighlightIdx(0);
     setError(null);
+    setSpawnWarning(null);
+    setPrimaryWorkspaceId(null);
     api.listWorkspaces().then((ws) => {
       setRepos(
         ws.map((w) => ({
           workspace: w,
           selected: false,
           alias: defaultAlias(w.repoPath),
+          spawn: false,
         })),
       );
     });
@@ -71,9 +88,59 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
   if (!open) return null;
 
   const toggleSelected = (origIndex: number) => {
+    // Compute next state based on current master array, then fold in the
+    // primary-assignment rule in a single pass so we don't race with React
+    // batching two setState calls.
+    setRepos((prev) => {
+      const next = prev.map((row, j) => {
+        if (j !== origIndex) return row;
+        const nowSelected = !row.selected;
+        // Deselecting also clears spawn so we don't carry a stale opt-in
+        // forward if the user re-selects later.
+        return {
+          ...row,
+          selected: nowSelected,
+          spawn: nowSelected ? row.spawn : false,
+        };
+      });
+      // Auto-assign / reassign primary:
+      //   - If nothing is currently primary and we just selected a row,
+      //     that row becomes primary.
+      //   - If the current primary just got unchecked, hand primary to the
+      //     earliest still-selected row (master-array order).
+      //   - If no selected rows remain, clear primary.
+      setPrimaryWorkspaceId((currentPrimary) => {
+        const selectedRows = next.filter((r) => r.selected);
+        if (selectedRows.length === 0) return null;
+        if (
+          currentPrimary &&
+          selectedRows.some((r) => r.workspace.workspaceId === currentPrimary)
+        ) {
+          return currentPrimary;
+        }
+        return selectedRows[0].workspace.workspaceId;
+      });
+      return next;
+    });
+  };
+
+  const setPrimary = (workspaceId: string) => {
+    // Radio-click: assumes the row is already selected (the radio is only
+    // rendered on selected rows). Defensive: verify and no-op otherwise.
+    setRepos((prev) => {
+      const match = prev.find(
+        (r) => r.workspace.workspaceId === workspaceId && r.selected,
+      );
+      if (!match) return prev;
+      setPrimaryWorkspaceId(workspaceId);
+      return prev;
+    });
+  };
+
+  const toggleSpawn = (origIndex: number) => {
     setRepos((prev) =>
       prev.map((row, j) =>
-        j === origIndex ? { ...row, selected: !row.selected } : row,
+        j === origIndex ? { ...row, spawn: !row.spawn } : row,
       ),
     );
   };
@@ -117,15 +184,57 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
     }
     setBusy(true);
     setError(null);
+    setSpawnWarning(null);
     try {
-      const selected = repos
-        .filter((r) => r.selected)
-        .map((r) => ({
-          alias: r.alias.trim() || defaultAlias(r.workspace.repoPath),
-          workspaceId: r.workspace.workspaceId,
-          repoPath: r.workspace.repoPath,
-        }));
-      const result = await api.createChannel(name.trim(), description.trim(), selected);
+      const selectedRows = repos.filter((r) => r.selected);
+      const selected = selectedRows.map((r) => ({
+        alias: r.alias.trim() || defaultAlias(r.workspace.repoPath),
+        workspaceId: r.workspace.workspaceId,
+        repoPath: r.workspace.repoPath,
+      }));
+      const effectivePrimary =
+        primaryWorkspaceId ?? selectedRows[0]?.workspace.workspaceId ?? undefined;
+      const result = await api.createChannel(
+        name.trim(),
+        description.trim(),
+        selected,
+        effectivePrimary,
+      );
+
+      // Spawn all non-primary rows that were opted-in. Run in parallel; a
+      // spawn failure surfaces as a warning but doesn't block navigation —
+      // the channel was created successfully, and the user can still
+      // launch agents later from the right pane.
+      const toSpawn = selectedRows.filter(
+        (r) =>
+          r.spawn &&
+          r.workspace.workspaceId !== effectivePrimary,
+      );
+      if (toSpawn.length > 0) {
+        const results = await Promise.all(
+          toSpawn.map(async (r) => {
+            const alias = r.alias.trim() || defaultAlias(r.workspace.repoPath);
+            try {
+              await api.spawnAgent(
+                result.channelId,
+                alias,
+                r.workspace.repoPath,
+              );
+              return { alias, ok: true as const };
+            } catch (e) {
+              return { alias, ok: false as const, error: String(e) };
+            }
+          }),
+        );
+        const failures = results.filter((x) => !x.ok);
+        if (failures.length > 0) {
+          setSpawnWarning(
+            `Channel created, but ${failures.length}/${results.length} spawn(s) failed: ` +
+              failures.map((f) => `@${f.alias}`).join(", "),
+          );
+        }
+      }
+
       onCreated(result.channelId);
       onClose();
     } catch (e) {
@@ -182,38 +291,88 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                   {visible.length === 0 ? (
                     <div className="empty">No repos match “{filter}”.</div>
                   ) : (
-                    visible.map(({ row, origIndex }, i) => (
-                      <div
-                        key={row.workspace.workspaceId}
-                        className={`repo-row ${i === highlightIdx ? "highlighted" : ""}`}
-                        onClick={() => setHighlightIdx(i)}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={row.selected}
-                          onChange={() => toggleSelected(origIndex)}
-                        />
-                        <span
-                          className="repo-path"
-                          title={row.workspace.repoPath}
+                    visible.map(({ row, origIndex }, i) => {
+                      const isPrimary =
+                        row.selected &&
+                        primaryWorkspaceId === row.workspace.workspaceId;
+                      return (
+                        <div
+                          key={row.workspace.workspaceId}
+                          className={`repo-row ${i === highlightIdx ? "highlighted" : ""}`}
+                          onClick={() => setHighlightIdx(i)}
                         >
-                          {basename(row.workspace.repoPath)}
-                        </span>
-                        <input
-                          className="alias-input"
-                          value={row.alias}
-                          onChange={(e) => updateAlias(origIndex, e.target.value)}
-                          placeholder="alias"
-                          disabled={!row.selected}
-                        />
-                      </div>
-                    ))
+                          <input
+                            type="checkbox"
+                            checked={row.selected}
+                            onChange={() => toggleSelected(origIndex)}
+                            title="Include this repo in the channel"
+                          />
+                          <span
+                            className="repo-path"
+                            title={row.workspace.repoPath}
+                          >
+                            {basename(row.workspace.repoPath)}
+                            {isPrimary && (
+                              <span className="primary-badge">PRIMARY</span>
+                            )}
+                          </span>
+                          <input
+                            className="alias-input"
+                            value={row.alias}
+                            onChange={(e) => updateAlias(origIndex, e.target.value)}
+                            placeholder="alias"
+                            disabled={!row.selected}
+                          />
+                          {/* Primary radio: only rendered on selected rows.
+                              The label is the clickable surface; clicking the
+                              radio explicitly promotes this repo to primary. */}
+                          {row.selected ? (
+                            <label
+                              className="repo-primary-radio"
+                              title="Primary agent runs in the GUI main chat"
+                            >
+                              <input
+                                type="radio"
+                                name="primary-workspace"
+                                checked={isPrimary}
+                                onChange={() =>
+                                  setPrimary(row.workspace.workspaceId)
+                                }
+                              />
+                              primary
+                            </label>
+                          ) : (
+                            <span className="repo-primary-radio placeholder" />
+                          )}
+                          {/* Spawn checkbox: opt-in, visible only for
+                              non-primary selected rows. The primary agent
+                              runs in the main chat, so "spawn" doesn't
+                              apply to it. */}
+                          {row.selected && !isPrimary ? (
+                            <label
+                              className="repo-spawn-toggle"
+                              title="Launch an external Terminal agent for this repo on channel create"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={row.spawn}
+                                onChange={() => toggleSpawn(origIndex)}
+                              />
+                              spawn
+                            </label>
+                          ) : (
+                            <span className="repo-spawn-toggle placeholder" />
+                          )}
+                        </div>
+                      );
+                    })
                   )}
                 </div>
               </>
             )}
           </div>
           {error && <div className="error">{error}</div>}
+          {spawnWarning && <div className="warning">{spawnWarning}</div>}
         </div>
         <div className="modal-footer">
           <button onClick={onClose} disabled={busy}>

--- a/gui/src/components/RightPane.tsx
+++ b/gui/src/components/RightPane.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
-import type { Channel, ChannelRunLink, RunIndexEntry } from "../types";
+import type { Channel, ChannelRunLink, RunIndexEntry, Spawn } from "../types";
 import { SessionList } from "./SessionList";
 
 type Props = {
@@ -68,15 +68,25 @@ export function RightPane({
 
       <div className="section">
         <h4>Repos ({channel.repoAssignments.length})</h4>
-        {channel.repoAssignments.map((r) => (
-          <div key={r.workspaceId} className="row">
-            <span>@{r.alias}</span>
-            <span className="right" title={r.repoPath}>
-              {basename(r.repoPath)}
-            </span>
-          </div>
-        ))}
+        {channel.repoAssignments.map((r) => {
+          const isPrimary =
+            channel.primaryWorkspaceId &&
+            r.workspaceId === channel.primaryWorkspaceId;
+          return (
+            <div key={r.workspaceId} className="row">
+              <span>
+                @{r.alias}
+                {isPrimary && <span className="primary-badge">PRIMARY</span>}
+              </span>
+              <span className="right" title={r.repoPath}>
+                {basename(r.repoPath)}
+              </span>
+            </div>
+          );
+        })}
       </div>
+
+      <SpawnedAgents channelId={channel.channelId} refreshTick={refreshTick} />
 
       <div className="section">
         <h4>Runs ({runs.length})</h4>
@@ -93,6 +103,84 @@ export function RightPane({
 }
 
 type RunInfo = { run: RunIndexEntry; workspaceId: string };
+
+/**
+ * Spawned agents panel — shows external Terminal-hosted agents launched
+ * from this channel via the spawn flow. Empty state hides the whole
+ * section (opt-in concept; not primary UI).
+ *
+ * We refetch on mount, on channelId change, and on every refreshTick so
+ * the list stays roughly in sync with backend state even when other
+ * surfaces trigger spawns. Kill is optimistic: we drop the row from
+ * local state before the async call resolves, then rollback if it fails.
+ */
+function SpawnedAgents({
+  channelId,
+  refreshTick,
+}: {
+  channelId: string;
+  refreshTick: number;
+}) {
+  const [spawns, setSpawns] = useState<Spawn[]>([]);
+  const [killError, setKillError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listSpawns(channelId)
+      .then((rows) => {
+        if (!cancelled) setSpawns(rows);
+      })
+      .catch(() => {
+        // Silently fall back to empty. listSpawns might fail if Task #24
+        // hasn't registered its Tauri command yet; the section just
+        // hides rather than showing a scary error.
+        if (!cancelled) setSpawns([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [channelId, refreshTick]);
+
+  if (spawns.length === 0) return null;
+
+  const kill = async (alias: string) => {
+    setKillError(null);
+    const before = spawns;
+    // Optimistic remove.
+    setSpawns((prev) => prev.filter((s) => s.alias !== alias));
+    try {
+      await api.killSpawnedAgent(channelId, alias);
+    } catch (e) {
+      setKillError(`Failed to kill @${alias}: ${e}`);
+      setSpawns(before);
+    }
+  };
+
+  return (
+    <div className="section">
+      <h4>Spawned agents ({spawns.length})</h4>
+      <div className="spawn-list">
+        {spawns.map((s) => (
+          <div key={s.alias} className="spawn-row">
+            <span className="spawn-alias">@{s.alias}</span>
+            <span className="spawn-repo" title={s.repoPath}>
+              {basename(s.repoPath)}
+            </span>
+            <button
+              className="kill-button"
+              onClick={() => kill(s.alias)}
+              title="Kill this spawned agent"
+            >
+              Kill
+            </button>
+          </div>
+        ))}
+      </div>
+      {killError && <div className="error">{killError}</div>}
+    </div>
+  );
+}
 
 function basename(p: string): string {
   return p.split("/").filter(Boolean).pop() ?? p;

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -237,6 +237,36 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
 }
 .ticket .ticket-meta { color: var(--text-muted); font-size: 10px; margin-top: 4px; }
 
+/* Small "@alias" pill on ticket cards + inline in other surfaces. Uses the
+   sapphire accent at low opacity so it reads as secondary metadata, not a
+   status signal. */
+.ticket-alias-chip {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 1px 6px;
+  font-size: 10px;
+  line-height: 1.4;
+  border-radius: 10px;
+  background: var(--accent-dim);
+  color: var(--text);
+}
+
+/* PRIMARY tag — rendered next to the selected primary row in the new-channel
+   modal and in the right pane's repo list. Mauve keeps it distinct from the
+   alias chip (sapphire) and from the accent-blue used for active channels. */
+.primary-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  border-radius: 3px;
+  background: var(--system);
+  color: var(--bg);
+  vertical-align: middle;
+}
+
 /* Ticket detail modal */
 .ticket-modal {
   width: 520px;
@@ -518,14 +548,38 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   padding-right: 4px;
 }
 .repo-row {
+  /* Columns: selected checkbox · path (grows) · alias input · primary radio
+     · spawn checkbox. The primary/spawn slots use fixed widths so rows
+     line up across checked/unchecked states (placeholders fill the gap
+     when the row is unselected). */
   display: grid;
-  grid-template-columns: auto 1fr 110px;
+  grid-template-columns: auto 1fr 110px 72px 68px;
   gap: 8px;
   align-items: center;
   font-size: 12px;
   padding: 4px 6px;
   border-radius: 3px;
   cursor: default;
+}
+.repo-primary-radio,
+.repo-spawn-toggle {
+  font-size: 10px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.repo-primary-radio input,
+.repo-spawn-toggle input {
+  margin: 0;
+}
+.repo-primary-radio.placeholder,
+.repo-spawn-toggle.placeholder {
+  visibility: hidden;
 }
 .repo-row.highlighted {
   background: var(--bg-hover);
@@ -549,4 +603,55 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+}
+
+/* Non-fatal warning — used in the new-channel modal when the channel is
+   created but one or more spawn calls failed. Warmer than .error and not
+   blocking. */
+.warning {
+  color: var(--warn);
+  font-size: 12px;
+  padding: 6px 8px;
+  background: rgba(250, 179, 135, 0.1);
+  border-radius: 4px;
+}
+
+/* Spawned-agents panel (RightPane). Mirrors .repo-row spacing so it reads
+   as peer visual weight to the Repos section just above it. */
+.spawn-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.spawn-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  padding: 3px 0;
+}
+.spawn-row .spawn-alias { color: var(--accent); font-weight: 500; }
+.spawn-row .spawn-repo {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.kill-button {
+  padding: 2px 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  background: transparent;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.kill-button:hover {
+  color: var(--error);
+  border-color: var(--error);
+  background: rgba(243, 139, 168, 0.08);
 }

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -33,6 +33,10 @@ export type Channel = {
   members: ChannelMember[];
   pinnedRefs: ChannelRef[];
   repoAssignments: RepoAssignment[];
+  // workspaceId of the repo flagged as primary for this channel. Optional
+  // for back-compat with older channel files; when unset, UI falls back to
+  // the first entry in `repoAssignments`.
+  primaryWorkspaceId?: string;
   // ISO 8601; optional for back-compat with older channel files.
   createdAt?: string;
   updatedAt?: string;
@@ -75,6 +79,9 @@ export type TicketLedgerEntry = {
   assignedAgentName?: string;
   verification: string;
   attempt: number;
+  // Alias of the channel repo assignment this ticket is routed to.
+  // Optional; absent on tickets written before per-repo routing existed.
+  assignedAlias?: string;
 };
 
 export type Decision = {
@@ -107,4 +114,16 @@ export type AgentNameEntry = {
   displayName: string;
   provider: string;
   role: string;
+};
+
+// An agent process launched into its own external terminal window via the
+// spawn flow. Mirrors the shape documented in Task #24's contract. Fields
+// other than alias/repoPath are populated best-effort by the platform
+// Terminal adapter and may be undefined when the adapter can't report them.
+export type Spawn = {
+  alias: string;
+  repoPath: string;
+  spawnedAt: string;
+  terminalWindowId?: number;
+  terminalTabId?: number;
 };

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -84,10 +84,21 @@ export class ChannelStore {
     description: string;
     workspaceIds?: string[];
     repoAssignments?: RepoAssignment[];
+    primaryWorkspaceId?: string;
   }): Promise<Channel> {
     await mkdir(this.channelsDir, { recursive: true });
 
     const now = new Date().toISOString();
+    // Only keep primaryWorkspaceId when it actually points at one of the
+    // provided assignments. Silently drop a dangling id so callers don't
+    // end up with a "primary" that resolves to nothing on the next read.
+    const assignments = input.repoAssignments;
+    const primaryWorkspaceId =
+      input.primaryWorkspaceId &&
+      assignments?.some((a) => a.workspaceId === input.primaryWorkspaceId)
+        ? input.primaryWorkspaceId
+        : undefined;
+
     const channel: Channel = {
       channelId: buildChannelId(),
       name: input.name,
@@ -96,7 +107,8 @@ export class ChannelStore {
       workspaceIds: input.workspaceIds ?? [],
       members: [],
       pinnedRefs: [],
-      repoAssignments: input.repoAssignments,
+      repoAssignments: assignments,
+      primaryWorkspaceId,
       createdAt: now,
       updatedAt: now
     };
@@ -144,7 +156,17 @@ export class ChannelStore {
 
   async updateChannel(
     channelId: string,
-    patch: Partial<Pick<Channel, "name" | "description" | "status" | "workspaceIds" | "repoAssignments">>
+    patch: Partial<
+      Pick<
+        Channel,
+        | "name"
+        | "description"
+        | "status"
+        | "workspaceIds"
+        | "repoAssignments"
+        | "primaryWorkspaceId"
+      >
+    >
   ): Promise<Channel | null> {
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
@@ -155,8 +177,61 @@ export class ChannelStore {
       updatedAt: new Date().toISOString()
     };
 
+    // Reconcile primaryWorkspaceId against the (possibly updated) repo list.
+    // Rules:
+    //   - If primaryWorkspaceId points at a workspace still present in
+    //     repoAssignments, keep it.
+    //   - If the caller explicitly set primaryWorkspaceId to undefined in
+    //     the patch (i.e. the key is present but the value is undefined),
+    //     respect that as "clear primary".
+    //   - Otherwise, if the current primary no longer matches any
+    //     assignment (e.g. because it was removed from the repos list),
+    //     fall back to the first remaining assignment, or clear the field
+    //     when no assignments remain.
+    const primaryExplicitlyCleared =
+      Object.prototype.hasOwnProperty.call(patch, "primaryWorkspaceId") &&
+      patch.primaryWorkspaceId === undefined;
+    const assignments = updated.repoAssignments ?? [];
+    const currentPrimary = updated.primaryWorkspaceId;
+    const primaryStillValid =
+      !!currentPrimary &&
+      assignments.some((a) => a.workspaceId === currentPrimary);
+
+    if (primaryExplicitlyCleared) {
+      updated.primaryWorkspaceId = undefined;
+    } else if (!primaryStillValid) {
+      updated.primaryWorkspaceId = assignments[0]?.workspaceId;
+    }
+
     await this.writeChannel(updated);
     return updated;
+  }
+
+  /**
+   * Return the `RepoAssignment` that should be treated as the channel's
+   * primary repo. Resolution order:
+   *   1. `channel.primaryWorkspaceId` matches an entry in `repoAssignments`.
+   *   2. Fall back to `repoAssignments[0]` (first registered repo).
+   *   3. `null` when the channel has no repo assignments at all.
+   *
+   * Back-compat: a `primaryWorkspaceId` that doesn't match any assignment
+   * is ignored in favor of the first-repo fallback, so a stale id from an
+   * older channel file never strands the channel.
+   */
+  getPrimaryAssignment(channel: Channel): RepoAssignment | null {
+    const assignments = channel.repoAssignments ?? [];
+    if (assignments.length === 0) {
+      return null;
+    }
+
+    if (channel.primaryWorkspaceId) {
+      const match = assignments.find(
+        (a) => a.workspaceId === channel.primaryWorkspaceId
+      );
+      if (match) return match;
+    }
+
+    return assignments[0] ?? null;
   }
 
   async archiveChannel(channelId: string): Promise<Channel | null> {

--- a/src/cli/chat-context.ts
+++ b/src/cli/chat-context.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { ChannelStore } from "../channels/channel-store.js";
+import type { Channel, RepoAssignment } from "../domain/channel.js";
 import { getHarnessStore } from "../storage/factory.js";
 import { getRelayDir } from "./paths.js";
 import { SessionStore } from "./session-store.js";
@@ -56,6 +57,57 @@ function collectRepoContext(repoPath: string): string {
   return lines.length > 0 ? lines.join("\n") : "";
 }
 
+/**
+ * Read up to `limit` lines of AGENTS.md from a repo root. Checks common
+ * case variants (`AGENTS.md`, `Agents.md`, `agents.md`) so we work on
+ * case-sensitive filesystems without silently missing a differently-cased
+ * file. Returns `null` when no variant exists or any read error occurs —
+ * callers render a short placeholder in that case so the system prompt
+ * never blows up on a missing doc.
+ */
+export function readAgentsMdSummary(repoPath: string, limit = 40): string | null {
+  const variants = ["AGENTS.md", "Agents.md", "agents.md"];
+  for (const name of variants) {
+    const path = join(repoPath, name);
+    if (!existsSync(path)) continue;
+    try {
+      const head = readFileSync(path, "utf8")
+        .split("\n")
+        .slice(0, limit)
+        .join("\n")
+        .trimEnd();
+      return head.length > 0 ? head : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the primary repo assignment for a channel. Prefers the repo whose
+ * workspaceId matches `channel.primaryWorkspaceId` (set by Task #22 when the
+ * user picks a primary in the GUI); falls back to the first assignment so
+ * pre-migration channels and channels created before the field existed keep
+ * working. Returns `null` only when there are no assignments at all.
+ *
+ * Inlined here instead of imported from `ChannelStore` so this file stays
+ * the single source of truth for the primary/associated rule in the chat
+ * prompt layer — and so we don't hard-depend on a helper that may not have
+ * landed yet in a sibling task.
+ */
+function getPrimaryAssignment(channel: Channel): RepoAssignment | null {
+  const assignments = channel.repoAssignments ?? [];
+  if (assignments.length === 0) return null;
+  const primaryWorkspaceId = (channel as Channel & { primaryWorkspaceId?: string })
+    .primaryWorkspaceId;
+  if (primaryWorkspaceId) {
+    const match = assignments.find((r) => r.workspaceId === primaryWorkspaceId);
+    if (match) return match;
+  }
+  return assignments[0] ?? null;
+}
+
 export async function buildSystemPrompt(input: {
   channelId: string;
   repoPath?: string;
@@ -63,60 +115,122 @@ export async function buildSystemPrompt(input: {
 }): Promise<string> {
   const parts: string[] = [];
 
-  // Always pull the channel so we can surface ALL attached repos, not just
-  // the one the user prefixed with @alias. Previously a message with no alias
-  // prefix gave the agent zero channel-repo awareness — it would fall back to
-  // whatever context the global CLAUDE.md describes (e.g. a different stack).
   const channelStore = new ChannelStore();
   const channel = await channelStore.getChannel(input.channelId).catch(() => null);
   const assignments = channel?.repoAssignments ?? [];
+  const primary = channel ? getPrimaryAssignment(channel) : null;
 
-  if (assignments.length > 0) {
-    const focused = input.alias
-      ? assignments.find((r) => r.alias === input.alias) ?? null
-      : null;
+  if (channel && primary && assignments.length > 0) {
+    const associated = assignments.filter((r) => r.workspaceId !== primary.workspaceId);
 
-    if (focused) {
-      const focusedName = focused.repoPath.split("/").pop() ?? focused.repoPath;
+    // Role resolution: the session is "associated" only when an alias prefix
+    // identifies one of the non-primary repos. Any other case (no alias, or
+    // alias matches the primary) is treated as the primary role so the
+    // default unprefixed chat continues to speak from the primary repo.
+    const isAssociated = Boolean(
+      input.alias &&
+        assignments.some(
+          (r) => r.alias === input.alias && r.workspaceId !== primary.workspaceId
+        )
+    );
+
+    if (isAssociated) {
+      // input.alias is guaranteed truthy inside this branch; the `!` just
+      // lets TS narrow without an extra conditional.
+      const selfAlias = input.alias!;
+      const self = assignments.find((r) => r.alias === selfAlias)!;
+      const selfName = self.repoPath.split("/").pop() ?? self.repoPath;
+
       parts.push(
-        `You are working in the '${focusedName}' repository (alias: @${focused.alias}) at: ${focused.repoPath}. ` +
+        `You are an associated agent for channel '${channel.name}', attached as \`@${selfAlias}\`. ` +
+          `You work in \`${selfName}\` at: ${self.repoPath}. ` +
           `Your working directory is already set to this repo — do NOT search for it elsewhere. ` +
           `All file operations should be relative to this directory.`
       );
-      const focusedCtx = collectRepoContext(focused.repoPath);
-      if (focusedCtx) {
+
+      const selfCtx = collectRepoContext(self.repoPath);
+      if (selfCtx) {
         parts.push(
-          "\nFocused repo context (read at session start — may be stale after long runs):\n" +
-            focusedCtx
+          "\nYour repo context (read at session start — may be stale after long runs):\n" +
+            selfCtx
         );
       }
-      const others = assignments.filter((r) => r.alias !== focused.alias);
-      if (others.length > 0) {
-        parts.push(
-          "\nOther repos attached to this channel (prefix a message with the alias to switch focus):\n" +
-            others.map((r) => `  - @${r.alias}: ${r.repoPath}`).join("\n")
-        );
-      }
+
+      parts.push(
+        `\nPrimary agent: \`@${primary.alias}\` at ${primary.repoPath}. ` +
+          `You may receive crosslink messages from them and should reply promptly.`
+      );
+
+      const channelDir = join(getRelayDir(), "channels", channel.channelId);
+      const ticketsPath = join(channelDir, "tickets.json");
+      parts.push(
+        `\n### Ticket polling\n` +
+          `Read \`${ticketsPath}\` at the start of every prompt. Tickets where ` +
+          `\`assignedAlias === '${selfAlias}'\` and \`status === 'ready'\` are yours to work. ` +
+          `Claim a ticket by setting \`status\` to \`executing\` and \`startedAt\` to the current ISO-8601 timestamp. ` +
+          `When finished, set \`status\` to \`completed\` (or \`failed\` with a reason in your chat reply) and populate \`completedAt\`. ` +
+          `Use the full TicketLedgerEntry shape documented in the "Shared Ticket Board" section below — do not invent new fields.`
+      );
     } else {
-      // No focused alias — list every attached repo with git context so the
-      // agent knows what's in scope and picks the right one without asking.
+      // Primary role — default for unprefixed chat and for explicit
+      // @<primary-alias> prefixes.
+      const primaryName = primary.repoPath.split("/").pop() ?? primary.repoPath;
       parts.push(
-        `This channel is attached to ${assignments.length} repo${assignments.length === 1 ? "" : "s"}. ` +
-          `No specific repo was selected for this message (no @alias prefix), so treat all of them as in scope. ` +
-          `If the user's question is clearly about one, focus there; otherwise ask which.`
+        `You are the primary agent for channel '${channel.name}'. ` +
+          `You work in \`${primaryName}\` (alias: \`@${primary.alias}\`) at: ${primary.repoPath}. ` +
+          `Your working directory is already set to this repo — do NOT search for it elsewhere. ` +
+          `All file operations should be relative to this directory.`
       );
-      for (const r of assignments) {
-        const ctx = collectRepoContext(r.repoPath);
-        const ctxBlock = ctx ? `\n${ctx}` : "";
-        parts.push(`\n### @${r.alias} — ${r.repoPath}${ctxBlock}`);
+
+      const primaryCtx = collectRepoContext(primary.repoPath);
+      if (primaryCtx) {
+        parts.push(
+          "\nPrimary repo context (read at session start — may be stale after long runs):\n" +
+            primaryCtx
+        );
       }
-      parts.push(
-        "\nWhen the user prefixes a message with `@<alias> ...`, that repo becomes the active working directory."
-      );
+
+      if (associated.length > 0) {
+        const blocks: string[] = [
+          `\n### Associated repos`,
+          `These repos are attached to the channel but you do NOT work in them directly. ` +
+            `An associated agent is (or can be) attached to each one.`
+        ];
+        for (const r of associated) {
+          const aName = r.repoPath.split("/").pop() ?? r.repoPath;
+          const summary = readAgentsMdSummary(r.repoPath);
+          if (summary) {
+            blocks.push(
+              `\n- \`@${r.alias}\` — ${aName} at ${r.repoPath}\n` +
+                `  AGENTS.md (first 40 lines):\n\n` +
+                summary
+                  .split("\n")
+                  .map((line) => `  ${line}`)
+                  .join("\n")
+            );
+          } else {
+            blocks.push(
+              `\n- \`@${r.alias}\` — ${aName} at ${r.repoPath}\n` +
+                `  (no AGENTS.md found — primary agent may Read files directly if needed)`
+            );
+          }
+        }
+
+        blocks.push(
+          `\n### Delegating to associated agents\n` +
+            `For quick questions about an associated repo, use \`crosslink_send\` to message the agent there. ` +
+            `For long-running or multi-step work, write a ticket to the channel's \`tickets.json\` with ` +
+            `\`assignedAlias: '<alias>'\` set to the target associated repo's alias — the associated agent will pick it up on its next poll. ` +
+            `Do NOT modify files in associated repos directly; delegate instead.`
+        );
+
+        parts.push(blocks.join("\n"));
+      }
     }
   } else if (input.repoPath) {
-    // No channel-level assignments but an explicit --repo was passed (e.g.
-    // from the TUI / CLI flow). Fall back to the legacy single-repo path.
+    // Legacy single-repo path: no channel / no assignments, but an explicit
+    // --repo was passed (e.g. from the TUI / CLI flow before channels were
+    // created). Preserved verbatim from the pre-Task-#23 behavior.
     const repoName = input.repoPath.split("/").pop() ?? input.repoPath;
     if (input.alias) {
       parts.push(

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -57,6 +57,15 @@ export interface Channel {
   members: ChannelMember[];
   pinnedRefs: ChannelRef[];
   repoAssignments?: RepoAssignment[];
+  /**
+   * When set, identifies which entry in `repoAssignments` is the "primary"
+   * repo for this channel — the one the user chats in by default and the
+   * one orchestrator/agents route to when a ticket has no explicit
+   * `assignedAlias`. When unset, callers fall back to `repoAssignments[0]`.
+   * Optional for back-compat with channel.json files written before the
+   * primary/associated model existed.
+   */
+  primaryWorkspaceId?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/domain/ticket.ts
+++ b/src/domain/ticket.ts
@@ -83,6 +83,15 @@ export interface TicketLedgerEntry {
    * must do so by re-initializing, not by patching this field in place.
    */
   runId: string | null;
+  /**
+   * Optional alias of the repo (from `Channel.repoAssignments[].alias`) this
+   * ticket should be routed to. When set, the orchestrator / spawner uses
+   * the matching repo assignment to pick the target workspace for the
+   * ticket's agent. When unset, callers fall back to the channel's primary
+   * repo (via `ChannelStore.getPrimaryAssignment`). Optional for back-compat
+   * with ticket files written before per-repo routing existed.
+   */
+  assignedAlias?: string;
 }
 
 export function initializeTicketLedger(

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,12 +470,15 @@ async function handleChannelCommand(args: string[]): Promise<void> {
   if (sub === "create") {
     const name = args[1];
     if (!name) {
-      console.error("Usage: rly channel create <name> [description] [--repos alias:wsId:path,...]");
+      console.error(
+        "Usage: rly channel create <name> [description] [--repos alias:wsId:path,...] [--primary <alias>]"
+      );
       process.exitCode = 1;
       return;
     }
 
     const reposArg = parseNamedArg(args, "--repos");
+    const primaryArg = parseNamedArg(args, "--primary");
     const repoAssignments = reposArg
       ? reposArg.split(",").map((r) => {
           const [alias, workspaceId, ...pathParts] = r.split(":");
@@ -483,11 +486,39 @@ async function handleChannelCommand(args: string[]): Promise<void> {
         })
       : undefined;
 
-    // Description is everything after name that isn't a flag
-    const descParts = args.slice(2).filter((a) => !a.startsWith("--") && a !== reposArg);
+    let primaryWorkspaceId: string | undefined;
+    if (primaryArg) {
+      if (!repoAssignments || repoAssignments.length === 0) {
+        console.error(
+          `--primary ${primaryArg} requires --repos with at least one entry.`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const match = repoAssignments.find((r) => r.alias === primaryArg);
+      if (!match) {
+        const known = repoAssignments.map((r) => r.alias).join(", ");
+        console.error(
+          `--primary alias "${primaryArg}" is not in --repos (known aliases: ${known}).`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      primaryWorkspaceId = match.workspaceId;
+    }
+
+    // Description is everything after name that isn't a flag value.
+    const descParts = args
+      .slice(2)
+      .filter((a) => !a.startsWith("--") && a !== reposArg && a !== primaryArg);
     const description = descParts.join(" ") || `Channel for ${name}`;
 
-    const channel = await store.createChannel({ name, description, repoAssignments });
+    const channel = await store.createChannel({
+      name,
+      description,
+      repoAssignments,
+      primaryWorkspaceId
+    });
 
     if (args.includes("--json")) {
       jsonOut(channel);
@@ -521,19 +552,51 @@ async function handleChannelCommand(args: string[]): Promise<void> {
   if (sub === "update") {
     const channelId = args[1];
     if (!channelId) {
-      console.error("Usage: rly channel update <channelId> --repos alias:wsId:path,...");
+      console.error(
+        "Usage: rly channel update <channelId> [--repos alias:wsId:path,...] [--primary <alias>]"
+      );
       process.exitCode = 1;
       return;
     }
 
     const reposArg = parseNamedArg(args, "--repos");
-    const patch: Record<string, unknown> = {};
+    const primaryArg = parseNamedArg(args, "--primary");
+    const patch: Partial<
+      Pick<
+        import("./domain/channel.js").Channel,
+        "repoAssignments" | "primaryWorkspaceId"
+      >
+    > = {};
 
     if (reposArg) {
       patch.repoAssignments = reposArg.split(",").map((r) => {
         const [alias, workspaceId, ...pathParts] = r.split(":");
         return { alias, workspaceId, repoPath: pathParts.join(":") };
       });
+    }
+
+    if (primaryArg) {
+      // Resolve --primary against the assignments that will be on the
+      // channel after this update: the patched repos (if provided) take
+      // precedence over what's currently on disk.
+      const existing = await store.getChannel(channelId);
+      if (!existing) {
+        console.error(`Channel not found: ${channelId}`);
+        process.exitCode = 1;
+        return;
+      }
+      const effectiveAssignments =
+        patch.repoAssignments ?? existing.repoAssignments ?? [];
+      const match = effectiveAssignments.find((r) => r.alias === primaryArg);
+      if (!match) {
+        const known = effectiveAssignments.map((r) => r.alias).join(", ") || "(none)";
+        console.error(
+          `--primary alias "${primaryArg}" is not in the channel's repos (known aliases: ${known}).`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      patch.primaryWorkspaceId = match.workspaceId;
     }
 
     const updated = await store.updateChannel(channelId, patch);

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -197,4 +197,209 @@ describe("channel store", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  describe("primary repo assignment", () => {
+    const assignments = [
+      { alias: "ui", workspaceId: "ws-ui", repoPath: "/tmp/ui" },
+      { alias: "be", workspaceId: "ws-be", repoPath: "/tmp/be" },
+      { alias: "brain", workspaceId: "ws-brain", repoPath: "/tmp/brain" }
+    ];
+
+    it("persists primaryWorkspaceId passed to createChannel", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#multi-repo",
+          description: "Multi-repo channel",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-be"
+        });
+
+        expect(channel.primaryWorkspaceId).toBe("ws-be");
+        const fetched = await store.getChannel(channel.channelId);
+        expect(fetched!.primaryWorkspaceId).toBe("ws-be");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("drops primaryWorkspaceId that doesn't match any assignment on create", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#bad-primary",
+          description: "Dangling primary",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-does-not-exist"
+        });
+
+        expect(channel.primaryWorkspaceId).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("getPrimaryAssignment returns the matching assignment when primary is set", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#primary-set",
+          description: "Primary set",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-brain"
+        });
+
+        const primary = store.getPrimaryAssignment(channel);
+        expect(primary).not.toBeNull();
+        expect(primary!.alias).toBe("brain");
+        expect(primary!.workspaceId).toBe("ws-brain");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("getPrimaryAssignment falls back to the first assignment when primary is unset", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#primary-unset",
+          description: "Primary unset",
+          repoAssignments: assignments
+        });
+
+        expect(channel.primaryWorkspaceId).toBeUndefined();
+        const primary = store.getPrimaryAssignment(channel);
+        expect(primary).not.toBeNull();
+        expect(primary!.alias).toBe("ui");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("getPrimaryAssignment falls back to first assignment when primary points at a missing workspaceId", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        // Simulate a channel file that was hand-edited or written by an
+        // older version: primaryWorkspaceId is set but isn't in
+        // repoAssignments. The helper must not strand the caller.
+        const channel = await store.createChannel({
+          name: "#stale-primary",
+          description: "Stale primary",
+          repoAssignments: assignments
+        });
+        const stale = { ...channel, primaryWorkspaceId: "ws-gone" };
+
+        const primary = store.getPrimaryAssignment(stale);
+        expect(primary).not.toBeNull();
+        expect(primary!.alias).toBe("ui");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("getPrimaryAssignment returns null when the channel has no repoAssignments", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#no-repos",
+          description: "No repos"
+        });
+        expect(store.getPrimaryAssignment(channel)).toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("updateChannel reassigns primary to first remaining repo when the current primary is removed", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#shrink",
+          description: "Shrink repos",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-brain"
+        });
+
+        const updated = await store.updateChannel(channel.channelId, {
+          repoAssignments: [assignments[0], assignments[1]] // drops brain
+        });
+
+        expect(updated).not.toBeNull();
+        // brain is gone → primary should fall back to first remaining (ui)
+        expect(updated!.primaryWorkspaceId).toBe("ws-ui");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("updateChannel preserves primaryWorkspaceId when the primary survives the repos update", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#preserve",
+          description: "Preserve primary",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-be"
+        });
+
+        const updated = await store.updateChannel(channel.channelId, {
+          repoAssignments: [assignments[0], assignments[1]] // keeps be
+        });
+
+        expect(updated!.primaryWorkspaceId).toBe("ws-be");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("updateChannel can change primaryWorkspaceId directly", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#repoint",
+          description: "Repoint primary",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-ui"
+        });
+
+        const updated = await store.updateChannel(channel.channelId, {
+          primaryWorkspaceId: "ws-brain"
+        });
+
+        expect(updated!.primaryWorkspaceId).toBe("ws-brain");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("updateChannel clears primaryWorkspaceId when repoAssignments is emptied", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#clear",
+          description: "Clear primary",
+          repoAssignments: assignments,
+          primaryWorkspaceId: "ws-ui"
+        });
+
+        const updated = await store.updateChannel(channel.channelId, {
+          repoAssignments: []
+        });
+
+        expect(updated!.primaryWorkspaceId).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/test/cli/chat-context.test.ts
+++ b/test/cli/chat-context.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readAgentsMdSummary } from "../../src/cli/chat-context.js";
+
+describe("readAgentsMdSummary", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "chat-ctx-agents-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when no AGENTS.md variant exists", () => {
+    expect(readAgentsMdSummary(dir)).toBeNull();
+  });
+
+  it("returns null for an unreadable/missing path", () => {
+    const bogus = join(dir, "does-not-exist");
+    expect(readAgentsMdSummary(bogus)).toBeNull();
+  });
+
+  it("reads AGENTS.md and caps the output at the requested line count", async () => {
+    const lines = Array.from({ length: 80 }, (_, i) => `line-${i + 1}`);
+    await writeFile(join(dir, "AGENTS.md"), lines.join("\n"));
+
+    const summary = readAgentsMdSummary(dir, 40);
+    expect(summary).not.toBeNull();
+
+    const out = summary!.split("\n");
+    expect(out).toHaveLength(40);
+    expect(out[0]).toBe("line-1");
+    expect(out[39]).toBe("line-40");
+  });
+
+  it("accepts alternate case variants (Agents.md, agents.md)", async () => {
+    await writeFile(join(dir, "agents.md"), "# Hello\nBody line");
+    const summary = readAgentsMdSummary(dir);
+    expect(summary).toBe("# Hello\nBody line");
+  });
+
+  it("returns null when AGENTS.md is empty", async () => {
+    await writeFile(join(dir, "AGENTS.md"), "");
+    expect(readAgentsMdSummary(dir)).toBeNull();
+  });
+
+  it("defaults to a 40-line cap when no limit is passed", async () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `l${i}`);
+    await writeFile(join(dir, "AGENTS.md"), lines.join("\n"));
+
+    const summary = readAgentsMdSummary(dir);
+    expect(summary!.split("\n")).toHaveLength(40);
+  });
+});


### PR DESCRIPTION
Ships the full primary/associated redesign in one PR. Four parallel subagent tasks + one integrator commit.

## The model
- **Primary** — one repo per channel. Agent's \`cwd\` defaults here. Gets full git context (remote / branch / tree / README head) in the system prompt.
- **Associated** — every other attached repo. Shows as alias + path + AGENTS.md summary (~40 lines). Agent is told NOT to grep associated repos; delegate instead.
- **Delegation patterns** — \`crosslink_send\` for quick questions, tickets with \`assignedAlias\` for long work. Both already have infrastructure; this PR just teaches the prompt to use them.
- **Spawn on demand** — opt-in per associated repo on channel create, or via future inline banner. Opens a Terminal.app tab running \`rly claude\`. Tracked per channel in \`spawns.json\` with kill + self-heal.

## Sub-packs merged
### Task #22 — Schema + stores
- \`Channel.primaryWorkspaceId?\`, \`TicketLedgerEntry.assignedAlias?\`, \`ChannelStore.getPrimaryAssignment\`, \`updateChannel\` reconciliation rules, Rust harness-data mirror, GUI types mirror, CLI \`--primary\` flag on create/update. Back-compat (all optional + serde default).
- **+10 tests** in \`test/channel-store.test.ts\`.

### Task #23 — Role-aware system prompt
- \`buildSystemPrompt\` splits into primary vs associated output based on whether \`input.alias\` matches a non-primary assignment.
- \`readAgentsMdSummary\` helper (AGENTS.md / Agents.md / agents.md), trims to 40 lines, never throws.
- Associated-role prompt includes ticket-polling instructions.
- **+6 tests** in \`test/cli/chat-context.test.ts\`.

### Task #24 — Spawn / kill / list Tauri commands
- \`spawn_agent(channelId, alias, repoPath)\` opens Terminal tab via osascript, parses window+tab id, falls back to front-window id on parse miss.
- \`kill_spawned_agent\` closes the tab + SIGTERMs the crosslink-session pid as fallback.
- \`list_spawns\` self-heals against \`~/.relay/crosslink/sessions\` (stale heartbeat > 120s drops).
- Commands registered. macOS-only (explicit error on other platforms).
- Fragility flagged for manual testing: Terminal.app return-format variance, tab_id=0 falls through to whole-window close, Automation permission prompt on first run.

### Task #25 — GUI
- Primary radio + spawn checkbox per selected row in NewChannelModal.
- Auto-primary rule: promotes first selected, reassigns to earliest still-selected when current primary is unchecked, clears to null when nothing selected. Explicit click always wins.
- After \`createChannel\` succeeds, rows with \`spawn=true\` trigger parallel \`spawn_agent\` calls; failures surface as inline warning but don't block navigation.
- \`.ticket-alias-chip\` under ticket card title + \`Assigned to:\` row in TicketDetailModal when \`assignedAlias\` is set.
- RightPane: PRIMARY badge + new SpawnedAgents subsection (hidden when empty, optimistic kill).

### Integrator commit
- Tauri \`create_channel\` now accepts \`primaryWorkspaceId\`, resolves to alias, forwards as \`--primary <alias>\` to the CLI. (Without this, Task #25's frontend wiring would be a no-op.)

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — **301/301 + 21 skipped** (baseline 285; +10 schema, +6 system prompt)
- [x] \`pnpm build\` clean
- [x] \`cd gui && pnpm build\` clean
- [x] \`cargo check -p relay-gui\` clean
- [ ] Manual: \`rly gui --rebuild\`, create a channel with 2+ repos, mark one primary + check spawn on the other, confirm Terminal tab opens, primary-repo-only context lands in the primary chat.
- [ ] Manual: ask primary a cross-repo question → primary uses crosslink / writes a ticket with assignedAlias instead of grepping.
- [ ] Manual: click Kill in RightPane's SpawnedAgents list, confirm Terminal tab closes and row drops.
- [ ] Manual (macOS permission): first spawn prompts for Terminal Automation access; once granted, subsequent spawns are silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)