### PR TITLE
rewind: roll repos + chat back to any prior user turn

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -414,6 +414,12 @@ pub struct PersistedChatMessage {
     pub content: String,
     pub timestamp: String,
     pub agent_alias: Option<String>,
+    /// Free-form per-message metadata. Used today by the rewind feature to
+    /// tag user turns with a `rewindKey` that points at the git refs
+    /// captured before that turn. `#[serde(default)]` keeps older JSONL
+    /// transcripts (no metadata field) loadable.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
 }
 
 fn sessions_dir(channel_id: &str) -> PathBuf {

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -233,7 +233,12 @@ fn append_session_message(
     role: String,
     content: String,
     agent_alias: Option<String>,
+    metadata: Option<serde_json::Value>,
 ) -> Result<serde_json::Value, String> {
+    let metadata_json = metadata
+        .as_ref()
+        .map(|v| serde_json::to_string(v).map_err(|e| e.to_string()))
+        .transpose()?;
     let mut args: Vec<&str> = vec![
         "session", "append", "--channel", &channel_id, "--session", &session_id, "--role", &role,
     ];
@@ -241,8 +246,48 @@ fn append_session_message(
         args.push("--alias");
         args.push(alias);
     }
+    if let Some(ref md) = metadata_json {
+        args.push("--metadata");
+        args.push(md);
+    }
     args.push(&content);
     cli_json(&args)
+}
+
+#[tauri::command]
+fn rewind_snapshot(
+    channel_id: String,
+    session_id: String,
+) -> Result<serde_json::Value, String> {
+    cli_json(&[
+        "chat",
+        "rewind-snapshot",
+        "--channel",
+        &channel_id,
+        "--session",
+        &session_id,
+    ])
+}
+
+#[tauri::command]
+fn rewind_apply(
+    channel_id: String,
+    session_id: String,
+    key: String,
+    message_timestamp: String,
+) -> Result<serde_json::Value, String> {
+    cli_json(&[
+        "chat",
+        "rewind-apply",
+        "--channel",
+        &channel_id,
+        "--session",
+        &session_id,
+        "--key",
+        &key,
+        "--message-timestamp",
+        &message_timestamp,
+    ])
 }
 
 // --- Chat streaming (claude-cli subprocess + Tauri events) ---
@@ -302,17 +347,28 @@ fn start_chat(
     cwd: Option<String>,
     claude_session_id: Option<String>,
     auto_approve: bool,
+    rewind_key: Option<String>,
 ) -> Result<u64, String> {
     let stream_id = CHAT_SEQ.fetch_add(1, Ordering::SeqCst);
 
     // Persist user message immediately so UI reflects history on reload.
+    // `rewind_key`, if supplied, is attached as `rewindKey` metadata so the
+    // frontend can later offer a Rewind button that resets repos to the
+    // snapshot captured before this turn.
     let alias_arg = alias.clone();
+    let metadata_json = rewind_key
+        .as_ref()
+        .map(|k| format!("{{\"rewindKey\":\"{}\"}}", k.replace('"', "\\\"")));
     let mut append_args: Vec<&str> = vec![
         "session", "append", "--channel", &channel_id, "--session", &session_id, "--role", "user",
     ];
     if let Some(ref a) = alias_arg {
         append_args.push("--alias");
         append_args.push(a);
+    }
+    if let Some(ref md) = metadata_json {
+        append_args.push("--metadata");
+        append_args.push(md);
     }
     append_args.push(&message);
     let _ = cli_run(&append_args);
@@ -948,6 +1004,8 @@ pub fn run() {
             create_session,
             delete_session,
             append_session_message,
+            rewind_snapshot,
+            rewind_apply,
             start_chat,
             spawn_agent,
             kill_spawned_agent,

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -7,6 +7,8 @@ import type {
   ChatSession,
   Decision,
   PersistedChatMessage,
+  RewindResult,
+  RewindSnapshot,
   RunIndexEntry,
   Spawn,
   TicketLedgerEntry,
@@ -87,6 +89,7 @@ export const api = {
     role: string,
     content: string,
     agentAlias?: string,
+    metadata?: Record<string, string>,
   ) =>
     invoke<unknown>("append_session_message", {
       channelId,
@@ -94,6 +97,22 @@ export const api = {
       role,
       content,
       agentAlias,
+      metadata,
+    }),
+
+  rewindSnapshot: (channelId: string, sessionId: string) =>
+    invoke<RewindSnapshot>("rewind_snapshot", { channelId, sessionId }),
+  rewindApply: (
+    channelId: string,
+    sessionId: string,
+    key: string,
+    messageTimestamp: string,
+  ) =>
+    invoke<RewindResult>("rewind_apply", {
+      channelId,
+      sessionId,
+      key,
+      messageTimestamp,
     }),
 
   startChat: (params: {
@@ -104,6 +123,7 @@ export const api = {
     cwd?: string;
     claudeSessionId?: string;
     autoApprove: boolean;
+    rewindKey?: string;
   }) => invoke<number>("start_chat", params),
 
   // Task #24 contract. These invoke wrappers are thin passthroughs that

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -140,6 +140,7 @@ export function CenterPane({
           stream={stream}
           onStartStream={setStream}
           onSessionCreated={onSessionCreated}
+          onRefresh={onRefresh}
         />
       )}
       {tab === "board" && (
@@ -185,6 +186,7 @@ function ChatView({
   stream,
   onStartStream,
   onSessionCreated,
+  onRefresh,
 }: {
   channel: Channel;
   sessionId: string | null;
@@ -194,6 +196,7 @@ function ChatView({
   stream: ActiveStream | null;
   onStartStream: (s: ActiveStream | null) => void;
   onSessionCreated: (sessionId: string) => void;
+  onRefresh: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -206,7 +209,16 @@ function ChatView({
     <>
       <div className="content" ref={scrollRef}>
         {sessionId ? (
-          <SessionMessages messages={sessionMessages} />
+          <SessionMessages
+            channel={channel}
+            sessionId={sessionId}
+            messages={sessionMessages}
+            streaming={!!stream}
+            onRewound={() => {
+              onStartStream(null);
+              onRefresh();
+            }}
+          />
         ) : (
           <FeedView entries={feed} />
         )}
@@ -315,23 +327,158 @@ function ActivityStreamCard({
   );
 }
 
-function SessionMessages({ messages }: { messages: PersistedChatMessage[] }) {
+function SessionMessages({
+  channel,
+  sessionId,
+  messages,
+  streaming,
+  onRewound,
+}: {
+  channel: Channel;
+  sessionId: string;
+  messages: PersistedChatMessage[];
+  streaming: boolean;
+  onRewound: () => void;
+}) {
+  const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(
+    null,
+  );
+
+
   if (messages.length === 0)
     return <div className="empty">No messages in this session yet</div>;
   return (
     <>
-      {messages.map((m, i) => (
-        <div key={i} className={`feed-entry role-${m.role}`}>
-          <div className="feed-header">
-            <span className="feed-author">
-              {m.agentAlias ? `@${m.agentAlias}` : m.role}
-            </span>
-            <span>{formatTime(m.timestamp)}</span>
+      {messages.map((m, i) => {
+        const rewindKey = m.metadata?.rewindKey;
+        const canRewind =
+          m.role === "user" && !!rewindKey && !streaming;
+        return (
+          <div key={i} className={`feed-entry role-${m.role}`}>
+            <div className="feed-header">
+              <span className="feed-author">
+                {m.agentAlias ? `@${m.agentAlias}` : m.role}
+              </span>
+              <span className="feed-header-right">
+                {formatTime(m.timestamp)}
+                {m.role === "user" && rewindKey && (
+                  <button
+                    type="button"
+                    className="rewind-btn"
+                    disabled={!canRewind}
+                    title={
+                      streaming
+                        ? "Finish the current stream before rewinding"
+                        : "Rewind repos + chat to this turn"
+                    }
+                    onClick={() => setRewindTarget(m)}
+                  >
+                    ⟲ Rewind
+                  </button>
+                )}
+              </span>
+            </div>
+            <div className="feed-content">{m.content}</div>
           </div>
-          <div className="feed-content">{m.content}</div>
-        </div>
-      ))}
+        );
+      })}
+      {rewindTarget && (
+        <RewindConfirmModal
+          channel={channel}
+          sessionId={sessionId}
+          target={rewindTarget}
+          onClose={() => setRewindTarget(null)}
+          onDone={() => {
+            setRewindTarget(null);
+            onRewound();
+          }}
+        />
+      )}
     </>
+  );
+}
+
+function RewindConfirmModal({
+  channel,
+  sessionId,
+  target,
+  onClose,
+  onDone,
+}: {
+  channel: Channel;
+  sessionId: string;
+  target: PersistedChatMessage;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const rewindKey = target.metadata?.rewindKey;
+
+  const apply = async () => {
+    if (!rewindKey) {
+      setError("Message has no rewindKey metadata — cannot rewind.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await api.rewindApply(
+        channel.channelId,
+        sessionId,
+        rewindKey,
+        target.timestamp,
+      );
+      onDone();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">Rewind to this turn?</div>
+        <div className="modal-body">
+          <p>
+            Each repo in this channel will be reset to the commit captured
+            before this message. All messages at or after this turn will be
+            removed from the session, and Claude session IDs will be cleared
+            so the next message starts a fresh conversation.
+          </p>
+          <div className="rewind-repo-list">
+            {channel.repoAssignments.map((r) => (
+              <div key={r.alias} className="rewind-repo-row">
+                <code>@{r.alias}</code>
+                <span className="rewind-repo-path">{r.repoPath}</span>
+              </div>
+            ))}
+          </div>
+          <p className="rewind-warning">
+            <strong>Warning:</strong> this runs <code>git reset --hard</code>.
+            Any uncommitted changes in these repos will be lost. Shell side
+            effects (API calls, spawned processes, database writes) are{" "}
+            <strong>not</strong> undone.
+          </p>
+          {error && <div className="composer-error">{error}</div>}
+        </div>
+        <div className="modal-footer">
+          <button type="button" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary"
+            onClick={apply}
+            disabled={busy || !rewindKey}
+          >
+            {busy ? "Rewinding…" : "Rewind"}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -396,6 +543,21 @@ function Composer({
         onSessionCreated(activeId);
       }
 
+      // Snapshot every repo in the channel *before* the turn runs so the
+      // user can later click Rewind on this message to restore state.
+      // Snapshot is best-effort — if a repo lacks commits or git errors,
+      // surface it but still let the user send; rewind just won't be
+      // offered for this turn.
+      let rewindKey: string | undefined;
+      if (channel.repoAssignments.length > 0) {
+        try {
+          const snap = await api.rewindSnapshot(channel.channelId, activeId);
+          rewindKey = snap.key;
+        } catch (err) {
+          console.warn("[rewind] snapshot failed:", err);
+        }
+      }
+
       const streamId = await api.startChat({
         channelId: channel.channelId,
         sessionId: activeId,
@@ -404,6 +566,7 @@ function Composer({
         cwd,
         claudeSessionId,
         autoApprove,
+        rewindKey,
       });
       onStartStream({
         streamId,

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -142,6 +142,63 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
 }
 .feed-entry .feed-author { color: var(--accent); font-weight: 500; }
 .feed-entry .feed-content { white-space: pre-wrap; word-break: break-word; }
+.feed-entry .feed-header-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+.rewind-btn {
+  font-size: 10px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  line-height: 1.2;
+}
+.rewind-btn:hover:not(:disabled) {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+.rewind-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.rewind-repo-list {
+  margin: 8px 0;
+  padding: 6px 8px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-size: 12px;
+}
+.rewind-repo-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 2px 0;
+}
+.rewind-repo-row code {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.rewind-repo-path {
+  color: var(--text-muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rewind-warning {
+  color: var(--warn);
+  font-size: 12px;
+  background: rgba(250, 179, 135, 0.08);
+  border-left: 2px solid var(--warn);
+  padding: 6px 8px;
+  margin: 8px 0 0;
+}
 
 .feed-entry.role-user { border-left-color: var(--user); }
 .feed-entry.role-assistant { border-left-color: var(--assistant); }

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -67,6 +67,25 @@ export type PersistedChatMessage = {
   content: string;
   timestamp: string;
   agentAlias?: string;
+  // Free-form per-message metadata. Rewind tags user turns with
+  // `rewindKey` to identify which git refs to restore.
+  metadata?: Record<string, string>;
+};
+
+export type RewindSnapshot = {
+  key: string;
+  snapshots: Array<{
+    alias: string;
+    repoPath: string;
+    sha: string;
+    ref: string;
+  }>;
+};
+
+export type RewindResult = {
+  reset: Array<{ alias: string; repoPath: string; sha: string }>;
+  removedMessages: number;
+  clearedClaudeSessions: boolean;
 };
 
 export type TicketLedgerEntry = {

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -269,6 +269,82 @@ export class SessionStore {
     await writeFile(path, lines.join("\n") + "\n", "utf8");
   }
 
+  /**
+   * Drop messages whose timestamp is >= `timestamp`. Rewrites the JSONL file
+   * atomically (temp-file + rename) and updates `messageCount` on the index.
+   * Returns the number of messages removed.
+   *
+   * Used by the rewind flow to roll the chat log back to a checkpoint. Treats
+   * `timestamp` as a string comparison against the stored ISO8601 — safe
+   * because ISO strings sort lexicographically in chronological order.
+   */
+  async truncateBeforeTimestamp(
+    channelId: string,
+    sessionId: string,
+    timestamp: string
+  ): Promise<number> {
+    const path = this.sessionChatPath(channelId, sessionId);
+    let content: string;
+    try {
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return 0;
+      }
+      throw err;
+    }
+    const lines = content.trimEnd().split("\n").filter((l) => l.length > 0);
+    const kept: string[] = [];
+    let removed = 0;
+    for (const line of lines) {
+      try {
+        const msg = JSON.parse(line) as PersistedChatMessage;
+        if (msg.timestamp >= timestamp) {
+          removed += 1;
+          continue;
+        }
+        kept.push(line);
+      } catch {
+        // Preserve unparseable lines — don't silently lose data.
+        kept.push(line);
+      }
+    }
+    const next = kept.length > 0 ? kept.join("\n") + "\n" : "";
+    const tmpPath = `${path}.tmp.${process.pid}.${sessionsTmpCounter++}`;
+    await writeFile(tmpPath, next, "utf8");
+    try {
+      await rename(tmpPath, path);
+    } catch (err) {
+      await rm(tmpPath, { force: true }).catch(() => {});
+      throw err;
+    }
+
+    const session = await this.getSession(channelId, sessionId);
+    if (session) {
+      session.messageCount = kept.length;
+      session.updatedAt = new Date().toISOString();
+      await this.updateSession(channelId, session);
+    }
+    return removed;
+  }
+
+  /**
+   * Clear all Claude CLI session ids for a session. Used by rewind so that
+   * the next message after a rollback starts a fresh Claude conversation
+   * (Claude can't itself be rewound server-side).
+   */
+  async clearClaudeSessionIds(
+    channelId: string,
+    sessionId: string
+  ): Promise<ChatSession | null> {
+    const session = await this.getSession(channelId, sessionId);
+    if (!session) return null;
+    session.claudeSessionIds = {};
+    session.updatedAt = new Date().toISOString();
+    await this.updateSession(channelId, session);
+    return session;
+  }
+
   async loadMessages(
     channelId: string,
     sessionId: string,

--- a/src/domain/session.ts
+++ b/src/domain/session.ts
@@ -12,6 +12,10 @@ export interface PersistedChatMessage {
   content: string;
   timestamp: string;
   agentAlias: string | null;
+  /** Free-form per-message metadata. Populated by the rewind feature with
+   *  `rewindKey` on user turns. Optional for back-compat with transcripts
+   *  written before the field existed. */
+  metadata?: Record<string, string>;
 }
 
 export function buildSessionId(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1199,19 +1199,40 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     const sessionId = parseNamedArg(args, "--session");
     const role = parseNamedArg(args, "--role") ?? "user";
     const alias = parseNamedArg(args, "--alias") ?? null;
+    const metadataRaw = parseNamedArg(args, "--metadata");
     const content = extractPositionals(args).slice(1).join(" ");
 
     if (!channelId || !sessionId || !content) {
-      console.error("Usage: rly session append --channel <id> --session <id> --role <role> [--alias <name>] <content>");
+      console.error("Usage: rly session append --channel <id> --session <id> --role <role> [--alias <name>] [--metadata <json>] <content>");
       process.exitCode = 1;
       return;
+    }
+
+    let metadata: Record<string, string> | undefined;
+    if (metadataRaw) {
+      try {
+        const parsed = JSON.parse(metadataRaw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          metadata = {};
+          for (const [k, v] of Object.entries(parsed)) {
+            metadata[k] = typeof v === "string" ? v : JSON.stringify(v);
+          }
+        } else {
+          throw new Error("--metadata must be a JSON object of string values");
+        }
+      } catch (err) {
+        console.error(`Invalid --metadata JSON: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+        return;
+      }
     }
 
     await store.appendMessage(channelId, sessionId, {
       role,
       content,
       timestamp: new Date().toISOString(),
-      agentAlias: alias
+      agentAlias: alias,
+      ...(metadata ? { metadata } : {})
     });
 
     jsonOut({ ok: true });
@@ -1322,8 +1343,107 @@ async function handleChatCommand(
     return;
   }
 
-  console.error("Usage: rly chat <system-prompt|resolve-refs|mcp-config>");
+  if (sub === "rewind-snapshot") {
+    const channelId = parseNamedArg(args, "--channel");
+    const sessionId = parseNamedArg(args, "--session");
+    if (!channelId || !sessionId) {
+      console.error("Usage: rly chat rewind-snapshot --channel <id> --session <id>");
+      process.exitCode = 1;
+      return;
+    }
+    const result = await rewindSnapshot(channelId, sessionId);
+    jsonOut(result);
+    return;
+  }
+
+  if (sub === "rewind-apply") {
+    const channelId = parseNamedArg(args, "--channel");
+    const sessionId = parseNamedArg(args, "--session");
+    const key = parseNamedArg(args, "--key");
+    const messageTimestamp = parseNamedArg(args, "--message-timestamp");
+    if (!channelId || !sessionId || !key || !messageTimestamp) {
+      console.error("Usage: rly chat rewind-apply --channel <id> --session <id> --key <ref-key> --message-timestamp <iso8601>");
+      process.exitCode = 1;
+      return;
+    }
+    const result = await rewindApply(channelId, sessionId, key, messageTimestamp);
+    jsonOut(result);
+    return;
+  }
+
+  console.error("Usage: rly chat <system-prompt|resolve-refs|mcp-config|rewind-snapshot|rewind-apply>");
   process.exitCode = 1;
+}
+
+async function rewindSnapshot(
+  channelId: string,
+  sessionId: string
+): Promise<{ key: string; snapshots: Array<{ alias: string; repoPath: string; sha: string; ref: string }> }> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execFileAsync = promisify(execFile);
+
+  const channelStore = new ChannelStore(undefined, getHarnessStore());
+  const channel = await channelStore.getChannel(channelId);
+  if (!channel) throw new Error(`Channel not found: ${channelId}`);
+
+  const key = `${Date.now()}`;
+  const snapshots: Array<{ alias: string; repoPath: string; sha: string; ref: string }> = [];
+  for (const assignment of channel.repoAssignments ?? []) {
+    const refName = `refs/harness-rewind/${sessionId}/${key}`;
+    const { stdout: shaOut } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: assignment.repoPath
+    });
+    const sha = shaOut.trim();
+    if (!sha) throw new Error(`git rev-parse HEAD produced empty output in ${assignment.repoPath}`);
+    await execFileAsync("git", ["update-ref", refName, sha], {
+      cwd: assignment.repoPath
+    });
+    snapshots.push({ alias: assignment.alias, repoPath: assignment.repoPath, sha, ref: refName });
+  }
+  return { key, snapshots };
+}
+
+async function rewindApply(
+  channelId: string,
+  sessionId: string,
+  key: string,
+  messageTimestamp: string
+): Promise<{
+  reset: Array<{ alias: string; repoPath: string; sha: string }>;
+  removedMessages: number;
+  clearedClaudeSessions: boolean;
+}> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execFileAsync = promisify(execFile);
+
+  const channelStore = new ChannelStore(undefined, getHarnessStore());
+  const channel = await channelStore.getChannel(channelId);
+  if (!channel) throw new Error(`Channel not found: ${channelId}`);
+
+  const refName = `refs/harness-rewind/${sessionId}/${key}`;
+  const reset: Array<{ alias: string; repoPath: string; sha: string }> = [];
+  for (const assignment of channel.repoAssignments ?? []) {
+    const { stdout: shaOut } = await execFileAsync("git", ["rev-parse", "--verify", refName], {
+      cwd: assignment.repoPath
+    }).catch((err) => {
+      throw new Error(`Rewind ref ${refName} missing in ${assignment.repoPath} (alias @${assignment.alias}): ${err instanceof Error ? err.message : String(err)}`);
+    });
+    const sha = shaOut.trim();
+    await execFileAsync("git", ["reset", "--hard", sha], { cwd: assignment.repoPath });
+    reset.push({ alias: assignment.alias, repoPath: assignment.repoPath, sha });
+  }
+
+  const sessionStore = new SessionStore();
+  const removedMessages = await sessionStore.truncateBeforeTimestamp(
+    channelId,
+    sessionId,
+    messageTimestamp
+  );
+  const cleared = await sessionStore.clearClaudeSessionIds(channelId, sessionId);
+
+  return { reset, removedMessages, clearedClaudeSessions: cleared !== null };
 }
 
 async function printRunsIndex(


### PR DESCRIPTION
## Summary
- Adds a Cursor-style "Rewind" button on GUI user messages. Before each user turn, the harness now snapshots every repo in the channel as a git ref under `refs/harness-rewind/<sessionId>/<key>` and tags the user message with `rewindKey` metadata.
- Clicking Rewind on any prior user turn resets each repo to its snapshot (`git reset --hard`), drops all messages at/after that turn from the session JSONL, and clears `claudeSessionIds` so the next message starts a fresh Claude conversation (Claude itself can't be rewound server-side — best we can do is fork).
- New CLI subcommands `rly chat rewind-snapshot` and `rly chat rewind-apply` do the git + store work; Tauri `rewind_snapshot` / `rewind_apply` commands are thin wrappers. `PersistedChatMessage.metadata` added (with `#[serde(default)]`) so old transcripts stay loadable.
- Rewind button is disabled while a stream is active. Confirm modal lists exactly which repos will be reset and warns that shell side effects (API calls, DB writes, spawned processes) and uncommitted changes are NOT recoverable.

## Scope / non-goals (v1)
- No snapshot GC — refs accumulate under `refs/harness-rewind/` per session; cheap but we should add pruning on session delete later.
- No cross-session rewind, no per-repo partial rewind.
- No rewind-while-streaming — the active stream is not aborted; button is disabled until stream ends.
- Uses dangling `refs/harness-rewind/<sessionId>/<key>` real refs so they survive `git gc`.

## Test plan
- [ ] `pnpm tauri dev` from `gui/`, open a channel with at least one repo
- [ ] Send a message that edits a file (e.g. "create foo.txt with hello"), confirm a small `⟲ Rewind` button appears on the user turn
- [ ] Send a second message that edits something else; now click Rewind on the FIRST message
- [ ] Confirm the modal lists the repo paths + warns about `git reset --hard`
- [ ] Confirm repo worktrees match the pre-turn state and the second user+assistant turn is gone from the session
- [ ] Confirm the next message starts a fresh Claude session (different `claudeSessionId`)
- [ ] Confirm the Rewind button is disabled while a stream is mid-flight
- [ ] `pnpm test test/session-store-harness-store.test.ts` passes (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)