### PR TITLE
OSS release prep: community health, CI, docs polish, SECURITY

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Something not working as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more concretely you can answer the questions below, the faster we can reproduce and fix.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what's broken.
+      placeholder: "rly board crashes with a TypeError when a channel has no tickets."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: The minimal sequence of commands or actions that triggers the bug. Start from a fresh state if possible.
+      placeholder: |
+        1. `rly up` in an empty repo
+        2. `rly channel create test`
+        3. `rly board <channelId>`
+        4. See crash
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+      description: What should have happened, and what actually happened.
+      placeholder: |
+        Expected: empty board renders with zero tickets per column.
+        Actual: TypeError: Cannot read properties of undefined (reading 'status').
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Relay version
+      description: Output of `rly --version`, or the commit hash you're running.
+      placeholder: "0.1.0 (commit abc1234)"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS / platform
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other (note in logs section)
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Which part of Relay is misbehaving?
+      multiple: true
+      options:
+        - CLI (rly)
+        - TUI (rly tui)
+        - GUI (rly gui)
+        - MCP tool
+        - Orchestrator / scheduler
+        - Installer
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste any stack traces, relevant lines from `~/.relay/` artifacts, or screenshots. Redact tokens.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new capability or UX change.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are easier to evaluate when they're grounded in a concrete problem. Please fill in the motivation before the proposal — it's more useful than the proposal alone.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what's getting in the way today? Include a concrete workflow or example if you can.
+      placeholder: |
+        When I run multi-repo refactors I can't see per-repo agent progress in the GUI — the sidebar only shows the primary. I end up tailing `~/.relay/` by hand.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: Roughly what the change would look like. CLI surface, UI sketch, config knob — whatever form fits. Doesn't have to be a full design.
+      placeholder: |
+        Add a "Associated agents" section to the GUI right pane showing live heartbeat status for every attached repo's `rly claude` session, pulling from `~/.relay/crosslink/sessions/`.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why the proposal above won out. Optional.
+    validations:
+      required: false
+  - type: dropdown
+    id: willing-to-implement
+    attributes:
+      label: Would you want to implement this yourself?
+      options:
+        - "Yes"
+        - "Maybe — with guidance"
+        - "No"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Keep the PR scope tight — one logical change. Update docs when behavior changes.
+If this PR is AI-assisted, leave the `Co-Authored-By:` footer on the commits.
+-->
+
+## Summary
+
+-
+-
+
+## Test plan
+
+- [ ] `pnpm test`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+- [ ] `cargo check --workspace` (if Rust changed)
+- [ ] Manual verification: <describe the flow you exercised>
+
+## Breaking changes?
+
+<!-- Yes / No. If yes, describe the break and the migration path. Mention any changes to CLI flags, config vars, `~/.relay/` file layout, MCP tool shapes, or the `crates/harness-data` struct. -->
+
+No.
+
+---
+
+<sub>AI-assisted PR? Keep the `Co-Authored-By: Claude …` footer on your commits so provenance is visible in `git log`.</sub>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ts-verify:
+    name: ts-verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Build GUI (Vite bundle)
+        run: |
+          cd gui
+          pnpm install --frozen-lockfile
+          pnpm build
+
+  rust-check:
+    name: rust-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo target
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check
+        run: cargo check --workspace --locked
+
+      - name: Cargo test (harness-data)
+        run: cargo test -p harness-data
+
+  format-check:
+    name: format-check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Prettier check
+        run: pnpm dlx prettier --check 'src/**/*.{ts,tsx}' 'gui/src/**/*.{ts,tsx}' '*.md'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at uruguay90@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Relay
+
+Practical notes for sending a patch. The README's **Contributing** section is the short version of this file.
+
+## Before you start
+
+For anything beyond a typo or a single-file fix, open an issue first. A 5-line sketch of what you want to change and why saves everyone time — especially for anything touching the orchestrator (classifier / planner / decomposer / scheduler), the MCP tool surface, or the `HarnessStore` interface. Small bugfixes, doc edits, and self-contained refactors can go straight to a PR.
+
+## Development setup
+
+```bash
+pnpm install && pnpm test
+```
+
+That's the loop. For a deeper tour of the pieces — channels, sessions, runs, tickets, dashboards — read [`docs/getting-started.md`](./docs/getting-started.md).
+
+A note on how `rly` runs: `bin/rly.mjs` invokes `src/cli.ts` through `tsx`, so edits to TS source are live on the next `rly …` invocation — no rebuild. Set `RELAY_USE_DIST=1` if you specifically want to exercise the pre-built `dist/` output (slightly faster startup, but stale until you `rly rebuild` / `pnpm build`).
+
+## Local verification
+
+Before you push, run:
+
+```bash
+pnpm test && pnpm typecheck && pnpm build
+```
+
+If your change touches any Rust code (`tui/`, `gui/src-tauri/`, `crates/`), also run:
+
+```bash
+cargo check --workspace
+```
+
+`pnpm test` is vitest; it should complete in well under a minute. `pnpm build` runs `tsc -p tsconfig.build.json` and the migration copier — it needs to pass for the published `dist/` to work.
+
+## Branch and commit conventions
+
+Looking at the commit log is the fastest way to match the house style — but concretely:
+
+- Short imperative title. Scope-prefix with a module or ticket tag (`T-104:`, `gui:`, `rly rebuild:`) when it helps readers scan.
+- Body explains the **why**, not a diff summary. Readers can see the diff; they can't see your reasoning.
+- No Conventional Commits spec, no emoji, no ticket-reference footers beyond the internal `T-###` shorthand.
+- If the change was AI-assisted, keep the `Co-Authored-By:` footer Claude adds. It's an honest provenance signal.
+- Branch names are free-form; recent branches use `feat/<short-slug>` or `feat/t-###-<slug>`. Match what's there.
+
+Prefer multiple small commits with coherent titles over one `"wip"` blob squashed at merge time.
+
+## PR conventions
+
+- **One logical change per PR.** If you touched two unrelated things, split them.
+- Update documentation (README, `docs/getting-started.md`, inline doc comments) in the same PR whenever behavior or the CLI surface changes.
+- Put a **Test plan** checklist at the end of the PR body — the commands you ran, the manual flows you exercised (e.g. "spun up `rly claude`, pasted a GitHub issue URL, watched board move to completed"). PRs without a test plan get sent back.
+- Call out behavior changes loudly. If you change a default, a config var, or a file layout under `~/.relay/`, say so in the summary.
+- If the PR is AI-assisted, leave the co-author footer on the commits and mention it in the body.
+
+## Testing conventions
+
+- Vitest, in `test/` mirroring `src/`. New behavior needs a test; new bugs need a regression test first.
+- Live-network tests (anything hitting real Claude / Codex / GitHub / Linear) sit inside `describe.skip(...)` blocks. Don't enable them in default CI paths.
+- **No snapshot tests for orchestrator output.** Assert on shape — ticket count, status transitions, specific fields — not on stringified blobs. Orchestrator output evolves; snapshots turn every legitimate change into churn.
+- `HARNESS_LIVE=1` switches from the scripted `ScriptedInvoker` to real Claude/Codex spawns. Leave it off for unit work — scripted mode is fast and deterministic. Turn it on only when you're specifically testing adapter plumbing.
+
+## Style
+
+- Two-space indent, double quotes, semicolons, trailing commas where the language allows them.
+- No linter config is enforced in CI. Run your editor's built-in formatter on files you touch; leave untouched files alone (no drive-by reformats in a feature PR).
+- Keep imports tidy — no unused, grouped roughly as node-builtin / dep / local.
+
+## Changes that span the dashboards
+
+The CLI, TUI, and GUI all read the same files under `~/.relay/`. If you change the data model the CLI writes, the Rust side needs to keep up:
+
+- Update `crates/harness-data/src/lib.rs` (the shared Rust types consumed by both `tui/` and `gui/`) in the same PR. Otherwise the TUI or GUI will silently drop fields or fail to parse.
+- If you add an MCP tool, update the **MCP tools** section in `README.md` and mention it in the PR summary. `rly inspect-mcp` is the authoritative live list, but the README count is what people grep for.
+- If you change the file layout under `~/.relay/`, update the **File layout** tree in `README.md` too.
+
+## Filing issues
+
+Use the forms under `.github/ISSUE_TEMPLATE/`:
+
+- **Bug report** for something not working as documented.
+- **Feature request** for new capabilities or UX changes.
+
+The templates ask the questions we'll otherwise have to ask you anyway — filling them in upfront shortens the round-trip.
+
+## Security issues
+
+If you think you've found a security issue, **don't open a public issue**. Email `uruguay90@gmail.com` with the details and we'll triage privately before any disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+Relay is a personal open-source project, not a corporate product. This policy is a good-faith coordinated-disclosure template — please treat it as such.
+
+## Reporting a vulnerability
+
+Email **uruguay90@gmail.com** with:
+
+- Affected version — a commit hash, or the output of `rly --version`.
+- A reproduction — minimal steps or a small script. Private repro repos are fine.
+- Impact — what an attacker gets, and what prerequisites they need.
+
+You can expect an acknowledgement within **72 hours**. Please do not open a public GitHub issue for suspected vulnerabilities until we've had a chance to discuss.
+
+## Scope
+
+**In scope:** the Relay codebase in this repository — CLI, MCP server, orchestrator, channel store, crosslink, dashboards, installer.
+
+**Out of scope:**
+
+- Vulnerabilities in Claude Code, Codex, or the `@aoagents/*` packages — please report those to their respective maintainers.
+- Issues in your own code that Relay dispatches agents to operate on. Relay doesn't protect you from yourself when running with `RELAY_AUTO_APPROVE=1`; that's by design.
+- Social-engineering a user into running a malicious issue URL / prompt. Prompt injection surfaces inside the agent's own trust boundary; see *Known-and-accepted risks* below.
+
+## Known-and-accepted risks
+
+These are deliberate trade-offs, not bugs. Please don't report them as vulnerabilities.
+
+- **`RELAY_AUTO_APPROVE=1` disables every permission check** in Claude and Codex (`--dangerously-skip-permissions` / `--full-auto`). That is the entire point of the flag — it exists so multi-hour unattended runs don't stall on prompts. Use it only when you trust the tasks you're dispatching.
+- **macOS Terminal spawning via `osascript`** requires the user to grant Automation permissions to their terminal once. Once granted, Relay can open Terminal tabs and run `rly claude` in them without further prompts. This is a feature (spawning associated-repo agents) not a privilege escalation.
+- **MCP tools run with the agent's full access.** Relay does not sandbox what Claude/Codex do inside a session — if the agent has shell access, so does anything it gets prompt-injected into running. For isolation, use the `PodExecutor` (Kubernetes) backend; verifications then run in a pod against a per-workspace PVC instead of on your laptop.
+- **Tokens live in `~/.relay/config.env`** with standard Unix permissions. `GITHUB_TOKEN`, `LINEAR_API_KEY`, `COMPOSIO_API_KEY`, and any other secrets you put there are readable by anything running as your user. If someone has read access to your home directory, they have your tokens.
+
+## Supported versions
+
+Pre-1.0. Only `main` is supported — there is no LTS branch. Fixes land as new commits on `main`; there are no backports.
+
+## Credit
+
+If you report a valid issue and want credit, I'm happy to name you in the release notes or commit message. If you'd rather stay anonymous, that's fine too.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,38 +1,78 @@
 # Getting started with Relay
 
