### PR TITLE
T-103: Migrate LocalArtifactStore to HarnessStore primitives

### DIFF
--- a/scripts/seed-plan-tickets.ts
+++ b/scripts/seed-plan-tickets.ts
@@ -16,6 +16,7 @@
 
 import { ChannelStore } from "../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { getHarnessStore } from "../src/storage/factory.js";
 import type { HarnessRun } from "../src/domain/run.js";
 import type { TicketDefinition } from "../src/domain/ticket.js";
 import { initializeTicketLedger } from "../src/domain/ticket.js";
@@ -423,7 +424,7 @@ async function main(): Promise<void> {
   const workspace =
     (await resolveWorkspaceForRepo(REPO)) ?? (await registerWorkspace(REPO));
   const artifactsDir = join(getWorkspaceDir(workspace.workspaceId), "artifacts");
-  const artifactStore = new LocalArtifactStore(artifactsDir);
+  const artifactStore = new LocalArtifactStore(artifactsDir, getHarnessStore());
 
   const runId = buildRunId();
   const now = new Date().toISOString();

--- a/src/execution/artifact-store.ts
+++ b/src/execution/artifact-store.ts
@@ -14,6 +14,9 @@ import type {
   RunEvent,
   RunIndexEntry
 } from "../domain/run.js";
+import { buildHarnessStore } from "../storage/factory.js";
+import { STORE_NS } from "../storage/namespaces.js";
+import type { HarnessStore } from "../storage/store.js";
 
 export interface SaveCommandArtifactInput {
   runId: string;
@@ -92,50 +95,135 @@ export interface ArtifactStore {
   readApprovalRecord(runId: string): Promise<{ decision: "approved" | "rejected"; feedback?: string; timestamp: string } | null>;
 }
 
+/**
+ * Coordination record written through the injected `HarnessStore` every time a
+ * Rust/GUI-visible run artifact is mutated. Rust and the Tauri GUI read the
+ * on-disk JSON/JSONL files directly (`runs-index.json`, `<runId>/run.json`,
+ * `<runId>/ticket-ledger.json`, `<runId>/phase-ledger.json`,
+ * `<runId>/pr-lifecycle.json`, `<runId>/events.jsonl`), so the data itself
+ * stays direct-file. This small record serializes concurrent writers through
+ * `store.mutate` — on Postgres (T-402) it runs under
+ * `pg_advisory_xact_lock`, giving multi-process schedulers a cross-process
+ * coordination hook. Advisory-only; nothing reads it today.
+ */
+interface RunArtifactCoordRecord {
+  kind:
+    | "run-snapshot"
+    | "runs-index"
+    | "phase-ledger"
+    | "ticket-ledger"
+    | "pr-lifecycle"
+    | "events";
+  updatedAt: string;
+  count?: number;
+}
+
+function coordId(runId: string, kind: RunArtifactCoordRecord["kind"]): string {
+  // Flat id encoding — `HarnessStore` rejects slashes in ids, so the runId
+  // and the record kind are joined with a double-underscore separator that
+  // cannot appear in a runId (`run-<ts>-<rand>`) or in the fixed kind set.
+  return `${runId}__${kind}`;
+}
+
+function blobId(runId: string, phaseId: string, artifactId: string): string {
+  return `${runId}__${phaseId}__${artifactId}`;
+}
+
+const BLOB_URI_PREFIX = "blob://";
+
+function buildBlobUri(id: string): string {
+  return `${BLOB_URI_PREFIX}${STORE_NS.runArtifacts}/${id}`;
+}
+
+function parseBlobUri(
+  uri: string
+): { ns: string; id: string } | null {
+  if (!uri.startsWith(BLOB_URI_PREFIX)) return null;
+  const rest = uri.slice(BLOB_URI_PREFIX.length);
+  const slash = rest.indexOf("/");
+  if (slash < 0) return null;
+  return { ns: rest.slice(0, slash), id: rest.slice(slash + 1) };
+}
+
 export class LocalArtifactStore implements ArtifactStore {
-  constructor(private readonly rootDir: string) {}
+  private readonly store: HarnessStore;
+
+  /**
+   * @param rootDir On-disk artifact root. This is the workspace-scoped
+   *   `artifacts/` directory that Rust's `crates/harness-data` and the Tauri
+   *   GUI read from directly — see `load_runs_for_workspace`,
+   *   `load_ticket_ledger`. Do not move these paths without also updating
+   *   the Rust crate and the desktop app.
+   * @param store `HarnessStore` used for artifacts that have migrated off
+   *   direct filesystem access (command results, failure classifications,
+   *   classification docs, approval records, design docs) and for the
+   *   coordination records written alongside Rust-compat writes. Defaults to
+   *   `buildHarnessStore()` so callers that don't inject one pick up the
+   *   process-wide default through the factory. Tests substitute a
+   *   `FakeHarnessStore` here.
+   *
+   * NOTE: The Rust-visible artifacts (`runs-index.json`,
+   * `<runId>/{run.json,events.jsonl,ticket-ledger.json,phase-ledger.json,
+   * pr-lifecycle.json}`) continue to be written directly to `rootDir`. A
+   * small coordination record is written through the store per mutation so
+   * T-402's Postgres backend can layer cross-process coordination on top.
+   * T-103a tracks aligning the Rust crate so the data itself can flow
+   * through `HarnessStore`.
+   */
+  constructor(
+    private readonly rootDir: string,
+    store?: HarnessStore
+  ) {
+    this.store = store ?? buildHarnessStore();
+  }
 
   async saveCommandResult(
     input: SaveCommandArtifactInput
   ): Promise<ArtifactRecord> {
     const artifactId = buildArtifactId();
-    const phaseDir = join(this.rootDir, input.runId, input.phaseId);
+    const content: CommandArtifactContent = {
+      artifactId,
+      phaseId: input.phaseId,
+      command: input.command,
+      cwd: input.cwd,
+      exitCode: input.result.exitCode,
+      stdout: input.result.stdout,
+      stderr: input.result.stderr,
+      capturedAt: new Date().toISOString()
+    };
 
-    await mkdir(phaseDir, {
-      recursive: true
+    const id = blobId(input.runId, input.phaseId, artifactId);
+    const bytes = new TextEncoder().encode(JSON.stringify(content, null, 2));
+    await this.store.putBlob(STORE_NS.runArtifacts, id, bytes, {
+      contentType: "application/json",
+      runId: input.runId,
+      phaseId: input.phaseId,
+      artifactType: "command_result"
     });
-
-    const path = join(phaseDir, `${artifactId}.json`);
-
-    await writeFile(
-      path,
-      JSON.stringify(
-        {
-          artifactId,
-          phaseId: input.phaseId,
-          command: input.command,
-          cwd: input.cwd,
-          exitCode: input.result.exitCode,
-          stdout: input.result.stdout,
-          stderr: input.result.stderr,
-          capturedAt: new Date().toISOString()
-        },
-        null,
-        2
-      )
-    );
 
     return {
       artifactId,
       phaseId: input.phaseId,
       type: "command_result",
-      path,
+      path: buildBlobUri(id),
       command: input.command,
       exitCode: input.result.exitCode
     };
   }
 
   async readCommandResult(path: string): Promise<CommandArtifactContent> {
+    const ref = parseBlobUri(path);
+    if (ref) {
+      const bytes = await this.store.getBlob({
+        ns: ref.ns,
+        id: ref.id,
+        size: 0
+      });
+      return JSON.parse(new TextDecoder().decode(bytes)) as CommandArtifactContent;
+    }
+    // Legacy: pre-T-103 artifacts stored as loose files under `<runId>/<phaseId>/<artifactId>.json`.
+    // Existing run histories still carry those absolute paths in `run.json`,
+    // so we fall back to a direct read when the path isn't a blob URI.
     return JSON.parse(await readFile(path, "utf8")) as CommandArtifactContent;
   }
 
@@ -145,35 +233,29 @@ export class LocalArtifactStore implements ArtifactStore {
     classification: FailureClassification;
   }): Promise<ArtifactRecord> {
     const artifactId = buildArtifactId();
-    const phaseDir = join(this.rootDir, input.runId, input.phaseId);
+    const content: FailureClassificationArtifactContent = {
+      artifactId,
+      phaseId: input.phaseId,
+      category: input.classification.category,
+      rationale: input.classification.rationale,
+      nextAction: input.classification.nextAction,
+      capturedAt: new Date().toISOString()
+    };
 
-    await mkdir(phaseDir, {
-      recursive: true
+    const id = blobId(input.runId, input.phaseId, artifactId);
+    const bytes = new TextEncoder().encode(JSON.stringify(content, null, 2));
+    await this.store.putBlob(STORE_NS.runArtifacts, id, bytes, {
+      contentType: "application/json",
+      runId: input.runId,
+      phaseId: input.phaseId,
+      artifactType: "failure_classification"
     });
-
-    const path = join(phaseDir, `${artifactId}.json`);
-
-    await writeFile(
-      path,
-      JSON.stringify(
-        {
-          artifactId,
-          phaseId: input.phaseId,
-          category: input.classification.category,
-          rationale: input.classification.rationale,
-          nextAction: input.classification.nextAction,
-          capturedAt: new Date().toISOString()
-        },
-        null,
-        2
-      )
-    );
 
     return {
       artifactId,
       phaseId: input.phaseId,
       type: "failure_classification",
-      path,
+      path: buildBlobUri(id),
       category: input.classification.category,
       rationale: input.classification.rationale,
       nextAction: input.classification.nextAction
@@ -183,6 +265,17 @@ export class LocalArtifactStore implements ArtifactStore {
   async readFailureClassification(
     path: string
   ): Promise<FailureClassificationArtifactContent> {
+    const ref = parseBlobUri(path);
+    if (ref) {
+      const bytes = await this.store.getBlob({
+        ns: ref.ns,
+        id: ref.id,
+        size: 0
+      });
+      return JSON.parse(
+        new TextDecoder().decode(bytes)
+      ) as FailureClassificationArtifactContent;
+    }
     return JSON.parse(
       await readFile(path, "utf8")
     ) as FailureClassificationArtifactContent;
@@ -213,6 +306,7 @@ export class LocalArtifactStore implements ArtifactStore {
       )
     );
 
+    await this.writeCoordRecord(input.runId, "phase-ledger", input.phaseLedger.length);
     return path;
   }
 
@@ -238,6 +332,9 @@ export class LocalArtifactStore implements ArtifactStore {
       )
     );
 
+    // Index-wide coordination record — shares the `runs-index` sentinel runId
+    // since there is only one index per rootDir (workspace).
+    await this.writeCoordRecord("runs-index", "runs-index", next.length);
     return path;
   }
 
@@ -278,6 +375,7 @@ export class LocalArtifactStore implements ArtifactStore {
     };
 
     await writeFile(path, JSON.stringify(snapshot, null, 2));
+    await this.writeCoordRecord(run.id, "run-snapshot", run.events.length);
     return path;
   }
 
@@ -297,6 +395,7 @@ export class LocalArtifactStore implements ArtifactStore {
 
     const path = join(runDir, "events.jsonl");
     await appendFile(path, JSON.stringify(event) + "\n");
+    await this.writeCoordRecord(runId, "events");
   }
 
   async readEventLog(runId: string): Promise<RunEvent[]> {
@@ -320,6 +419,7 @@ export class LocalArtifactStore implements ArtifactStore {
 
     const path = join(runDir, "pr-lifecycle.json");
     await writeFile(path, JSON.stringify(lifecycle, null, 2));
+    await this.writeCoordRecord(lifecycle.runId, "pr-lifecycle");
     return path;
   }
 
@@ -355,6 +455,11 @@ export class LocalArtifactStore implements ArtifactStore {
       )
     );
 
+    await this.writeCoordRecord(
+      input.runId,
+      "ticket-ledger",
+      input.ticketLedger.length
+    );
     return path;
   }
 
@@ -375,37 +480,28 @@ export class LocalArtifactStore implements ArtifactStore {
     runId: string;
     classification: ClassificationResult;
   }): Promise<string> {
-    const runDir = join(this.rootDir, input.runId);
-    await mkdir(runDir, { recursive: true });
-
-    const path = join(runDir, "classification.json");
-
-    await writeFile(
-      path,
-      JSON.stringify(
-        {
-          runId: input.runId,
-          ...input.classification,
-          classifiedAt: new Date().toISOString()
-        },
-        null,
-        2
-      )
-    );
-
-    return path;
+    const id = `${input.runId}__classification`;
+    const doc = {
+      runId: input.runId,
+      ...input.classification,
+      classifiedAt: new Date().toISOString()
+    };
+    await this.store.putDoc(STORE_NS.runArtifacts, id, doc);
+    return buildBlobUri(id);
   }
 
   async saveDesignDoc(input: {
     runId: string;
     content: string;
   }): Promise<string> {
-    const runDir = join(this.rootDir, input.runId);
-    await mkdir(runDir, { recursive: true });
-
-    const path = join(runDir, "design-doc.md");
-    await writeFile(path, input.content);
-    return path;
+    const id = `${input.runId}__design-doc`;
+    const bytes = new TextEncoder().encode(input.content);
+    await this.store.putBlob(STORE_NS.runArtifacts, id, bytes, {
+      contentType: "text/markdown",
+      runId: input.runId,
+      artifactType: "design_doc"
+    });
+    return buildBlobUri(id);
   }
 
   async saveApprovalRecord(input: {
@@ -413,26 +509,15 @@ export class LocalArtifactStore implements ArtifactStore {
     decision: "approved" | "rejected";
     feedback?: string;
   }): Promise<string> {
-    const runDir = join(this.rootDir, input.runId);
-    await mkdir(runDir, { recursive: true });
-
-    const path = join(runDir, "approval.json");
-
-    await writeFile(
-      path,
-      JSON.stringify(
-        {
-          runId: input.runId,
-          decision: input.decision,
-          feedback: input.feedback ?? null,
-          timestamp: new Date().toISOString()
-        },
-        null,
-        2
-      )
-    );
-
-    return path;
+    const id = `${input.runId}__approval`;
+    const doc = {
+      runId: input.runId,
+      decision: input.decision,
+      feedback: input.feedback ?? null,
+      timestamp: new Date().toISOString()
+    };
+    await this.store.putDoc(STORE_NS.runArtifacts, id, doc);
+    return buildBlobUri(id);
   }
 
   async readApprovalRecord(runId: string): Promise<{
@@ -440,17 +525,41 @@ export class LocalArtifactStore implements ArtifactStore {
     feedback?: string;
     timestamp: string;
   } | null> {
-    const path = join(this.rootDir, runId, "approval.json");
+    const id = `${runId}__approval`;
+    const doc = await this.store.getDoc<{
+      runId: string;
+      decision: "approved" | "rejected";
+      feedback: string | null;
+      timestamp: string;
+    }>(STORE_NS.runArtifacts, id);
+    if (!doc) return null;
+    return {
+      decision: doc.decision,
+      feedback: doc.feedback ?? undefined,
+      timestamp: doc.timestamp
+    };
+  }
 
-    try {
-      return JSON.parse(await readFile(path, "utf8")) as {
-        decision: "approved" | "rejected";
-        feedback?: string;
-        timestamp: string;
-      };
-    } catch {
-      return null;
-    }
+  /**
+   * Advisory coordination record for Rust-visible run artifacts. See the
+   * `RunArtifactCoordRecord` doc for rationale. Uses `mutate` so the call
+   * runs under the backend's serialization primitive (in-process Promise
+   * chain on `FileHarnessStore`; `pg_advisory_xact_lock` on Postgres).
+   */
+  private async writeCoordRecord(
+    runId: string,
+    kind: RunArtifactCoordRecord["kind"],
+    count?: number
+  ): Promise<void> {
+    await this.store.mutate<RunArtifactCoordRecord>(
+      STORE_NS.runArtifacts,
+      coordId(runId, kind),
+      () => ({
+        kind,
+        updatedAt: new Date().toISOString(),
+        ...(count !== undefined ? { count } : {})
+      })
+    );
   }
 }
 

--- a/src/execution/artifact-store.ts
+++ b/src/execution/artifact-store.ts
@@ -135,14 +135,66 @@ function buildBlobUri(id: string): string {
   return `${BLOB_URI_PREFIX}${STORE_NS.runArtifacts}/${id}`;
 }
 
+/**
+ * Parse a `blob://<ns>/<id>` URI or signal legacy-path fallback.
+ *
+ * Three possible outcomes:
+ * - Input starts with `blob://` and is well-formed → returns `{ ns, id }`.
+ * - Input starts with `blob://` but is malformed (missing slash, empty ns,
+ *   or empty id) → throws with the offending URI included in the message.
+ *   We do NOT silently treat a half-baked blob URI as a filesystem path;
+ *   that would mask a real bug in whoever produced the URI.
+ * - Input does not start with `blob://` → returns `null`, signaling that
+ *   the caller should fall through to the pre-T-103 legacy absolute-path
+ *   read. Existing run histories still carry absolute paths in `run.json`.
+ */
 function parseBlobUri(
   uri: string
 ): { ns: string; id: string } | null {
   if (!uri.startsWith(BLOB_URI_PREFIX)) return null;
   const rest = uri.slice(BLOB_URI_PREFIX.length);
   const slash = rest.indexOf("/");
-  if (slash < 0) return null;
-  return { ns: rest.slice(0, slash), id: rest.slice(slash + 1) };
+  if (slash < 0) {
+    throw new Error(
+      `Invalid blob URI (missing '/'): ${uri}`
+    );
+  }
+  const ns = rest.slice(0, slash);
+  const id = rest.slice(slash + 1);
+  if (!ns) {
+    throw new Error(`Invalid blob URI (empty namespace): ${uri}`);
+  }
+  if (!id) {
+    throw new Error(`Invalid blob URI (empty id): ${uri}`);
+  }
+  return { ns, id };
+}
+
+// Warn once per distinct legacy absolute path so operators know that an
+// older run history is driving a direct-file read rather than the
+// HarnessStore blob path.
+const legacyPathWarned = new Set<string>();
+function warnLegacyArtifactPath(path: string): void {
+  if (legacyPathWarned.has(path)) return;
+  legacyPathWarned.add(path);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[artifact-store] Reading artifact via legacy absolute-path fallback: ${path}. ` +
+      `This run predates T-103 and should be regenerated to migrate onto the HarnessStore blob backend.`
+  );
+}
+
+async function readLegacyArtifactFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        `Artifact not found at ${path} (legacy absolute-path fallback). Artifact may have been cleaned or written by a run on another machine.`
+      );
+    }
+    throw err;
+  }
 }
 
 export class LocalArtifactStore implements ArtifactStore {
@@ -224,7 +276,8 @@ export class LocalArtifactStore implements ArtifactStore {
     // Legacy: pre-T-103 artifacts stored as loose files under `<runId>/<phaseId>/<artifactId>.json`.
     // Existing run histories still carry those absolute paths in `run.json`,
     // so we fall back to a direct read when the path isn't a blob URI.
-    return JSON.parse(await readFile(path, "utf8")) as CommandArtifactContent;
+    warnLegacyArtifactPath(path);
+    return JSON.parse(await readLegacyArtifactFile(path)) as CommandArtifactContent;
   }
 
   async saveFailureClassification(input: {
@@ -276,8 +329,9 @@ export class LocalArtifactStore implements ArtifactStore {
         new TextDecoder().decode(bytes)
       ) as FailureClassificationArtifactContent;
     }
+    warnLegacyArtifactPath(path);
     return JSON.parse(
-      await readFile(path, "utf8")
+      await readLegacyArtifactFile(path)
     ) as FailureClassificationArtifactContent;
   }
 
@@ -340,14 +394,30 @@ export class LocalArtifactStore implements ArtifactStore {
 
   async readRunsIndex(): Promise<RunIndexEntry[]> {
     const path = join(this.rootDir, "runs-index.json");
+    let content: string;
 
     try {
-      const raw = JSON.parse(await readFile(path, "utf8")) as {
-        runs?: RunIndexEntry[];
-      };
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw new Error(
+        `Failed to read runs index at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
+      const raw = JSON.parse(content) as { runs?: RunIndexEntry[] };
       return raw.runs ?? [];
-    } catch {
-      return [];
+    } catch (err) {
+      throw new Error(
+        `Failed to parse runs index at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 
@@ -381,11 +451,29 @@ export class LocalArtifactStore implements ArtifactStore {
 
   async readRunSnapshot(runId: string): Promise<RunSnapshot | null> {
     const path = join(this.rootDir, runId, "run.json");
+    let content: string;
 
     try {
-      return JSON.parse(await readFile(path, "utf8")) as RunSnapshot;
-    } catch {
-      return null;
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw new Error(
+        `Failed to read run snapshot at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
+      return JSON.parse(content) as RunSnapshot;
+    } catch (err) {
+      throw new Error(
+        `Failed to parse run snapshot at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 
@@ -400,16 +488,33 @@ export class LocalArtifactStore implements ArtifactStore {
 
   async readEventLog(runId: string): Promise<RunEvent[]> {
     const path = join(this.rootDir, runId, "events.jsonl");
+    let raw: string;
 
     try {
-      const raw = await readFile(path, "utf8");
+      raw = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw new Error(
+        `Failed to read event log at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
       return raw
         .trim()
         .split("\n")
         .filter(Boolean)
         .map((line) => JSON.parse(line) as RunEvent);
-    } catch {
-      return [];
+    } catch (err) {
+      throw new Error(
+        `Failed to parse event log at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 
@@ -425,11 +530,29 @@ export class LocalArtifactStore implements ArtifactStore {
 
   async readPrLifecycle(runId: string): Promise<PrLifecycle | null> {
     const path = join(this.rootDir, runId, "pr-lifecycle.json");
+    let content: string;
 
     try {
-      return JSON.parse(await readFile(path, "utf8")) as PrLifecycle;
-    } catch {
-      return null;
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw new Error(
+        `Failed to read PR lifecycle at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
+      return JSON.parse(content) as PrLifecycle;
+    } catch (err) {
+      throw new Error(
+        `Failed to parse PR lifecycle at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 
@@ -465,14 +588,30 @@ export class LocalArtifactStore implements ArtifactStore {
 
   async readTicketLedger(runId: string): Promise<TicketLedgerEntry[] | null> {
     const path = join(this.rootDir, runId, "ticket-ledger.json");
+    let content: string;
 
     try {
-      const raw = JSON.parse(await readFile(path, "utf8")) as {
-        tickets?: TicketLedgerEntry[];
-      };
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw new Error(
+        `Failed to read ticket ledger at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    try {
+      const raw = JSON.parse(content) as { tickets?: TicketLedgerEntry[] };
       return raw.tickets ?? null;
-    } catch {
-      return null;
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ticket ledger at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export async function main(): Promise<void> {
   const live = process.env.HARNESS_LIVE === "1";
   const packageVersion = await readPackageVersion();
   const workspace = await ensureHarnessWorkspace(cwd, packageVersion);
-  const artifactStore = new LocalArtifactStore(workspace.paths.artifactsDir);
+  const artifactStore = new LocalArtifactStore(workspace.paths.artifactsDir, getHarnessStore());
 
   if (command === "up") {
     await printUpStatus(workspace);
@@ -894,7 +894,8 @@ async function printRunningTasks(args: string[] = []): Promise<void> {
 
   for (const ws of workspaces) {
     const wsArtifactStore = new LocalArtifactStore(
-      `${getGlobalRoot()}/workspaces/${ws.workspaceId}/artifacts`
+      `${getGlobalRoot()}/workspaces/${ws.workspaceId}/artifacts`,
+      getHarnessStore()
     );
     const runs = await wsArtifactStore.readRunsIndex();
 
@@ -953,7 +954,8 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
     runId
   ) => {
     const wsStore = new LocalArtifactStore(
-      `${getGlobalRoot()}/workspaces/${workspaceId}/artifacts`
+      `${getGlobalRoot()}/workspaces/${workspaceId}/artifacts`,
+      getHarnessStore()
     );
     return wsStore.readTicketLedger(runId);
   });

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -6,6 +6,7 @@ import {
   getGlobalRoot,
   listRegisteredWorkspaces
 } from "../cli/workspace-registry.js";
+import { getHarnessStore } from "../storage/factory.js";
 
 export interface ChannelToolState {
   sessionId: string | null;
@@ -236,5 +237,5 @@ export async function callChannelTool(
 
 function buildArtifactStoreForWorkspace(workspaceId: string): LocalArtifactStore {
   const globalRoot = getGlobalRoot();
-  return new LocalArtifactStore(`${globalRoot}/workspaces/${workspaceId}/artifacts`);
+  return new LocalArtifactStore(`${globalRoot}/workspaces/${workspaceId}/artifacts`, getHarnessStore());
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -53,7 +53,7 @@ export async function buildMcpMessageHandler(
   workspaceRoot: string
 ): Promise<{ handler: McpMessageHandler; context: McpHandlerContext }> {
   const paths = getHarnessWorkspacePaths(workspaceRoot);
-  const artifactStore = new LocalArtifactStore(paths.artifactsDir);
+  const artifactStore = new LocalArtifactStore(paths.artifactsDir, getHarnessStore());
   const crosslinkStore = new CrosslinkStore();
   const crosslinkState: CrosslinkToolState = {
     sessionId: null,

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -35,7 +35,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const { featureRequest, repoPath } = input;
   const workspaceId = buildWorkspaceId(repoPath);
   const artifactsDir = `${getWorkspaceDir(workspaceId)}/artifacts`;
-  const artifactStore = new LocalArtifactStore(artifactsDir);
+  const artifactStore = new LocalArtifactStore(artifactsDir, getHarnessStore());
   const channelStore = new ChannelStore(undefined, getHarnessStore());
 
   // Ensure agents are registered

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -40,7 +40,15 @@ export class NotImplementedError extends Error {
  *                                          On-disk layout stays for
  *                                          Rust/GUI compat — T-101a aligns)
  *   - src/crosslink/store.ts             -> T-104
- *   - src/execution/artifact-store.ts    -> T-103
+ *   - src/execution/artifact-store.ts    -> T-103 (partial: ctor takes a
+ *                                          HarnessStore; command-result and
+ *                                          failure-classification blobs plus
+ *                                          classification/approval/design-doc
+ *                                          migrated; Rust-visible run
+ *                                          snapshots/indexes/ledgers stay
+ *                                          direct-file with a coordination
+ *                                          record written through the store.
+ *                                          T-103a aligns the Rust reader)
  *
  * Other `node:fs/promises` importers (workspace bootstrap, agent wrapper,
  * crosslink hook/tools, config, welcome, mcp server, scripted invoker,

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -351,6 +351,7 @@ function groupTicketsByStatus(
 
 function buildArtifactStore(workspaceId: string): LocalArtifactStore {
   return new LocalArtifactStore(
-    `${getGlobalRoot()}/workspaces/${workspaceId}/artifacts`
+    `${getGlobalRoot()}/workspaces/${workspaceId}/artifacts`,
+    getHarnessStore()
   );
 }

--- a/test/artifact-store-harness-store.test.ts
+++ b/test/artifact-store-harness-store.test.ts
@@ -1,16 +1,19 @@
 import {
   cp,
+  mkdir,
   mkdtemp,
   readFile,
   rm,
-  stat
+  stat,
+  writeFile
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createPrLifecycle } from "../src/domain/pr-lifecycle.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import { STORE_NS } from "../src/storage/namespaces.js";
@@ -389,6 +392,216 @@ describe("LocalArtifactStore reads legacy Rust-layout fixtures", () => {
       expect(content.stdout).toContain("legacy stdout");
     } finally {
       await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("LocalArtifactStore error handling (malformed URIs & missing legacy paths)", () => {
+  let artifactsDir: string;
+  let fake: FakeHarnessStore;
+  let store: LocalArtifactStore;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    artifactsDir = await mkdtemp(join(tmpdir(), "as-err-"));
+    fake = new FakeHarnessStore();
+    store = new LocalArtifactStore(artifactsDir, fake);
+    // Silence the legacy-path warn so test output stays clean; tests that
+    // care about the warning message assert against the spy explicitly.
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await rm(artifactsDir, { recursive: true, force: true });
+  });
+
+  it("throws on a blob:// URI missing a slash", async () => {
+    await expect(
+      store.readCommandResult("blob://run-artifacts")
+    ).rejects.toThrow(/Invalid blob URI.*blob:\/\/run-artifacts/);
+  });
+
+  it("throws on a blob:// URI with an empty namespace", async () => {
+    await expect(
+      store.readCommandResult("blob:///abc")
+    ).rejects.toThrow(/Invalid blob URI.*empty namespace/);
+  });
+
+  it("throws on a blob:// URI with an empty id", async () => {
+    await expect(
+      store.readCommandResult("blob://run-artifacts/")
+    ).rejects.toThrow(/Invalid blob URI.*empty id/);
+  });
+
+  it("throws on a malformed blob:// URI passed to readFailureClassification", async () => {
+    await expect(
+      store.readFailureClassification("blob://bogus")
+    ).rejects.toThrow(/Invalid blob URI.*blob:\/\/bogus/);
+  });
+
+  it("wraps ENOENT on a legacy absolute path with contextual error", async () => {
+    const missing = join(artifactsDir, "run-x", "phase_01", "missing.json");
+    await expect(store.readCommandResult(missing)).rejects.toThrow(
+      /Artifact not found at .*missing\.json.*legacy absolute-path fallback/
+    );
+  });
+
+  it("warns once per distinct legacy path (but still reads the artifact)", async () => {
+    // Seed a legacy artifact that can actually be read back so the call
+    // resolves normally; we only care that the warn was triggered.
+    const legacyDir = join(artifactsDir, "run-warn-1", "phase_00");
+    await mkdir(legacyDir, { recursive: true });
+    const legacyPath = join(legacyDir, "artifact-warn-1.json");
+    await writeFile(
+      legacyPath,
+      JSON.stringify({
+        artifactId: "artifact-warn-1",
+        phaseId: "phase_00",
+        command: "pnpm run x",
+        cwd: "/tmp",
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        capturedAt: "2026-04-20T00:00:00.000Z"
+      })
+    );
+
+    await store.readCommandResult(legacyPath);
+    await store.readCommandResult(legacyPath);
+    const legacyCalls = warnSpy.mock.calls.filter((args) =>
+      String(args[0]).includes("legacy absolute-path fallback")
+    );
+    expect(legacyCalls).toHaveLength(1);
+  });
+
+  it("throws (not silent null) on corrupt runs-index.json", async () => {
+    await writeFile(join(artifactsDir, "runs-index.json"), "not json at all");
+    await expect(store.readRunsIndex()).rejects.toThrow(
+      /Failed to parse runs index at .*runs-index\.json/
+    );
+  });
+
+  it("throws (not silent null) on corrupt run.json snapshot", async () => {
+    await mkdir(join(artifactsDir, "run-bad"), { recursive: true });
+    await writeFile(join(artifactsDir, "run-bad", "run.json"), "{broken");
+    await expect(store.readRunSnapshot("run-bad")).rejects.toThrow(
+      /Failed to parse run snapshot at .*run\.json/
+    );
+  });
+
+  it("throws (not silent empty) on corrupt events.jsonl", async () => {
+    await mkdir(join(artifactsDir, "run-bad-events"), { recursive: true });
+    await writeFile(
+      join(artifactsDir, "run-bad-events", "events.jsonl"),
+      "{not json}\n"
+    );
+    await expect(store.readEventLog("run-bad-events")).rejects.toThrow(
+      /Failed to parse event log at .*events\.jsonl/
+    );
+  });
+
+  it("throws (not silent null) on corrupt pr-lifecycle.json", async () => {
+    await mkdir(join(artifactsDir, "run-bad-pr"), { recursive: true });
+    await writeFile(
+      join(artifactsDir, "run-bad-pr", "pr-lifecycle.json"),
+      "nope"
+    );
+    await expect(store.readPrLifecycle("run-bad-pr")).rejects.toThrow(
+      /Failed to parse PR lifecycle at .*pr-lifecycle\.json/
+    );
+  });
+
+  it("throws (not silent null) on corrupt ticket-ledger.json", async () => {
+    await mkdir(join(artifactsDir, "run-bad-tickets"), { recursive: true });
+    await writeFile(
+      join(artifactsDir, "run-bad-tickets", "ticket-ledger.json"),
+      "still not json"
+    );
+    await expect(store.readTicketLedger("run-bad-tickets")).rejects.toThrow(
+      /Failed to parse ticket ledger at .*ticket-ledger\.json/
+    );
+  });
+
+  it("still returns [] for missing runs-index and null for missing snapshot/ledger/lifecycle", async () => {
+    // ENOENT path must remain the original sentinel-return behavior; only
+    // non-ENOENT errors are expected to throw.
+    expect(await store.readRunsIndex()).toEqual([]);
+    expect(await store.readRunSnapshot("run-nope")).toBeNull();
+    expect(await store.readEventLog("run-nope")).toEqual([]);
+    expect(await store.readPrLifecycle("run-nope")).toBeNull();
+    expect(await store.readTicketLedger("run-nope")).toBeNull();
+  });
+});
+
+describe("LocalArtifactStore blob round-trip (saveCommandResult -> readCommandResult)", () => {
+  let artifactsDir: string;
+  let fake: FakeHarnessStore;
+  let store: LocalArtifactStore;
+
+  beforeEach(async () => {
+    artifactsDir = await mkdtemp(join(tmpdir(), "as-rt-"));
+    fake = new FakeHarnessStore();
+    store = new LocalArtifactStore(artifactsDir, fake);
+  });
+
+  afterEach(async () => {
+    await rm(artifactsDir, { recursive: true, force: true });
+  });
+
+  it("writes a blob under the right ns/id and round-trips the exact bytes", async () => {
+    const record = await store.saveCommandResult({
+      runId: "run-rt-1",
+      phaseId: "phase_07",
+      command: "pnpm run build",
+      result: { exitCode: 1, stdout: "line one\nline two", stderr: "boom" },
+      cwd: "/work"
+    });
+
+    // The returned path is a blob URI with the expected ns prefix.
+    expect(record.path).toMatch(/^blob:\/\/run-artifacts\/run-rt-1__phase_07__artifact-/);
+
+    // Exactly one putBlob call landed under the run-artifacts ns.
+    expect(fake.blobCalls).toHaveLength(1);
+    expect(fake.blobCalls[0].ns).toBe(STORE_NS.runArtifacts);
+    expect(fake.blobCalls[0].id).toMatch(/^run-rt-1__phase_07__artifact-/);
+
+    // Round-trip recovers the original fields verbatim.
+    const read = await store.readCommandResult(record.path);
+    expect(read.command).toBe("pnpm run build");
+    expect(read.cwd).toBe("/work");
+    expect(read.exitCode).toBe(1);
+    expect(read.stdout).toBe("line one\nline two");
+    expect(read.stderr).toBe("boom");
+    expect(read.phaseId).toBe("phase_07");
+  });
+});
+
+describe("LocalArtifactStore PR lifecycle coordination record", () => {
+  it("writes a coordination record through HarnessStore.mutate when savePrLifecycle runs", async () => {
+    const artifactsDir = await mkdtemp(join(tmpdir(), "as-pr-coord-"));
+    const fake = new FakeHarnessStore();
+    const store = new LocalArtifactStore(artifactsDir, fake);
+
+    try {
+      const lifecycle = createPrLifecycle({
+        runId: "run-pr-coord-1",
+        branch: "feature/x"
+      });
+      await store.savePrLifecycle(lifecycle);
+
+      expect(fake.mutateCalls).toContainEqual({
+        ns: STORE_NS.runArtifacts,
+        id: "run-pr-coord-1__pr-lifecycle"
+      });
+      const coord = await fake.getDoc<{ kind: string }>(
+        STORE_NS.runArtifacts,
+        "run-pr-coord-1__pr-lifecycle"
+      );
+      expect(coord).not.toBeNull();
+      expect(coord!.kind).toBe("pr-lifecycle");
+    } finally {
+      await rm(artifactsDir, { recursive: true, force: true });
     }
   });
 });

--- a/test/artifact-store-harness-store.test.ts
+++ b/test/artifact-store-harness-store.test.ts
@@ -1,0 +1,394 @@
+import {
+  cp,
+  mkdtemp,
+  readFile,
+  rm,
+  stat
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
+import { STORE_NS } from "../src/storage/namespaces.js";
+import type {
+  BlobRef,
+  ChangeEvent,
+  HarnessStore,
+  ReadLogOptions
+} from "../src/storage/store.js";
+import type { HarnessRun, RunEvent } from "../src/domain/run.js";
+
+/**
+ * Minimal in-memory HarnessStore. Mirrors the T-101 FakeHarnessStore pattern
+ * (test/channel-store-harness-store.test.ts) — only the methods the
+ * LocalArtifactStore migration actually exercises are wired up with real
+ * semantics; the rest throw to surface accidental usage during tests.
+ */
+class FakeHarnessStore implements HarnessStore {
+  readonly docs: Map<string, unknown> = new Map();
+  readonly blobs: Map<string, Uint8Array> = new Map();
+  readonly mutateCalls: Array<{ ns: string; id: string }> = [];
+  readonly blobCalls: Array<{ ns: string; id: string; meta?: Record<string, string> }> = [];
+
+  private key(ns: string, id: string): string {
+    return `${ns}\u0000${id}`;
+  }
+
+  async getDoc<T>(ns: string, id: string): Promise<T | null> {
+    const v = this.docs.get(this.key(ns, id));
+    return (v as T | undefined) ?? null;
+  }
+
+  async putDoc<T>(ns: string, id: string, doc: T): Promise<void> {
+    this.docs.set(this.key(ns, id), doc);
+  }
+
+  async listDocs<T>(): Promise<T[]> {
+    throw new Error("FakeHarnessStore.listDocs is not implemented");
+  }
+
+  async deleteDoc(): Promise<void> {
+    throw new Error("FakeHarnessStore.deleteDoc is not implemented");
+  }
+
+  async appendLog(): Promise<void> {
+    throw new Error("FakeHarnessStore.appendLog is not implemented");
+  }
+
+  async readLog<T>(
+    _ns: string,
+    _id: string,
+    _opts?: ReadLogOptions
+  ): Promise<T[]> {
+    throw new Error("FakeHarnessStore.readLog is not implemented");
+  }
+
+  async putBlob(
+    ns: string,
+    id: string,
+    bytes: Uint8Array,
+    meta?: Record<string, string>
+  ): Promise<BlobRef> {
+    this.blobCalls.push({ ns, id, meta });
+    this.blobs.set(this.key(ns, id), bytes);
+    return {
+      ns,
+      id,
+      size: bytes.byteLength,
+      contentType: meta?.["contentType"]
+    };
+  }
+
+  async getBlob(ref: BlobRef): Promise<Uint8Array> {
+    const bytes = this.blobs.get(this.key(ref.ns, ref.id));
+    if (!bytes) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    return bytes;
+  }
+
+  async mutate<T>(
+    ns: string,
+    id: string,
+    fn: (prev: T | null) => T
+  ): Promise<T> {
+    this.mutateCalls.push({ ns, id });
+    const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
+    const next = fn(prev);
+    this.docs.set(this.key(ns, id), next);
+    return next;
+  }
+
+  // eslint-disable-next-line require-yield
+  async *watch(): AsyncIterable<ChangeEvent> {
+    throw new Error("FakeHarnessStore.watch is not implemented");
+  }
+}
+
+function buildTestRun(overrides?: Partial<HarnessRun>): HarnessRun {
+  const now = "2026-04-20T00:00:00.000Z";
+  return {
+    id: "run-hs-1",
+    featureRequest: "Widget",
+    state: "PHASE_EXECUTE",
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    channelId: null,
+    classification: null,
+    plan: null,
+    ticketPlan: null,
+    events: [],
+    evidence: [],
+    artifacts: [],
+    phaseLedger: [],
+    phaseLedgerPath: null,
+    ticketLedger: [],
+    ticketLedgerPath: null,
+    runIndexPath: null,
+    ...overrides
+  };
+}
+
+describe("LocalArtifactStore with HarnessStore injection", () => {
+  let artifactsDir: string;
+  let fake: FakeHarnessStore;
+  let store: LocalArtifactStore;
+
+  beforeEach(async () => {
+    artifactsDir = await mkdtemp(join(tmpdir(), "as-hs-"));
+    fake = new FakeHarnessStore();
+    store = new LocalArtifactStore(artifactsDir, fake);
+  });
+
+  afterEach(async () => {
+    await rm(artifactsDir, { recursive: true, force: true });
+  });
+
+  it("routes command-result artifacts through putBlob", async () => {
+    const record = await store.saveCommandResult({
+      runId: "run-hs-1",
+      phaseId: "phase_01",
+      command: "pnpm test",
+      result: { exitCode: 0, stdout: "ok", stderr: "" },
+      cwd: "/tmp"
+    });
+
+    expect(record.type).toBe("command_result");
+    expect(record.path.startsWith("blob://")).toBe(true);
+    expect(fake.blobCalls).toHaveLength(1);
+    expect(fake.blobCalls[0].ns).toBe(STORE_NS.runArtifacts);
+    expect(fake.blobCalls[0].meta?.contentType).toBe("application/json");
+
+    const content = await store.readCommandResult(record.path);
+    expect(content.command).toBe("pnpm test");
+    expect(content.stdout).toBe("ok");
+    expect(content.exitCode).toBe(0);
+  });
+
+  it("routes failure-classification artifacts through putBlob", async () => {
+    const record = await store.saveFailureClassification({
+      runId: "run-hs-1",
+      phaseId: "phase_01",
+      classification: {
+        category: "fix_test",
+        rationale: "verification setup",
+        nextAction: "repair tests"
+      }
+    });
+
+    expect(record.type).toBe("failure_classification");
+    expect(record.path.startsWith("blob://")).toBe(true);
+    expect(fake.blobCalls).toHaveLength(1);
+    expect(fake.blobCalls[0].meta?.artifactType).toBe("failure_classification");
+
+    const content = await store.readFailureClassification(record.path);
+    expect(content.category).toBe("fix_test");
+    expect(content.rationale).toBe("verification setup");
+  });
+
+  it("routes classification docs through putDoc", async () => {
+    const uri = await store.saveClassification({
+      runId: "run-hs-1",
+      classification: {
+        tier: "feature_small",
+        rationale: "small change",
+        suggestedSpecialties: [],
+        estimatedTicketCount: 1,
+        needsDesignDoc: false,
+        needsUserApproval: false,
+        crosslinkRepos: []
+      }
+    });
+
+    expect(uri.startsWith("blob://")).toBe(true);
+    const doc = await fake.getDoc<{ tier: string }>(
+      STORE_NS.runArtifacts,
+      "run-hs-1__classification"
+    );
+    expect(doc).not.toBeNull();
+    expect(doc!.tier).toBe("feature_small");
+  });
+
+  it("routes design docs through putBlob", async () => {
+    const uri = await store.saveDesignDoc({
+      runId: "run-hs-1",
+      content: "# Design\n\nSome markdown."
+    });
+
+    expect(uri.startsWith("blob://")).toBe(true);
+    expect(fake.blobCalls.some((c) => c.meta?.artifactType === "design_doc")).toBe(true);
+    const bytes = await fake.getBlob({
+      ns: STORE_NS.runArtifacts,
+      id: "run-hs-1__design-doc",
+      size: 0
+    });
+    expect(new TextDecoder().decode(bytes)).toContain("# Design");
+  });
+
+  it("routes approval records through putDoc + getDoc", async () => {
+    await store.saveApprovalRecord({
+      runId: "run-hs-1",
+      decision: "approved",
+      feedback: "LGTM"
+    });
+    const record = await store.readApprovalRecord("run-hs-1");
+    expect(record).not.toBeNull();
+    expect(record!.decision).toBe("approved");
+    expect(record!.feedback).toBe("LGTM");
+  });
+
+  it("writes a coordination record through HarnessStore.mutate for run snapshots", async () => {
+    await store.saveRunSnapshot(buildTestRun());
+
+    expect(fake.mutateCalls).toContainEqual({
+      ns: STORE_NS.runArtifacts,
+      id: "run-hs-1__run-snapshot"
+    });
+
+    // And the on-disk Rust-visible snapshot is still present at the
+    // canonical path.
+    const onDisk = join(artifactsDir, "run-hs-1", "run.json");
+    await expect(stat(onDisk)).resolves.toBeTruthy();
+  });
+
+  it("writes coordination records for each Rust-visible mutation", async () => {
+    const event: RunEvent = {
+      type: "TaskSubmitted",
+      phaseId: "phase_00",
+      details: {},
+      createdAt: "2026-04-20T00:00:00.000Z"
+    };
+
+    await store.appendEvent("run-hs-1", event);
+    await store.saveTicketLedger({ runId: "run-hs-1", ticketLedger: [] });
+    await store.savePhaseLedger({ runId: "run-hs-1", phaseLedger: [] });
+    await store.saveRunsIndex({
+      entry: {
+        runId: "run-hs-1",
+        featureRequest: "hi",
+        state: "COMPLETE",
+        startedAt: "2026-04-20T00:00:00.000Z",
+        updatedAt: "2026-04-20T00:00:00.000Z",
+        completedAt: "2026-04-20T00:00:00.000Z",
+        channelId: null,
+        phaseLedgerPath: "/tmp/phase-ledger.json",
+        artifactsRoot: "/tmp"
+      }
+    });
+
+    const ids = new Set(fake.mutateCalls.map((c) => c.id));
+    expect(ids.has("run-hs-1__events")).toBe(true);
+    expect(ids.has("run-hs-1__ticket-ledger")).toBe(true);
+    expect(ids.has("run-hs-1__phase-ledger")).toBe(true);
+    expect(ids.has("runs-index__runs-index")).toBe(true);
+  });
+
+  it("keeps Rust-visible run artifacts on disk (not under run-artifacts/)", async () => {
+    await store.saveRunSnapshot(buildTestRun());
+    await store.saveTicketLedger({ runId: "run-hs-1", ticketLedger: [] });
+    await store.savePhaseLedger({ runId: "run-hs-1", phaseLedger: [] });
+
+    // The data itself is on disk at the Rust-compat paths.
+    await expect(stat(join(artifactsDir, "run-hs-1", "run.json"))).resolves.toBeTruthy();
+    await expect(
+      stat(join(artifactsDir, "run-hs-1", "ticket-ledger.json"))
+    ).resolves.toBeTruthy();
+    await expect(
+      stat(join(artifactsDir, "run-hs-1", "phase-ledger.json"))
+    ).resolves.toBeTruthy();
+
+    // The HarnessStore's runArtifacts ns must NOT have picked up a doc mirror
+    // for the Rust-visible payloads — only the coordination record.
+    const snapshotDoc = await fake.getDoc(STORE_NS.runArtifacts, "run-hs-1");
+    expect(snapshotDoc).toBeNull();
+  });
+
+  it("defaults to a real FileHarnessStore when no store is injected", async () => {
+    // Smoke test: no store arg → ctor builds one via `buildHarnessStore()`.
+    // Construction is lazy but must not throw.
+    const defaulted = new LocalArtifactStore(artifactsDir);
+    expect(defaulted).toBeInstanceOf(LocalArtifactStore);
+  });
+});
+
+describe("LocalArtifactStore reads legacy Rust-layout fixtures", () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), "as-legacy-"));
+    const src = fileURLToPath(
+      new URL("./fixtures/legacy-artifacts", import.meta.url)
+    );
+    await cp(src, workDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("reads pre-migration run.json, events.jsonl, and ledgers", async () => {
+    const storeRoot = await mkdtemp(join(tmpdir(), "as-legacy-hs-"));
+    try {
+      const store = new LocalArtifactStore(
+        workDir,
+        new FileHarnessStore(storeRoot)
+      );
+
+      const snapshot = await store.readRunSnapshot("run-legacy-1");
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.runId).toBe("run-legacy-1");
+      expect(snapshot!.featureRequest).toBe("Legacy feature");
+      expect(snapshot!.state).toBe("COMPLETE");
+
+      const events = await store.readEventLog("run-legacy-1");
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe("TaskSubmitted");
+      expect(events[1].type).toBe("ClassificationComplete");
+
+      const tickets = await store.readTicketLedger("run-legacy-1");
+      expect(tickets).not.toBeNull();
+      expect(tickets!.map((t) => t.ticketId)).toEqual([
+        "ticket-legacy-1"
+      ]);
+
+      const runs = await store.readRunsIndex();
+      expect(runs).toHaveLength(1);
+      expect(runs[0].runId).toBe("run-legacy-1");
+
+      const lifecycle = await store.readPrLifecycle("run-legacy-1");
+      expect(lifecycle).not.toBeNull();
+      expect(lifecycle!.currentStage).toBe("merged");
+    } finally {
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a pre-migration command-result artifact via its absolute path", async () => {
+    const storeRoot = await mkdtemp(join(tmpdir(), "as-legacy-cmd-hs-"));
+    try {
+      const store = new LocalArtifactStore(
+        workDir,
+        new FileHarnessStore(storeRoot)
+      );
+
+      // Pre-T-103 artifacts were loose JSON files under
+      // `<runId>/<phaseId>/<artifactId>.json` — the fallback path in
+      // `readCommandResult` must still resolve them.
+      const path = join(
+        workDir,
+        "run-legacy-1",
+        "phase_01",
+        "artifact-legacy-1.json"
+      );
+      const content = await store.readCommandResult(path);
+      expect(content.command).toBe("pnpm test");
+      expect(content.exitCode).toBe(0);
+      expect(content.stdout).toContain("legacy stdout");
+    } finally {
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/artifact-store.test.ts
+++ b/test/artifact-store.test.ts
@@ -5,11 +5,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 
 describe("artifact store", () => {
   it("persists and reads failure classification artifacts", async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "agent-harness-artifacts-"));
-    const store = new LocalArtifactStore(artifactRoot);
+    const storeRoot = await mkdtemp(join(tmpdir(), "agent-harness-artifacts-hs-"));
+    const store = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
 
     try {
       const artifact = await store.saveFailureClassification({
@@ -33,6 +35,10 @@ describe("artifact store", () => {
       expect(content.nextAction).toContain("Repair the tests");
     } finally {
       await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await rm(storeRoot, {
         recursive: true,
         force: true
       });

--- a/test/fixtures/legacy-artifacts/run-legacy-1/events.jsonl
+++ b/test/fixtures/legacy-artifacts/run-legacy-1/events.jsonl
@@ -1,0 +1,2 @@
+{"type":"TaskSubmitted","phaseId":"phase_00","details":{"featureRequest":"Legacy feature"},"createdAt":"2026-04-20T00:00:00.000Z"}
+{"type":"ClassificationComplete","phaseId":"phase_00","details":{"tier":"feature_small"},"createdAt":"2026-04-20T00:00:01.000Z"}

--- a/test/fixtures/legacy-artifacts/run-legacy-1/phase-ledger.json
+++ b/test/fixtures/legacy-artifacts/run-legacy-1/phase-ledger.json
@@ -1,0 +1,5 @@
+{
+  "runId": "run-legacy-1",
+  "updatedAt": "2026-04-20T00:00:01.000Z",
+  "phases": []
+}

--- a/test/fixtures/legacy-artifacts/run-legacy-1/phase_01/artifact-legacy-1.json
+++ b/test/fixtures/legacy-artifacts/run-legacy-1/phase_01/artifact-legacy-1.json
@@ -1,0 +1,10 @@
+{
+  "artifactId": "artifact-legacy-1",
+  "phaseId": "phase_01",
+  "command": "pnpm test",
+  "cwd": "/tmp/repo",
+  "exitCode": 0,
+  "stdout": "legacy stdout output",
+  "stderr": "",
+  "capturedAt": "2026-04-20T00:00:01.000Z"
+}

--- a/test/fixtures/legacy-artifacts/run-legacy-1/pr-lifecycle.json
+++ b/test/fixtures/legacy-artifacts/run-legacy-1/pr-lifecycle.json
@@ -1,0 +1,20 @@
+{
+  "runId": "run-legacy-1",
+  "branch": "feature/legacy",
+  "baseBranch": "main",
+  "currentStage": "merged",
+  "prNumber": 42,
+  "prUrl": "https://github.com/org/repo/pull/42",
+  "events": [
+    {
+      "stage": "branch_created",
+      "timestamp": "2026-04-20T00:00:00.000Z",
+      "details": {}
+    },
+    {
+      "stage": "merged",
+      "timestamp": "2026-04-20T00:00:01.000Z",
+      "details": {}
+    }
+  ]
+}

--- a/test/fixtures/legacy-artifacts/run-legacy-1/run.json
+++ b/test/fixtures/legacy-artifacts/run-legacy-1/run.json
@@ -1,0 +1,17 @@
+{
+  "runId": "run-legacy-1",
+  "featureRequest": "Legacy feature",
+  "state": "COMPLETE",
+  "startedAt": "2026-04-20T00:00:00.000Z",
+  "updatedAt": "2026-04-20T00:00:01.000Z",
+  "completedAt": "2026-04-20T00:00:01.000Z",
+  "channelId": null,
+  "classification": null,
+  "plan": null,
+  "ticketPlan": null,
+  "evidence": [],
+  "artifacts": [],
+  "phaseLedger": [],
+  "ticketLedger": [],
+  "eventCount": 2
+}

--- a/test/fixtures/legacy-artifacts/run-legacy-1/ticket-ledger.json
+++ b/test/fixtures/legacy-artifacts/run-legacy-1/ticket-ledger.json
@@ -1,0 +1,24 @@
+{
+  "runId": "run-legacy-1",
+  "updatedAt": "2026-04-20T00:00:01.000Z",
+  "tickets": [
+    {
+      "ticketId": "ticket-legacy-1",
+      "title": "Legacy ticket",
+      "specialty": "general",
+      "status": "complete",
+      "dependsOn": [],
+      "assignedAgentId": null,
+      "assignedAgentName": null,
+      "crosslinkSessionId": null,
+      "verification": "passed",
+      "lastClassification": null,
+      "chosenNextAction": null,
+      "attempt": 1,
+      "startedAt": "2026-04-20T00:00:00.000Z",
+      "completedAt": "2026-04-20T00:00:01.000Z",
+      "updatedAt": "2026-04-20T00:00:01.000Z",
+      "runId": "run-legacy-1"
+    }
+  ]
+}

--- a/test/fixtures/legacy-artifacts/runs-index.json
+++ b/test/fixtures/legacy-artifacts/runs-index.json
@@ -1,0 +1,16 @@
+{
+  "updatedAt": "2026-04-20T00:00:00.000Z",
+  "runs": [
+    {
+      "runId": "run-legacy-1",
+      "featureRequest": "Legacy feature",
+      "state": "COMPLETE",
+      "startedAt": "2026-04-20T00:00:00.000Z",
+      "updatedAt": "2026-04-20T00:00:01.000Z",
+      "completedAt": "2026-04-20T00:00:01.000Z",
+      "channelId": null,
+      "phaseLedgerPath": "/tmp/run-legacy-1/phase-ledger.json",
+      "artifactsRoot": "/tmp/run-legacy-1"
+    }
+  ]
+}

--- a/test/orchestrator-v2.test.ts
+++ b/test/orchestrator-v2.test.ts
@@ -9,6 +9,7 @@ import { createLiveAgents } from "../src/agents/factory.js";
 import { NodeCommandInvoker } from "../src/agents/command-invoker.js";
 import { ChannelStore } from "../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 import { VerificationRunner } from "../src/execution/verification-runner.js";
 import { OrchestratorV2 } from "../src/orchestrator/orchestrator-v2.js";
 import { ScriptedInvoker } from "../src/simulation/scripted-invoker.js";
@@ -28,7 +29,10 @@ function buildOrchestrator(
     registry.register(agent);
   }
 
-  const artifactStore = new LocalArtifactStore(artifactsDir);
+  const artifactStore = new LocalArtifactStore(
+    artifactsDir,
+    new FileHarnessStore(join(artifactsDir, "__hs__"))
+  );
   const verificationRunner = new VerificationRunner(
     new NodeCommandInvoker(),
     artifactStore
@@ -130,7 +134,10 @@ describe("OrchestratorV2 integration", () => {
     const artifactsDir = join(tmpDir, "artifacts");
 
     try {
-      const artifactStore = new LocalArtifactStore(artifactsDir);
+      const artifactStore = new LocalArtifactStore(
+    artifactsDir,
+    new FileHarnessStore(join(artifactsDir, "__hs__"))
+  );
       const orchestrator = buildOrchestrator(tmpDir, artifactsDir);
       const run = await orchestrator.run("Fix typo in README");
 

--- a/test/orchestrator/ticket-scheduler-enqueue.test.ts
+++ b/test/orchestrator/ticket-scheduler-enqueue.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../src/domain/ticket.js";
 import { ChannelStore } from "../../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
 import { VerificationRunner } from "../../src/execution/verification-runner.js";
 import { TicketScheduler } from "../../src/orchestrator/ticket-scheduler.js";
 import { ScriptedInvoker } from "../../src/simulation/scripted-invoker.js";
@@ -116,7 +117,10 @@ async function buildScheduler(
     registry.register(agent);
   }
 
-  const artifactStore = new LocalArtifactStore(join(repoRoot, "artifacts"));
+  const artifactStore = new LocalArtifactStore(
+    join(repoRoot, "artifacts"),
+    new FileHarnessStore(join(repoRoot, "__hs__"))
+  );
   const verificationRunner = new VerificationRunner(
     new NodeCommandInvoker(),
     artifactStore

--- a/test/orchestrator/ticket-scheduler-executor.test.ts
+++ b/test/orchestrator/ticket-scheduler-executor.test.ts
@@ -18,6 +18,7 @@ import {
   type TicketDefinition
 } from "../../src/domain/ticket.js";
 import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
 import type { AgentExecutor, ExecutionHandle } from "../../src/execution/executor.js";
 import { NoopExecutor, NoopSandboxProvider } from "../../src/execution/noop-executor.js";
 import { VerificationRunner } from "../../src/execution/verification-runner.js";
@@ -92,7 +93,10 @@ async function buildBasics(repoRoot: string) {
     registry.register(agent);
   }
 
-  const artifactStore = new LocalArtifactStore(join(repoRoot, "artifacts"));
+  const artifactStore = new LocalArtifactStore(
+    join(repoRoot, "artifacts"),
+    new FileHarnessStore(join(repoRoot, "__hs__"))
+  );
   const verificationRunner = new VerificationRunner(
     new NodeCommandInvoker(),
     artifactStore

--- a/test/phase-ledger.test.ts
+++ b/test/phase-ledger.test.ts
@@ -5,11 +5,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 
 describe("phase ledger persistence", () => {
   it("writes a compact phase ledger per run", async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "agent-harness-ledger-"));
-    const store = new LocalArtifactStore(artifactRoot);
+    const storeRoot = await mkdtemp(join(tmpdir(), "agent-harness-ledger-hs-"));
+    const store = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
 
     try {
       const path = await store.savePhaseLedger({
@@ -48,6 +50,10 @@ describe("phase ledger persistence", () => {
       expect(file.phases[0]?.chosenNextAction).toContain("Repair the tests");
     } finally {
       await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await rm(storeRoot, {
         recursive: true,
         force: true
       });

--- a/test/pr-lifecycle.test.ts
+++ b/test/pr-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   canTransition
 } from "../src/domain/pr-lifecycle.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 
 describe("PR lifecycle domain", () => {
   it("creates a lifecycle in branch_created stage", () => {
@@ -60,7 +61,8 @@ describe("PR lifecycle domain", () => {
 describe("PR lifecycle persistence", () => {
   it("saves and reads PR lifecycle from disk", async () => {
     const root = await mkdtemp(join(tmpdir(), "pr-lifecycle-"));
-    const store = new LocalArtifactStore(root);
+    const storeRoot = await mkdtemp(join(tmpdir(), "pr-lifecycle-hs-"));
+    const store = new LocalArtifactStore(root, new FileHarnessStore(storeRoot));
 
     try {
       const lifecycle = createPrLifecycle({
@@ -79,18 +81,21 @@ describe("PR lifecycle persistence", () => {
       expect(read!.currentStage).toBe("branch_created");
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
     }
   });
 
   it("returns null for missing PR lifecycle", async () => {
     const root = await mkdtemp(join(tmpdir(), "pr-lifecycle-"));
-    const store = new LocalArtifactStore(root);
+    const storeRoot = await mkdtemp(join(tmpdir(), "pr-lifecycle-hs-"));
+    const store = new LocalArtifactStore(root, new FileHarnessStore(storeRoot));
 
     try {
       const result = await store.readPrLifecycle("nonexistent");
       expect(result).toBeNull();
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
     }
   });
 });

--- a/test/run-persistence.test.ts
+++ b/test/run-persistence.test.ts
@@ -5,7 +5,18 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 import type { HarnessRun, RunEvent } from "../src/domain/run.js";
+
+async function makeStore(): Promise<{ root: string; store: LocalArtifactStore; storeRoot: string }> {
+  const root = await mkdtemp(join(tmpdir(), "run-persist-"));
+  const storeRoot = await mkdtemp(join(tmpdir(), "run-persist-hs-"));
+  return {
+    root,
+    storeRoot,
+    store: new LocalArtifactStore(root, new FileHarnessStore(storeRoot))
+  };
+}
 
 function buildTestRun(overrides?: Partial<HarnessRun>): HarnessRun {
   const now = new Date().toISOString();
@@ -42,8 +53,7 @@ function buildTestRun(overrides?: Partial<HarnessRun>): HarnessRun {
 
 describe("run persistence", () => {
   it("saves and reads a full run snapshot", async () => {
-    const root = await mkdtemp(join(tmpdir(), "run-persist-"));
-    const store = new LocalArtifactStore(root);
+    const { root, store, storeRoot } = await makeStore();
 
     try {
       const run = buildTestRun();
@@ -60,24 +70,24 @@ describe("run persistence", () => {
       expect(snapshot!.eventCount).toBe(1);
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
     }
   });
 
   it("returns null for missing run snapshot", async () => {
-    const root = await mkdtemp(join(tmpdir(), "run-persist-"));
-    const store = new LocalArtifactStore(root);
+    const { root, store, storeRoot } = await makeStore();
 
     try {
       const snapshot = await store.readRunSnapshot("nonexistent-run");
       expect(snapshot).toBeNull();
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
     }
   });
 
   it("appends and reads events from jsonl log", async () => {
-    const root = await mkdtemp(join(tmpdir(), "run-persist-"));
-    const store = new LocalArtifactStore(root);
+    const { root, store, storeRoot } = await makeStore();
 
     try {
       const event1: RunEvent = {
@@ -104,18 +114,19 @@ describe("run persistence", () => {
       expect(events[1].type).toBe("PlanGenerated");
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
     }
   });
 
   it("returns empty array for missing event log", async () => {
-    const root = await mkdtemp(join(tmpdir(), "run-persist-"));
-    const store = new LocalArtifactStore(root);
+    const { root, store, storeRoot } = await makeStore();
 
     try {
       const events = await store.readEventLog("nonexistent");
       expect(events).toEqual([]);
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
     }
   });
 });

--- a/test/runs-index.test.ts
+++ b/test/runs-index.test.ts
@@ -5,11 +5,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 
 describe("runs index", () => {
   it("persists recent runs with jump targets", async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "agent-harness-runs-index-"));
-    const store = new LocalArtifactStore(artifactRoot);
+    const storeRoot = await mkdtemp(join(tmpdir(), "agent-harness-runs-index-hs-"));
+    const store = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
 
     try {
       const firstPath = await store.saveRunsIndex({
@@ -49,6 +51,10 @@ describe("runs index", () => {
       expect(entries[1]?.runId).toBe("run-1");
     } finally {
       await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await rm(storeRoot, {
         recursive: true,
         force: true
       });

--- a/test/verification-runner.test.ts
+++ b/test/verification-runner.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CommandInvocation, CommandInvoker } from "../src/agents/command-invoker.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
 import {
   selectVerificationCommands,
   VerificationRunner
@@ -35,7 +36,8 @@ describe("verification command selection", () => {
 describe("verification runner", () => {
   it("captures command results as artifacts", async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "agent-harness-artifacts-"));
-    const artifactStore = new LocalArtifactStore(artifactRoot);
+    const storeRoot = await mkdtemp(join(tmpdir(), "agent-harness-artifacts-hs-"));
+    const artifactStore = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
     const runner = new VerificationRunner(
       new FakeCommandInvoker(),
       artifactStore
@@ -58,6 +60,10 @@ describe("verification runner", () => {
       expect(file.stdout).toContain("simulated");
     } finally {
       await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await rm(storeRoot, {
         recursive: true,
         force: true
       });


### PR DESCRIPTION
## Option chosen: A (partial migration)

Injects `HarnessStore` into `LocalArtifactStore`'s ctor as the T-103
plumbing; migrates the artifacts Rust and the Tauri GUI don't read,
keeps the Rust-visible artifacts direct-file, and writes a small
coordination record through the store per mutation so T-402's
Postgres-backed store can layer `pg_advisory_xact_lock` coordination
on top without changing the artifact-store interface.

## What migrated vs what stayed direct-file

**Migrated to `HarnessStore`** (`STORE_NS.runArtifacts`)
- `saveCommandResult` / `readCommandResult` → `store.putBlob` /
  `store.getBlob`. `ArtifactRecord.path` now carries a
  `blob://run-artifacts/<id>` URI; the reader resolves URIs through
  the store and falls back to a direct-file read when the path is an
  absolute filesystem path (pre-T-103 histories still carry those).
- `saveFailureClassification` / `readFailureClassification` → same
  blob path pattern.
- `saveClassification` → `store.putDoc`.
- `saveApprovalRecord` / `readApprovalRecord` → `store.putDoc` /
  `store.getDoc`.
- `saveDesignDoc` → `store.putBlob` with `contentType: text/markdown`.

**Stayed direct-file (Rust/GUI compat)**
- `runs-index.json` — `load_runs_for_workspace` in
  `crates/harness-data/src/lib.rs`.
- `<runId>/run.json` — run snapshot, read by the Tauri GUI.
- `<runId>/events.jsonl` — event log.
- `<runId>/ticket-ledger.json` — `load_ticket_ledger`.
- `<runId>/phase-ledger.json` — phase ledger.
- `<runId>/pr-lifecycle.json` — PR lifecycle.

Each of those writes is paired with a `store.mutate` coordination
record at `(run-artifacts, <runId>__<kind>)` so multi-process
schedulers on T-402 can serialize without the artifact-store owning
that logic. Advisory only — nothing reads these today.

## Rust/GUI compat preservation

- No change to `crates/harness-data/src/lib.rs` or the Tauri app.
- `cargo test -p harness-data` stays green.
- A new fixture at `test/fixtures/legacy-artifacts/` covers a
  pre-migration run layout (runs-index, run.json, events.jsonl,
  ticket-ledger, phase-ledger, pr-lifecycle, and a loose
  `<runId>/<phaseId>/<artifactId>.json` command artifact). The
  legacy-fixture test loads all of it through the new ctor without
  error.

## Wiring

- All `new LocalArtifactStore(...)` sites in `src/` and `scripts/` now
  pass `getHarnessStore()` as the second ctor arg so every caller
  observes the same store instance (`src/index.ts`,
  `src/mcp/server.ts`, `src/mcp/channel-tools.ts`,
  `src/tui/dashboard.ts`, `src/orchestrator/dispatch.ts`,
  `scripts/seed-plan-tickets.ts`).
- `LocalArtifactStore(rootDir, store?)` keeps the second arg optional
  so legacy callers during rollout continue to compile; the default
  goes through `buildHarnessStore()`.
- Tests construct an isolated `FileHarnessStore` rooted in `tmpdir`
  rather than relying on the home-dir default, so coordination writes
  don't leak into `~/.relay`.
- `src/storage/factory.ts` allowlist comment updated to reflect T-103
  partial-migration status.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 312 passing (+11 new), 21 skipped, existing
      artifact/run/orchestrator tests unchanged
- [x] `cargo test -p harness-data` clean (compile-only)
- [x] New test file `test/artifact-store-harness-store.test.ts`:
  - `FakeHarnessStore` substituted in ctor verifies
    `saveCommandResult`, `saveFailureClassification`,
    `saveDesignDoc`, `saveClassification`, `saveApprovalRecord` all
    call through to `store.putBlob` / `store.putDoc`.
  - Round-trip `readCommandResult` / `readFailureClassification` /
    `readApprovalRecord` through the store.
  - Coordination records on `store.mutate` cover run-snapshot,
    events, ticket-ledger, phase-ledger, runs-index.
  - Rust-visible paths (`run.json`, `ticket-ledger.json`,
    `phase-ledger.json`) still exist on disk after migration writes.
  - Snapshot doc is NOT mirrored under `run-artifacts/` — catches an
    accidental migration of Rust-visible data.
  - Default ctor still works when no store is injected.
- [x] Legacy-fixture test reads `runs-index.json`, `run.json`,
      `events.jsonl`, `ticket-ledger.json`, `pr-lifecycle.json`, and a
      loose pre-T-103 `<runId>/<phaseId>/<artifactId>.json` command
      artifact through the new ctor without error.

## Out of scope / follow-ups

- **T-103a**: align the Rust crate's on-disk layout so the
  Rust-visible run data can flow through HarnessStore. Today only the
  coordination record is advisory; Rust and the GUI don't read it.
- Pre-T-103 `ArtifactRecord` entries persisted in older `run.json`
  snapshots still use absolute filesystem paths; the `readCommandResult`
  fallback preserves compatibility until those runs age out.