### PR TITLE
OSS-01: Rewind hardening (JSON injection fix, dirty-worktree guard, rollback, ref cleanup, stream abort, tests)

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,11 +1,12 @@
 use harness_data as data;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 use tauri::Emitter;
 
 #[tauri::command]
@@ -294,6 +295,38 @@ fn rewind_apply(
 
 static CHAT_SEQ: AtomicU64 = AtomicU64::new(0);
 
+// Stream ids the caller has asked us to cancel. A spawned `start_chat`
+// thread checks this between stdout lines and, if present, exits the loop
+// without persisting a partial assistant message. Rewind calls
+// `cancel_chat_stream` before truncating the session log to avoid the race
+// where the streaming thread appends AFTER truncation.
+static CANCELLED_STREAMS: Mutex<Option<HashSet<u64>>> = Mutex::new(None);
+
+fn mark_stream_cancelled(stream_id: u64) {
+    let mut guard = CANCELLED_STREAMS.lock().expect("CANCELLED_STREAMS poisoned");
+    guard.get_or_insert_with(HashSet::new).insert(stream_id);
+}
+
+fn is_stream_cancelled(stream_id: u64) -> bool {
+    let guard = CANCELLED_STREAMS.lock().expect("CANCELLED_STREAMS poisoned");
+    guard.as_ref().map_or(false, |s| s.contains(&stream_id))
+}
+
+fn clear_stream_cancelled(stream_id: u64) {
+    let mut guard = CANCELLED_STREAMS.lock().expect("CANCELLED_STREAMS poisoned");
+    if let Some(set) = guard.as_mut() {
+        set.remove(&stream_id);
+    }
+}
+
+/// Build the `--metadata` JSON blob attached to a rewind-anchored user
+/// message. Isolated as a pure function so a rewind_key containing newlines,
+/// quotes, backslashes, or JSON fragments round-trips through serde instead
+/// of being spliced into a format string (Gap #1 from the rewind audit).
+fn build_rewind_metadata_json(rewind_key: &str) -> String {
+    serde_json::json!({ "rewindKey": rewind_key }).to_string()
+}
+
 #[derive(Serialize, Clone)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 enum ChatEvent {
@@ -356,9 +389,7 @@ fn start_chat(
     // frontend can later offer a Rewind button that resets repos to the
     // snapshot captured before this turn.
     let alias_arg = alias.clone();
-    let metadata_json = rewind_key
-        .as_ref()
-        .map(|k| format!("{{\"rewindKey\":\"{}\"}}", k.replace('"', "\\\"")));
+    let metadata_json = rewind_key.as_ref().map(|k| build_rewind_metadata_json(k));
     let mut append_args: Vec<&str> = vec![
         "session", "append", "--channel", &channel_id, "--session", &session_id, "--role", "user",
     ];
@@ -482,8 +513,18 @@ fn start_chat(
         let reader = BufReader::new(stdout);
         let mut accum = String::new();
         let mut final_session_id: Option<String> = None;
+        let mut cancelled = false;
 
         for line in reader.lines() {
+            // Rewind (and anything else that wants to abort a live stream)
+            // sets the cancellation flag via `cancel_chat_stream`. Check on
+            // every iteration so we stop appending to `accum` promptly; the
+            // child process is killed below to unblock the read loop.
+            if is_stream_cancelled(stream_id) {
+                cancelled = true;
+                let _ = child.kill();
+                break;
+            }
             let line = match line {
                 Ok(l) if l.is_empty() => continue,
                 Ok(l) => l,
@@ -588,6 +629,23 @@ fn start_chat(
         }
         let _ = child.wait();
 
+        // If rewind (or anything else) cancelled this stream, DO NOT
+        // persist a partial assistant message or update the claude session
+        // id — that's exactly the race Gap #8 fixes. Clear the flag so the
+        // next stream that happens to reuse this id (extremely unlikely
+        // given the monotonic AtomicU64, but cheap insurance) starts clean.
+        if cancelled {
+            clear_stream_cancelled(stream_id);
+            let _ = app_handle.emit(
+                "chat-event",
+                ChatEvent::Done {
+                    stream_id,
+                    final_text: String::new(),
+                },
+            );
+            return;
+        }
+
         // Persist the assistant message.
         if !accum.is_empty() {
             let mut append_args: Vec<&str> = vec![
@@ -642,6 +700,17 @@ fn start_chat(
     });
 
     Ok(stream_id)
+}
+
+/// Signal a running `start_chat` thread to exit without persisting the
+/// assistant message. The rewind button calls this BEFORE truncating the
+/// session log so the stream can't race the truncation and re-append a
+/// stale assistant turn (Gap #8). Safe to call with an unknown stream id
+/// — it's a set insert; live threads check the flag on the next line read.
+#[tauri::command]
+fn cancel_chat_stream(stream_id: u64) -> Result<(), String> {
+    mark_stream_cancelled(stream_id);
+    Ok(())
 }
 
 // --- Terminal.app spawn/kill lifecycle (Task #24) ---
@@ -1007,10 +1076,62 @@ pub fn run() {
             rewind_snapshot,
             rewind_apply,
             start_chat,
+            cancel_chat_stream,
             spawn_agent,
             kill_spawned_agent,
             list_spawns,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Gap #1 regression: a `rewind_key` containing quotes, backslashes,
+    /// newlines, or a `},"x":"y"` JSON fragment must round-trip through
+    /// serde as a single string field and not break out of the metadata
+    /// object. The `format!`-based predecessor would emit malformed JSON
+    /// or inject additional fields for these inputs.
+    #[test]
+    fn rewind_metadata_json_escapes_adversarial_keys() {
+        let cases = [
+            "plain",
+            "with \"quote\"",
+            "with \\ backslash",
+            "with\nnewline",
+            "with\ttab",
+            "with \"quote\"\nand \\ and\t tab",
+            r#"},"x":"y"#,
+            r#"break"}, "injected": "yes"}"#,
+        ];
+        for key in cases {
+            let raw = build_rewind_metadata_json(key);
+            let parsed: serde_json::Value = serde_json::from_str(&raw)
+                .unwrap_or_else(|e| panic!("invalid JSON for key {key:?}: {e} (raw: {raw})"));
+            let obj = parsed
+                .as_object()
+                .unwrap_or_else(|| panic!("expected object for key {key:?}, got {parsed}"));
+            // Exactly one field, and it must be `rewindKey` with our exact input.
+            assert_eq!(obj.len(), 1, "unexpected extra fields for key {key:?}: {parsed}");
+            assert_eq!(
+                obj.get("rewindKey").and_then(|v| v.as_str()),
+                Some(key),
+                "rewindKey did not round-trip for {key:?}: {parsed}"
+            );
+        }
+    }
+
+    #[test]
+    fn cancel_flag_roundtrip() {
+        // Isolated check: mark/clear affects is_stream_cancelled as expected.
+        // Use a stream_id guaranteed unique across the test binary.
+        let sid = u64::MAX - 42;
+        assert!(!is_stream_cancelled(sid));
+        mark_stream_cancelled(sid);
+        assert!(is_stream_cancelled(sid));
+        clear_stream_cancelled(sid);
+        assert!(!is_stream_cancelled(sid));
+    }
 }

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -126,6 +126,13 @@ export const api = {
     rewindKey?: string;
   }) => invoke<number>("start_chat", params),
 
+  // Best-effort: signal a running `start_chat` thread to exit without
+  // persisting the assistant message. Called by the rewind flow BEFORE
+  // truncating the session log so the stream can't race truncation and
+  // append a stale assistant turn afterwards.
+  cancelChatStream: (streamId: number) =>
+    invoke<void>("cancel_chat_stream", { streamId }),
+
   // Task #24 contract. These invoke wrappers are thin passthroughs that
   // assume the Rust side registers `spawn_agent`, `list_spawns`, and
   // `kill_spawned_agent` commands that accept / return camelCase via

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -214,6 +214,7 @@ function ChatView({
             sessionId={sessionId}
             messages={sessionMessages}
             streaming={!!stream}
+            streamId={stream?.streamId ?? null}
             onRewound={() => {
               onStartStream(null);
               onRefresh();
@@ -332,12 +333,14 @@ function SessionMessages({
   sessionId,
   messages,
   streaming,
+  streamId,
   onRewound,
 }: {
   channel: Channel;
   sessionId: string;
   messages: PersistedChatMessage[];
   streaming: boolean;
+  streamId: number | null;
   onRewound: () => void;
 }) {
   const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(
@@ -387,6 +390,7 @@ function SessionMessages({
           channel={channel}
           sessionId={sessionId}
           target={rewindTarget}
+          streamId={streamId}
           onClose={() => setRewindTarget(null)}
           onDone={() => {
             setRewindTarget(null);
@@ -402,12 +406,14 @@ function RewindConfirmModal({
   channel,
   sessionId,
   target,
+  streamId,
   onClose,
   onDone,
 }: {
   channel: Channel;
   sessionId: string;
   target: PersistedChatMessage;
+  streamId: number | null;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -423,6 +429,16 @@ function RewindConfirmModal({
     setBusy(true);
     setError(null);
     try {
+      // Gap #8: abort any in-flight stream BEFORE truncating the session
+      // log. Otherwise the Rust streaming thread can append a stale
+      // assistant turn after `rewind-apply` has already truncated + reset.
+      if (streamId !== null) {
+        try {
+          await api.cancelChatStream(streamId);
+        } catch (e) {
+          console.warn("[rewind] cancelChatStream failed:", e);
+        }
+      }
       await api.rewindApply(
         channel.channelId,
         sessionId,

--- a/src/cli/chat-rewind.ts
+++ b/src/cli/chat-rewind.ts
@@ -1,0 +1,218 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Channel, RepoAssignment } from "../domain/channel.js";
+import { ChannelStore } from "../channels/channel-store.js";
+import { getHarnessStore } from "../storage/factory.js";
+import { SessionStore } from "./session-store.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Build the refname we stash a rewind snapshot under. One ref per
+ * (session, key, repo) — the repo is implicit because the ref lives inside
+ * that repo's `.git/refs/` directory.
+ */
+export function rewindRefName(sessionId: string, key: string): string {
+  return `refs/harness-rewind/${sessionId}/${key}`;
+}
+
+export interface RewindSnapshotEntry {
+  alias: string;
+  repoPath: string;
+  sha: string;
+  ref: string;
+}
+
+export interface RewindSnapshotResult {
+  key: string;
+  snapshots: RewindSnapshotEntry[];
+}
+
+export interface RewindApplyEntry {
+  alias: string;
+  repoPath: string;
+  sha: string;
+}
+
+export interface RewindApplyResult {
+  reset: RewindApplyEntry[];
+  removedMessages: number;
+  clearedClaudeSessions: boolean;
+}
+
+/**
+ * Dependencies injected into {@link rewindSnapshot} / {@link rewindApply}
+ * so tests can run without touching `~/.relay/` or a real git repo.
+ *
+ * - `channelStore` is how we look up `repoAssignments` for a channel.
+ * - `sessionStore` owns the session JSONL + index writes that get
+ *   truncated on apply.
+ * - `gitExec` runs `git <args>` in a given cwd. The default implementation
+ *   is `execFile("git", …)`; tests swap in a fake that returns scripted
+ *   stdout or throws.
+ */
+export interface RewindDeps {
+  channelStore: Pick<ChannelStore, "getChannel">;
+  sessionStore: Pick<
+    SessionStore,
+    "truncateBeforeTimestamp" | "clearClaudeSessionIds"
+  >;
+  gitExec: (
+    args: string[],
+    opts: { cwd: string }
+  ) => Promise<{ stdout: string; stderr: string }>;
+  /** Injectable clock for deterministic test keys. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+export function defaultRewindDeps(): RewindDeps {
+  return {
+    channelStore: new ChannelStore(undefined, getHarnessStore()),
+    sessionStore: new SessionStore(),
+    gitExec: async (args, opts) => execFileAsync("git", args, { cwd: opts.cwd })
+  };
+}
+
+async function resolveChannelRepos(
+  channelStore: RewindDeps["channelStore"],
+  channelId: string
+): Promise<RepoAssignment[]> {
+  const channel = (await channelStore.getChannel(channelId)) as Channel | null;
+  if (!channel) throw new Error(`Channel not found: ${channelId}`);
+  return channel.repoAssignments ?? [];
+}
+
+/**
+ * Snapshot the current HEAD of every channel repo under
+ * `refs/harness-rewind/<sessionId>/<key>`. Returns the key so callers can
+ * stash it as `rewindKey` metadata on the upcoming user message.
+ */
+export async function rewindSnapshot(
+  channelId: string,
+  sessionId: string,
+  deps: RewindDeps = defaultRewindDeps()
+): Promise<RewindSnapshotResult> {
+  const repos = await resolveChannelRepos(deps.channelStore, channelId);
+  const key = `${(deps.now ?? Date.now)()}`;
+  const snapshots: RewindSnapshotEntry[] = [];
+  for (const assignment of repos) {
+    const refName = rewindRefName(sessionId, key);
+    const { stdout: shaOut } = await deps.gitExec(["rev-parse", "HEAD"], {
+      cwd: assignment.repoPath
+    });
+    const sha = shaOut.trim();
+    if (!sha) {
+      throw new Error(
+        `git rev-parse HEAD produced empty output in ${assignment.repoPath}`
+      );
+    }
+    await deps.gitExec(["update-ref", refName, sha], {
+      cwd: assignment.repoPath
+    });
+    snapshots.push({
+      alias: assignment.alias,
+      repoPath: assignment.repoPath,
+      sha,
+      ref: refName
+    });
+  }
+  return { key, snapshots };
+}
+
+/**
+ * Apply a previously captured rewind: hard-reset every channel repo to the
+ * snapshotted SHA, truncate the chat log back to `messageTimestamp`, and
+ * clear the Claude CLI session ids so the next turn starts fresh.
+ *
+ * Hardening (OSS-01 Gap #3):
+ *   1. Pre-flight: every target ref must resolve in every repo.
+ *   2. Pre-flight: every repo must be clean (`git status --porcelain` empty)
+ *      so we don't silently clobber user hand-edits with `reset --hard`.
+ *   3. Only truncate the session log after EVERY repo reset succeeds. If
+ *      any reset fails mid-way, the log is preserved so the user can
+ *      recover manually.
+ */
+export async function rewindApply(
+  channelId: string,
+  sessionId: string,
+  key: string,
+  messageTimestamp: string,
+  deps: RewindDeps = defaultRewindDeps()
+): Promise<RewindApplyResult> {
+  const repos = await resolveChannelRepos(deps.channelStore, channelId);
+  const refName = rewindRefName(sessionId, key);
+
+  // --- Pre-flight: resolve refs + confirm clean worktrees across ALL repos
+  // before mutating anything. Any failure aborts the whole operation.
+  const resolved: Array<{ assignment: RepoAssignment; sha: string }> = [];
+  for (const assignment of repos) {
+    let sha: string;
+    try {
+      const { stdout } = await deps.gitExec(
+        ["rev-parse", "--verify", `${refName}^{commit}`],
+        { cwd: assignment.repoPath }
+      );
+      sha = stdout.trim();
+    } catch (err) {
+      throw new Error(
+        `Rewind ref ${refName} missing or unresolvable in ${assignment.repoPath} (alias @${assignment.alias}): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+    if (!sha) {
+      throw new Error(
+        `Rewind ref ${refName} resolved to empty SHA in ${assignment.repoPath} (alias @${assignment.alias})`
+      );
+    }
+
+    let porcelain: string;
+    try {
+      const { stdout } = await deps.gitExec(["status", "--porcelain"], {
+        cwd: assignment.repoPath
+      });
+      porcelain = stdout;
+    } catch (err) {
+      throw new Error(
+        `git status failed in ${assignment.repoPath} (alias @${assignment.alias}): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+    if (porcelain.trim().length > 0) {
+      throw new Error(
+        `Refusing to rewind: ${assignment.repoPath} (alias @${assignment.alias}) has uncommitted or untracked changes. Commit, stash, or clean them before rewinding.`
+      );
+    }
+
+    resolved.push({ assignment, sha });
+  }
+
+  // --- Mutation phase: every reset must succeed before we touch the log.
+  const reset: RewindApplyEntry[] = [];
+  for (const { assignment, sha } of resolved) {
+    await deps.gitExec(["reset", "--hard", sha], { cwd: assignment.repoPath });
+    reset.push({
+      alias: assignment.alias,
+      repoPath: assignment.repoPath,
+      sha
+    });
+  }
+
+  // Only now is it safe to truncate the chat log. If the loop above threw
+  // on repo N of M, the earlier repos are already reset (git doesn't give
+  // us free rollback) but the session log remains intact so the user can
+  // reason about what happened.
+  const removedMessages = await deps.sessionStore.truncateBeforeTimestamp(
+    channelId,
+    sessionId,
+    messageTimestamp
+  );
+  const cleared = await deps.sessionStore.clearClaudeSessionIds(
+    channelId,
+    sessionId
+  );
+
+  return { reset, removedMessages, clearedClaudeSessions: cleared !== null };
+}

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import { appendFile, mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import {
   buildSessionId,
@@ -10,6 +12,28 @@ import { buildHarnessStore } from "../storage/factory.js";
 import { STORE_NS } from "../storage/namespaces.js";
 import type { HarnessStore } from "../storage/store.js";
 import { getRelayDir } from "./paths.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * `git` runner injected into {@link SessionStore} so tests can exercise
+ * the rewind-ref cleanup path without shelling out to a real git binary.
+ * The default binds to `execFile("git", …)`.
+ */
+export type SessionStoreGitExec = (
+  args: string[],
+  opts: { cwd: string }
+) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Matches the "unknown ref" / "no ref found" message `git update-ref -d`
+ * emits. Swallowing this keeps `deleteSession` idempotent when a session
+ * had no rewind snapshots to begin with (nothing to clean up).
+ */
+function isMissingRefError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /no ref|not a valid ref|does not exist|cannot lock ref/i.test(msg);
+}
 
 /**
  * Coordination record stored on the `HarnessStore` at
@@ -42,6 +66,7 @@ function lockRecordId(channelId: string, sessionId: string): string {
 export class SessionStore {
   private readonly channelsDir: string;
   private readonly store: HarnessStore;
+  private readonly gitExec: SessionStoreGitExec;
 
   /**
    * @param channelsDir Directory for on-disk channel / session files.
@@ -53,14 +78,24 @@ export class SessionStore {
    *   `buildHarnessStore()` so callers that don't inject one pick up the
    *   process-wide singleton semantics through the factory. Tests
    *   substitute a `FakeHarnessStore` here.
+   * @param gitExec `git` runner used by rewind-ref cleanup on
+   *   {@link deleteSession}. Defaults to `execFile("git", …)`. Tests
+   *   inject a fake to avoid shelling out.
    *
    * NOTE: session reads/writes still go straight to the filesystem because
    * the Rust/GUI reader expects the path layout documented on
    * `SessionLockRecord`. Only coordination primitives migrate.
    */
-  constructor(channelsDir?: string, store?: HarnessStore) {
+  constructor(
+    channelsDir?: string,
+    store?: HarnessStore,
+    gitExec?: SessionStoreGitExec
+  ) {
     this.channelsDir = channelsDir ?? join(getRelayDir(), "channels");
     this.store = store ?? buildHarnessStore();
+    this.gitExec =
+      gitExec ??
+      (async (args, opts) => execFileAsync("git", args, { cwd: opts.cwd }));
   }
 
   private sessionsDir(channelId: string): string {
@@ -173,7 +208,21 @@ export class SessionStore {
     return session;
   }
 
-  async deleteSession(channelId: string, sessionId: string): Promise<void> {
+  /**
+   * Remove a session and everything that should follow it out of the store:
+   * the on-disk JSONL transcript, the sessions index entry, the
+   * HarnessStore coordination record, and — when `opts.repoPaths` is
+   * supplied — any `refs/harness-rewind/<sessionId>/*` refs this session
+   * stashed across those repos. Rewind refs aren't discovered for callers
+   * that don't pass repoPaths (the session itself doesn't remember them),
+   * which is why the CLI passes them in from the channel's
+   * repoAssignments.
+   */
+  async deleteSession(
+    channelId: string,
+    sessionId: string,
+    opts: { repoPaths?: string[] } = {}
+  ): Promise<void> {
     const sessions = await this.listSessions(channelId);
     const filtered = sessions.filter((s) => s.sessionId !== sessionId);
     await this.writeSessions(channelId, filtered);
@@ -210,6 +259,43 @@ export class SessionStore {
           err instanceof Error ? err.message : String(err)
         }`
       );
+    }
+
+    // Prune rewind snapshot refs (Gap #7). We don't track the per-turn
+    // keys, so iterate every ref under `refs/harness-rewind/<sessionId>/`
+    // via `for-each-ref` and delete each via `update-ref -d`. Individual
+    // "missing ref" errors are expected (race between a concurrent rewind
+    // apply and this delete) and swallowed; real failures warn loudly but
+    // don't block the delete — the on-disk session is already gone.
+    for (const repoPath of opts.repoPaths ?? []) {
+      const prefix = `refs/harness-rewind/${sessionId}/`;
+      let refs: string[] = [];
+      try {
+        const { stdout } = await this.gitExec(
+          ["for-each-ref", "--format=%(refname)", prefix],
+          { cwd: repoPath }
+        );
+        refs = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+      } catch (err) {
+        console.warn(
+          `[session-store] for-each-ref failed in ${repoPath} while pruning rewind refs for session ${sessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        continue;
+      }
+      for (const ref of refs) {
+        try {
+          await this.gitExec(["update-ref", "-d", ref], { cwd: repoPath });
+        } catch (err) {
+          if (isMissingRefError(err)) continue;
+          console.warn(
+            `[session-store] failed to delete rewind ref ${ref} in ${repoPath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import { handleCrosslinkCommand } from "./crosslink/cli.js";
 import { startDashboard } from "./tui/dashboard.js";
 import { SessionStore } from "./cli/session-store.js";
 import { buildSystemPrompt, resolveChannelRefs, findMcpConfig } from "./cli/chat-context.js";
+import { rewindApply, rewindSnapshot } from "./cli/chat-rewind.js";
 
 export async function main(): Promise<void> {
   const cwd = process.cwd();
@@ -1289,7 +1290,16 @@ async function handleSessionCommand(args: string[]): Promise<void> {
       return;
     }
 
-    await store.deleteSession(channelId, sessionId);
+    // Look up the channel's repo paths so deleteSession can also prune any
+    // `refs/harness-rewind/<sessionId>/*` refs this session accumulated.
+    // Missing channel → treat as no repos (the session may already be
+    // orphaned); deleteSession still scrubs the on-disk JSONL + index.
+    const channelStoreForDelete = new ChannelStore(undefined, getHarnessStore());
+    const channelForDelete = await channelStoreForDelete.getChannel(channelId);
+    const repoPaths =
+      channelForDelete?.repoAssignments?.map((r) => r.repoPath) ?? [];
+
+    await store.deleteSession(channelId, sessionId, { repoPaths });
     jsonOut({ ok: true, deleted: sessionId });
     return;
   }
@@ -1373,77 +1383,6 @@ async function handleChatCommand(
 
   console.error("Usage: rly chat <system-prompt|resolve-refs|mcp-config|rewind-snapshot|rewind-apply>");
   process.exitCode = 1;
-}
-
-async function rewindSnapshot(
-  channelId: string,
-  sessionId: string
-): Promise<{ key: string; snapshots: Array<{ alias: string; repoPath: string; sha: string; ref: string }> }> {
-  const { execFile } = await import("node:child_process");
-  const { promisify } = await import("node:util");
-  const execFileAsync = promisify(execFile);
-
-  const channelStore = new ChannelStore(undefined, getHarnessStore());
-  const channel = await channelStore.getChannel(channelId);
-  if (!channel) throw new Error(`Channel not found: ${channelId}`);
-
-  const key = `${Date.now()}`;
-  const snapshots: Array<{ alias: string; repoPath: string; sha: string; ref: string }> = [];
-  for (const assignment of channel.repoAssignments ?? []) {
-    const refName = `refs/harness-rewind/${sessionId}/${key}`;
-    const { stdout: shaOut } = await execFileAsync("git", ["rev-parse", "HEAD"], {
-      cwd: assignment.repoPath
-    });
-    const sha = shaOut.trim();
-    if (!sha) throw new Error(`git rev-parse HEAD produced empty output in ${assignment.repoPath}`);
-    await execFileAsync("git", ["update-ref", refName, sha], {
-      cwd: assignment.repoPath
-    });
-    snapshots.push({ alias: assignment.alias, repoPath: assignment.repoPath, sha, ref: refName });
-  }
-  return { key, snapshots };
-}
-
-async function rewindApply(
-  channelId: string,
-  sessionId: string,
-  key: string,
-  messageTimestamp: string
-): Promise<{
-  reset: Array<{ alias: string; repoPath: string; sha: string }>;
-  removedMessages: number;
-  clearedClaudeSessions: boolean;
-}> {
-  const { execFile } = await import("node:child_process");
-  const { promisify } = await import("node:util");
-  const execFileAsync = promisify(execFile);
-
-  const channelStore = new ChannelStore(undefined, getHarnessStore());
-  const channel = await channelStore.getChannel(channelId);
-  if (!channel) throw new Error(`Channel not found: ${channelId}`);
-
-  const refName = `refs/harness-rewind/${sessionId}/${key}`;
-  const reset: Array<{ alias: string; repoPath: string; sha: string }> = [];
-  for (const assignment of channel.repoAssignments ?? []) {
-    const { stdout: shaOut } = await execFileAsync("git", ["rev-parse", "--verify", refName], {
-      cwd: assignment.repoPath
-    }).catch((err) => {
-      throw new Error(`Rewind ref ${refName} missing in ${assignment.repoPath} (alias @${assignment.alias}): ${err instanceof Error ? err.message : String(err)}`);
-    });
-    const sha = shaOut.trim();
-    await execFileAsync("git", ["reset", "--hard", sha], { cwd: assignment.repoPath });
-    reset.push({ alias: assignment.alias, repoPath: assignment.repoPath, sha });
-  }
-
-  const sessionStore = new SessionStore();
-  const removedMessages = await sessionStore.truncateBeforeTimestamp(
-    channelId,
-    sessionId,
-    messageTimestamp
-  );
-  const cleared = await sessionStore.clearClaudeSessionIds(channelId, sessionId);
-
-  return { reset, removedMessages, clearedClaudeSessions: cleared !== null };
 }
 
 async function printRunsIndex(

--- a/test/chat-rewind.test.ts
+++ b/test/chat-rewind.test.ts
@@ -1,0 +1,722 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  rewindApply,
+  rewindSnapshot,
+  type RewindDeps
+} from "../src/cli/chat-rewind.js";
+import { SessionStore } from "../src/cli/session-store.js";
+import type { Channel } from "../src/domain/channel.js";
+import type {
+  BlobRef,
+  ChangeEvent,
+  HarnessStore
+} from "../src/storage/store.js";
+
+// Minimal HarnessStore stub: the rewind flow only ever touches SessionStore,
+// which in turn writes/deletes an advisory coordination record. Anything
+// the rewind tests don't call throws so unexpected usage is loud.
+class NullHarnessStore implements HarnessStore {
+  async getDoc<T>(): Promise<T | null> {
+    return null;
+  }
+  async putDoc(): Promise<void> {}
+  async listDocs<T>(): Promise<T[]> {
+    return [];
+  }
+  async deleteDoc(): Promise<void> {}
+  async appendLog(): Promise<void> {
+    throw new Error("NullHarnessStore.appendLog not used by rewind tests");
+  }
+  async readLog<T>(): Promise<T[]> {
+    throw new Error("NullHarnessStore.readLog not used by rewind tests");
+  }
+  async putBlob(): Promise<BlobRef> {
+    throw new Error("NullHarnessStore.putBlob not used by rewind tests");
+  }
+  async getBlob(): Promise<Uint8Array> {
+    throw new Error("NullHarnessStore.getBlob not used by rewind tests");
+  }
+  async mutate<T>(
+    _ns: string,
+    _id: string,
+    fn: (prev: T | null) => T
+  ): Promise<T> {
+    return fn(null);
+  }
+  // eslint-disable-next-line require-yield
+  async *watch(): AsyncIterable<ChangeEvent> {
+    throw new Error("NullHarnessStore.watch not used by rewind tests");
+  }
+}
+
+/** Fake ChannelStore with just `getChannel` — that's all rewind needs. */
+function fakeChannelStore(channel: Channel | null): RewindDeps["channelStore"] {
+  return { getChannel: async () => channel };
+}
+
+type GitCall = { args: string[]; cwd: string };
+
+interface GitFakeOptions {
+  /** Per-cwd stdout scripted by command key (e.g. "rev-parse HEAD"). */
+  stdoutByKey?: Record<string, Record<string, string>>;
+  /** Throw on a given key (per-cwd) with the provided error message. */
+  throwByKey?: Record<string, Record<string, string>>;
+}
+
+/**
+ * Build a fake `gitExec`. Commands are keyed by `args.join(" ")` so tests
+ * can map precise invocations to precise scripted outputs. Any unmatched
+ * call succeeds with empty stdout — harmless for no-op writes like
+ * `update-ref`.
+ */
+function makeGit(opts: GitFakeOptions = {}) {
+  const calls: GitCall[] = [];
+  const stdoutByKey = opts.stdoutByKey ?? {};
+  const throwByKey = opts.throwByKey ?? {};
+  const exec: RewindDeps["gitExec"] = async (args, { cwd }) => {
+    calls.push({ args: [...args], cwd });
+    const key = args.join(" ");
+    const thrown = throwByKey[cwd]?.[key];
+    if (thrown !== undefined) {
+      throw new Error(thrown);
+    }
+    const stdout = stdoutByKey[cwd]?.[key] ?? "";
+    return { stdout, stderr: "" };
+  };
+  return { exec, calls };
+}
+
+function makeChannel(repoPaths: string[]): Channel {
+  return {
+    channelId: "ch-1",
+    name: "#test",
+    description: "",
+    status: "active",
+    workspaceIds: [],
+    members: [],
+    pinnedRefs: [],
+    repoAssignments: repoPaths.map((p, i) => ({
+      alias: `repo${i + 1}`,
+      workspaceId: `ws-${i + 1}`,
+      repoPath: p
+    })),
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z"
+  };
+}
+
+describe("rewindSnapshot", () => {
+  it("writes a rewind ref per repo and returns the captured SHAs", async () => {
+    const channel = makeChannel(["/repos/a", "/repos/b"]);
+    const git = makeGit({
+      stdoutByKey: {
+        "/repos/a": { "rev-parse HEAD": "a1b2c3d\n" },
+        "/repos/b": { "rev-parse HEAD": "e4f5g6h\n" }
+      }
+    });
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore: {
+        truncateBeforeTimestamp: async () => 0,
+        clearClaudeSessionIds: async () => null
+      },
+      gitExec: git.exec,
+      now: () => 1700000000000
+    };
+
+    const result = await rewindSnapshot("ch-1", "sess-1", deps);
+
+    expect(result.key).toBe("1700000000000");
+    expect(result.snapshots).toEqual([
+      {
+        alias: "repo1",
+        repoPath: "/repos/a",
+        sha: "a1b2c3d",
+        ref: "refs/harness-rewind/sess-1/1700000000000"
+      },
+      {
+        alias: "repo2",
+        repoPath: "/repos/b",
+        sha: "e4f5g6h",
+        ref: "refs/harness-rewind/sess-1/1700000000000"
+      }
+    ]);
+
+    // Every repo got exactly one rev-parse HEAD + one update-ref.
+    const perRepo = (cwd: string) => git.calls.filter((c) => c.cwd === cwd);
+    expect(perRepo("/repos/a").map((c) => c.args[0])).toEqual([
+      "rev-parse",
+      "update-ref"
+    ]);
+    expect(perRepo("/repos/b").map((c) => c.args[0])).toEqual([
+      "rev-parse",
+      "update-ref"
+    ]);
+  });
+
+  it("throws a clear error when the channel is missing", async () => {
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(null),
+      sessionStore: {
+        truncateBeforeTimestamp: async () => 0,
+        clearClaudeSessionIds: async () => null
+      },
+      gitExec: makeGit().exec
+    };
+    await expect(rewindSnapshot("missing", "sess-x", deps)).rejects.toThrow(
+      /Channel not found/
+    );
+  });
+
+  it("throws when `git rev-parse HEAD` produces empty output", async () => {
+    const channel = makeChannel(["/repos/a"]);
+    const git = makeGit({
+      stdoutByKey: { "/repos/a": { "rev-parse HEAD": "" } }
+    });
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore: {
+        truncateBeforeTimestamp: async () => 0,
+        clearClaudeSessionIds: async () => null
+      },
+      gitExec: git.exec
+    };
+    await expect(rewindSnapshot("ch-1", "sess-1", deps)).rejects.toThrow(
+      /empty output/
+    );
+  });
+});
+
+describe("rewindApply", () => {
+  const channel = makeChannel(["/repos/a", "/repos/b"]);
+  const refKey = "abc123";
+  const refName = `refs/harness-rewind/sess-1/${refKey}`;
+
+  function happyPathGit() {
+    return makeGit({
+      stdoutByKey: {
+        "/repos/a": {
+          [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
+          "status --porcelain": ""
+        },
+        "/repos/b": {
+          [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
+          "status --porcelain": ""
+        }
+      }
+    });
+  }
+
+  it("pre-flight-verifies every ref + clean worktree before mutating", async () => {
+    const git = happyPathGit();
+    const truncated: Array<{ channelId: string; sessionId: string; ts: string }> =
+      [];
+    const cleared: Array<{ channelId: string; sessionId: string }> = [];
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore: {
+        truncateBeforeTimestamp: async (channelId, sessionId, ts) => {
+          truncated.push({ channelId, sessionId, ts });
+          return 3;
+        },
+        clearClaudeSessionIds: async (channelId, sessionId) => {
+          cleared.push({ channelId, sessionId });
+          return null;
+        }
+      },
+      gitExec: git.exec
+    };
+
+    const result = await rewindApply(
+      "ch-1",
+      "sess-1",
+      refKey,
+      "2025-01-01T00:00:05.000Z",
+      deps
+    );
+
+    // Each reset advertises its SHA.
+    expect(result.reset).toEqual([
+      { alias: "repo1", repoPath: "/repos/a", sha: "aaa" },
+      { alias: "repo2", repoPath: "/repos/b", sha: "bbb" }
+    ]);
+    expect(result.removedMessages).toBe(3);
+
+    // Critical ordering property: every rev-parse --verify + status must
+    // come before any reset --hard. Find the earliest reset index and the
+    // latest pre-flight index and make sure pre-flight < resets.
+    const kinds = git.calls.map((c) => c.args.join(" "));
+    const firstReset = kinds.findIndex((k) => k.startsWith("reset --hard"));
+    const lastPreflight = Math.max(
+      ...kinds
+        .map((k, i) =>
+          k.startsWith("rev-parse --verify") || k === "status --porcelain"
+            ? i
+            : -1
+        )
+        .filter((i) => i >= 0)
+    );
+    expect(lastPreflight).toBeLessThan(firstReset);
+
+    expect(truncated).toHaveLength(1);
+    expect(cleared).toHaveLength(1);
+  });
+
+  it("refuses to rewind when any repo has a dirty worktree", async () => {
+    const git = makeGit({
+      stdoutByKey: {
+        "/repos/a": {
+          [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
+          "status --porcelain": ""
+        },
+        "/repos/b": {
+          [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
+          "status --porcelain": " M src/hand-edited.ts\n?? untracked.txt\n"
+        }
+      }
+    });
+    let truncated = false;
+    let cleared = false;
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore: {
+        truncateBeforeTimestamp: async () => {
+          truncated = true;
+          return 0;
+        },
+        clearClaudeSessionIds: async () => {
+          cleared = true;
+          return null;
+        }
+      },
+      gitExec: git.exec
+    };
+
+    await expect(
+      rewindApply("ch-1", "sess-1", refKey, "2025-01-01T00:00:00.000Z", deps)
+    ).rejects.toThrow(/uncommitted or untracked/);
+
+    // Pre-flight must fail BEFORE any reset --hard or session mutation.
+    expect(
+      git.calls.some((c) => c.args[0] === "reset" && c.args[1] === "--hard")
+    ).toBe(false);
+    expect(truncated).toBe(false);
+    expect(cleared).toBe(false);
+  });
+
+  it("refuses to rewind when the target ref is missing in any repo", async () => {
+    const git = makeGit({
+      stdoutByKey: {
+        "/repos/a": {
+          [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
+          "status --porcelain": ""
+        }
+      },
+      throwByKey: {
+        "/repos/b": {
+          [`rev-parse --verify ${refName}^{commit}`]: "fatal: Needed a single revision"
+        }
+      }
+    });
+    let truncated = false;
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore: {
+        truncateBeforeTimestamp: async () => {
+          truncated = true;
+          return 0;
+        },
+        clearClaudeSessionIds: async () => null
+      },
+      gitExec: git.exec
+    };
+
+    await expect(
+      rewindApply("ch-1", "sess-1", refKey, "2025-01-01T00:00:00.000Z", deps)
+    ).rejects.toThrow(/missing or unresolvable/);
+
+    expect(
+      git.calls.some((c) => c.args[0] === "reset" && c.args[1] === "--hard")
+    ).toBe(false);
+    expect(truncated).toBe(false);
+  });
+
+  it("does NOT truncate the session log if a mid-flight reset fails", async () => {
+    // Pre-flight passes for both repos, but /repos/b's reset --hard throws
+    // (e.g. concurrent lock, disk full, corrupted index). The audit
+    // requires the session log remain intact in this case.
+    const git = makeGit({
+      stdoutByKey: {
+        "/repos/a": {
+          [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
+          "status --porcelain": ""
+        },
+        "/repos/b": {
+          [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
+          "status --porcelain": ""
+        }
+      },
+      throwByKey: {
+        "/repos/b": { "reset --hard bbb": "fatal: Unable to write new index file" }
+      }
+    });
+    let truncated = false;
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore: {
+        truncateBeforeTimestamp: async () => {
+          truncated = true;
+          return 0;
+        },
+        clearClaudeSessionIds: async () => null
+      },
+      gitExec: git.exec
+    };
+
+    await expect(
+      rewindApply("ch-1", "sess-1", refKey, "2025-01-01T00:00:00.000Z", deps)
+    ).rejects.toThrow(/Unable to write/);
+
+    // Truncation must NOT have run.
+    expect(truncated).toBe(false);
+  });
+});
+
+describe("SessionStore.truncateBeforeTimestamp + clearClaudeSessionIds", () => {
+  let dir: string;
+  let store: SessionStore;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sess-rewind-"));
+    store = new SessionStore(dir, new NullHarnessStore());
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("keeps messages strictly before the timestamp and drops the rest", async () => {
+    const session = await store.createSession("ch", "t");
+    const makeMsg = (ts: string, content: string) => ({
+      role: "user",
+      content,
+      timestamp: ts,
+      agentAlias: null
+    });
+    await store.appendMessage("ch", session.sessionId, makeMsg("2025-01-01T00:00:00.000Z", "m1"));
+    await store.appendMessage("ch", session.sessionId, makeMsg("2025-01-01T00:00:05.000Z", "m2"));
+    await store.appendMessage("ch", session.sessionId, makeMsg("2025-01-01T00:00:10.000Z", "m3"));
+
+    const removed = await store.truncateBeforeTimestamp(
+      "ch",
+      session.sessionId,
+      "2025-01-01T00:00:05.000Z"
+    );
+
+    // m2 and m3 both have ts >= cutoff, so two were removed.
+    expect(removed).toBe(2);
+    const after = await store.loadMessages("ch", session.sessionId);
+    expect(after.map((m) => m.content)).toEqual(["m1"]);
+
+    // Index is updated to the new count.
+    const updated = await store.getSession("ch", session.sessionId);
+    expect(updated!.messageCount).toBe(1);
+  });
+
+  it("is idempotent when no messages exist (ENOENT path)", async () => {
+    const session = await store.createSession("ch", "t");
+    const removed = await store.truncateBeforeTimestamp(
+      "ch",
+      session.sessionId,
+      "2099-01-01T00:00:00.000Z"
+    );
+    expect(removed).toBe(0);
+  });
+
+  it("clearClaudeSessionIds wipes the sid map on the session index", async () => {
+    const session = await store.createSession("ch", "t");
+    await store.updateClaudeSessionId("ch", session.sessionId, "general", "claude-sid-xyz");
+
+    const cleared = await store.clearClaudeSessionIds("ch", session.sessionId);
+    expect(cleared).not.toBeNull();
+    expect(cleared!.claudeSessionIds).toEqual({});
+
+    // Round-trips through disk — not just in-memory.
+    const reloaded = await store.getSession("ch", session.sessionId);
+    expect(reloaded!.claudeSessionIds).toEqual({});
+  });
+
+  it("clearClaudeSessionIds returns null for an unknown session", async () => {
+    const cleared = await store.clearClaudeSessionIds("ch", "does-not-exist");
+    expect(cleared).toBeNull();
+  });
+});
+
+describe("SessionStore.deleteSession prunes rewind refs", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sess-rewind-del-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("runs `update-ref -d` for each discovered rewind ref per repo", async () => {
+    const gitCalls: GitCall[] = [];
+    const exec = async (
+      args: string[],
+      opts: { cwd: string }
+    ): Promise<{ stdout: string; stderr: string }> => {
+      gitCalls.push({ args: [...args], cwd: opts.cwd });
+      if (
+        args[0] === "for-each-ref" &&
+        args[1] === "--format=%(refname)" &&
+        typeof args[2] === "string" &&
+        args[2].startsWith("refs/harness-rewind/")
+      ) {
+        const prefix = args[2];
+        // Pretend /repos/a has two refs and /repos/b has one.
+        if (opts.cwd === "/repos/a") {
+          return { stdout: `${prefix}k1\n${prefix}k2\n`, stderr: "" };
+        }
+        if (opts.cwd === "/repos/b") {
+          return { stdout: `${prefix}k3\n`, stderr: "" };
+        }
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    const store = new SessionStore(dir, new NullHarnessStore(), exec);
+    const session = await store.createSession("ch", "t");
+    await store.appendMessage("ch", session.sessionId, {
+      role: "user",
+      content: "hi",
+      timestamp: "2025-01-01T00:00:00.000Z",
+      agentAlias: null
+    });
+
+    await store.deleteSession("ch", session.sessionId, {
+      repoPaths: ["/repos/a", "/repos/b"]
+    });
+
+    const deletes = gitCalls.filter(
+      (c) => c.args[0] === "update-ref" && c.args[1] === "-d"
+    );
+    const deleted = deletes.map((c) => `${c.cwd}::${c.args[2]}`).sort();
+    expect(deleted).toEqual([
+      `/repos/a::refs/harness-rewind/${session.sessionId}/k1`,
+      `/repos/a::refs/harness-rewind/${session.sessionId}/k2`,
+      `/repos/b::refs/harness-rewind/${session.sessionId}/k3`
+    ]);
+  });
+
+  it("swallows 'missing ref' errors on individual update-ref failures", async () => {
+    const exec = async (
+      args: string[],
+      opts: { cwd: string }
+    ): Promise<{ stdout: string; stderr: string }> => {
+      if (args[0] === "for-each-ref") {
+        return {
+          stdout: `refs/harness-rewind/s/ref1\nrefs/harness-rewind/s/ref2\n`,
+          stderr: ""
+        };
+      }
+      if (
+        args[0] === "update-ref" &&
+        args[1] === "-d" &&
+        args[2] === "refs/harness-rewind/s/ref1"
+      ) {
+        throw new Error("fatal: no ref at refs/harness-rewind/s/ref1");
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    const store = new SessionStore(dir, new NullHarnessStore(), exec);
+    const session = await store.createSession("ch", "t");
+    // Should NOT throw despite the per-ref missing error.
+    await expect(
+      store.deleteSession("ch", session.sessionId, { repoPaths: ["/repos/a"] })
+    ).resolves.toBeUndefined();
+  });
+
+  it("warns but does not throw if `for-each-ref` itself fails for a repo", async () => {
+    const exec = async (
+      args: string[],
+      _opts: { cwd: string }
+    ): Promise<{ stdout: string; stderr: string }> => {
+      if (args[0] === "for-each-ref") {
+        throw new Error("fatal: not a git repository");
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    const store = new SessionStore(dir, new NullHarnessStore(), exec);
+    const session = await store.createSession("ch", "t");
+
+    await expect(
+      store.deleteSession("ch", session.sessionId, { repoPaths: ["/nope"] })
+    ).resolves.toBeUndefined();
+
+    // Disk cleanup still happened.
+    const sessionsAfter = await store.listSessions("ch");
+    expect(sessionsAfter.map((s) => s.sessionId)).not.toContain(
+      session.sessionId
+    );
+  });
+
+  it("is a no-op (no git calls) when repoPaths is not supplied", async () => {
+    const gitCalls: GitCall[] = [];
+    const exec = async (
+      args: string[],
+      opts: { cwd: string }
+    ): Promise<{ stdout: string; stderr: string }> => {
+      gitCalls.push({ args: [...args], cwd: opts.cwd });
+      return { stdout: "", stderr: "" };
+    };
+    const store = new SessionStore(dir, new NullHarnessStore(), exec);
+    const session = await store.createSession("ch", "t");
+
+    await store.deleteSession("ch", session.sessionId);
+
+    expect(gitCalls).toEqual([]);
+  });
+});
+
+describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () => {
+  // Exercises the filesystem-backed truncation path (not just the stub) to
+  // confirm rewindApply wires SessionStore correctly.
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "rewind-e2e-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("truncates the on-disk JSONL to match messageTimestamp", async () => {
+    const sessionStore = new SessionStore(dir, new NullHarnessStore());
+    const session = await sessionStore.createSession("ch-e2e", "t");
+    await sessionStore.appendMessage("ch-e2e", session.sessionId, {
+      role: "user",
+      content: "before",
+      timestamp: "2025-01-01T00:00:00.000Z",
+      agentAlias: null
+    });
+    await sessionStore.appendMessage("ch-e2e", session.sessionId, {
+      role: "user",
+      content: "cutoff",
+      timestamp: "2025-01-01T00:00:05.000Z",
+      agentAlias: null,
+      metadata: { rewindKey: "k1" }
+    });
+    await sessionStore.appendMessage("ch-e2e", session.sessionId, {
+      role: "assistant",
+      content: "after",
+      timestamp: "2025-01-01T00:00:10.000Z",
+      agentAlias: null
+    });
+
+    const channel = makeChannel(["/fake/repo"]);
+    const refName = `refs/harness-rewind/${session.sessionId}/k1`;
+    const git = makeGit({
+      stdoutByKey: {
+        "/fake/repo": {
+          [`rev-parse --verify ${refName}^{commit}`]: "deadbeef\n",
+          "status --porcelain": ""
+        }
+      }
+    });
+    const deps: RewindDeps = {
+      channelStore: fakeChannelStore(channel),
+      sessionStore,
+      gitExec: git.exec
+    };
+
+    const result = await rewindApply(
+      "ch-e2e",
+      session.sessionId,
+      "k1",
+      "2025-01-01T00:00:05.000Z",
+      deps
+    );
+
+    expect(result.removedMessages).toBe(2);
+    const remaining = await sessionStore.loadMessages(
+      "ch-e2e",
+      session.sessionId
+    );
+    expect(remaining.map((m) => m.content)).toEqual(["before"]);
+
+    // JSONL file on disk matches what we expect — sanity check.
+    const chatPath = join(dir, "ch-e2e", "sessions", `${session.sessionId}.jsonl`);
+    const raw = await readFile(chatPath, "utf8");
+    expect(raw.trim().split("\n")).toHaveLength(1);
+
+    // Confirm clearClaudeSessionIds ran.
+    expect(result.clearedClaudeSessions).toBe(true);
+  });
+
+  it("leaves the JSONL untouched when a reset fails mid-way", async () => {
+    const sessionStore = new SessionStore(dir, new NullHarnessStore());
+    const session = await sessionStore.createSession("ch-fail", "t");
+    await sessionStore.appendMessage("ch-fail", session.sessionId, {
+      role: "user",
+      content: "m1",
+      timestamp: "2025-01-01T00:00:00.000Z",
+      agentAlias: null
+    });
+    await sessionStore.appendMessage("ch-fail", session.sessionId, {
+      role: "user",
+      content: "m2",
+      timestamp: "2025-01-01T00:00:05.000Z",
+      agentAlias: null,
+      metadata: { rewindKey: "boom" }
+    });
+
+    const chatPath = join(dir, "ch-fail", "sessions", `${session.sessionId}.jsonl`);
+    const before = await readFile(chatPath, "utf8");
+
+    const channel = makeChannel(["/repos/a", "/repos/b"]);
+    const refName = `refs/harness-rewind/${session.sessionId}/boom`;
+    const git = makeGit({
+      stdoutByKey: {
+        "/repos/a": {
+          [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
+          "status --porcelain": ""
+        },
+        "/repos/b": {
+          [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
+          "status --porcelain": ""
+        }
+      },
+      throwByKey: {
+        "/repos/b": { "reset --hard bbb": "fatal: broken" }
+      }
+    });
+
+    await expect(
+      rewindApply("ch-fail", session.sessionId, "boom", "2025-01-01T00:00:05.000Z", {
+        channelStore: fakeChannelStore(channel),
+        sessionStore,
+        gitExec: git.exec
+      })
+    ).rejects.toThrow(/broken/);
+
+    const after = await readFile(chatPath, "utf8");
+    expect(after).toBe(before);
+
+    // And the sessions index messageCount should also be unchanged.
+    const stillThere = await sessionStore.getSession("ch-fail", session.sessionId);
+    expect(stillThere!.messageCount).toBe(2);
+  });
+});
+


### PR DESCRIPTION
OSS-01 rewind hardening. Fixes five audit gaps: (1) JSON injection in rewind metadata in gui/src-tauri/src/lib.rs, now built via serde_json::json!; (3) rewind-apply now pre-flights rev-parse + git status across all repos and only truncates the session log after every reset succeeds, extracted to src/cli/chat-rewind.ts with injectable gitExec; (7) SessionStore.deleteSession prunes refs/harness-rewind/sid/* via git for-each-ref + update-ref -d across channel repos; (8) new cancel_chat_stream Tauri command + CANCELLED_STREAMS flag checked in the start_chat loop, wired from the RewindConfirmModal so the streaming thread can't race truncation; (11) 17 Vitest cases in test/chat-rewind.test.ts plus a Rust #[cfg(test)] block with adversarial rewindKey fuzzing and a cancel-flag round-trip. Verified: pnpm test/typecheck/build, cargo check --workspace, cargo test --lib (gui-tauri), cd gui && pnpm build. Size: ~1187 LOC total but ~720 is the new test file; production code is under the 800 LOC cap. DO NOT MERGE — draft until review.