-A 10-minute read. Once you're past Install, run `rly welcome` for the interactive tour — this doc is the reference it points at.
+The deeper walkthrough. Start here once the README has sold you on the idea and you want to build the mental model.
 
-## 1. Install
+If you haven't installed yet: `./install.sh` from the repo root, then `cp ~/.relay/config.env.template ~/.relay/config.env` and fill in `GITHUB_TOKEN`, `LINEAR_API_KEY`, `HARNESS_LIVE=1`. The README covers the details.
 
-One command from a fresh clone:
+## From zero to first merged PR
 
-```bash
-./install.sh
+Ten concrete steps. Assumes `GITHUB_TOKEN`, `HARNESS_LIVE=1`, and `RELAY_AUTO_APPROVE=1` are all set.
+
+1. **`cd /path/to/your/repo && rly up`** — registers the repo in `~/.relay/workspace-registry.json`. Expect: `registered workspace <hash> → <path>`.
+2. **`rly doctor`** — checks tokens, MCP wiring, binary paths. Expect a grid of green check marks. A red line here means stop and fix before step 3.
+3. **`rly claude`** — launches Claude with the Relay MCP server attached. Expect: Claude's banner, then the MCP toolbar showing 18 tools (6 harness / 7 channel / 5 crosslink).
+4. **Paste a GitHub issue URL** as your first message — e.g. `https://github.com/your-org/your-repo/issues/42`. Expect: the classifier prints `resolved: <title>`, `tier: feature_small`, `suggestedBranch: feat/42-…`.
+5. **Planner runs** — you see a phased plan in the feed (`phase 1: scaffold`, `phase 2: wire`, `phase 3: tests`). No approval prompt on `feature_small`; `feature_large`/`architectural` would pause here.
+6. **Decomposer emits tickets** — watch the feed print `T-1 … T-4 ready`. Tickets with no `dependsOn` go `ready` immediately; others stay `blocked`.
+7. **In a second terminal: `rly board <channelId>`** — live kanban. Tickets move `ready → executing → verifying → completed` as scheduler-dispatched agents pick them up (max 3 concurrent).
+8. **First PR opens** — the feed prints `PR #123 opened https://github.com/…`. The PR watcher auto-registers it and begins polling every 30 s.
+9. **`rly pr-status`** — shows every tracked PR with live CI + review state. Wait for `ci: passing / review: approved`. If CI fails, the watcher files a follow-up ticket automatically; no manual retriage.
+10. **PR merges** — the feed prints `PR #123 merged`. The channel's ticket board shows all tickets `completed`. You never touched the keyboard after step 4.
+
+If you're not on `RELAY_AUTO_APPROVE=1`, steps 3–10 pause for per-tool permission prompts.
+
+## The five nouns
+
+- **Channel** — a Slack-like space for one piece of work. Carries a feed, ticket ledger, decisions, and linked runs.
+- **Session** — your Claude/Codex CLI with the Relay MCP server attached. All agent activity flows through it.
+- **Run** — one execution of the classifier → planner → scheduler pipeline. Lives under a channel.
+- **Ticket** — a parallelisable work unit produced by the decomposer. Has dependencies, retry budget, verification commands.
+- **Decision** — a recorded choice with rationale + alternatives considered. Queryable per channel.
+
+## A worked example
+
+Paste this into a fresh `rly claude` session:
+
+```
+https://github.com/acme/api/issues/42
 ```
 
