### PR TITLE
OSS-07: README drift fixes + welcome scaffolds config.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ A channel can attach multiple repos. Exactly **one is primary** — that's where
 
 ### Crosslink
 
-Live agents in different repos (each a `rly claude` session) discover each other via heartbeat files in `~/.relay/crosslink/sessions/` and exchange messages. MCP tools: `crosslink_discover` / `crosslink_send` / `crosslink_poll` / `crosslink_reply` / `crosslink_register`.
+Live agents in different repos (each a `rly claude` session) discover each other via heartbeat files in `~/.relay/crosslink/sessions/` and exchange messages. MCP tools: `crosslink_discover` / `crosslink_send` / `crosslink_poll`.
 
 ### Spawning associated agents
 
@@ -276,11 +276,11 @@ The legacy `agent-harness <cmd>` alias is accepted for all commands so existing 
 
 Exposed to Claude and Codex via the Relay MCP server:
 
-**Harness (6)**: `harness_status`, `harness_list_runs`, `harness_get_run_detail`, `harness_get_artifact`, `harness_approve_plan`, `harness_reject_plan`
+**Harness (8)**: `harness_status`, `harness_list_runs`, `harness_get_run_detail`, `harness_get_artifact`, `harness_approve_plan`, `harness_reject_plan`, `harness_dispatch`, `project_create`
 
-**Channels (7)**: `channel_create`, `channel_get`, `channel_post`, `channel_record_decision`, `channel_task_board`, `channel_list_tickets`, `harness_running_tasks`
+**Channels (6)**: `channel_create`, `channel_get`, `channel_post`, `channel_record_decision`, `channel_task_board`, `harness_running_tasks`
 
-**Crosslink (5)**: `crosslink_discover`, `crosslink_send`, `crosslink_poll`, `crosslink_reply`, `crosslink_register`
+**Crosslink (3)**: `crosslink_discover`, `crosslink_send`, `crosslink_poll`
 
 Run `rly inspect-mcp` for the authoritative live list.
 

--- a/src/cli/welcome.ts
+++ b/src/cli/welcome.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { createInterface, Interface } from "node:readline/promises";
 import { join } from "node:path";
 
@@ -7,6 +7,37 @@ import { getRelayDir } from "./paths.js";
 import { listRegisteredWorkspaces } from "./workspace-registry.js";
 
 const ONBOARDED_FILE = "onboarded.json";
+const CONFIG_ENV = "config.env";
+const CONFIG_ENV_TEMPLATE = "config.env.template";
+
+export type ScaffoldResult =
+  | { status: "created"; from: string; to: string }
+  | { status: "already-exists"; path: string }
+  | { status: "missing-template"; expectedTemplate: string };
+
+/**
+ * Copy `config.env.template` into `config.env` inside the given relay dir.
+ * Idempotent — never overwrites an existing `config.env`. If the template is
+ * missing (fresh clone without `install.sh` run, or a manual install), the
+ * caller gets `missing-template` back so it can show the user the right hint.
+ *
+ * Exported for unit tests; `runWelcome` calls this when the user opts in.
+ */
+export async function scaffoldConfigEnv(relayDir: string): Promise<ScaffoldResult> {
+  const target = join(relayDir, CONFIG_ENV);
+  const template = join(relayDir, CONFIG_ENV_TEMPLATE);
+
+  if (existsSync(target)) {
+    return { status: "already-exists", path: target };
+  }
+  if (!existsSync(template)) {
+    return { status: "missing-template", expectedTemplate: template };
+  }
+
+  await mkdir(relayDir, { recursive: true });
+  await copyFile(template, target);
+  return { status: "created", from: template, to: target };
+}
 
 // Catppuccin-ish ANSI for terminal output. Falls back gracefully on
 // non-colour terminals — no library dependency.
@@ -139,6 +170,9 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
 
     // ── 2. Setup check ───────────────────────────────────────────────────
     header(2, total, "Setup check");
+    const relayDir = getRelayDir();
+    const configEnvPath = join(relayDir, CONFIG_ENV);
+    const configEnvExists = existsSync(configEnvPath);
     const tokens = await readTokensFromConfig();
     const workspaces = await listRegisteredWorkspaces();
 
@@ -146,16 +180,49 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
       b ? `${c.green}✓${c.reset}` : `${c.peach}·${c.reset}`;
 
     p("");
