### PR TITLE
T-403: PodExecutor + PVCSandbox (K8s) — cloud-pod keystone

### DIFF
--- a/docs/cloud-execution.md
+++ b/docs/cloud-execution.md
@@ -73,3 +73,82 @@ const executor = new PodExecutor({
   (audit, forensics). The default `"delete"` removes the PVC on teardown.
 - RBAC manifests and Helm charts are out of scope for this PR; an ops
   ticket will follow.
+
+## Slug normalization
+
+`runId` and `ticketId` are user-controlled, but Kubernetes resource names
+must be valid DNS-1123 labels (lowercase alphanumeric + `-`, start/end
+alphanumeric, ≤ 63 chars). The helpers in `src/execution/k8s-names.ts`
+apply a deterministic pipeline:
+
+1. `assertSafePathSegment` rejects whitespace, `/`, `\`, null bytes, and
+   `..` traversal fragments up front.
+2. `slugifyForK8s` lowercases, collapses any non-`[a-z0-9-]` run into a
+   single `-`, and trims leading/trailing hyphens.
+3. `finalizeK8sName` caps the composed name at 63 chars and strips
+   trailing non-alphanumerics so a mid-hyphen truncation can't produce an
+   invalid name.
+4. `sanitizeK8sLabelValue` is used for `relay.run-id` / `relay.ticket-id`
+   label values. Labels preserve case and allow `.`/`_`, but still must
+   start+end with an alphanumeric and stay ≤ 63 chars.
+
+## PVC reuse guard (label match)
+
+`ensurePvc` reads the existing PVC by name. If it exists, we check the
+`relay.run-id` / `relay.ticket-id` labels against the caller's sanitized
+values. Two inputs that slugify to the same PVC name but have different
+original identifiers will produce different labels — the second `create()`
+throws an error containing both label sets rather than silently reusing
+the foreign run's volume.
+
+The match is exact string equality on the sanitized label value, not on
+the raw input, so a restart of the same run with the same id is still
+idempotent.
+
+## `readJob` retry policy
+
+`wait()` wraps each `readJob` tick in a try/catch. One transient 5xx,
+network blip, or DNS glitch is absorbed — the loop logs a warning with the
+failure count and backs off for `pollIntervalMs` before retrying. After
+`maxConsecutivePollFailures` consecutive failures (default: 5) the handle
+finalizes with exit code 1, a summary of `"K8s API unavailable after N
+retries: <last error>"`, and an identical stderr event so users see why
+their run stopped. A successful read resets the counter.
+
+## Log stream mid-disconnect
+
+The streaming log sink has explicit `error` and `close` handlers. If the
+stream ends before the worker exits (pod eviction, log-api restart,
+network partition), the executor emits a `stderr` event of the form
+`[pod-executor] log stream ended unexpectedly: <reason>` so the failure
+is visible in the run's event log. The `wait()` poll loop is unaffected
+— it continues reading Job status and will finalize normally when the
+pod terminates.
+
+## Running integration tests
+
+The integration test file
+`test/execution/pod-executor.integration.test.ts` is skipped unless
+`RELAY_TEST_K8S_KUBECONFIG` is set. With a local cluster available:
+
+```sh
+kind create cluster --name relay-t403
+export RELAY_TEST_K8S_KUBECONFIG=$(kind get kubeconfig-path --name relay-t403 2>/dev/null || echo ~/.kube/config)
+export RELAY_TEST_K8S_NAMESPACE=default
+export RELAY_TEST_WORKER_IMAGE=busybox:1.36
+pnpm test
+kind delete cluster --name relay-t403
+```
+
+Or with k3d:
+
+```sh
+k3d cluster create relay-t403
+export RELAY_TEST_K8S_KUBECONFIG=~/.kube/config
+pnpm test
+k3d cluster delete relay-t403
+```
+
+Unit tests use the in-memory `K8sClientLike` fake and always run — the
+integration test is gated behind the env var so CI without a cluster
+isn't required to provision one.

--- a/docs/cloud-execution.md
+++ b/docs/cloud-execution.md
@@ -1,0 +1,75 @@
+# Cloud Execution (Kubernetes)
+
+Relay can run each ticket as a Kubernetes Job against a PVC-backed sandbox.
+Two building blocks ship with this feature:
+
+- `PVCSandboxProvider` — creates a namespace-scoped `PersistentVolumeClaim`
+  and seeds it with the repo contents via a short init `Job` that runs
+  `git clone`.
+- `PodExecutor` — implements `AgentExecutor` by launching a worker `Job`
+  that mounts the PVC at the sandbox workdir and runs the provided
+  `workerImage`.
+
+The executor polls the Job's status (default 3s cadence) and streams pod
+logs. When the Job reports `succeeded`, logs are drained and `wait()`
+resolves with the terminated container's `exitCode`. On `kill()`, the
+executor deletes the Pod then the Job with background propagation.
+
+## Worker image contract
+
+The worker image is supplied by the operator. On startup the executor
+injects three environment variables:
+
+- `RELAY_RUN_ID` — orchestrator run id
+- `RELAY_TICKET_ID` — ticket id
+- `RELAY_WORK_REQUEST` — JSON-serialized work request (title, objective,
+  acceptance criteria, allowed/verification commands, docs to update)
+
+The container's `workingDir` is set to the mounted PVC path (default
+`/work`), and the repo is already checked out at the requested base ref.
+The container should write its output under `$PWD` — results are persisted
+in the PVC until the sandbox is destroyed.
+
+## Local testing with kind
+
+```sh
+kind create cluster --name relay-t403
+export RELAY_TEST_K8S_KUBECONFIG=$(kind get kubeconfig --name relay-t403)
+export RELAY_TEST_K8S_NAMESPACE=default
+export RELAY_TEST_WORKER_IMAGE=busybox:1.36
+pnpm test
+kind delete cluster --name relay-t403
+```
+
+Unit tests use an in-memory `K8sClientLike` fake and run everywhere; the
+file `test/execution/pod-executor.integration.test.ts` is skipped unless
+`RELAY_TEST_K8S_KUBECONFIG` is set.
+
+## Composition
+
+Wiring `HARNESS_EXECUTOR=pod` into the orchestrator constructor is deferred
+to a follow-up PR. Until then, consumers instantiate the executor directly:
+
+```ts
+const k8s = await createDefaultK8sClient({ kubeconfig });
+const sandboxes = new PVCSandboxProvider({ namespace, k8sClient: k8s });
+const executor = new PodExecutor({
+  sandboxProvider: sandboxes,
+  k8sClient: k8s,
+  namespace,
+  workerImage: "ghcr.io/example/relay-worker:latest"
+});
+```
+
+## Security posture
+
+- Every Job and PVC is namespace-scoped. Tenant isolation is an operator
+  concern: run each tenant in its own namespace and bind a restricted
+  ServiceAccount via `serviceAccountName`.
+- The worker pod has read/write access to the PVC. Do NOT share a PVC
+  across tenants — `PVCSandboxProvider` uses `pvc-<runId>-<ticketId>` names
+  so each sandbox lives in its own volume.
+- `destroyPolicy: "retain"` can be set to keep PVCs for out-of-band GC
+  (audit, forensics). The default `"delete"` removes the PVC on teardown.
+- RBAC manifests and Helm charts are out of scope for this PR; an ops
+  ticket will follow.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@aoagents/ao-plugin-scm-github": "0.2.5",
     "@aoagents/ao-plugin-tracker-github": "0.2.5",
     "@aoagents/ao-plugin-tracker-linear": "0.2.5",
+    "@kubernetes/client-node": "^1.4.0",
     "pg": "^8.20.0",
     "tsx": "^4.20.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@aoagents/ao-plugin-tracker-linear':
         specifier: 0.2.5
         version: 0.2.5
+      '@kubernetes/client-node':
+        specifier: ^1.4.0
+        version: 1.4.0
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -220,6 +223,21 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@kubernetes/client-node@1.4.0':
+    resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
+
   '@rollup/rollup-android-arm-eabi@4.60.0':
     resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
     cpu: [arm]
@@ -354,11 +372,23 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/stream-buffers@3.0.8':
+    resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -389,13 +419,76 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.8.7:
+    resolution: {integrity: sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.2:
+    resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -404,6 +497,10 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -418,8 +515,35 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -429,9 +553,15 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -442,22 +572,94 @@ packages:
       picomatch:
         optional: true
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -466,6 +668,24 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  oauth4webapi@3.8.5:
+    resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openid-client@6.8.3:
+    resolution: {integrity: sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -535,8 +755,14 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
@@ -545,6 +771,18 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -560,8 +798,27 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -585,6 +842,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -597,6 +857,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -671,10 +934,31 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -787,6 +1071,41 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@kubernetes/client-node@1.4.0':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 24.12.2
+      '@types/node-fetch': 2.6.13
+      '@types/stream-buffers': 3.0.8
+      form-data: 4.0.5
+      hpagent: 1.2.0
+      isomorphic-ws: 5.0.0(ws@8.20.0)
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.4.0
+      node-fetch: 2.7.0
+      openid-client: 6.8.3
+      rfc4648: 1.5.4
+      socks-proxy-agent: 8.0.5
+      stream-buffers: 3.0.3
+      tar-fs: 3.1.2
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
@@ -871,15 +1190,30 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-yaml@4.0.9': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.15
+      form-data: 4.0.5
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 22.19.15
       pg-protocol: 1.13.0
       pg-types: 2.2.0
+
+  '@types/stream-buffers@3.0.8':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -923,9 +1257,54 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  agent-base@7.1.4: {}
+
+  argparse@2.0.1: {}
+
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
+  b4a@1.8.0: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.8.7: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.8.7
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.2:
+    dependencies:
+      bare-path: 3.0.0
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   chai@5.3.3:
     dependencies:
@@ -937,13 +1316,44 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
 
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -978,20 +1388,90 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hpagent@1.2.0: {}
+
+  ip-address@10.1.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.20.0):
+    dependencies:
+      ws: 8.20.0
+
+  jose@6.2.2: {}
+
   js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsep@1.4.0: {}
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   loupe@3.2.1: {}
 
@@ -999,9 +1479,32 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  oauth4webapi@3.8.5: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openid-client@6.8.3:
+    dependencies:
+      jose: 6.2.2
+      oauth4webapi: 3.8.5
 
   pathe@2.0.3: {}
 
@@ -1062,7 +1565,14 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   resolve-pkg-maps@1.0.0: {}
+
+  rfc4648@1.5.4: {}
 
   rollup@4.60.0:
     dependencies:
@@ -1097,6 +1607,21 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
 
   split2@4.2.0: {}
@@ -1105,9 +1630,56 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream-buffers@3.0.3: {}
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinybench@2.9.0: {}
 
@@ -1124,6 +1696,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tr46@0.0.3: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.4
@@ -1134,6 +1708,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -1211,10 +1787,21 @@ snapshots:
       - tsx
       - yaml
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xtend@4.0.2: {}
 

--- a/src/execution/k8s-client.ts
+++ b/src/execution/k8s-client.ts
@@ -103,7 +103,7 @@ export interface DefaultK8sClientOptions {
 export async function createDefaultK8sClient(
   options: DefaultK8sClientOptions = {}
 ): Promise<K8sClientLike> {
-  const k8s = await import("@kubernetes/client-node");
+  const k8s = await loadK8sModule();
   const config = new k8s.KubeConfig();
   if (options.kubeconfig) {
     config.loadFromFile(options.kubeconfig);
@@ -210,6 +210,34 @@ export async function createDefaultK8sClient(
       });
     }
   };
+}
+
+/**
+ * Wrap the dynamic import so a missing optional peer surfaces an actionable
+ * message. `@kubernetes/client-node` lives under `dependencies` today but we
+ * want the error to survive any future shift to `optionalDependencies` or a
+ * pruned install — `ERR_MODULE_NOT_FOUND` on its own tells operators nothing.
+ */
+async function loadK8sModule(): Promise<typeof import("@kubernetes/client-node")> {
+  return wrapK8sLoader(() => import("@kubernetes/client-node"));
+}
+
+/**
+ * Exported for unit tests: accepts an arbitrary loader, applies the same
+ * actionable-error wrapping. Lets us assert the error shape without having
+ * to uninstall the real dependency.
+ */
+export async function wrapK8sLoader<T>(loader: () => Promise<T>): Promise<T> {
+  try {
+    return await loader();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `@kubernetes/client-node is required for HARNESS_EXECUTOR=pod. ` +
+        `Install via: pnpm add @kubernetes/client-node. Underlying: ${detail}`,
+      { cause: err }
+    );
+  }
 }
 
 function isNotFound(err: unknown): boolean {

--- a/src/execution/k8s-client.ts
+++ b/src/execution/k8s-client.ts
@@ -1,0 +1,226 @@
+import type { Writable } from "node:stream";
+
+/**
+ * Minimal surface of @kubernetes/client-node that the pod executor and PVC
+ * sandbox rely on. Kept narrow so tests can inject fakes without reproducing
+ * the full generated client.
+ */
+
+export interface K8sJobStatus {
+  active?: number;
+  succeeded?: number;
+  failed?: number;
+  conditions?: Array<{ type: string; status: string; reason?: string; message?: string }>;
+}
+
+export interface K8sJob {
+  metadata?: { name?: string; namespace?: string; labels?: Record<string, string> };
+  spec?: Record<string, unknown>;
+  status?: K8sJobStatus;
+}
+
+export interface K8sPodContainerState {
+  terminated?: { exitCode?: number; reason?: string; message?: string };
+  running?: Record<string, unknown>;
+  waiting?: { reason?: string; message?: string };
+}
+
+export interface K8sPodContainerStatus {
+  name: string;
+  state?: K8sPodContainerState;
+  ready?: boolean;
+  restartCount?: number;
+}
+
+export interface K8sPodStatus {
+  phase?: string;
+  containerStatuses?: K8sPodContainerStatus[];
+}
+
+export interface K8sPod {
+  metadata?: { name?: string; namespace?: string; labels?: Record<string, string> };
+  status?: K8sPodStatus;
+}
+
+export interface K8sPersistentVolumeClaim {
+  metadata?: { name?: string; namespace?: string; labels?: Record<string, string> };
+  spec?: Record<string, unknown>;
+  status?: Record<string, unknown>;
+}
+
+export interface K8sDeleteOptions {
+  gracePeriodSeconds?: number;
+  propagationPolicy?: "Orphan" | "Background" | "Foreground";
+}
+
+export interface K8sClientLike {
+  createPersistentVolumeClaim(
+    namespace: string,
+    pvc: K8sPersistentVolumeClaim
+  ): Promise<K8sPersistentVolumeClaim>;
+  readPersistentVolumeClaim(
+    namespace: string,
+    name: string
+  ): Promise<K8sPersistentVolumeClaim | null>;
+  deletePersistentVolumeClaim(
+    namespace: string,
+    name: string,
+    opts?: K8sDeleteOptions
+  ): Promise<void>;
+
+  createJob(namespace: string, job: K8sJob): Promise<K8sJob>;
+  readJob(namespace: string, name: string): Promise<K8sJob | null>;
+  deleteJob(namespace: string, name: string, opts?: K8sDeleteOptions): Promise<void>;
+
+  listPodsForJob(namespace: string, jobName: string): Promise<K8sPod[]>;
+  deletePod(namespace: string, name: string, opts?: K8sDeleteOptions): Promise<void>;
+  readPodLog(
+    namespace: string,
+    podName: string,
+    opts?: { container?: string; tailLines?: number; sinceSeconds?: number }
+  ): Promise<string>;
+  /**
+   * Stream logs for a pod container to the provided writable. Returns an
+   * abort controller — calling `abort()` cancels the log stream. Optional:
+   * fakes may omit this and callers will fall back to polling `readPodLog`.
+   */
+  streamPodLog?(
+    namespace: string,
+    podName: string,
+    stream: Writable,
+    opts?: { container?: string; follow?: boolean }
+  ): Promise<AbortController>;
+}
+
+export interface DefaultK8sClientOptions {
+  kubeconfig?: string;
+}
+
+/**
+ * Lazy-imported so unit tests that inject a fake never touch the real
+ * package's transitive deps.
+ */
+export async function createDefaultK8sClient(
+  options: DefaultK8sClientOptions = {}
+): Promise<K8sClientLike> {
+  const k8s = await import("@kubernetes/client-node");
+  const config = new k8s.KubeConfig();
+  if (options.kubeconfig) {
+    config.loadFromFile(options.kubeconfig);
+  } else {
+    config.loadFromDefault();
+  }
+  const core = config.makeApiClient(k8s.CoreV1Api);
+  const batch = config.makeApiClient(k8s.BatchV1Api);
+  const logApi = new k8s.Log(config);
+
+  return {
+    async createPersistentVolumeClaim(namespace, pvc) {
+      const res = await core.createNamespacedPersistentVolumeClaim({
+        namespace,
+        body: pvc as never
+      });
+      return res as unknown as K8sPersistentVolumeClaim;
+    },
+    async readPersistentVolumeClaim(namespace, name) {
+      try {
+        const res = await core.readNamespacedPersistentVolumeClaim({ name, namespace });
+        return res as unknown as K8sPersistentVolumeClaim;
+      } catch (err) {
+        if (isNotFound(err)) return null;
+        throw err;
+      }
+    },
+    async deletePersistentVolumeClaim(namespace, name, opts) {
+      try {
+        await core.deleteNamespacedPersistentVolumeClaim({
+          name,
+          namespace,
+          gracePeriodSeconds: opts?.gracePeriodSeconds,
+          propagationPolicy: opts?.propagationPolicy
+        });
+      } catch (err) {
+        if (isNotFound(err)) return;
+        throw err;
+      }
+    },
+
+    async createJob(namespace, job) {
+      const res = await batch.createNamespacedJob({ namespace, body: job as never });
+      return res as unknown as K8sJob;
+    },
+    async readJob(namespace, name) {
+      try {
+        const res = await batch.readNamespacedJob({ name, namespace });
+        return res as unknown as K8sJob;
+      } catch (err) {
+        if (isNotFound(err)) return null;
+        throw err;
+      }
+    },
+    async deleteJob(namespace, name, opts) {
+      try {
+        await batch.deleteNamespacedJob({
+          name,
+          namespace,
+          gracePeriodSeconds: opts?.gracePeriodSeconds,
+          propagationPolicy: opts?.propagationPolicy ?? "Background"
+        });
+      } catch (err) {
+        if (isNotFound(err)) return;
+        throw err;
+      }
+    },
+
+    async listPodsForJob(namespace, jobName) {
+      const res = await core.listNamespacedPod({
+        namespace,
+        labelSelector: `job-name=${jobName}`
+      });
+      const items = (res as unknown as { items?: K8sPod[] }).items ?? [];
+      return items;
+    },
+    async deletePod(namespace, name, opts) {
+      try {
+        await core.deleteNamespacedPod({
+          name,
+          namespace,
+          gracePeriodSeconds: opts?.gracePeriodSeconds,
+          propagationPolicy: opts?.propagationPolicy
+        });
+      } catch (err) {
+        if (isNotFound(err)) return;
+        throw err;
+      }
+    },
+    async readPodLog(namespace, podName, opts) {
+      const res = await core.readNamespacedPodLog({
+        name: podName,
+        namespace,
+        container: opts?.container,
+        sinceSeconds: opts?.sinceSeconds,
+        tailLines: opts?.tailLines
+      });
+      if (typeof res === "string") return res;
+      return String(res ?? "");
+    },
+    async streamPodLog(namespace, podName, stream, opts) {
+      return logApi.log(namespace, podName, opts?.container ?? "", stream, {
+        follow: opts?.follow ?? true
+      });
+    }
+  };
+}
+
+function isNotFound(err: unknown): boolean {
+  const anyErr = err as {
+    code?: number;
+    statusCode?: number;
+    response?: { statusCode?: number };
+  };
+  return (
+    anyErr?.code === 404 ||
+    anyErr?.statusCode === 404 ||
+    anyErr?.response?.statusCode === 404
+  );
+}

--- a/src/execution/k8s-names.ts
+++ b/src/execution/k8s-names.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared helpers for turning user-controlled ids (runId, ticketId) into
+ * Kubernetes resource names and label values. Kept in one place so the
+ * PVC sandbox and the pod executor can't drift — label-based lookups across
+ * them rely on byte-for-byte agreement.
+ *
+ * K8s rules we enforce:
+ *   - Resource names are DNS-1123 labels: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`,
+ *     <= 63 chars, must start AND end with an alphanumeric.
+ *   - Label values are `[A-Za-z0-9][A-Za-z0-9._-]*`, <= 63 chars, same
+ *     start/end rule (or the empty string, which we never emit).
+ */
+
+const DNS1123_MAX = 63;
+const TRAVERSAL_RE = /[\s/\\\0]|\.\.|^\.$/;
+
+/**
+ * Reject traversal / whitespace / null bytes before we attempt to use an id
+ * in any resource name. Callers should invoke this on raw runId/ticketId
+ * values before slugifying — the slug alone is not enough because two
+ * different-but-unsafe inputs can collide to the same legal slug.
+ */
+export function assertSafePathSegment(value: string, kind: string): void {
+  if (!value || TRAVERSAL_RE.test(value)) {
+    throw new Error(`Unsafe ${kind} segment: ${JSON.stringify(value)}`);
+  }
+}
+
+/**
+ * Lowercase + collapse non-[a-z0-9-] runs into a single `-`, trim leading
+ * and trailing hyphens, and guarantee a non-empty result. The trimmed
+ * output is a legal DNS-1123 label fragment (though callers still need to
+ * cap total length after concatenating prefixes).
+ */
+export function slugifyForK8s(value: string): string {
+  const lowered = value.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
+  const trimmed = lowered.replace(/^[-]+|[-]+$/g, "");
+  return trimmed || "x";
+}
+
+/**
+ * Cap a composed K8s resource name at 63 chars AND enforce the "ends in an
+ * alphanumeric" rule. Slicing mid-hyphen is the common hazard when we
+ * template `${prefix}-${slug}-${slug}-${counter}` — the tail can land on a
+ * `-` and produce an invalid name.
+ */
+export function finalizeK8sName(name: string): string {
+  const capped = name.slice(0, DNS1123_MAX);
+  // Strip trailing non-alphanumerics. If that empties the string (would
+  // never happen with our prefixes, but defensive), fall back to "x".
+  const trimmed = capped.replace(/[^a-z0-9]+$/g, "");
+  return trimmed || "x";
+}
+
+/**
+ * Label values allow `.` and `_` on top of the DNS-1123 alphabet, but still
+ * must start AND end with an alphanumeric and stay <= 63 chars. We use this
+ * for `relay.run-id` / `relay.ticket-id` so label selectors (e.g. the PVC
+ * reuse guard, or `kubectl get -l relay.run-id=...`) round-trip cleanly.
+ */
+export function sanitizeK8sLabelValue(value: string): string {
+  // Replace disallowed chars first (keep alnum, `.`, `_`, `-`).
+  const cleaned = value.replace(/[^A-Za-z0-9._-]+/g, "-");
+  // Trim leading/trailing non-alphanumerics.
+  const trimmed = cleaned.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9]+$/g, "");
+  const capped = trimmed.slice(0, DNS1123_MAX);
+  // Trim again in case the cap landed on a separator.
+  const final = capped.replace(/[^A-Za-z0-9]+$/g, "");
+  return final || "x";
+}

--- a/src/execution/pod-executor.ts
+++ b/src/execution/pod-executor.ts
@@ -14,6 +14,11 @@ import type {
 } from "./executor.js";
 import type { SandboxRef } from "./sandbox.js";
 import type { K8sClientLike, K8sJob } from "./k8s-client.js";
+import {
+  finalizeK8sName,
+  sanitizeK8sLabelValue,
+  slugifyForK8s
+} from "./k8s-names.js";
 import type { PVCSandboxProvider } from "./sandboxes/pvc-sandbox.js";
 
 const DEFAULT_POLL_MS = 3_000;
@@ -21,6 +26,11 @@ const DEFAULT_TERMINATION_GRACE_S = 10;
 const KILLED_EXIT_CODE = 137;
 const JOB_FAILED_EXIT_CODE = 1;
 const SUMMARY_PREFIX_LENGTH = 120;
+const DEFAULT_MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
+function formatErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 export interface PodResourceRequests {
   cpu?: string;
@@ -46,6 +56,12 @@ export interface PodExecutorOptions {
    * streamPodLog. Useful when the client doesn't implement streaming.
    */
   useStreamingLogs?: boolean;
+  /**
+   * Number of consecutive `readJob` failures tolerated inside `wait()`
+   * before we give up and surface an "API unavailable" error. Defaults to
+   * 5. A single transient 5xx or network blip must not terminate the run.
+   */
+  maxConsecutivePollFailures?: number;
 }
 
 interface ParsedRemoteUri {
@@ -157,6 +173,7 @@ interface PodHandleDeps {
   postKillWatchdogMs: number;
   timeoutMs?: number;
   useStreamingLogs: boolean;
+  maxConsecutivePollFailures: number;
 }
 
 class PodExecutionHandle implements ExecutionHandle {
@@ -203,21 +220,38 @@ class PodExecutionHandle implements ExecutionHandle {
   }
 
   async kill(_signal: "SIGTERM" | "SIGKILL" = "SIGTERM"): Promise<void> {
+    // Idempotent: if wait() has already resolved OR a prior kill() started
+    // the teardown, this call is a no-op. The post-kill watchdog ensures
+    // wait() can't hang even if the underlying API is unresponsive.
     if (this.cachedResult) return;
+    if (this.killRequested) return;
     this.killRequested = true;
     this.armPostKillWatchdog();
     this.stopLogStream();
-    const podNames = await this.resolvePodNames().catch(() => [] as string[]);
+    const podNames = await this.resolvePodNames().catch((err) => {
+      console.warn(
+        `[pod-executor] kill: resolvePodNames failed for ${this.deps.jobName}: ${formatErr(err)}`
+      );
+      return [] as string[];
+    });
     for (const name of podNames) {
       await this.deps.client
         .deletePod(this.deps.namespace, name, { gracePeriodSeconds: 5 })
-        .catch(() => undefined);
+        .catch((err) => {
+          console.warn(
+            `[pod-executor] kill: deletePod ${name} failed: ${formatErr(err)}`
+          );
+        });
     }
     await this.deps.client
       .deleteJob(this.deps.namespace, this.deps.jobName, {
         propagationPolicy: "Background"
       })
-      .catch(() => undefined);
+      .catch((err) => {
+        console.warn(
+          `[pod-executor] kill: deleteJob ${this.deps.jobName} failed: ${formatErr(err)}`
+        );
+      });
   }
 
   async *stream(): AsyncIterable<ExecutionEvent> {
@@ -258,21 +292,64 @@ class PodExecutionHandle implements ExecutionHandle {
     const deadline = this.deps.timeoutMs
       ? Date.now() + this.deps.timeoutMs
       : Number.POSITIVE_INFINITY;
-    this.pokeLogStream().catch(() => undefined);
+    this.pokeLogStream().catch((err) => {
+      console.warn(
+        `[pod-executor] wait: initial pokeLogStream failed for ${this.deps.jobName}: ${formatErr(err)}`
+      );
+    });
+
+    let consecutiveFailures = 0;
+    let lastPollError: unknown = null;
 
     while (!this.cachedResult) {
       if (Date.now() >= deadline && !this.timedOut) {
         this.timedOut = true;
         await this.kill("SIGTERM");
       }
-      const job = await this.deps.client.readJob(this.deps.namespace, this.deps.jobName);
+      // Wrap the poll tick: a single transient 5xx / network blip must not
+      // terminate wait(). We count consecutive failures and give up cleanly
+      // only after `maxConsecutivePollFailures` in a row — at which point
+      // we surface the real reason instead of hanging.
+      let job: K8sJob | null;
+      try {
+        job = await this.deps.client.readJob(this.deps.namespace, this.deps.jobName);
+        consecutiveFailures = 0;
+        lastPollError = null;
+      } catch (err) {
+        consecutiveFailures += 1;
+        lastPollError = err;
+        console.warn(
+          `[pod-executor] wait: readJob ${this.deps.jobName} failed ` +
+            `(${consecutiveFailures}/${this.deps.maxConsecutivePollFailures}), ` +
+            `backing off ${this.deps.pollIntervalMs}ms: ${formatErr(err)}`
+        );
+        if (consecutiveFailures >= this.deps.maxConsecutivePollFailures) {
+          this.bus.emit({
+            kind: "stderr",
+            at: new Date().toISOString(),
+            data: `[pod-executor] K8s API unavailable after ${this.deps.maxConsecutivePollFailures} retries: ${formatErr(lastPollError)}\n`
+          });
+          this.stderrBuf += `[pod-executor] K8s API unavailable after ${this.deps.maxConsecutivePollFailures} retries: ${formatErr(lastPollError)}\n`;
+          this.finalize(
+            JOB_FAILED_EXIT_CODE,
+            `K8s API unavailable after ${this.deps.maxConsecutivePollFailures} retries: ${formatErr(lastPollError)}`
+          );
+          break;
+        }
+        await sleep(this.deps.pollIntervalMs);
+        continue;
+      }
       if (!job) {
         this.finalize(this.killRequested ? KILLED_EXIT_CODE : JOB_FAILED_EXIT_CODE, "job missing");
         break;
       }
       const status = job.status ?? {};
       if (this.podName === null) {
-        await this.pokeLogStream().catch(() => undefined);
+        await this.pokeLogStream().catch((err) => {
+          console.warn(
+            `[pod-executor] wait: pokeLogStream failed for ${this.deps.jobName}: ${formatErr(err)}`
+          );
+        });
       }
       if (status.succeeded && status.succeeded > 0) {
         await this.finalizeFromPodLogs(0);
@@ -296,7 +373,11 @@ class PodExecutionHandle implements ExecutionHandle {
     this.timeoutHandle = setTimeout(() => {
       if (this.cachedResult) return;
       this.timedOut = true;
-      this.kill("SIGTERM").catch(() => undefined);
+      this.kill("SIGTERM").catch((err) => {
+        console.warn(
+          `[pod-executor] timeout: kill(${this.deps.jobName}) failed: ${formatErr(err)}`
+        );
+      });
     }, this.deps.timeoutMs);
     this.timeoutHandle.unref?.();
   }
@@ -323,7 +404,12 @@ class PodExecutionHandle implements ExecutionHandle {
   private async resolveFailureExitCode(): Promise<number> {
     const pods = await this.deps.client
       .listPodsForJob(this.deps.namespace, this.deps.jobName)
-      .catch(() => [] as Awaited<ReturnType<K8sClientLike["listPodsForJob"]>>);
+      .catch((err) => {
+        console.warn(
+          `[pod-executor] resolveFailureExitCode: listPodsForJob ${this.deps.jobName} failed: ${formatErr(err)}`
+        );
+        return [] as Awaited<ReturnType<K8sClientLike["listPodsForJob"]>>;
+      });
     for (const pod of pods) {
       for (const cs of pod.status?.containerStatuses ?? []) {
         if (cs.state?.terminated?.exitCode !== undefined) {
@@ -344,13 +430,24 @@ class PodExecutionHandle implements ExecutionHandle {
       for (const pod of pods) {
         const name = pod.metadata?.name;
         if (!name) continue;
-        const log = await this.deps.client.readPodLog(this.deps.namespace, name);
-        if (log && !this.stdoutBuf.includes(log)) {
-          this.stdoutBuf += log;
+        try {
+          const log = await this.deps.client.readPodLog(this.deps.namespace, name);
+          if (log && !this.stdoutBuf.includes(log)) {
+            this.stdoutBuf += log;
+          }
+        } catch (logErr) {
+          // Surface the failure to the user via stderr so they don't wonder
+          // why stdout is empty. The exit code is already determined; we
+          // just couldn't retrieve the pod's output.
+          const msg = `[pod-executor] logs unavailable for pod ${name}: ${formatErr(logErr)}\n`;
+          console.warn(msg.trim());
+          this.stderrBuf += msg;
         }
       }
-    } catch {
-      // best-effort; missing logs shouldn't block exit.
+    } catch (err) {
+      const msg = `[pod-executor] logs unavailable (listPodsForJob failed): ${formatErr(err)}\n`;
+      console.warn(msg.trim());
+      this.stderrBuf += msg;
     }
     this.finalize(exitCode);
   }
@@ -380,6 +477,21 @@ class PodExecutionHandle implements ExecutionHandle {
           data: text
         });
       });
+      const emitStreamEnd = (reason: string): void => {
+        if (this.cachedResult) return;
+        // The user sees this on any mid-run disconnect (network blip, pod
+        // eviction, log-api crash). wait() will continue polling readJob and
+        // will finalize when the Job itself reports succeeded/failed.
+        const msg = `[pod-executor] log stream ended unexpectedly: ${reason}\n`;
+        this.stderrBuf += msg;
+        this.bus.emit({
+          kind: "stderr",
+          at: new Date().toISOString(),
+          data: msg
+        });
+      };
+      sink.on("error", (err) => emitStreamEnd(formatErr(err)));
+      sink.on("close", () => emitStreamEnd("sink closed"));
       try {
         this.logAborter = await this.deps.client.streamPodLog(
           this.deps.namespace,
@@ -387,7 +499,10 @@ class PodExecutionHandle implements ExecutionHandle {
           sink as Writable,
           { follow: true }
         );
-      } catch {
+      } catch (err) {
+        console.warn(
+          `[pod-executor] streamPodLog ${this.podName} failed, falling back to poll: ${formatErr(err)}`
+        );
         await this.tryStartPollingLogs();
       }
     } else {
@@ -426,8 +541,12 @@ class PodExecutionHandle implements ExecutionHandle {
           this.logSinceSeconds,
           Math.ceil(this.deps.pollIntervalMs / 1_000) + 1
         );
-      } catch {
-        // ignore transient read failures
+      } catch (err) {
+        // Transient read failures don't kill wait() — it has its own
+        // readJob-based poll loop. We warn so repeated failures are visible.
+        console.warn(
+          `[pod-executor] log poll tick failed for ${this.podName}: ${formatErr(err)}`
+        );
       }
     };
     this.logPollTimer = setInterval(tick, this.deps.pollIntervalMs);
@@ -439,8 +558,10 @@ class PodExecutionHandle implements ExecutionHandle {
     if (this.logAborter) {
       try {
         this.logAborter.abort();
-      } catch {
-        // ignore
+      } catch (err) {
+        console.warn(
+          `[pod-executor] stopLogStream: aborter.abort() threw: ${formatErr(err)}`
+        );
       }
       this.logAborter = null;
     }
@@ -485,6 +606,7 @@ export class PodExecutor implements AgentExecutor {
   private readonly pollIntervalMs: number;
   private readonly postKillWatchdogMs: number;
   private readonly useStreamingLogs: boolean;
+  private readonly maxConsecutivePollFailures: number;
   private counter = 0;
 
   constructor(options: PodExecutorOptions) {
@@ -503,6 +625,8 @@ export class PodExecutor implements AgentExecutor {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_MS;
     this.postKillWatchdogMs = options.postKillWatchdogMs ?? 30_000;
     this.useStreamingLogs = options.useStreamingLogs ?? true;
+    this.maxConsecutivePollFailures =
+      options.maxConsecutivePollFailures ?? DEFAULT_MAX_CONSECUTIVE_POLL_FAILURES;
   }
 
   async start(
@@ -547,10 +671,19 @@ export class PodExecutor implements AgentExecutor {
       env.push({ name: key, value });
     }
 
-    const jobName = `worker-${opts.runId}-${ticket.id}-${++this.counter}`.slice(0, 63);
+    // Slugify + finalize so arbitrary runId/ticketId (UUIDs, uppercase, `_`)
+    // produce DNS-1123 legal names. `finalizeK8sName` caps at 63 chars and
+    // strips trailing `-` so the name ends in an alphanumeric as required.
+    const runSlug = slugifyForK8s(opts.runId);
+    const ticketSlug = slugifyForK8s(ticket.id);
+    const counter = ++this.counter;
+    const jobName = finalizeK8sName(`worker-${runSlug}-${ticketSlug}-${counter}`);
+    // Label values allow `.` and `_` in addition to DNS-1123's alphabet, but
+    // must start+end alphanumeric and stay <= 63 chars. We sanitize here so
+    // later label selectors (e.g. the PVC reuse guard) round-trip cleanly.
     const labels = {
-      "relay.run-id": opts.runId,
-      "relay.ticket-id": ticket.id,
+      "relay.run-id": sanitizeK8sLabelValue(opts.runId),
+      "relay.ticket-id": sanitizeK8sLabelValue(ticket.id),
       "relay.role": "worker"
     };
     const job = buildJobManifest({
@@ -569,7 +702,7 @@ export class PodExecutor implements AgentExecutor {
 
     await this.client.createJob(this.namespace, job);
 
-    const handleId = `${ticket.id}-${Date.now()}-${this.counter}`;
+    const handleId = `${ticket.id}-${Date.now()}-${counter}`;
     return new PodExecutionHandle({
       id: handleId,
       sandbox,
@@ -579,7 +712,8 @@ export class PodExecutor implements AgentExecutor {
       pollIntervalMs: this.pollIntervalMs,
       postKillWatchdogMs: this.postKillWatchdogMs,
       timeoutMs: opts.timeoutMs,
-      useStreamingLogs: this.useStreamingLogs
+      useStreamingLogs: this.useStreamingLogs,
+      maxConsecutivePollFailures: this.maxConsecutivePollFailures
     });
   }
 }

--- a/src/execution/pod-executor.ts
+++ b/src/execution/pod-executor.ts
@@ -1,0 +1,602 @@
+// Composition wiring (HARNESS_EXECUTOR=pod env selection into orchestrator-v2)
+// is a follow-up PR. This file ships the executor + sandbox provider impl.
+
+import { PassThrough, Writable } from "node:stream";
+
+import type { TicketDefinition } from "../domain/ticket.js";
+import type {
+  AgentExecutor,
+  ExecutionEvent,
+  ExecutionHandle,
+  ExecutionResult,
+  ExecutionStatus,
+  ExecutorStartOptions
+} from "./executor.js";
+import type { SandboxRef } from "./sandbox.js";
+import type { K8sClientLike, K8sJob } from "./k8s-client.js";
+import type { PVCSandboxProvider } from "./sandboxes/pvc-sandbox.js";
+
+const DEFAULT_POLL_MS = 3_000;
+const DEFAULT_TERMINATION_GRACE_S = 10;
+const KILLED_EXIT_CODE = 137;
+const JOB_FAILED_EXIT_CODE = 1;
+const SUMMARY_PREFIX_LENGTH = 120;
+
+export interface PodResourceRequests {
+  cpu?: string;
+  memory?: string;
+}
+
+export interface PodExecutorOptions {
+  sandboxProvider: PVCSandboxProvider;
+  k8sClient: K8sClientLike;
+  namespace: string;
+  workerImage: string;
+  imagePullSecrets?: string[];
+  serviceAccountName?: string;
+  resources?: { requests?: PodResourceRequests; limits?: PodResourceRequests };
+  pollIntervalMs?: number;
+  /**
+   * Max time after kill() before we synthesize an exit. Mirrors the
+   * LocalChildProcessExecutor's post-kill watchdog so wait() can never hang.
+   */
+  postKillWatchdogMs?: number;
+  /**
+   * If false, the executor polls readPodLog in chunks instead of using
+   * streamPodLog. Useful when the client doesn't implement streaming.
+   */
+  useStreamingLogs?: boolean;
+}
+
+interface ParsedRemoteUri {
+  namespace: string;
+  pvcName: string;
+  mountPath: string;
+}
+
+function parsePodUri(uri: string): ParsedRemoteUri {
+  const match = /^pod:\/\/([^/]+)\/([^:]+):(.+)$/.exec(uri);
+  if (!match) {
+    throw new Error(
+      `PodExecutor requires a sandbox URI like pod://<ns>/<pvc>:/work; got ${uri}`
+    );
+  }
+  return { namespace: match[1], pvcName: match[2], mountPath: match[3] };
+}
+
+function buildJobManifest(opts: {
+  jobName: string;
+  namespace: string;
+  pvcName: string;
+  mountPath: string;
+  workerImage: string;
+  imagePullSecrets?: string[];
+  serviceAccountName?: string;
+  env: Array<{ name: string; value: string }>;
+  resources?: PodExecutorOptions["resources"];
+  labels: Record<string, string>;
+  terminationGracePeriodSeconds: number;
+}): K8sJob {
+  const containerResources: Record<string, unknown> = {};
+  if (opts.resources?.requests) containerResources.requests = opts.resources.requests;
+  if (opts.resources?.limits) containerResources.limits = opts.resources.limits;
+
+  return {
+    metadata: { name: opts.jobName, namespace: opts.namespace, labels: opts.labels },
+    spec: {
+      backoffLimit: 0,
+      ttlSecondsAfterFinished: 600,
+      template: {
+        metadata: { labels: opts.labels },
+        spec: {
+          restartPolicy: "Never",
+          terminationGracePeriodSeconds: opts.terminationGracePeriodSeconds,
+          ...(opts.serviceAccountName
+            ? { serviceAccountName: opts.serviceAccountName }
+            : {}),
+          ...(opts.imagePullSecrets && opts.imagePullSecrets.length > 0
+            ? { imagePullSecrets: opts.imagePullSecrets.map((name) => ({ name })) }
+            : {}),
+          containers: [
+            {
+              name: "worker",
+              image: opts.workerImage,
+              workingDir: opts.mountPath,
+              env: opts.env,
+              ...(Object.keys(containerResources).length > 0
+                ? { resources: containerResources }
+                : {}),
+              volumeMounts: [{ name: "work", mountPath: opts.mountPath }]
+            }
+          ],
+          volumes: [
+            {
+              name: "work",
+              persistentVolumeClaim: { claimName: opts.pvcName }
+            }
+          ]
+        }
+      }
+    }
+  };
+}
+
+class EventBus {
+  private readonly subscribers = new Set<(event: ExecutionEvent, terminal: boolean) => void>();
+  private cachedStart: ExecutionEvent | null = null;
+  private cachedExit: ExecutionEvent | null = null;
+
+  emit(event: ExecutionEvent, terminal = false): void {
+    if (event.kind === "start") this.cachedStart = event;
+    else if (event.kind === "exit") this.cachedExit = event;
+    for (const sub of this.subscribers) sub(event, terminal);
+  }
+
+  subscribe(onEvent: (event: ExecutionEvent, terminal: boolean) => void): () => void {
+    this.subscribers.add(onEvent);
+    return () => {
+      this.subscribers.delete(onEvent);
+    };
+  }
+
+  get completed(): boolean {
+    return this.cachedExit !== null;
+  }
+  get cache(): { start: ExecutionEvent | null; exit: ExecutionEvent | null } {
+    return { start: this.cachedStart, exit: this.cachedExit };
+  }
+}
+
+interface PodHandleDeps {
+  id: string;
+  sandbox: SandboxRef;
+  namespace: string;
+  jobName: string;
+  client: K8sClientLike;
+  pollIntervalMs: number;
+  postKillWatchdogMs: number;
+  timeoutMs?: number;
+  useStreamingLogs: boolean;
+}
+
+class PodExecutionHandle implements ExecutionHandle {
+  readonly id: string;
+  readonly sandbox: SandboxRef;
+
+  private readonly bus = new EventBus();
+  private readonly deps: PodHandleDeps;
+  private cachedResult: ExecutionResult | null = null;
+  private waitPromise: Promise<ExecutionResult> | null = null;
+  private killRequested = false;
+  private timedOut = false;
+  private logAborter: AbortController | null = null;
+  private logPollTimer: NodeJS.Timeout | null = null;
+  private logSinceSeconds = 0;
+  private timeoutHandle: NodeJS.Timeout | null = null;
+  private postKillTimer: NodeJS.Timeout | null = null;
+  private stdoutBuf = "";
+  private stderrBuf = "";
+  private podName: string | null = null;
+
+  constructor(deps: PodHandleDeps) {
+    this.id = deps.id;
+    this.sandbox = deps.sandbox;
+    this.deps = deps;
+    this.bus.emit({ kind: "start", at: new Date().toISOString() });
+    this.armTimeout();
+  }
+
+  get status(): ExecutionStatus {
+    if (this.cachedResult) {
+      return this.killRequested && this.cachedResult.exitCode === KILLED_EXIT_CODE
+        ? "killed"
+        : "exited";
+    }
+    return this.killRequested ? "killed" : "running";
+  }
+
+  wait(): Promise<ExecutionResult> {
+    if (!this.waitPromise) {
+      this.waitPromise = this.runWait();
+    }
+    return this.waitPromise;
+  }
+
+  async kill(_signal: "SIGTERM" | "SIGKILL" = "SIGTERM"): Promise<void> {
+    if (this.cachedResult) return;
+    this.killRequested = true;
+    this.armPostKillWatchdog();
+    this.stopLogStream();
+    const podNames = await this.resolvePodNames().catch(() => [] as string[]);
+    for (const name of podNames) {
+      await this.deps.client
+        .deletePod(this.deps.namespace, name, { gracePeriodSeconds: 5 })
+        .catch(() => undefined);
+    }
+    await this.deps.client
+      .deleteJob(this.deps.namespace, this.deps.jobName, {
+        propagationPolicy: "Background"
+      })
+      .catch(() => undefined);
+  }
+
+  async *stream(): AsyncIterable<ExecutionEvent> {
+    if (this.bus.completed) {
+      const { start, exit } = this.bus.cache;
+      if (start) yield start;
+      if (exit) yield exit;
+      return;
+    }
+    const queue: Array<{ event: ExecutionEvent; terminal: boolean }> = [];
+    let resolver: (() => void) | null = null;
+    const unsubscribe = this.bus.subscribe((event, terminal) => {
+      queue.push({ event, terminal });
+      resolver?.();
+      resolver = null;
+    });
+    const cachedStart = this.bus.cache.start;
+    if (cachedStart) yield cachedStart;
+    try {
+      while (true) {
+        if (queue.length === 0) {
+          await new Promise<void>((resolve) => {
+            resolver = resolve;
+          });
+        }
+        const next = queue.shift();
+        if (!next) continue;
+        if (next.event.kind === "start" && cachedStart) continue;
+        yield next.event;
+        if (next.terminal) return;
+      }
+    } finally {
+      unsubscribe();
+    }
+  }
+
+  private async runWait(): Promise<ExecutionResult> {
+    const deadline = this.deps.timeoutMs
+      ? Date.now() + this.deps.timeoutMs
+      : Number.POSITIVE_INFINITY;
+    this.pokeLogStream().catch(() => undefined);
+
+    while (!this.cachedResult) {
+      if (Date.now() >= deadline && !this.timedOut) {
+        this.timedOut = true;
+        await this.kill("SIGTERM");
+      }
+      const job = await this.deps.client.readJob(this.deps.namespace, this.deps.jobName);
+      if (!job) {
+        this.finalize(this.killRequested ? KILLED_EXIT_CODE : JOB_FAILED_EXIT_CODE, "job missing");
+        break;
+      }
+      const status = job.status ?? {};
+      if (this.podName === null) {
+        await this.pokeLogStream().catch(() => undefined);
+      }
+      if (status.succeeded && status.succeeded > 0) {
+        await this.finalizeFromPodLogs(0);
+        break;
+      }
+      if (status.failed && status.failed > 0) {
+        const exitCode = await this.resolveFailureExitCode();
+        await this.finalizeFromPodLogs(exitCode);
+        break;
+      }
+      await sleep(this.deps.pollIntervalMs);
+    }
+    if (!this.cachedResult) {
+      this.finalize(KILLED_EXIT_CODE, "exit synthesized");
+    }
+    return this.cachedResult!;
+  }
+
+  private armTimeout(): void {
+    if (!this.deps.timeoutMs) return;
+    this.timeoutHandle = setTimeout(() => {
+      if (this.cachedResult) return;
+      this.timedOut = true;
+      this.kill("SIGTERM").catch(() => undefined);
+    }, this.deps.timeoutMs);
+    this.timeoutHandle.unref?.();
+  }
+
+  private armPostKillWatchdog(): void {
+    if (this.postKillTimer) return;
+    this.postKillTimer = setTimeout(() => {
+      if (this.cachedResult) return;
+      this.finalize(KILLED_EXIT_CODE, "killed but never exited");
+    }, this.deps.postKillWatchdogMs);
+    this.postKillTimer.unref?.();
+  }
+
+  private async resolvePodNames(): Promise<string[]> {
+    const pods = await this.deps.client.listPodsForJob(
+      this.deps.namespace,
+      this.deps.jobName
+    );
+    return pods
+      .map((p) => p.metadata?.name)
+      .filter((n): n is string => typeof n === "string");
+  }
+
+  private async resolveFailureExitCode(): Promise<number> {
+    const pods = await this.deps.client
+      .listPodsForJob(this.deps.namespace, this.deps.jobName)
+      .catch(() => [] as Awaited<ReturnType<K8sClientLike["listPodsForJob"]>>);
+    for (const pod of pods) {
+      for (const cs of pod.status?.containerStatuses ?? []) {
+        if (cs.state?.terminated?.exitCode !== undefined) {
+          return cs.state.terminated.exitCode;
+        }
+      }
+    }
+    return JOB_FAILED_EXIT_CODE;
+  }
+
+  private async finalizeFromPodLogs(exitCode: number): Promise<void> {
+    this.stopLogStream();
+    try {
+      const pods = await this.deps.client.listPodsForJob(
+        this.deps.namespace,
+        this.deps.jobName
+      );
+      for (const pod of pods) {
+        const name = pod.metadata?.name;
+        if (!name) continue;
+        const log = await this.deps.client.readPodLog(this.deps.namespace, name);
+        if (log && !this.stdoutBuf.includes(log)) {
+          this.stdoutBuf += log;
+        }
+      }
+    } catch {
+      // best-effort; missing logs shouldn't block exit.
+    }
+    this.finalize(exitCode);
+  }
+
+  private async pokeLogStream(): Promise<void> {
+    if (this.podName || !this.deps.useStreamingLogs) {
+      if (!this.podName) {
+        await this.tryStartPollingLogs();
+      }
+      return;
+    }
+    const pods = await this.deps.client.listPodsForJob(
+      this.deps.namespace,
+      this.deps.jobName
+    );
+    const pod = pods.find((p) => p.metadata?.name);
+    if (!pod || !pod.metadata?.name) return;
+    this.podName = pod.metadata.name;
+    if (this.deps.client.streamPodLog) {
+      const sink = new PassThrough();
+      sink.on("data", (chunk: Buffer | string) => {
+        const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+        this.stdoutBuf += text;
+        this.bus.emit({
+          kind: "stdout",
+          at: new Date().toISOString(),
+          data: text
+        });
+      });
+      try {
+        this.logAborter = await this.deps.client.streamPodLog(
+          this.deps.namespace,
+          this.podName,
+          sink as Writable,
+          { follow: true }
+        );
+      } catch {
+        await this.tryStartPollingLogs();
+      }
+    } else {
+      await this.tryStartPollingLogs();
+    }
+  }
+
+  private async tryStartPollingLogs(): Promise<void> {
+    if (this.logPollTimer) return;
+    if (!this.podName) {
+      const pods = await this.deps.client.listPodsForJob(
+        this.deps.namespace,
+        this.deps.jobName
+      );
+      const name = pods.find((p) => p.metadata?.name)?.metadata?.name;
+      if (!name) return;
+      this.podName = name;
+    }
+    const tick = async () => {
+      if (this.cachedResult || !this.podName) return;
+      try {
+        const log = await this.deps.client.readPodLog(
+          this.deps.namespace,
+          this.podName,
+          { sinceSeconds: this.logSinceSeconds || undefined }
+        );
+        if (log) {
+          this.stdoutBuf += log;
+          this.bus.emit({
+            kind: "stdout",
+            at: new Date().toISOString(),
+            data: log
+          });
+        }
+        this.logSinceSeconds = Math.max(
+          this.logSinceSeconds,
+          Math.ceil(this.deps.pollIntervalMs / 1_000) + 1
+        );
+      } catch {
+        // ignore transient read failures
+      }
+    };
+    this.logPollTimer = setInterval(tick, this.deps.pollIntervalMs);
+    this.logPollTimer.unref?.();
+    void tick();
+  }
+
+  private stopLogStream(): void {
+    if (this.logAborter) {
+      try {
+        this.logAborter.abort();
+      } catch {
+        // ignore
+      }
+      this.logAborter = null;
+    }
+    if (this.logPollTimer) {
+      clearInterval(this.logPollTimer);
+      this.logPollTimer = null;
+    }
+  }
+
+  private finalize(exitCode: number, reason?: string): void {
+    if (this.cachedResult) return;
+    const summary = buildSummary(this.stdoutBuf, this.stderrBuf, exitCode, reason);
+    this.cachedResult = {
+      exitCode,
+      summary,
+      stdout: this.stdoutBuf,
+      stderr: this.stderrBuf
+    };
+    if (this.timeoutHandle) clearTimeout(this.timeoutHandle);
+    if (this.postKillTimer) clearTimeout(this.postKillTimer);
+    this.stopLogStream();
+    this.bus.emit(
+      { kind: "exit", at: new Date().toISOString(), data: String(exitCode) },
+      true
+    );
+  }
+}
+
+/**
+ * AgentExecutor that runs each ticket as a K8s Job against a PVC-backed
+ * sandbox produced by PVCSandboxProvider. The worker image is expected to
+ * consume the injected env (RELAY_WORK_REQUEST, RELAY_RUN_ID,
+ * RELAY_TICKET_ID) and write its output under the mounted workdir.
+ */
+export class PodExecutor implements AgentExecutor {
+  private readonly client: K8sClientLike;
+  private readonly namespace: string;
+  private readonly workerImage: string;
+  private readonly imagePullSecrets: string[] | undefined;
+  private readonly serviceAccountName: string | undefined;
+  private readonly resources: PodExecutorOptions["resources"];
+  private readonly pollIntervalMs: number;
+  private readonly postKillWatchdogMs: number;
+  private readonly useStreamingLogs: boolean;
+  private counter = 0;
+
+  constructor(options: PodExecutorOptions) {
+    if (!options.namespace) throw new Error("PodExecutor requires a namespace");
+    if (!options.workerImage) throw new Error("PodExecutor requires a workerImage");
+    if (!options.k8sClient) throw new Error("PodExecutor requires a k8sClient");
+    if (!options.sandboxProvider) {
+      throw new Error("PodExecutor requires a sandboxProvider (PVCSandboxProvider)");
+    }
+    this.client = options.k8sClient;
+    this.namespace = options.namespace;
+    this.workerImage = options.workerImage;
+    this.imagePullSecrets = options.imagePullSecrets;
+    this.serviceAccountName = options.serviceAccountName;
+    this.resources = options.resources;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_MS;
+    this.postKillWatchdogMs = options.postKillWatchdogMs ?? 30_000;
+    this.useStreamingLogs = options.useStreamingLogs ?? true;
+  }
+
+  async start(
+    ticket: TicketDefinition,
+    opts: ExecutorStartOptions
+  ): Promise<ExecutionHandle> {
+    if (!opts.sandbox) {
+      throw new Error("PodExecutor requires opts.sandbox (create via PVCSandboxProvider)");
+    }
+    const sandbox = opts.sandbox;
+    if (sandbox.workdir.kind !== "remote") {
+      throw new Error(
+        `PodExecutor requires sandbox.workdir.kind === "remote"; got "${sandbox.workdir.kind}"`
+      );
+    }
+    const parsed = parsePodUri(sandbox.workdir.uri);
+    if (parsed.namespace !== this.namespace) {
+      throw new Error(
+        `Sandbox namespace ${parsed.namespace} does not match executor namespace ${this.namespace}`
+      );
+    }
+
+    const workRequest = {
+      runId: opts.runId,
+      ticketId: ticket.id,
+      specialty: ticket.specialty,
+      title: ticket.title,
+      objective: ticket.objective,
+      acceptanceCriteria: ticket.acceptanceCriteria,
+      allowedCommands: ticket.allowedCommands,
+      verificationCommands: ticket.verificationCommands,
+      docsToUpdate: ticket.docsToUpdate
+    };
+
+    const env: Array<{ name: string; value: string }> = [
+      { name: "RELAY_RUN_ID", value: opts.runId },
+      { name: "RELAY_TICKET_ID", value: ticket.id },
+      { name: "RELAY_WORK_REQUEST", value: JSON.stringify(workRequest) }
+    ];
+    for (const [key, value] of Object.entries(opts.env ?? {})) {
+      if (value === undefined) continue;
+      env.push({ name: key, value });
+    }
+
+    const jobName = `worker-${opts.runId}-${ticket.id}-${++this.counter}`.slice(0, 63);
+    const labels = {
+      "relay.run-id": opts.runId,
+      "relay.ticket-id": ticket.id,
+      "relay.role": "worker"
+    };
+    const job = buildJobManifest({
+      jobName,
+      namespace: this.namespace,
+      pvcName: parsed.pvcName,
+      mountPath: parsed.mountPath,
+      workerImage: this.workerImage,
+      imagePullSecrets: this.imagePullSecrets,
+      serviceAccountName: this.serviceAccountName,
+      env,
+      resources: this.resources,
+      labels,
+      terminationGracePeriodSeconds: DEFAULT_TERMINATION_GRACE_S
+    });
+
+    await this.client.createJob(this.namespace, job);
+
+    const handleId = `${ticket.id}-${Date.now()}-${this.counter}`;
+    return new PodExecutionHandle({
+      id: handleId,
+      sandbox,
+      namespace: this.namespace,
+      jobName,
+      client: this.client,
+      pollIntervalMs: this.pollIntervalMs,
+      postKillWatchdogMs: this.postKillWatchdogMs,
+      timeoutMs: opts.timeoutMs,
+      useStreamingLogs: this.useStreamingLogs
+    });
+  }
+}
+
+function buildSummary(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  reason?: string
+): string {
+  if (reason) return reason;
+  if (exitCode === 0 && stderr.trim() === "") {
+    return stdout.slice(0, SUMMARY_PREFIX_LENGTH);
+  }
+  return `failed (exit ${exitCode})`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/execution/sandboxes/pvc-sandbox.ts
+++ b/src/execution/sandboxes/pvc-sandbox.ts
@@ -9,6 +9,12 @@ import type {
   K8sJob,
   K8sPersistentVolumeClaim
 } from "../k8s-client.js";
+import {
+  assertSafePathSegment,
+  finalizeK8sName,
+  sanitizeK8sLabelValue,
+  slugifyForK8s
+} from "../k8s-names.js";
 
 const DEFAULT_STORAGE_SIZE = "1Gi";
 const DEFAULT_INIT_IMAGE = "alpine/git:latest";
@@ -61,25 +67,6 @@ export interface PVCSandboxMeta extends Record<string, string> {
   runId: string;
   ticketId: string;
   workdir: string;
-}
-
-const TRAVERSAL_RE = /[\s/\\\0]|\.\.|^\.$/;
-
-function assertSafePathSegment(value: string, kind: string): void {
-  // Reject traversal / whitespace / null bytes before we attempt to use the id
-  // in any resource name. DNS-1123 legality is handled separately by slugify.
-  if (!value || TRAVERSAL_RE.test(value)) {
-    throw new Error(`Unsafe ${kind} segment: ${JSON.stringify(value)}`);
-  }
-}
-
-function slugifyForK8s(value: string): string {
-  // K8s object names are DNS-1123 labels: lowercase alphanumeric + hyphen,
-  // starting and ending with alphanumeric. We lowercase, replace runs of
-  // non-matching chars with '-', and trim leading/trailing non-alphanum.
-  const lowered = value.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
-  const trimmed = lowered.replace(/^[-]+|[-]+$/g, "");
-  return trimmed || "x";
 }
 
 /**
@@ -138,12 +125,21 @@ export class PVCSandboxProvider implements SandboxProvider {
 
     const runSlug = slugifyForK8s(runId);
     const ticketSlug = slugifyForK8s(ticketId);
-    const pvcName = `pvc-${runSlug}-${ticketSlug}`.slice(0, 63);
-    const jobName = `init-${runSlug}-${ticketSlug}`.slice(0, 63);
+    const pvcName = finalizeK8sName(`pvc-${runSlug}-${ticketSlug}`);
+    const jobName = finalizeK8sName(`init-${runSlug}-${ticketSlug}`);
+    const runLabel = sanitizeK8sLabelValue(runId);
+    const ticketLabel = sanitizeK8sLabelValue(ticketId);
 
-    await this.ensurePvc(pvcName, runId, ticketId);
+    await this.ensurePvc(pvcName, runLabel, ticketLabel);
 
-    const job = this.buildInitJob(jobName, pvcName, repo.remoteUrl, base, runId, ticketId);
+    const job = this.buildInitJob(
+      jobName,
+      pvcName,
+      repo.remoteUrl,
+      base,
+      runLabel,
+      ticketLabel
+    );
     await this.client.createJob(this.namespace, job);
     try {
       await this.waitForJob(jobName);
@@ -152,7 +148,13 @@ export class PVCSandboxProvider implements SandboxProvider {
       // so the namespace stays tidy. The PVC survives for the executor.
       await this.client
         .deleteJob(this.namespace, jobName, { propagationPolicy: "Background" })
-        .catch(() => undefined);
+        .catch((err) => {
+          // Best-effort: the init job had a TTL and will eventually GC itself.
+          // We warn so the operator can investigate repeated leaks.
+          console.warn(
+            `[pvc-sandbox] failed to delete init job ${jobName} in ${this.namespace}: ${formatErr(err)}`
+          );
+        });
     }
 
     const meta: PVCSandboxMeta = {
@@ -191,21 +193,38 @@ export class PVCSandboxProvider implements SandboxProvider {
 
   private async ensurePvc(
     pvcName: string,
-    runId: string,
-    ticketId: string
+    runLabel: string,
+    ticketLabel: string
   ): Promise<void> {
     const existing = await this.client.readPersistentVolumeClaim(
       this.namespace,
       pvcName
     );
-    if (existing) return;
+    if (existing) {
+      // Reuse guard: two different runId/ticketId pairs can slugify to the
+      // same PVC name (e.g. case differences, unicode folding). If the
+      // existing PVC's labels don't match us, we MUST NOT share it — the
+      // init job would overwrite the other run's checkout.
+      const existingRun = existing.metadata?.labels?.["relay.run-id"];
+      const existingTicket = existing.metadata?.labels?.["relay.ticket-id"];
+      if (existingRun !== runLabel || existingTicket !== ticketLabel) {
+        throw new Error(
+          `PVC ${pvcName} in namespace ${this.namespace} already exists with ` +
+            `labels run-id=${JSON.stringify(existingRun)} ticket-id=${JSON.stringify(existingTicket)}, ` +
+            `but this create() call is for run-id=${JSON.stringify(runLabel)} ticket-id=${JSON.stringify(ticketLabel)}. ` +
+            `Two ids that slugify to the same name cannot share a PVC — ` +
+            `choose distinct ids or delete the existing PVC.`
+        );
+      }
+      return;
+    }
     const pvc: K8sPersistentVolumeClaim = {
       metadata: {
         name: pvcName,
         namespace: this.namespace,
         labels: {
-          "relay.run-id": runId,
-          "relay.ticket-id": ticketId,
+          "relay.run-id": runLabel,
+          "relay.ticket-id": ticketLabel,
           "relay.role": "sandbox"
         }
       },
@@ -223,16 +242,16 @@ export class PVCSandboxProvider implements SandboxProvider {
     pvcName: string,
     remoteUrl: string,
     base: string,
-    runId: string,
-    ticketId: string
+    runLabel: string,
+    ticketLabel: string
   ): K8sJob {
     return {
       metadata: {
         name: jobName,
         namespace: this.namespace,
         labels: {
-          "relay.run-id": runId,
-          "relay.ticket-id": ticketId,
+          "relay.run-id": runLabel,
+          "relay.ticket-id": ticketLabel,
           "relay.role": "sandbox-init"
         }
       },
@@ -242,8 +261,8 @@ export class PVCSandboxProvider implements SandboxProvider {
         template: {
           metadata: {
             labels: {
-              "relay.run-id": runId,
-              "relay.ticket-id": ticketId,
+              "relay.run-id": runLabel,
+              "relay.ticket-id": ticketLabel,
               "relay.role": "sandbox-init"
             }
           },
@@ -311,4 +330,8 @@ function shellEscape(value: string): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/src/execution/sandboxes/pvc-sandbox.ts
+++ b/src/execution/sandboxes/pvc-sandbox.ts
@@ -1,0 +1,314 @@
+import type {
+  DestroyResult,
+  RepoRef,
+  SandboxProvider,
+  SandboxRef
+} from "../sandbox.js";
+import type {
+  K8sClientLike,
+  K8sJob,
+  K8sPersistentVolumeClaim
+} from "../k8s-client.js";
+
+const DEFAULT_STORAGE_SIZE = "1Gi";
+const DEFAULT_INIT_IMAGE = "alpine/git:latest";
+const DEFAULT_INIT_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_WORKDIR = "/work";
+
+export interface PVCSandboxProviderOptions {
+  namespace: string;
+  k8sClient: K8sClientLike;
+  /**
+   * Optional storage class for the PVC. Omit to let the cluster pick its
+   * default provisioner.
+   */
+  storageClassName?: string;
+  /** Requested volume size. Defaults to 1Gi. */
+  storageSize?: string;
+  /** Image used to clone the repo into the PVC. */
+  initContainerImage?: string;
+  /**
+   * Namespace-local workdir mount path inside the init container (and later
+   * the worker pod). Defaults to /work.
+   */
+  workdir?: string;
+  /**
+   * Max time to wait for the init clone job to succeed. Exceeding this throws
+   * and the PVC is left in place for diagnostic inspection.
+   */
+  initTimeoutMs?: number;
+  /**
+   * Poll cadence while waiting for the init job. Separate from
+   * `initTimeoutMs` so tests can tighten the loop.
+   */
+  initPollIntervalMs?: number;
+  /**
+   * Destroy policy. `"delete"` removes the PVC on destroy(); `"retain"` marks
+   * it as preserved for GC out-of-band (e.g. an ops sweep). Default: delete.
+   */
+  destroyPolicy?: "delete" | "retain";
+}
+
+export interface PVCSandboxCreateOptions {
+  runId: string;
+  ticketId: string;
+}
+
+export interface PVCSandboxMeta extends Record<string, string> {
+  pvcName: string;
+  namespace: string;
+  base: string;
+  runId: string;
+  ticketId: string;
+  workdir: string;
+}
+
+const TRAVERSAL_RE = /[\s/\\\0]|\.\.|^\.$/;
+
+function assertSafePathSegment(value: string, kind: string): void {
+  // Reject traversal / whitespace / null bytes before we attempt to use the id
+  // in any resource name. DNS-1123 legality is handled separately by slugify.
+  if (!value || TRAVERSAL_RE.test(value)) {
+    throw new Error(`Unsafe ${kind} segment: ${JSON.stringify(value)}`);
+  }
+}
+
+function slugifyForK8s(value: string): string {
+  // K8s object names are DNS-1123 labels: lowercase alphanumeric + hyphen,
+  // starting and ending with alphanumeric. We lowercase, replace runs of
+  // non-matching chars with '-', and trim leading/trailing non-alphanum.
+  const lowered = value.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
+  const trimmed = lowered.replace(/^[-]+|[-]+$/g, "");
+  return trimmed || "x";
+}
+
+/**
+ * SandboxProvider that backs each ticket with a namespace-scoped
+ * PersistentVolumeClaim seeded by an init Job that clones the repo at the
+ * requested base. The resulting SandboxRef is remote — only the PodExecutor
+ * (or another K8s-aware executor) can consume it.
+ */
+export class PVCSandboxProvider implements SandboxProvider {
+  private readonly namespace: string;
+  private readonly client: K8sClientLike;
+  private readonly storageClassName: string | undefined;
+  private readonly storageSize: string;
+  private readonly initContainerImage: string;
+  private readonly workdir: string;
+  private readonly initTimeoutMs: number;
+  private readonly initPollIntervalMs: number;
+  private readonly destroyPolicy: "delete" | "retain";
+
+  constructor(options: PVCSandboxProviderOptions) {
+    if (!options.namespace) {
+      throw new Error("PVCSandboxProvider requires a namespace");
+    }
+    if (!options.k8sClient) {
+      throw new Error("PVCSandboxProvider requires a k8sClient");
+    }
+    this.namespace = options.namespace;
+    this.client = options.k8sClient;
+    this.storageClassName = options.storageClassName;
+    this.storageSize = options.storageSize ?? DEFAULT_STORAGE_SIZE;
+    this.initContainerImage = options.initContainerImage ?? DEFAULT_INIT_IMAGE;
+    this.workdir = options.workdir ?? DEFAULT_WORKDIR;
+    this.initTimeoutMs = options.initTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS;
+    this.initPollIntervalMs = options.initPollIntervalMs ?? 2_000;
+    this.destroyPolicy = options.destroyPolicy ?? "delete";
+  }
+
+  async create(
+    repo: RepoRef,
+    base: string,
+    options?: PVCSandboxCreateOptions
+  ): Promise<SandboxRef> {
+    if (!options) {
+      throw new Error("PVCSandboxProvider.create requires { runId, ticketId }");
+    }
+    const runId = requireNonEmpty(options.runId, "runId");
+    const ticketId = requireNonEmpty(options.ticketId, "ticketId");
+    assertSafePathSegment(runId, "runId");
+    assertSafePathSegment(ticketId, "ticketId");
+
+    if (!repo.remoteUrl) {
+      throw new Error(
+        "PVCSandboxProvider.create requires repo.remoteUrl to seed the PVC clone"
+      );
+    }
+
+    const runSlug = slugifyForK8s(runId);
+    const ticketSlug = slugifyForK8s(ticketId);
+    const pvcName = `pvc-${runSlug}-${ticketSlug}`.slice(0, 63);
+    const jobName = `init-${runSlug}-${ticketSlug}`.slice(0, 63);
+
+    await this.ensurePvc(pvcName, runId, ticketId);
+
+    const job = this.buildInitJob(jobName, pvcName, repo.remoteUrl, base, runId, ticketId);
+    await this.client.createJob(this.namespace, job);
+    try {
+      await this.waitForJob(jobName);
+    } finally {
+      // Init jobs are short-lived; we always tear them down even on failure
+      // so the namespace stays tidy. The PVC survives for the executor.
+      await this.client
+        .deleteJob(this.namespace, jobName, { propagationPolicy: "Background" })
+        .catch(() => undefined);
+    }
+
+    const meta: PVCSandboxMeta = {
+      pvcName,
+      namespace: this.namespace,
+      base,
+      runId,
+      ticketId,
+      workdir: this.workdir
+    };
+
+    return {
+      id: pvcName,
+      workdir: {
+        kind: "remote",
+        uri: `pod://${this.namespace}/${pvcName}:${this.workdir}`
+      },
+      meta
+    };
+  }
+
+  async destroy(ref: SandboxRef): Promise<DestroyResult> {
+    if (ref.workdir.kind !== "remote") return { kind: "missing" };
+    const pvcName = ref.meta?.pvcName ?? ref.id;
+    const namespace = ref.meta?.namespace ?? this.namespace;
+    if (this.destroyPolicy === "retain") {
+      return { kind: "preserved", reason: "dirty", stderr: "retain policy" };
+    }
+    const existing = await this.client.readPersistentVolumeClaim(namespace, pvcName);
+    if (!existing) return { kind: "missing" };
+    await this.client.deletePersistentVolumeClaim(namespace, pvcName, {
+      propagationPolicy: "Background"
+    });
+    return { kind: "removed" };
+  }
+
+  private async ensurePvc(
+    pvcName: string,
+    runId: string,
+    ticketId: string
+  ): Promise<void> {
+    const existing = await this.client.readPersistentVolumeClaim(
+      this.namespace,
+      pvcName
+    );
+    if (existing) return;
+    const pvc: K8sPersistentVolumeClaim = {
+      metadata: {
+        name: pvcName,
+        namespace: this.namespace,
+        labels: {
+          "relay.run-id": runId,
+          "relay.ticket-id": ticketId,
+          "relay.role": "sandbox"
+        }
+      },
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        resources: { requests: { storage: this.storageSize } },
+        ...(this.storageClassName ? { storageClassName: this.storageClassName } : {})
+      }
+    };
+    await this.client.createPersistentVolumeClaim(this.namespace, pvc);
+  }
+
+  private buildInitJob(
+    jobName: string,
+    pvcName: string,
+    remoteUrl: string,
+    base: string,
+    runId: string,
+    ticketId: string
+  ): K8sJob {
+    return {
+      metadata: {
+        name: jobName,
+        namespace: this.namespace,
+        labels: {
+          "relay.run-id": runId,
+          "relay.ticket-id": ticketId,
+          "relay.role": "sandbox-init"
+        }
+      },
+      spec: {
+        backoffLimit: 0,
+        ttlSecondsAfterFinished: 60,
+        template: {
+          metadata: {
+            labels: {
+              "relay.run-id": runId,
+              "relay.ticket-id": ticketId,
+              "relay.role": "sandbox-init"
+            }
+          },
+          spec: {
+            restartPolicy: "Never",
+            containers: [
+              {
+                name: "clone",
+                image: this.initContainerImage,
+                command: ["/bin/sh", "-c"],
+                args: [
+                  // Clone the repo into the empty PVC and check out `base`.
+                  // Use a sub-shell trap so the exit code flows out.
+                  `set -euo pipefail; ` +
+                    `cd ${this.workdir}; ` +
+                    `git clone --no-single-branch ${shellEscape(remoteUrl)} . && ` +
+                    `git checkout ${shellEscape(base)}`
+                ],
+                volumeMounts: [{ name: "work", mountPath: this.workdir }]
+              }
+            ],
+            volumes: [
+              {
+                name: "work",
+                persistentVolumeClaim: { claimName: pvcName }
+              }
+            ]
+          }
+        }
+      }
+    };
+  }
+
+  private async waitForJob(jobName: string): Promise<void> {
+    const deadline = Date.now() + this.initTimeoutMs;
+    while (Date.now() < deadline) {
+      const job = await this.client.readJob(this.namespace, jobName);
+      const status = job?.status;
+      if (status?.succeeded && status.succeeded > 0) return;
+      if (status?.failed && status.failed > 0) {
+        const reason = status.conditions?.find((c) => c.type === "Failed")?.message;
+        throw new Error(
+          `Init clone job ${jobName} failed${reason ? `: ${reason}` : ""}`
+        );
+      }
+      await sleep(this.initPollIntervalMs);
+    }
+    throw new Error(
+      `Init clone job ${jobName} did not complete within ${this.initTimeoutMs}ms`
+    );
+  }
+}
+
+function requireNonEmpty(value: string | undefined, kind: string): string {
+  if (!value) throw new Error(`PVCSandboxProvider.create: ${kind} required`);
+  return value;
+}
+
+function shellEscape(value: string): string {
+  // Single-quote wrap and escape embedded quotes. The init job runs via
+  // /bin/sh -c, so this is the safest way to pass opaque ref/url text
+  // without further substitution.
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/execution/pod-executor.integration.test.ts
+++ b/test/execution/pod-executor.integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+
+import { createDefaultK8sClient } from "../../src/execution/k8s-client.js";
+import { PodExecutor } from "../../src/execution/pod-executor.js";
+import { PVCSandboxProvider } from "../../src/execution/sandboxes/pvc-sandbox.js";
+
+const kubeconfig = process.env.RELAY_TEST_K8S_KUBECONFIG;
+const namespace = process.env.RELAY_TEST_K8S_NAMESPACE ?? "default";
+const workerImage = process.env.RELAY_TEST_WORKER_IMAGE ?? "busybox:1.36";
+
+const describeOrSkip = kubeconfig ? describe : describe.skip;
+
+describeOrSkip("PodExecutor integration (real cluster)", () => {
+  it("runs a trivial worker Job and reports success", async () => {
+    const client = await createDefaultK8sClient({ kubeconfig });
+    const sandboxes = new PVCSandboxProvider({
+      namespace,
+      k8sClient: client,
+      storageSize: "256Mi",
+      initContainerImage: "alpine/git:latest",
+      initTimeoutMs: 120_000,
+      initPollIntervalMs: 2_000
+    });
+    const executor = new PodExecutor({
+      sandboxProvider: sandboxes,
+      k8sClient: client,
+      namespace,
+      workerImage,
+      pollIntervalMs: 2_000,
+      postKillWatchdogMs: 10_000
+    });
+
+    const ticket = {
+      id: "integ",
+      title: "integration smoke",
+      objective: "echo hello",
+      specialty: "general" as const,
+      acceptanceCriteria: ["echoes hello"],
+      allowedCommands: [],
+      verificationCommands: [],
+      docsToUpdate: [],
+      dependsOn: [],
+      retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+    };
+
+    const sandbox = await sandboxes.create(
+      { root: "/tmp", remoteUrl: "https://github.com/jcast90/agent-harness.git" },
+      "main",
+      { runId: "it1", ticketId: "integ" }
+    );
+
+    try {
+      const handle = await executor.start(ticket, {
+        runId: "it1",
+        repoRoot: "/tmp",
+        sandbox
+      });
+      const result = await handle.wait();
+      expect(result.exitCode).toBeTypeOf("number");
+    } finally {
+      await sandboxes.destroy(sandbox).catch(() => undefined);
+    }
+  }, 10 * 60_000);
+});

--- a/test/execution/pod-executor.test.ts
+++ b/test/execution/pod-executor.test.ts
@@ -1,0 +1,410 @@
+import type { Writable } from "node:stream";
+import { describe, expect, it, beforeEach } from "vitest";
+
+import type { TicketDefinition } from "../../src/domain/ticket.js";
+import type { ExecutionEvent } from "../../src/execution/executor.js";
+import type {
+  K8sClientLike,
+  K8sJob,
+  K8sPersistentVolumeClaim,
+  K8sPod
+} from "../../src/execution/k8s-client.js";
+import { PodExecutor } from "../../src/execution/pod-executor.js";
+import { PVCSandboxProvider } from "../../src/execution/sandboxes/pvc-sandbox.js";
+import type { SandboxRef } from "../../src/execution/sandbox.js";
+
+function makeTicket(partial: Partial<TicketDefinition> = {}): TicketDefinition {
+  return {
+    id: partial.id ?? "T-pod",
+    title: partial.title ?? "Pod test",
+    objective: partial.objective ?? "Run in a pod",
+    specialty: partial.specialty ?? "general",
+    acceptanceCriteria: partial.acceptanceCriteria ?? ["pod exits 0"],
+    allowedCommands: partial.allowedCommands ?? [],
+    verificationCommands: partial.verificationCommands ?? [],
+    docsToUpdate: partial.docsToUpdate ?? [],
+    dependsOn: partial.dependsOn ?? [],
+    retryPolicy: partial.retryPolicy ?? { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+  };
+}
+
+interface JobRecord {
+  job: K8sJob;
+  succeeded: number;
+  failed: number;
+  terminatedExitCode?: number;
+}
+
+class FakeK8sClient implements K8sClientLike {
+  readonly pvcs = new Map<string, K8sPersistentVolumeClaim>();
+  readonly jobs = new Map<string, JobRecord>();
+  readonly podsForJob = new Map<string, K8sPod[]>();
+  public jobCreates: K8sJob[] = [];
+  public jobDeletes: string[] = [];
+  public podDeletes: string[] = [];
+  public logReads: Array<{ name: string; since?: number }> = [];
+  public logStreamCalls = 0;
+  public logsByPod = new Map<string, string>();
+  public enableStreaming = false;
+
+  async createPersistentVolumeClaim(_ns: string, pvc: K8sPersistentVolumeClaim) {
+    this.pvcs.set(pvc.metadata?.name ?? "", pvc);
+    return pvc;
+  }
+  async readPersistentVolumeClaim(_ns: string, name: string) {
+    return this.pvcs.get(name) ?? null;
+  }
+  async deletePersistentVolumeClaim(_ns: string, name: string) {
+    this.pvcs.delete(name);
+  }
+  async createJob(_ns: string, job: K8sJob): Promise<K8sJob> {
+    const name = job.metadata?.name ?? "";
+    this.jobCreates.push(job);
+    this.jobs.set(name, { job, succeeded: 0, failed: 0 });
+    return job;
+  }
+  async readJob(_ns: string, name: string): Promise<K8sJob | null> {
+    const rec = this.jobs.get(name);
+    if (!rec) return null;
+    return {
+      ...rec.job,
+      status: {
+        succeeded: rec.succeeded,
+        failed: rec.failed
+      }
+    };
+  }
+  async deleteJob(_ns: string, name: string) {
+    this.jobDeletes.push(name);
+    this.jobs.delete(name);
+  }
+  async listPodsForJob(_ns: string, jobName: string): Promise<K8sPod[]> {
+    return this.podsForJob.get(jobName) ?? [];
+  }
+  async deletePod(_ns: string, name: string) {
+    this.podDeletes.push(name);
+  }
+  async readPodLog(
+    _ns: string,
+    podName: string,
+    opts?: { sinceSeconds?: number }
+  ): Promise<string> {
+    this.logReads.push({ name: podName, since: opts?.sinceSeconds });
+    return this.logsByPod.get(podName) ?? "";
+  }
+  // Optional — only present when streaming is enabled
+  streamPodLog?(
+    _ns: string,
+    podName: string,
+    stream: Writable
+  ): Promise<AbortController> {
+    if (!this.enableStreaming) throw new Error("streaming disabled");
+    this.logStreamCalls += 1;
+    const controller = new AbortController();
+    const chunk = this.logsByPod.get(podName) ?? "";
+    if (chunk) setImmediate(() => stream.write(chunk));
+    return Promise.resolve(controller);
+  }
+}
+
+function makeStreamCapableClient(): FakeK8sClient {
+  const c = new FakeK8sClient();
+  c.enableStreaming = true;
+  return c;
+}
+
+function makeNonStreamingClient(): FakeK8sClient {
+  const c = new FakeK8sClient();
+  // Remove the streamPodLog method to simulate a client that doesn't implement it.
+  delete (c as Partial<K8sClientLike>).streamPodLog;
+  return c;
+}
+
+async function createSandbox(
+  client: FakeK8sClient,
+  runId: string,
+  ticketId: string
+): Promise<SandboxRef> {
+  const provider = new PVCSandboxProvider({
+    namespace: "relay-test",
+    k8sClient: client,
+    initPollIntervalMs: 1,
+    initTimeoutMs: 1_000
+  });
+  // Pre-mark job success so PVC init returns immediately.
+  const originalCreateJob = client.createJob.bind(client);
+  client.createJob = async (ns, job) => {
+    const res = await originalCreateJob(ns, job);
+    const name = job.metadata?.name ?? "";
+    const rec = client.jobs.get(name);
+    if (rec) rec.succeeded = 1;
+    return res;
+  };
+  const ref = await provider.create(
+    { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+    "main",
+    { runId, ticketId }
+  );
+  // Reset for executor flow. Clear init-job bookkeeping so tests that
+  // inspect `client.jobCreates[0]` see only the worker Job the executor
+  // is about to produce.
+  client.createJob = originalCreateJob;
+  client.jobCreates = [];
+  client.jobDeletes = [];
+  return ref;
+}
+
+async function collect(
+  stream: AsyncIterable<ExecutionEvent>,
+  limit = 10
+): Promise<ExecutionEvent[]> {
+  const out: ExecutionEvent[] = [];
+  for await (const ev of stream) {
+    out.push(ev);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+describe("PodExecutor", () => {
+  let client: FakeK8sClient;
+  let provider: PVCSandboxProvider;
+  let executor: PodExecutor;
+  let sandbox: SandboxRef;
+
+  beforeEach(async () => {
+    client = makeStreamCapableClient();
+    sandbox = await createSandbox(client, "r", "T1");
+    provider = new PVCSandboxProvider({
+      namespace: "relay-test",
+      k8sClient: client
+    });
+    executor = new PodExecutor({
+      sandboxProvider: provider,
+      k8sClient: client,
+      namespace: "relay-test",
+      workerImage: "ghcr.io/example/worker:latest",
+      pollIntervalMs: 5,
+      postKillWatchdogMs: 50
+    });
+  });
+
+  it("creates a Job referencing the PVC and mounting at the parsed workdir", async () => {
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    expect(client.jobCreates).toHaveLength(1);
+    const job = client.jobCreates[0];
+    const template = job.spec as {
+      template: {
+        spec: {
+          containers: Array<{
+            image: string;
+            workingDir: string;
+            env: Array<{ name: string; value: string }>;
+            volumeMounts: Array<{ name: string; mountPath: string }>;
+          }>;
+          volumes: Array<{ persistentVolumeClaim?: { claimName: string } }>;
+        };
+      };
+    };
+    expect(template.template.spec.containers[0].image).toBe(
+      "ghcr.io/example/worker:latest"
+    );
+    expect(template.template.spec.containers[0].workingDir).toBe("/work");
+    expect(template.template.spec.containers[0].volumeMounts[0].mountPath).toBe(
+      "/work"
+    );
+    expect(template.template.spec.volumes[0].persistentVolumeClaim?.claimName).toBe(
+      "pvc-r-t1"
+    );
+    const envByName = Object.fromEntries(
+      template.template.spec.containers[0].env.map((e) => [e.name, e.value])
+    );
+    expect(envByName.RELAY_RUN_ID).toBe("r");
+    expect(envByName.RELAY_TICKET_ID).toBe("T1");
+    expect(JSON.parse(envByName.RELAY_WORK_REQUEST)).toMatchObject({
+      runId: "r",
+      ticketId: "T1",
+      title: "Pod test"
+    });
+    // kill the handle to release its internal timers
+    await handle.kill();
+  });
+
+  it("wait() resolves with exitCode 0 once the Job reports success", async () => {
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [
+      {
+        metadata: { name: `${jobName}-pod` },
+        status: {
+          containerStatuses: [
+            { name: "worker", state: { terminated: { exitCode: 0 } } }
+          ]
+        }
+      }
+    ]);
+    client.logsByPod.set(`${jobName}-pod`, "hello from pod\n");
+    // Flip succeeded shortly after start
+    setTimeout(() => {
+      const rec = client.jobs.get(jobName)!;
+      rec.succeeded = 1;
+    }, 10);
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello from pod");
+    expect(handle.status).toBe("exited");
+  });
+
+  it("wait() resolves with the terminated container exitCode on Job failure", async () => {
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [
+      {
+        metadata: { name: `${jobName}-pod` },
+        status: {
+          containerStatuses: [
+            { name: "worker", state: { terminated: { exitCode: 42 } } }
+          ]
+        }
+      }
+    ]);
+    setTimeout(() => {
+      const rec = client.jobs.get(jobName)!;
+      rec.failed = 1;
+    }, 10);
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(42);
+  });
+
+  it("kill() deletes the Pod and the Job, and wait resolves as killed", async () => {
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [
+      { metadata: { name: `${jobName}-pod` } }
+    ]);
+    await handle.kill();
+    const result = await handle.wait();
+    expect(client.jobDeletes).toContain(jobName);
+    expect(client.podDeletes).toContain(`${jobName}-pod`);
+    expect(result.exitCode).toBe(137);
+    expect(handle.status).toBe("killed");
+  });
+
+  it("stream() yields stdout chunks from the streaming client", async () => {
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [
+      {
+        metadata: { name: `${jobName}-pod` },
+        status: {
+          containerStatuses: [
+            { name: "worker", state: { terminated: { exitCode: 0 } } }
+          ]
+        }
+      }
+    ]);
+    client.logsByPod.set(`${jobName}-pod`, "chunk-A\nchunk-B\n");
+    setTimeout(() => {
+      const rec = client.jobs.get(jobName)!;
+      rec.succeeded = 1;
+    }, 15);
+    // Fire wait() so the executor's poll loop drives state transitions; the
+    // stream subscribes to events it emits.
+    const waitPromise = handle.wait();
+    const events = await collect(handle.stream(), 20);
+    await waitPromise;
+    const stdoutEvents = events.filter((e) => e.kind === "stdout");
+    // Either the streaming hook or a post-exit drain should produce stdout.
+    const concatenated = stdoutEvents.map((e) => String(e.data)).join("");
+    expect(concatenated.length === 0 || concatenated.includes("chunk-A")).toBe(true);
+    expect(events.some((e) => e.kind === "start")).toBe(true);
+    expect(events.some((e) => e.kind === "exit")).toBe(true);
+  });
+
+  it("falls back to polling logs when streamPodLog isn't implemented", async () => {
+    const noStreamClient = makeNonStreamingClient();
+    const sb = await createSandbox(noStreamClient, "r2", "T2");
+    const exec2 = new PodExecutor({
+      sandboxProvider: new PVCSandboxProvider({
+        namespace: "relay-test",
+        k8sClient: noStreamClient
+      }),
+      k8sClient: noStreamClient,
+      namespace: "relay-test",
+      workerImage: "ghcr.io/example/worker:latest",
+      pollIntervalMs: 5,
+      postKillWatchdogMs: 50
+    });
+    const handle = await exec2.start(makeTicket({ id: "T2" }), {
+      runId: "r2",
+      repoRoot: "/tmp/fake",
+      sandbox: sb
+    });
+    const jobName = noStreamClient.jobCreates[0].metadata?.name!;
+    noStreamClient.podsForJob.set(jobName, [
+      {
+        metadata: { name: `${jobName}-pod` },
+        status: {
+          containerStatuses: [
+            { name: "worker", state: { terminated: { exitCode: 0 } } }
+          ]
+        }
+      }
+    ]);
+    noStreamClient.logsByPod.set(`${jobName}-pod`, "polled-line\n");
+    setTimeout(() => {
+      const rec = noStreamClient.jobs.get(jobName)!;
+      rec.succeeded = 1;
+    }, 10);
+    const result = await handle.wait();
+    expect(noStreamClient.logReads.length).toBeGreaterThanOrEqual(1);
+    expect(result.stdout).toContain("polled-line");
+  });
+
+  it("requires a remote sandbox in the matching namespace", async () => {
+    const otherSandbox: SandboxRef = {
+      id: "x",
+      workdir: { kind: "remote", uri: "pod://other-ns/x:/work" },
+      meta: { pvcName: "x", namespace: "other-ns" }
+    };
+    await expect(
+      executor.start(makeTicket({ id: "T1" }), {
+        runId: "r",
+        repoRoot: "/tmp/fake",
+        sandbox: otherSandbox
+      })
+    ).rejects.toThrow(/namespace/);
+
+    const localSandbox: SandboxRef = {
+      id: "y",
+      workdir: { kind: "local", path: "/tmp/fake" }
+    };
+    await expect(
+      executor.start(makeTicket({ id: "T1" }), {
+        runId: "r",
+        repoRoot: "/tmp/fake",
+        sandbox: localSandbox
+      })
+    ).rejects.toThrow(/remote/);
+  });
+});

--- a/test/execution/pod-executor.test.ts
+++ b/test/execution/pod-executor.test.ts
@@ -334,9 +334,12 @@ describe("PodExecutor", () => {
     const events = await collect(handle.stream(), 20);
     await waitPromise;
     const stdoutEvents = events.filter((e) => e.kind === "stdout");
-    // Either the streaming hook or a post-exit drain should produce stdout.
+    // Deterministic assertion: the streaming hook writes the configured
+    // chunk synchronously (via setImmediate), so at least one stdout event
+    // MUST be observed and MUST include the seeded chunk.
+    expect(stdoutEvents.length).toBeGreaterThan(0);
     const concatenated = stdoutEvents.map((e) => String(e.data)).join("");
-    expect(concatenated.length === 0 || concatenated.includes("chunk-A")).toBe(true);
+    expect(concatenated).toContain("chunk-A");
     expect(events.some((e) => e.kind === "start")).toBe(true);
     expect(events.some((e) => e.kind === "exit")).toBe(true);
   });
@@ -379,6 +382,234 @@ describe("PodExecutor", () => {
     const result = await handle.wait();
     expect(noStreamClient.logReads.length).toBeGreaterThanOrEqual(1);
     expect(result.stdout).toContain("polled-line");
+  });
+
+  it("kill() after wait() resolves is a no-op (idempotent)", async () => {
+    // Parity with LocalChildProcessExecutor contract: kill() after exit is
+    // a no-op and must not tear down an already-cleaned resource a second
+    // time. We prove it by counting deleteJob calls.
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [
+      {
+        metadata: { name: `${jobName}-pod` },
+        status: {
+          containerStatuses: [
+            { name: "worker", state: { terminated: { exitCode: 0 } } }
+          ]
+        }
+      }
+    ]);
+    setTimeout(() => {
+      const rec = client.jobs.get(jobName)!;
+      rec.succeeded = 1;
+    }, 5);
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(0);
+    const jobDeletesBefore = client.jobDeletes.length;
+    const podDeletesBefore = client.podDeletes.length;
+    await handle.kill();
+    expect(client.jobDeletes).toHaveLength(jobDeletesBefore);
+    expect(client.podDeletes).toHaveLength(podDeletesBefore);
+    expect(handle.status).toBe("exited");
+  });
+
+  it("double kill() is a no-op on the second call", async () => {
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [{ metadata: { name: `${jobName}-pod` } }]);
+    await handle.kill();
+    const jobDeletesAfterFirst = client.jobDeletes.length;
+    const podDeletesAfterFirst = client.podDeletes.length;
+    await handle.kill();
+    // Second kill must NOT re-issue API calls.
+    expect(client.jobDeletes).toHaveLength(jobDeletesAfterFirst);
+    expect(client.podDeletes).toHaveLength(podDeletesAfterFirst);
+    await handle.wait();
+    expect(handle.status).toBe("killed");
+  });
+
+  it("post-kill watchdog synthesizes exit 137 when the Job never flips", async () => {
+    // Fake never marks the job as failed/succeeded after deleteJob. The
+    // watchdog must fire within postKillWatchdogMs and finalize the handle
+    // with exit 137 and reason "killed but never exited".
+    const stuckClient = makeStreamCapableClient();
+    // Override deleteJob so the Job record stays put and readJob keeps
+    // returning running status. This simulates a wedged kubelet/api where
+    // the Job stays "active" indefinitely.
+    stuckClient.deleteJob = async (_ns: string, name: string) => {
+      stuckClient.jobDeletes.push(name);
+      // Deliberately DO NOT delete from `stuckClient.jobs` so readJob still returns running.
+    };
+    const sb = await createSandbox(stuckClient, "rr", "TW");
+    const exec2 = new PodExecutor({
+      sandboxProvider: new PVCSandboxProvider({
+        namespace: "relay-test",
+        k8sClient: stuckClient
+      }),
+      k8sClient: stuckClient,
+      namespace: "relay-test",
+      workerImage: "ghcr.io/example/worker:latest",
+      pollIntervalMs: 5,
+      postKillWatchdogMs: 30
+    });
+    const handle = await exec2.start(makeTicket({ id: "TW" }), {
+      runId: "rr",
+      repoRoot: "/tmp/fake",
+      sandbox: sb
+    });
+    const jobName = stuckClient.jobCreates[0].metadata?.name!;
+    stuckClient.podsForJob.set(jobName, [{ metadata: { name: `${jobName}-pod` } }]);
+    await handle.kill();
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(137);
+    expect(result.summary).toContain("killed but never exited");
+  });
+
+  it("initTimeoutMs exceeded causes sandbox create() to reject", async () => {
+    // The init job never reports succeeded/failed; the provider must give
+    // up after initTimeoutMs and surface a timeout error.
+    const slowClient = new FakeK8sClient();
+    // Do not flip succeeded. Default FakeK8sClient leaves both at 0.
+    const slow = new PVCSandboxProvider({
+      namespace: "relay-test",
+      k8sClient: slowClient,
+      initPollIntervalMs: 2,
+      initTimeoutMs: 15
+    });
+    await expect(
+      slow.create(
+        { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+        "main",
+        { runId: "slow", ticketId: "T" }
+      )
+    ).rejects.toThrow(/did not complete within/);
+  });
+
+  it("slug collision: two creates with ids that slugify the same throw label-mismatch", async () => {
+    // "MY_RUN" lowercases to "my_run", then `_` collapses to `-` → "my-run".
+    // "my-run" slugifies to itself. Both produce pvc-my-run-t1, but the
+    // labels (preserved via sanitizeK8sLabelValue, which keeps `_`) differ.
+    // The second create() must refuse rather than silently reuse a foreign
+    // run's volume.
+    const collideClient = new FakeK8sClient();
+    const provider = new PVCSandboxProvider({
+      namespace: "relay-test",
+      k8sClient: collideClient,
+      initPollIntervalMs: 1,
+      initTimeoutMs: 1_000
+    });
+    // Auto-succeed init jobs so create() doesn't hang on the first call.
+    const originalCreate = collideClient.createJob.bind(collideClient);
+    collideClient.createJob = async (ns, job) => {
+      const res = await originalCreate(ns, job);
+      const name = job.metadata?.name ?? "";
+      const rec = collideClient.jobs.get(name);
+      if (rec) rec.succeeded = 1;
+      return res;
+    };
+    await provider.create(
+      { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+      "main",
+      { runId: "MY_RUN", ticketId: "T1" }
+    );
+    await expect(
+      provider.create(
+        { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+        "main",
+        { runId: "my-run", ticketId: "T1" }
+      )
+    ).rejects.toThrow(/already exists with labels/);
+  });
+
+  it("readJob transient failures are retried up to maxConsecutivePollFailures", async () => {
+    // Three transient failures then success: wait() must still resolve.
+    const handle = await executor.start(makeTicket({ id: "T1" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox
+    });
+    const jobName = client.jobCreates[0].metadata?.name!;
+    client.podsForJob.set(jobName, [
+      {
+        metadata: { name: `${jobName}-pod` },
+        status: {
+          containerStatuses: [
+            { name: "worker", state: { terminated: { exitCode: 0 } } }
+          ]
+        }
+      }
+    ]);
+    let calls = 0;
+    const realReadJob = client.readJob.bind(client);
+    client.readJob = async (ns, name) => {
+      calls += 1;
+      if (calls <= 3) throw new Error(`simulated transient 5xx #${calls}`);
+      return realReadJob(ns, name);
+    };
+    setTimeout(() => {
+      const rec = client.jobs.get(jobName)!;
+      rec.succeeded = 1;
+    }, 20);
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(0);
+    expect(calls).toBeGreaterThan(3);
+  });
+
+  it("readJob persistent failures finalize with an API-unavailable error", async () => {
+    const sb2 = await createSandbox(client, "r", "TX");
+    const exec2 = new PodExecutor({
+      sandboxProvider: new PVCSandboxProvider({
+        namespace: "relay-test",
+        k8sClient: client
+      }),
+      k8sClient: client,
+      namespace: "relay-test",
+      workerImage: "ghcr.io/example/worker:latest",
+      pollIntervalMs: 2,
+      postKillWatchdogMs: 50,
+      maxConsecutivePollFailures: 3
+    });
+    const handle = await exec2.start(makeTicket({ id: "TX" }), {
+      runId: "r",
+      repoRoot: "/tmp/fake",
+      sandbox: sb2
+    });
+    // Force readJob to fail forever.
+    client.readJob = async () => {
+      throw new Error("simulated persistent API down");
+    };
+    const result = await handle.wait();
+    expect(result.summary).toMatch(/K8s API unavailable after 3 retries/);
+    expect(result.stderr).toMatch(/K8s API unavailable after 3 retries/);
+  });
+
+  it("surfaces an actionable error when the k8s client module fails to load", async () => {
+    // `wrapK8sLoader` is the exported helper that wraps the dynamic import
+    // in `createDefaultK8sClient`. Feeding it a rejecting loader simulates
+    // the real `ERR_MODULE_NOT_FOUND` shape an operator sees when they run
+    // `HARNESS_EXECUTOR=pod` without installing `@kubernetes/client-node`.
+    const { wrapK8sLoader } = await import("../../src/execution/k8s-client.js");
+    const brokenLoader = () =>
+      Promise.reject(
+        Object.assign(new Error("Cannot find package '@kubernetes/client-node'"), {
+          code: "ERR_MODULE_NOT_FOUND"
+        })
+      );
+    await expect(wrapK8sLoader(brokenLoader)).rejects.toThrow(
+      /@kubernetes\/client-node is required for HARNESS_EXECUTOR=pod/
+    );
+    await expect(wrapK8sLoader(brokenLoader)).rejects.toThrow(
+      /pnpm add @kubernetes\/client-node/
+    );
   });
 
   it("requires a remote sandbox in the matching namespace", async () => {

--- a/test/execution/pvc-sandbox.test.ts
+++ b/test/execution/pvc-sandbox.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import type {
+  K8sClientLike,
+  K8sJob,
+  K8sPersistentVolumeClaim,
+  K8sPod
+} from "../../src/execution/k8s-client.js";
+import { PVCSandboxProvider } from "../../src/execution/sandboxes/pvc-sandbox.js";
+
+interface JobState {
+  job: K8sJob;
+  succeeded: boolean;
+  failed: boolean;
+  failureMessage?: string;
+}
+
+class FakeK8sClient implements K8sClientLike {
+  readonly pvcs = new Map<string, K8sPersistentVolumeClaim>();
+  readonly jobs = new Map<string, JobState>();
+  public jobCreates: K8sJob[] = [];
+  public pvcCreates: K8sPersistentVolumeClaim[] = [];
+  public pvcDeletes: string[] = [];
+  public jobDeletes: string[] = [];
+  public autoSucceed = true;
+
+  async createPersistentVolumeClaim(
+    _ns: string,
+    pvc: K8sPersistentVolumeClaim
+  ): Promise<K8sPersistentVolumeClaim> {
+    const name = pvc.metadata?.name ?? "";
+    this.pvcs.set(name, pvc);
+    this.pvcCreates.push(pvc);
+    return pvc;
+  }
+  async readPersistentVolumeClaim(_ns: string, name: string) {
+    return this.pvcs.get(name) ?? null;
+  }
+  async deletePersistentVolumeClaim(_ns: string, name: string) {
+    this.pvcs.delete(name);
+    this.pvcDeletes.push(name);
+  }
+  async createJob(_ns: string, job: K8sJob): Promise<K8sJob> {
+    const name = job.metadata?.name ?? "";
+    this.jobCreates.push(job);
+    this.jobs.set(name, {
+      job,
+      succeeded: this.autoSucceed,
+      failed: !this.autoSucceed
+    });
+    return job;
+  }
+  async readJob(_ns: string, name: string): Promise<K8sJob | null> {
+    const state = this.jobs.get(name);
+    if (!state) return null;
+    return {
+      ...state.job,
+      status: {
+        succeeded: state.succeeded ? 1 : 0,
+        failed: state.failed ? 1 : 0,
+        conditions: state.failed
+          ? [{ type: "Failed", status: "True", message: state.failureMessage }]
+          : undefined
+      }
+    };
+  }
+  async deleteJob(_ns: string, name: string) {
+    this.jobs.delete(name);
+    this.jobDeletes.push(name);
+  }
+  async listPodsForJob(_ns: string, _jobName: string): Promise<K8sPod[]> {
+    return [];
+  }
+  async deletePod() {
+    // noop
+  }
+  async readPodLog() {
+    return "";
+  }
+}
+
+describe("PVCSandboxProvider", () => {
+  let client: FakeK8sClient;
+  let provider: PVCSandboxProvider;
+
+  beforeEach(() => {
+    client = new FakeK8sClient();
+    provider = new PVCSandboxProvider({
+      namespace: "relay-test",
+      k8sClient: client,
+      storageClassName: "fast-ssd",
+      storageSize: "2Gi",
+      initPollIntervalMs: 1,
+      initTimeoutMs: 1_000
+    });
+  });
+
+  it("creates a PVC with the expected spec and an init job, then waits for success", async () => {
+    const ref = await provider.create(
+      { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+      "main",
+      { runId: "r1", ticketId: "t1" }
+    );
+
+    expect(ref.id).toBe("pvc-r1-t1");
+    expect(ref.workdir.kind).toBe("remote");
+    expect(ref.workdir.kind === "remote" && ref.workdir.uri).toBe(
+      "pod://relay-test/pvc-r1-t1:/work"
+    );
+    expect(ref.meta?.pvcName).toBe("pvc-r1-t1");
+    expect(ref.meta?.namespace).toBe("relay-test");
+    expect(ref.meta?.base).toBe("main");
+
+    expect(client.pvcCreates).toHaveLength(1);
+    const pvc = client.pvcCreates[0];
+    expect(pvc.metadata?.name).toBe("pvc-r1-t1");
+    expect(pvc.metadata?.labels?.["relay.run-id"]).toBe("r1");
+    const pvcSpec = pvc.spec as { resources?: { requests?: { storage?: string } }; storageClassName?: string; accessModes?: string[] };
+    expect(pvcSpec.resources?.requests?.storage).toBe("2Gi");
+    expect(pvcSpec.storageClassName).toBe("fast-ssd");
+    expect(pvcSpec.accessModes).toEqual(["ReadWriteOnce"]);
+
+    expect(client.jobCreates).toHaveLength(1);
+    const job = client.jobCreates[0];
+    expect(job.metadata?.name).toBe("init-r1-t1");
+    const template = (job.spec as { template: { spec: { containers: Array<{ args: string[]; volumeMounts: Array<{ name: string; mountPath: string }> }>; volumes: Array<{ persistentVolumeClaim?: { claimName: string } }> } } }).template;
+    expect(template.spec.containers[0].args[0]).toContain("git clone");
+    expect(template.spec.containers[0].args[0]).toContain("'https://example.com/repo.git'");
+    expect(template.spec.containers[0].args[0]).toContain("git checkout 'main'");
+    expect(template.spec.containers[0].volumeMounts[0]).toEqual({
+      name: "work",
+      mountPath: "/work"
+    });
+    expect(template.spec.volumes[0].persistentVolumeClaim?.claimName).toBe("pvc-r1-t1");
+
+    // Init job is cleaned up after success.
+    expect(client.jobDeletes).toContain("init-r1-t1");
+  });
+
+  it("reuses an existing PVC (idempotent create)", async () => {
+    await provider.create(
+      { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+      "main",
+      { runId: "r2", ticketId: "t2" }
+    );
+    await provider.create(
+      { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+      "main",
+      { runId: "r2", ticketId: "t2" }
+    );
+    expect(client.pvcCreates).toHaveLength(1);
+    expect(client.jobCreates).toHaveLength(2);
+  });
+
+  it("throws when init job fails and still cleans up the job", async () => {
+    client.autoSucceed = false;
+    await expect(
+      provider.create(
+        { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+        "main",
+        { runId: "r3", ticketId: "t3" }
+      )
+    ).rejects.toThrow(/Init clone job/);
+    expect(client.jobDeletes).toContain("init-r3-t3");
+  });
+
+  it("rejects unsafe runId/ticketId (K8s DNS-1123 and path traversal)", async () => {
+    await expect(
+      provider.create(
+        { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+        "main",
+        { runId: "bad/run", ticketId: "t" }
+      )
+    ).rejects.toThrow(/Unsafe/);
+    await expect(
+      provider.create(
+        { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+        "main",
+        { runId: "r", ticketId: ".." }
+      )
+    ).rejects.toThrow(/Unsafe/);
+  });
+
+  it("requires remoteUrl to seed the clone", async () => {
+    await expect(
+      provider.create({ root: "/tmp/fake" }, "main", {
+        runId: "r4",
+        ticketId: "t4"
+      })
+    ).rejects.toThrow(/remoteUrl/);
+  });
+
+  it("destroy deletes the PVC and is idempotent for missing refs", async () => {
+    const ref = await provider.create(
+      { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+      "main",
+      { runId: "r5", ticketId: "t5" }
+    );
+    const res1 = await provider.destroy(ref);
+    expect(res1.kind).toBe("removed");
+    expect(client.pvcDeletes).toContain("pvc-r5-t5");
+    const res2 = await provider.destroy(ref);
+    expect(res2.kind).toBe("missing");
+  });
+
+  it("destroy with retain policy preserves the PVC", async () => {
+    const retainClient = new FakeK8sClient();
+    const retain = new PVCSandboxProvider({
+      namespace: "relay-test",
+      k8sClient: retainClient,
+      destroyPolicy: "retain",
+      initPollIntervalMs: 1
+    });
+    const ref = await retain.create(
+      { root: "/tmp/fake", remoteUrl: "https://example.com/repo.git" },
+      "main",
+      { runId: "r6", ticketId: "t6" }
+    );
+    const res = await retain.destroy(ref);
+    expect(res.kind).toBe("preserved");
+    expect(retainClient.pvcDeletes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the cloud-pod critical path with three new building blocks that compose on top of the existing AgentExecutor / SandboxProvider seams (T-201, T-202):

- **PVCSandboxProvider** (`src/execution/sandboxes/pvc-sandbox.ts`) — creates or reuses a namespace-scoped PersistentVolumeClaim and seeds it via a short-lived init `Job` that runs `git clone` + `git checkout`. Returns a remote `SandboxRef` with a `pod://<ns>/<pvc>:<path>` URI that the executor consumes.
- **PodExecutor** (`src/execution/pod-executor.ts`) — implements `AgentExecutor` by creating a worker `Job` that mounts the PVC at the sandbox workdir and invokes the operator-supplied `workerImage` with `RELAY_RUN_ID` / `RELAY_TICKET_ID` / `RELAY_WORK_REQUEST` injected as env vars.
- **K8sClientLike** (`src/execution/k8s-client.ts`) — narrow wrapper over `@kubernetes/client-node` covering only the surface the above need (PVC/Job CRUD, pod listing, log read + stream). The default impl lazy-imports the SDK so unit tests that inject a fake never pull in the real transport.

## Design decisions

- **Job vs. Pod.** Both sandbox init and worker runs use `Job` (not raw `Pod`), with `restartPolicy: Never`, `backoffLimit: 0`, and `ttlSecondsAfterFinished` set so the control-plane GCs stale objects without our bookkeeping. The executor also explicitly deletes the Job on `kill()` with `propagationPolicy: Background`.
- **Init container vs. exec into the worker.** Cloning is done in the init `Job`, not as an `initContainer` on the worker pod, so the worker image is free of tooling requirements (doesn't need git). Side effect: the init Job is tiny and disposable.
- **Polling vs. informer.** `wait()` polls `readJob` on a configurable cadence (default 3s). Informers would add complexity and a long-lived watch connection; polling is straightforward, cache-friendly, and the executor rarely has more than a handful of concurrent runs.
- **wait() semantics.** When the Job reports `succeeded > 0` or `failed > 0`, the executor drains pod logs, reads the terminated container's `exitCode` on failure, and resolves `wait()` with `{ exitCode, summary, stdout, stderr }`. On `kill()` there's a post-kill watchdog mirroring `LocalChildProcessExecutor` so `wait()` can never hang if the control-plane is slow to report the delete.
- **stream() mapping.** When the client exposes `streamPodLog`, the executor pipes log data into the event bus via `PassThrough`. When it doesn't (fakes, or the real client errors), it falls back to polling `readPodLog` with a forward-moving `sinceSeconds` so chunks don't replay. Start and exit events are synthetic and cached, matching the `LocalChildProcessExecutor` contract.
- **Name slugging.** Ticket IDs like `T-403` aren't valid DNS-1123 labels. The provider slugifies run/ticket segments (lowercase, `-` runs) while separately guarding against path-traversal before slugging.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 299 passing, 22 skipped (integration suite gated behind `RELAY_TEST_K8S_KUBECONFIG`). +7 new tests.
- [ ] Integration test against a real kind cluster. NOT run in this PR — reviewer can exercise it via `export RELAY_TEST_K8S_KUBECONFIG=$(kind get kubeconfig --name relay-t403)` and rerun `pnpm test`.

## Explicit deferral

Wiring `HARNESS_EXECUTOR=pod` into the orchestrator-v2 composition root is out of scope. `src/execution/pod-executor.ts` carries a short note at the top flagging this; the follow-up PR will add the env-driven selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)