-The installer verifies prereqs (`node >=20`, `pnpm`, `git`), builds the TS, links the `rly` and `agent-harness` binaries on your PATH, and scaffolds `~/.relay/config.env.template`. Safe to re-run.
+where issue #42 says *"Rate-limit `/api/search` to 60 req/min per API key, return 429 with `Retry-After` header."*
 
-Add `--with-tui` / `--with-gui` to build the Rust dashboards, or `--skip-link` for CI.
+What happens, in order:
 
-If you've previously installed the tool under the old `agent-harness` name, the installer auto-migrates `~/.agent-harness/` → `~/.relay/` and leaves a back-compat symlink.
+1. **Classifier** hits GitHub, pulls title + body + labels (`enhancement`, `api`, `backend`). Emits `tier: feature_small`, `suggestedBranch: feat/42-rate-limit-search`.
+2. **Planner** writes a 3-phase plan: *(1) add middleware + token-bucket store, (2) wire into `/api/search` route, (3) tests + error-shape*. Feed entry `plan_created`.
+3. **Decomposer** fans out: `T-1 add rate-limit middleware (general)`, `T-2 wire into /api/search (api_crud, depends on T-1)`, `T-3 integration test for 429 + Retry-After (testing, depends on T-2)`, `T-4 update OpenAPI spec (general, depends on T-2)`. Ticket board is live in `rly board <channelId>`.
+4. **Scheduler** starts T-1 (the only `ready` ticket). T-2/T-3/T-4 sit `blocked`. As T-1 completes and verifies, T-2 unblocks, then T-3 + T-4 run in parallel. Max-concurrency defaults to 3 — you can watch the `executing` column fill up.
+5. **Each ticket** spawns its own Claude subprocess with a scoped prompt, runs verification commands (test / lint / typecheck) through the `Executor` abstraction, retries up to `maxTestFixLoops` on failure.
+6. **PR opens** on branch `feat/42-rate-limit-search`. Feed prints the URL. PR watcher auto-registers.
+7. **`rly pr-status`** shows `ci: pending → passing`, `review: pending`. If a reviewer asks for changes, `review: changes_requested` triggers a new follow-up ticket and the loop closes itself.
+8. **Merge** — feed prints `PR #123 merged`. Channel stays around as a record of the whole thing; `rly decisions <channelId>` shows every choice with rationale.
 
