### PR TITLE
gui: stacked tool-activity during streams

### DIFF
--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -19,12 +19,18 @@ type Props = {
   onSessionCreated: (sessionId: string) => void;
 };
 
+type ActivityEntry = { text: string; ts: number };
+
 type ActiveStream = {
   streamId: number;
   alias: string | null;
   accum: string;
-  activity: string[];
+  activity: ActivityEntry[];
+  expanded: boolean;
 };
+
+const ACTIVITY_STACK_MAX = 20;
+const ACTIVITY_TOP_N = 3;
 
 export function CenterPane({
   channel,
@@ -154,8 +160,17 @@ function reduceStream(current: ActiveStream, event: ChatEvent): ActiveStream {
   switch (event.kind) {
     case "chunk":
       return { ...current, accum: current.accum + event.text };
-    case "activity":
-      return { ...current, activity: [...current.activity, event.text] };
+    case "activity": {
+      const next = [
+        ...current.activity,
+        { text: event.text, ts: Date.now() },
+      ];
+      const trimmed =
+        next.length > ACTIVITY_STACK_MAX
+          ? next.slice(next.length - ACTIVITY_STACK_MAX)
+          : next;
+      return { ...current, activity: trimmed };
+    }
     default:
       return current;
   }
@@ -196,32 +211,12 @@ function ChatView({
           <FeedView entries={feed} />
         )}
         {stream && (
-          <div className={`feed-entry role-assistant streaming`}>
-            <div className="feed-header">
-              <span className="feed-author">
-                {stream.alias ? `@${stream.alias}` : "assistant"}
-              </span>
-              <span className="stream-status">
-                <span className="stream-dot" /> streaming
-              </span>
-            </div>
-            <div className="stream-activity">
-              {stream.activity.length === 0 ? (
-                <div className="stream-activity-empty">
-                  {stream.accum ? "writing response…" : "thinking…"}
-                </div>
-              ) : (
-                stream.activity.slice(-5).map((a, i) => (
-                  <div key={i} className="stream-activity-line">
-                    · {a}
-                  </div>
-                ))
-              )}
-            </div>
-            {stream.accum && (
-              <div className="feed-content">{stream.accum}</div>
-            )}
-          </div>
+          <ActivityStreamCard
+            stream={stream}
+            onToggleExpanded={() =>
+              onStartStream({ ...stream, expanded: !stream.expanded })
+            }
+          />
         )}
       </div>
       <Composer
@@ -233,6 +228,90 @@ function ChatView({
         onSessionCreated={onSessionCreated}
       />
     </>
+  );
+}
+
+function ActivityStreamCard({
+  stream,
+  onToggleExpanded,
+}: {
+  stream: ActiveStream;
+  onToggleExpanded: () => void;
+}) {
+  const total = stream.activity.length;
+  const visibleCount = stream.expanded ? total : Math.min(ACTIVITY_TOP_N, total);
+  const visible = total === 0 ? [] : stream.activity.slice(total - visibleCount);
+  const hiddenCount = total - visibleCount;
+  const agentBadge = stream.alias ? `@${stream.alias}` : "agent";
+  const latestTs = total > 0 ? stream.activity[total - 1].ts : null;
+
+  return (
+    <div className="feed-entry role-assistant streaming">
+      <div className="feed-header">
+        <span className="feed-author">
+          {stream.alias ? `@${stream.alias}` : "assistant"}
+        </span>
+        <span className="stream-status">
+          <span className="stream-dot" />
+          {stream.accum ? "writing response" : "thinking"}
+          {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
+        </span>
+      </div>
+      <div className={`stream-activity ${stream.expanded ? "expanded" : ""}`}>
+        {total === 0 ? (
+          <div className="stream-activity-empty">
+            <span className="activity-badge">{agentBadge}</span>
+            <span className="activity-icon">⚙</span>
+            <span className="activity-ellipsis">
+              {stream.accum ? "writing response…" : "thinking…"}
+            </span>
+          </div>
+        ) : (
+          <>
+            {visible.map((entry, i) => {
+              const isNewest = i === visible.length - 1;
+              return (
+                <div
+                  key={`${entry.ts}-${i}`}
+                  className={`stream-activity-line ${isNewest ? "newest" : ""}`}
+                  title={new Date(entry.ts).toLocaleTimeString()}
+                >
+                  {isNewest && (
+                    <span className="activity-badge">{agentBadge}</span>
+                  )}
+                  <span className="activity-icon">⚙</span>
+                  <span className="activity-text">{entry.text}</span>
+                </div>
+              );
+            })}
+            {hiddenCount > 0 && (
+              <button
+                type="button"
+                className="stream-activity-more"
+                onClick={onToggleExpanded}
+              >
+                +{hiddenCount} more
+              </button>
+            )}
+            {stream.expanded && total > ACTIVITY_TOP_N && (
+              <button
+                type="button"
+                className="stream-activity-more"
+                onClick={onToggleExpanded}
+              >
+                collapse
+              </button>
+            )}
+          </>
+        )}
+        {latestTs && (
+          <div className="stream-activity-meta">
+            last update {new Date(latestTs).toLocaleTimeString()}
+          </div>
+        )}
+      </div>
+      {stream.accum && <div className="feed-content">{stream.accum}</div>}
+    </div>
   );
 }
 
@@ -326,7 +405,13 @@ function Composer({
         claudeSessionId,
         autoApprove,
       });
-      onStartStream({ streamId, alias, accum: "", activity: [] });
+      onStartStream({
+        streamId,
+        alias,
+        accum: "",
+        activity: [],
+        expanded: false,
+      });
       setText("");
     } catch (e) {
       setError(String(e));

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -406,15 +406,78 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   padding: 4px 8px;
   background: rgba(250, 179, 135, 0.04);
   border-radius: 0 3px 3px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.stream-activity.expanded {
+  max-height: 280px;
+  overflow-y: auto;
 }
 .stream-activity-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   line-height: 1.5;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  color: rgba(150, 150, 180, 0.9);
+}
+.stream-activity-line.newest {
+  color: rgb(200, 200, 230);
+}
+.stream-activity-line .activity-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.activity-badge {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 2px;
+  background: rgba(80, 80, 100, 0.55);
+  color: #1a1a1a;
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  flex-shrink: 0;
+}
+.activity-icon {
+  color: rgb(150, 150, 180);
+  font-style: normal;
+  flex-shrink: 0;
 }
 .stream-activity-empty {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   color: var(--text-muted);
+}
+.activity-ellipsis {
+  font-style: italic;
+}
+.stream-activity-more {
+  align-self: flex-start;
+  margin-top: 2px;
+  background: transparent;
+  border: none;
+  color: var(--accent-dim);
+  font-size: 10px;
+  cursor: pointer;
+  padding: 2px 0;
+  font-style: italic;
+}
+.stream-activity-more:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.stream-activity-meta {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: normal;
 }
 .feed-entry.streaming {
   border: 1px solid var(--accent-dim);


### PR DESCRIPTION
## Summary
- Port the TUI's `ActivityStack` rendering (tui/src/ui.rs:371-411, tui/src/main.rs:756-808) into `CenterPane` so the GUI surfaces the agent's tool calls instead of showing a bare `thinking…` placeholder.
- `ActiveStream.activity` is now `{ text, ts }[]` capped at 20 entries, with top-3 shown + a clickable `+N more` / `collapse` toggle, agent badge on the newest line, ⚙ icons, and a "last update" timestamp.
- New CSS gives older entries dim color, the newest one a brighter accent, and the expanded view a capped scroll region so long stacks stay contained.

## Test plan
- [ ] `pnpm tauri dev` in `gui/`, open a channel, send a message that triggers tool calls (e.g. "read package.json then list this directory")
- [ ] Confirm activity lines appear live as each tool fires (Read/Bash/Grep/Glob/etc.)
- [ ] Confirm the `+N more` toggle expands and collapses the full stack
- [ ] Confirm the placeholder state still renders gracefully when no tools have fired yet
- [ ] Confirm no regression in assistant text streaming below the activity block

🤖 Generated with [Claude Code](https://claude.com/claude-code)