### PR TITLE
Post-rename cleanup + chmod 600 on config files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,11 +165,17 @@ cat > "$TEMPLATE" <<'ENVEOF'
 # export RELAY_AUTO_APPROVE=1
 ENVEOF
 
+# Tighten perms — these files hold (or will hold) API tokens. Making them
+# owner-read-only reduces blast radius if a backup tool, shared dev machine,
+# or Time Machine snapshot ends up somewhere it shouldn't. Idempotent.
+chmod 600 "$TEMPLATE" 2>/dev/null || true
+
 CONFIG="${RELAY_DIR}/config.env"
 if [ ! -f "$CONFIG" ]; then
   log "No existing config.env found — leaving template only (copy it over when ready)"
 else
   log "Existing config.env preserved at ${CONFIG}"
+  chmod 600 "$CONFIG" 2>/dev/null || true
 fi
 
 # ---------- next-steps banner ----------

--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
   "name": "relay",
   "version": "0.1.0",
+  "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
+  "license": "MIT",
   "private": false,
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jcast90/relay.git"
+  },
+  "homepage": "https://github.com/jcast90/relay#readme",
+  "bugs": {
+    "url": "https://github.com/jcast90/relay/issues"
+  },
   "bin": {
     "rly": "bin/rly.mjs",
     "agent-harness": "bin/rly.mjs"
@@ -11,6 +21,7 @@
     "bin",
     "dist",
     "src",
+    "LICENSE",
     "README.md"
   ],
   "scripts": {

--- a/test/execution/pod-executor.integration.test.ts
+++ b/test/execution/pod-executor.integration.test.ts
@@ -44,7 +44,7 @@ describeOrSkip("PodExecutor integration (real cluster)", () => {
     };
 
     const sandbox = await sandboxes.create(
-      { root: "/tmp", remoteUrl: "https://github.com/jcast90/agent-harness.git" },
+      { root: "/tmp", remoteUrl: "https://github.com/jcast90/relay.git" },
       "main",
       { runId: "it1", ticketId: "integ" }
     );


### PR DESCRIPTION
Three post-rename / release-hardening items.

## 1. Stale repo URL
\`test/execution/pod-executor.integration.test.ts\` referenced \`github.com/jcast90/agent-harness.git\` as a sandbox fixture. Updated to \`github.com/jcast90/relay.git\`. Only occurrence in the repo.

## 2. \`package.json\` metadata
Added the fields a public OSS npm listing expects: \`description\`, \`license: MIT\`, \`repository\`, \`homepage\`, \`bugs\`. Added \`LICENSE\` to \`files[]\` so the published tarball carries it.

## 3. chmod 600 on config files
\`install.sh\` now sets mode \`0600\` on \`~/.relay/config.env.template\` and any existing \`~/.relay/config.env\` after scaffolding. These hold \`GITHUB_TOKEN\` / \`LINEAR_API_KEY\` / \`COMPOSIO_API_KEY\` — owner-read-only reduces blast radius if a backup tool, shared machine, or Time Machine snapshot lands somewhere it shouldn't. Idempotent + swallows chmod errors so filesystems without Unix perms don't block the installer.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 381/381 + 22 skipped
- [x] \`bash -n install.sh\` clean
- [ ] Manual: run \`./install.sh\`, confirm \`stat -f '%p' ~/.relay/config.env.template\` ends in \`600\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)