-## 2. Tokens
+## Second channel: cross-repo delegation
+
+The interesting case. You have a monorepo front + back-end, or two separate repos:
 
 ```bash
-cp ~/.relay/config.env.template ~/.relay/config.env
-# edit ~/.relay/config.env and set tokens
-echo 'source ~/.relay/config.env' >> ~/.zshrc
-source ~/.zshrc
+rly channel create "auth-v2" \
+  --repos "api:<ws-id>:/path/to/api,web:<ws-id>:/path/to/web" \
+  --primary api
 ```
 
-| Env var | What it unlocks |
-|---|---|
-| `GITHUB_TOKEN` | GitHub issue ingestion + PR watcher (auto CI/review follow-ups) |
-| `LINEAR_API_KEY` | Linear issue ingestion |
-| `HARNESS_LIVE=1` | Real Claude/Codex adapters instead of the scripted demo |
-| `RELAY_AUTO_APPROVE=1` | Unattended mode — no permission prompts. Required for multi-hour runs |
+- `api` is **primary** — the main chat agent runs there; its `cwd` defaults to the API repo.
+- `web` is **associated** — visible to the primary as `alias + path + AGENTS.md summary` (first ~40 lines), not full context.
 
-## 3. Mental model
+The primary is told **not** to grep or edit `web/` directly. Instead:
+
+- **Quick question** → `crosslink_send` to the live `web` agent ("does `/auth/login` still return a JWT?")
+- **Long task** → file a ticket with `assignedAlias: "web"`. The `web` agent polls `tickets.json` and picks it up.
+
+If no `web` agent is live, the primary sees `no_session` and (on macOS) can spawn one: Relay `osascript`s a new Terminal tab and runs `rly claude` in the `web` repo. Tracked in `spawns.json`. Kill it from the GUI and the tab closes.
+
+## Mental model (reference)
+
+For when you want to see the pipeline at a glance:
 
 ```
      you type something          tracker URL?
@@ -69,91 +109,53 @@ source ~/.zshrc
                            merged
 ```
 
