### PR TITLE
Fix scrolling in chat, decisions, and board (flex chain pinning)

### DIFF
--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -62,6 +62,13 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   display: flex;
   flex-direction: column;
   min-width: 0;
+  /* Without min-height: 0, flex children with overflow-y: auto grow to their
+     natural content height and blow past the grid row, so nothing appears
+     scrollable — the outer `html { overflow: hidden }` just clips them. */
+  min-height: 0;
+  /* Belt-and-braces: clip at the panel boundary so runaway content can't
+     push the composer / sidebars off-screen. */
+  overflow: hidden;
 }
 .panel:last-child { border-right: none; border-left: 1px solid var(--border); }
 
@@ -76,6 +83,8 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   display: flex;
   justify-content: space-between;
   align-items: center;
+  /* Pin so .content / .list can flex-grow into the remaining space. */
+  flex-shrink: 0;
 }
 
 .list { flex: 1; overflow-y: auto; }
@@ -96,6 +105,8 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   display: flex;
   border-bottom: 1px solid var(--border);
   background: var(--bg-alt);
+  /* Pin so .content can claim remaining vertical space. */
+  flex-shrink: 0;
 }
 .tab {
   padding: 10px 16px;
@@ -343,6 +354,9 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   border-top: 1px solid var(--border);
   background: var(--bg-alt);
   align-items: flex-end;
+  /* Pinned at the bottom of the panel — must not be squeezed when the chat
+     feed grows. */
+  flex-shrink: 0;
 }
 .composer textarea {
   flex: 1;


### PR DESCRIPTION
**Symptom:** nothing scrolls — Chat, Decisions, Board, channel sidebar. All the scroll containers have \`overflow-y: auto\` but content just got clipped at the viewport.

**Cause:** \`.panel\` was missing \`min-height: 0\`. In a grid item that contains \`display: flex; flex-direction: column\`, the default min-height is auto, which means flex children grow to natural content height instead of being constrained to the grid row. The outer \`html { overflow: hidden }\` then clips the runaway — producing the "nothing scrolls" effect even though every scroll container was correctly configured.

**Fix:**
- \`.panel\`: add \`min-height: 0\` + \`overflow: hidden\`.
- \`.panel-header\`, \`.tabs\`, \`.composer\`: \`flex-shrink: 0\` so they can't be squeezed when the content area grows, which also guarantees \`.content\` / \`.list\` claim the remaining space.

Board's per-column scroll from a previous PR still works untouched — \`.content.board-content\` keeps \`overflow-y: hidden\` and \`.board-column-body\` owns its own scroll.

## Test plan
- [x] \`cd gui && pnpm build\` clean
- [ ] Manual: \`rly gui --rebuild\` — scroll a long chat, scroll a long decisions list, scroll a column with 21+ blocked tickets, scroll the channel sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)