+    p(`  ${ok(configEnvExists)} ~/.relay/config.env ${configEnvExists ? "present" : "missing"}`);
     p(`  ${ok(tokens.github)} GITHUB_TOKEN      ${tokens.github ? "set" : "not set — PR watcher + GitHub issues disabled"}`);
     p(`  ${ok(tokens.linear)} LINEAR_API_KEY    ${tokens.linear ? "set" : "not set — Linear issue ingestion disabled"}`);
     p(
       `  ${ok(workspaces.length > 0)} repos registered  ${workspaces.length} workspace${workspaces.length === 1 ? "" : "s"}`
     );
     p("");
-    if (!tokens.github) {
-      p(`  ${c.dim}To enable:${c.reset}`);
-      p(`    cp ~/.relay/config.env.template ~/.relay/config.env`);
-      p(`    ${c.dim}# fill in tokens${c.reset}`);
+
+    // If config.env is missing, offer to scaffold it so the user doesn't
+    // hit runtime errors later from a missing file. Interactive flows prompt;
+    // non-interactive flows just print the cp command.
+    if (!configEnvExists) {
+      if (rl) {
+        const answer = (
+          await ask(
+            rl,
+            "No ~/.relay/config.env yet — copy the template into place now? [Y/n]"
+          )
+        ).toLowerCase();
+        if (answer === "" || answer === "y" || answer === "yes") {
+          const result = await scaffoldConfigEnv(relayDir);
+          if (result.status === "created") {
+            p(`  ${c.green}✓${c.reset} Created ${result.to}`);
+            p(`    ${c.dim}Open it and fill in your tokens, then:${c.reset}`);
+            p(`    source ~/.relay/config.env    ${c.dim}# or add to ~/.zshrc${c.reset}`);
+          } else if (result.status === "already-exists") {
+            p(`  ${c.dim}Already exists at ${result.path} — left untouched.${c.reset}`);
+          } else {
+            p(`  ${c.peach}!${c.reset} Template not found at ${result.expectedTemplate}.`);
+            p(`    ${c.dim}Re-run install.sh to drop it in, or create config.env by hand.${c.reset}`);
+          }
+        } else {
+          p(`  ${c.dim}Skipped — when you're ready, run:${c.reset}`);
+          p(`    cp ~/.relay/config.env.template ~/.relay/config.env`);
+        }
+      } else {
+        p(`  ${c.dim}To create it:${c.reset}`);
+        p(`    cp ~/.relay/config.env.template ~/.relay/config.env`);
+        p(`    ${c.dim}# fill in tokens${c.reset}`);
+        p(`    source ~/.relay/config.env    ${c.dim}# or add to ~/.zshrc${c.reset}`);
+      }
+    } else if (!tokens.github) {
+      p(`  ${c.dim}To enable GitHub/Linear, open${c.reset} ${c.bold}~/.relay/config.env${c.reset} ${c.dim}and fill in tokens, then:${c.reset}`);
       p(`    source ~/.relay/config.env    ${c.dim}# or add to ~/.zshrc${c.reset}`);
     }
     if (workspaces.length === 0) {

--- a/test/cli/welcome-scaffold.test.ts
+++ b/test/cli/welcome-scaffold.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { scaffoldConfigEnv } from "../../src/cli/welcome.js";
+
+/**
+ * Unit tests for the `scaffoldConfigEnv` helper used by `rly welcome`.
+ *
+ * The welcome flow needs to drop a `config.env` into a fresh `~/.relay/` when
+ * the user opts in. These tests pin down the three cases the welcome prompt
+ * can land on: template present / target already present / template missing.
+ * Idempotency matters — running the welcome tour twice must not clobber a
+ * config file the user has already edited.
+ */
+
+describe("scaffoldConfigEnv", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "relay-scaffold-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("copies template -> config.env when target is missing", async () => {
+    const templateBody = "# test template\n# export GITHUB_TOKEN=\"\"\n";
+    await writeFile(join(dir, "config.env.template"), templateBody);
+
+    const result = await scaffoldConfigEnv(dir);
+
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.to).toBe(join(dir, "config.env"));
+      expect(result.from).toBe(join(dir, "config.env.template"));
+    }
+
+    const copied = await readFile(join(dir, "config.env"), "utf8");
+    expect(copied).toBe(templateBody);
+  });
+
+  it("is idempotent — never overwrites an existing config.env", async () => {
+    await writeFile(join(dir, "config.env.template"), "# template\n");
+    await writeFile(join(dir, "config.env"), "# user edits — do not touch\n");
+
+    const first = await scaffoldConfigEnv(dir);
+    expect(first.status).toBe("already-exists");
+
+    // Run again — still untouched.
+    const second = await scaffoldConfigEnv(dir);
+    expect(second.status).toBe("already-exists");
+
+    const preserved = await readFile(join(dir, "config.env"), "utf8");
+    expect(preserved).toBe("# user edits — do not touch\n");
+  });
+
+  it("returns missing-template when the template isn't there", async () => {
+    const result = await scaffoldConfigEnv(dir);
+    expect(result.status).toBe("missing-template");
+    if (result.status === "missing-template") {
+      expect(result.expectedTemplate).toBe(join(dir, "config.env.template"));
+    }
+
+    // And no config.env was created as a side effect.
+    await expect(stat(join(dir, "config.env"))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Two onboarding/docs gaps (OSS-07). Docs-only except for a small welcome-flow add.

### README drift fixes (`README.md`)

Current `tools/list` response in `src/mcp/server.ts` + `src/mcp/channel-tools.ts` + `src/crosslink/tools.ts` advertises **17 tools**, not what the README said.

| README line | Was | Now |
|---|---|---|
| L170 | Crosslink MCP tools listed as 5 (`crosslink_discover / _send / _poll / _reply / _register`) | 3 (`crosslink_discover / _send / _poll`). `_reply`, `_register`, `_deregister` are handled by the dispatcher but not advertised in `tools/list` — so they're not exposed as MCP tools |
| L279 | **Harness (6)** | **Harness (8)** — added `harness_dispatch` and `project_create` (both defined in `src/mcp/server.ts:225,246`) |
| L281 | **Channels (7)** with `channel_list_tickets` | **Channels (6)** — removed `channel_list_tickets` (doesn't exist anywhere in `src/`) |
| L283 | **Crosslink (5)** with `_reply` + `_register` | **Crosslink (3)** — same reasoning as L170 |

Other README claims spot-checked and kept:

- `rly init` / `rly dev` — not mentioned in README or `docs/`. Nothing to remove.
- Slack "integration" — only appears as a metaphor ("Slack-like space", "Slack-style channels"). No implementation claim to downgrade.
- "380+ vitest cases" (L428) — currently 384 passing + 22 skipped. Accurate.
- All CLI commands in the reference table exist in `src/index.ts`.

### Welcome tour now scaffolds `config.env` (`src/cli/welcome.ts`)

Previously, step 2 told the user to run `cp ~/.relay/config.env.template ~/.relay/config.env` themselves. If they skipped it, later commands hit runtime errors.

Now:
- Step 2 shows whether `~/.relay/config.env` exists.
- If missing and running interactively, prompts `Copy the template into place now? [Y/n]`. On yes, copies it; on no, prints the exact `cp` command.
- Non-interactive (`--non-interactive` or no TTY) just prints the `cp` command like before.
- New exported `scaffoldConfigEnv(relayDir)` helper — idempotent, never overwrites, returns a descriminated result so the UI can show the right hint if the template itself is missing.

### Tests (`test/cli/welcome-scaffold.test.ts`)

Three cases on a per-test `tmpdir`:
1. Template present, target missing -> copies, returns `created`.
2. Target already exists -> returns `already-exists`, contents untouched (idempotency).
3. Template missing -> returns `missing-template`, no file created.

## Verification

- `pnpm test`: 384 passed, 22 skipped (was 381 / 22)
- `pnpm typecheck`: clean
- `pnpm build`: clean

## Test plan

- [ ] `rly welcome --reset` on a machine with no `~/.relay/config.env` — prompt appears, accepting copies the template.
- [ ] Same flow, decline the prompt — exact `cp` command is printed.
- [ ] `rly welcome --reset --non-interactive` — just prints the `cp` command, does not prompt.
- [ ] Already-present `config.env` is never overwritten.
- [ ] README MCP counts reconcile with `rly inspect-mcp` / `src/mcp/server.ts`.

Sub-150 LOC total. Draft — do not merge until approved.