-### The five nouns
+## `~/.relay/` file layout
 
-- **Channel** — a Slack-like space for one piece of work. Carries a feed, ticket ledger, decisions, and linked runs.
-- **Session** — your Claude/Codex CLI with the Relay MCP server attached. All agent activity flows through it.
-- **Run** — one execution of the classifier → planner → scheduler pipeline. Lives under a channel.
-- **Ticket** — a parallelisable work unit produced by the decomposer. Has dependencies, retry budget, verification commands.
-- **Decision** — a recorded choice with rationale + alternatives considered. Queryable per channel.
+All three dashboards (CLI / TUI / GUI) read the same files. No synchronisation layer — the filesystem *is* the state.
 
-## 4. Your first flow
-
-```bash
-cd /path/to/some/repo
-rly up                # register the repo
-rly doctor            # sanity check
-rly claude            # launch a session — paste a request or issue URL
-rly board <channelId> # watch tickets move
-rly pr-status         # see live PRs as they open
+```
+~/.relay/
+  config.json                 # global config (project dirs, etc.)
+  config.env                  # tokens + flags (source from your shell rc)
+  workspace-registry.json     # all registered repos
+  workspaces/<hash>/
+    artifacts/runs-index.json
+    artifacts/<runId>/run.json, events.jsonl, ticket-ledger.json, classification.json, approval.json
+  channels/<channelId>/
+    channel.json              # name, members, repoAssignments, primaryWorkspaceId
+    feed.jsonl                # append-only feed
+    tickets.json              # unified ticket board
+    runs.json                 # linked orchestrator runs
+    decisions/<id>.json       # one file per decision (atomic temp-rename)
+    sessions/<sessionId>.jsonl
+    spawns.json               # spawned-agent tracking (macOS GUI)
+  crosslink/
+    sessions/<sessionId>.json # live session heartbeats
+    mailboxes/<sessionId>/    # pending crosslink messages
+    hooks/                    # generated shell hooks for Claude/Codex
+  agent-names.json            # display-name registry
 ```
 
-Issue URLs (GitHub, Linear, or bare `ABC-123` Linear keys) are auto-resolved — the classifier fetches full title / body / labels / branch hint before planning.
+Opting in to Postgres (`PostgresHarnessStore`) keeps the same on-disk layout and adds `LISTEN/NOTIFY` on top for cross-agent coordination.
 
-## 5. Dashboards
-
-Three views, all backed by the same `~/.relay/` files.
-
-```bash
-rly channels              # CLI list
-rly board <channelId>     # CLI kanban
-rly tui                   # ratatui terminal dashboard
-rly gui                   # Tauri desktop app
-```
-
-`rly tui` auto-builds `relay-tui` on first run (~1 min). `rly gui` auto-builds the `.app` bundle on first run (~2–3 min) then `open`s it. `rly gui --dev` launches the Vite hot-reload flow.
-
-## 6. Going unattended
-
-For multi-hour runs where you don't want to click "allow" every few minutes:
-
-```bash
-export RELAY_AUTO_APPROVE=1        # or in ~/.relay/config.env
-rly claude
-```
-
-This passes `--dangerously-skip-permissions` to Claude and `--full-auto` + workspace-write sandbox to Codex. **Only use when you trust the tasks you're dispatching** — there's no per-tool review.
-
-One-off: `rly claude --yolo` or `rly claude --auto-approve`.
-
-## 7. Day-to-day commands
-
-| Command | What it does |
-|---|---|
-| `rly status` | Workspace paths, recent runs, MCP state |
-| `rly running` | Active tasks across every registered workspace |
-| `rly channels` | List channels (sorted by most-recent activity) |
-| `rly channel <id>` | Show one channel's feed |
-| `rly board <id>` | Tickets-by-status kanban |
-| `rly decisions <id>` | Recorded decisions with rationale |
-| `rly list-runs` | Recent persisted runs across workspaces |
-| `rly pr-watch <url>` | Manually track a PR |
-| `rly pr-status` | Show tracked PRs with CI / review state |
-| `rly crosslink status` | Active cross-session messaging |
-| `rly doctor` | Diagnostics |
-| `rly rebuild` | Rebuild TS dist / `--tui` / `--gui` / `--all` |
-| `rly welcome --reset` | Re-run the interactive tour |
-
-## 8. Advanced
-
-- **Crosslink**: concurrent `rly claude` sessions in different repos can discover and message each other via `crosslink_discover` / `crosslink_send` / `crosslink_poll` / `crosslink_reply`. Useful for multi-repo refactors.
-- **Scheduler enqueue**: PR follow-ups (CI fail / changes-requested) become real tickets via the scheduler's dynamic `enqueue` surface, so the loop closes without human intervention.
-- **AO-compatible notifier**: `src/channels/ao-notifier.ts` implements Composio's Notifier interface so Relay can be plugged in as an AO notifier if you ever run their stack.
-- **MCP tools**: 15 exposed to Claude/Codex. See `rly inspect-mcp` for the live list.
-
-## 9. Troubleshooting
+## Troubleshooting
 
 | Symptom | Likely cause / fix |
 |---|---|
-| "GITHUB_TOKEN not set — PR watching disabled" | Expected if you didn't set the token; PRs won't auto-track. |
-| Claude keeps prompting for permissions | Set `RELAY_AUTO_APPROVE=1` or pass `--yolo`. |
-| `rly` runs stale code after `git pull` | Default behavior reads current source via `tsx`, so this shouldn't happen. If you set `RELAY_USE_DIST=1`, run `rly rebuild`. |
+| `GITHUB_TOKEN not set — PR watching disabled` | Expected if you didn't set the token; PRs won't auto-track. |
+| Classifier can't resolve a Linear key like `ABC-123` | `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) not set, or the key doesn't match any issue visible to your token. |
+| Claude keeps prompting for permissions | Set `RELAY_AUTO_APPROVE=1` or pass `--yolo` / `--auto-approve`. |
+| Tickets stuck in `blocked` forever | Check `dependsOn` chain — a failed upstream ticket blocks everything downstream. `rly board <id>` shows the edges. |
+| Ticket retries exhausted (`failed`) | Verification commands kept failing past `maxTestFixLoops`. Feed shows the last verification output; fix manually, mark the ticket `completed`, and the scheduler unblocks downstream. |
+| `rly` runs stale code after `git pull` | Default reads current source via `tsx`, so this shouldn't happen. If you set `RELAY_USE_DIST=1`, run `rly rebuild`. |
 | `rly tui` / `rly gui` fails on first run | Install `cargo` (rustup). The auto-build needs it. |
-| TUI shows no channels | Make sure you've registered at least one workspace with `rly up`. |
+| TUI shows no channels | Register at least one workspace with `rly up` and create a channel (or launch a session, which creates one). |
 | GUI shows stale data | `rly gui --rebuild` to refresh the bundle after a code change. |
+| Crosslink `no_session` when spawning an associated agent | macOS-only today. On Linux/Windows, run `rly claude` in the associated repo manually — crosslink picks it up. |
+| PR watcher never updates | Check `rly pr-status` for errors. Usually a scoping issue on `GITHUB_TOKEN` (needs `repo` scope for private repos). |
 
-## 10. Where to go next
+## Next
 
-- Read `README.md` for the full feature matrix.
-- Run `rly inspect-mcp` to see every MCP tool exposed to your agent.
-- Run `rly welcome --reset` any time to re-play the interactive tour.
+- `rly welcome` for the 6-step interactive tour (`--reset` to replay).
+- `rly inspect-mcp` for the live list of MCP tools exposed to the agent.
+- README for the full feature matrix, CLI reference, MCP catalogue, and architecture map.


### PR DESCRIPTION
Everything GitHub looks for when listing a repo as an OSS project — so we're ready to flip public.

## What lands
- **CONTRIBUTING.md** — setup, verification commands, commit / PR conventions grounded in the existing log, testing conventions, style, cross-dashboard note (touch harness-data when data model changes).
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 verbatim, maintainer email set.
- **.github/ISSUE_TEMPLATE/bug_report.yml** + **feature_request.yml** — GitHub issue forms.
- **.github/PULL_REQUEST_TEMPLATE.md** — summary / test plan / breaking changes / AI co-author reminder.
- **.github/workflows/ci.yml** — 3 parallel jobs (ts-verify, rust-check, format-check-soft). Concurrency group cancels stale PR runs.
- **docs/getting-started.md** — rewritten to complement README instead of repeating it. New \"zero to first merged PR\" walkthrough, concrete worked example, primary+associated+crosslink+spawn section, expanded troubleshooting matrix.
- **SECURITY.md** — coordinated disclosure, 72h ack, scope + known-accepted risks spelled out honestly for a personal OSS project (no corporate bounty language).

## Flagged for a follow-up PR (not here)
- Installer should \`chmod 600\` \`~/.relay/config.env.template\` and any generated \`config.env\` to reduce token-leak blast radius.
- Full-session pod isolation (vs only verification running in pods) is the real path to sandboxing MCP tool calls.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 381/381 + 22 skipped
- [x] \`pnpm build\` clean
- [x] YAML files parse (ci.yml + issue templates)
- [ ] Merge, confirm GitHub renders the community-standards checklist as complete (Settings → Insights → Community).
- [ ] First CI run on a subsequent PR — watch for Tauri system-deps failure on ubuntu-latest; if it happens, add \`apt-get install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev\` before \`cargo check\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)