### PR TITLE
OSS-04: Observability (orchestrator error surface, verification override signal, PR-watcher startup warning)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,11 +142,12 @@ Opting in to Postgres (`PostgresHarnessStore`) keeps the same on-disk layout and
 
 | Symptom | Likely cause / fix |
 |---|---|
-| `GITHUB_TOKEN not set — PR watching disabled` | Expected if you didn't set the token; PRs won't auto-track. |
+| `GITHUB_TOKEN not set — PR watching disabled` | Expected if you didn't set the token; PRs won't auto-track. Also posted once per channel to the feed (visible in TUI/GUI) so you see it even if you closed the terminal. |
 | Classifier can't resolve a Linear key like `ABC-123` | `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) not set, or the key doesn't match any issue visible to your token. |
 | Claude keeps prompting for permissions | Set `RELAY_AUTO_APPROVE=1` or pass `--yolo` / `--auto-approve`. |
 | Tickets stuck in `blocked` forever | Check `dependsOn` chain — a failed upstream ticket blocks everything downstream. `rly board <id>` shows the edges. |
 | Ticket retries exhausted (`failed`) | Verification commands kept failing past `maxTestFixLoops`. Feed shows the last verification output; fix manually, mark the ticket `completed`, and the scheduler unblocks downstream. |
+| `Verification override` in feed | The agent proposed commands that weren't on the ticket's allowlist, so the scheduler ran the allowlist instead. The feed entry lists `rejectedCommands` and `substitutedCommands` — if the substitution is wrong, update the ticket's `allowedCommands` / `verificationCommands`. |
 | `rly` runs stale code after `git pull` | Default reads current source via `tsx`, so this shouldn't happen. If you set `RELAY_USE_DIST=1`, run `rly rebuild`. |
 | `rly tui` / `rly gui` fails on first run | Install `cargo` (rustup). The auto-build needs it. |
 | TUI shows no channels | Register at least one workspace with `rly up` and create a channel (or launch a session, which creates one). |

--- a/src/cli/pr-watcher-factory.ts
+++ b/src/cli/pr-watcher-factory.ts
@@ -108,6 +108,17 @@ interface ActiveWatcherEntry {
 
 let activeWatcher: ActiveWatcherEntry | null = null;
 
+/**
+ * Tracks which channels have already received the "GITHUB_TOKEN missing"
+ * warning entry during this process. The warning is a useful one-shot
+ * signal — without this guard, every factory invocation (one per run) would
+ * append a fresh warning to the feed and spam the channel.
+ *
+ * Cleared by `__resetActiveWatcherForTests` so tests can observe the
+ * warning on demand.
+ */
+const missingTokenWarnedChannels = new Set<string>();
+
 /** Access the live watcher. Returns null when no run is wired or token missing. */
 export function getActiveWatcher(): ActiveWatcherView | null {
   return activeWatcher?.view ?? null;
@@ -116,6 +127,7 @@ export function getActiveWatcher(): ActiveWatcherView | null {
 /** Test helper — force-clear the singleton between test cases. */
 export function __resetActiveWatcherForTests(): void {
   activeWatcher = null;
+  missingTokenWarnedChannels.clear();
 }
 
 /**
@@ -211,7 +223,38 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
 
   return ({ run, scheduler }) => {
     if (!process.env.GITHUB_TOKEN) {
+      // Keep the stdout info line for CLI users who don't have the GUI/TUI
+      // open — they still need to see this in plain terminal output.
       console.info("[pr-watcher] GITHUB_TOKEN not set — PR watching disabled");
+      // Also surface as a channel-level warning so the GUI/TUI show it. Post
+      // at most once per (channel, process) to avoid spamming: the factory is
+      // invoked once per run and the message is invariant until the operator
+      // sets GITHUB_TOKEN and restarts.
+      const channelId = run.channelId ?? opts.defaultChannelId;
+      if (channelId && !missingTokenWarnedChannels.has(channelId)) {
+        missingTokenWarnedChannels.add(channelId);
+        opts.channelStore
+          .postEntry(channelId, {
+            type: "status_update",
+            fromAgentId: null,
+            fromDisplayName: "PR Watcher",
+            content:
+              "GITHUB_TOKEN not set — PR watching is disabled. Set the env var and " +
+              "restart to enable PR status updates for this channel.",
+            metadata: {
+              runId: run.id,
+              channelId,
+              warning: "missing_github_token",
+              component: "pr-watcher"
+            }
+          })
+          .catch((err: unknown) => {
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(
+              `[pr-watcher] failed to post missing-token warning to channel ${channelId}: ${message}`
+            );
+          });
+      }
       return noopHandle();
     }
 

--- a/src/execution/verification-runner.ts
+++ b/src/execution/verification-runner.ts
@@ -12,6 +12,19 @@ export interface VerificationRunResult {
   success: boolean;
   executed: VerificationCommandResult[];
   rejected: string[];
+  /**
+   * True when the agent's proposed commands were all rejected (not on the
+   * allowlist) and we substituted the full allowlist instead of running the
+   * agent's choices. Callers should surface this to users — otherwise
+   * "verification passed" can hide the fact that none of the agent's
+   * intended checks actually ran.
+   */
+  overridden: boolean;
+  /**
+   * When `overridden` is true, the commands the runner actually executed in
+   * place of the agent's rejected proposals. Empty otherwise.
+   */
+  substitutedCommands: string[];
 }
 
 export interface VerificationRunInput {
@@ -53,7 +66,9 @@ export class VerificationRunner {
     return {
       success: executed.every((entry) => entry.result.exitCode === 0),
       executed,
-      rejected: selection.rejected
+      rejected: selection.rejected,
+      overridden: selection.overridden,
+      substitutedCommands: selection.overridden ? [...selection.commandsToRun] : []
     };
   }
 
@@ -93,18 +108,31 @@ export function selectVerificationCommands(
 ): {
   commandsToRun: string[];
   rejected: string[];
+  /**
+   * True when the agent proposed commands but none of them were on the
+   * allowlist, so we fell back to running the full allowlist instead of the
+   * agent's picks. Callers should surface this — otherwise the run appears
+   * "verification passed" when the agent's intended checks never ran.
+   */
+  overridden: boolean;
 } {
   const allowed = new Set(allowlistedCommands.map(normalizeCommand));
   const normalizedProposed = uniqueNormalizedCommands(proposedCommands);
   const approvedProposed = normalizedProposed.filter((command) => allowed.has(command));
   const rejected = normalizedProposed.filter((command) => !allowed.has(command));
 
+  // Substitution happens when the agent proposed *something* but nothing it
+  // proposed was approved, so we fall back to the allowlist. "No proposals"
+  // does not count as an override — that's the documented default path.
+  const overridden = normalizedProposed.length > 0 && approvedProposed.length === 0;
+
   return {
     commandsToRun:
       approvedProposed.length > 0
         ? approvedProposed
         : uniqueNormalizedCommands(allowlistedCommands),
-    rejected
+    rejected,
+    overridden
   };
 }
 

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -93,16 +93,37 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   await channelStore.linkRun(channelId, runId, workspaceId);
 
   // Fire and forget — the orchestrator writes progress to the channel feed
-  // and artifact store as it runs.
+  // and artifact store as it runs. If the top-level run promise rejects we
+  // surface the failure to the channel feed so users don't see "dispatched"
+  // and then nothing. We only swallow the *return value* (the background task
+  // must not throw), never the error itself.
   orchestrator.run(featureRequest, runId)
     .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error && error.stack
+        ? error.stack.split("\n").slice(0, 20).join("\n")
+        : "";
       channelStore.postEntry(channelId!, {
         type: "status_update",
         fromAgentId: null,
         fromDisplayName: "Orchestrator",
-        content: `Run failed: ${error instanceof Error ? error.message : String(error)}`,
-        metadata: { runId, error: "true" }
-      }).catch(() => {});
+        content: `Run failed: ${message}`,
+        metadata: {
+          runId,
+          channelId,
+          workspaceId,
+          error: "true",
+          errorMessage: message,
+          ...(stack ? { errorStack: stack } : {})
+        }
+      }).catch((postErr: unknown) => {
+        // If posting the failure entry itself fails there is nowhere left to
+        // surface it — log to stderr so operators still see the loss.
+        const postMessage = postErr instanceof Error ? postErr.message : String(postErr);
+        console.warn(
+          `[orchestrator] failed to post run-failure entry (runId=${runId} channelId=${channelId}): ${postMessage}`
+        );
+      });
     });
 
   return {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -480,7 +480,16 @@ export class Orchestrator {
     };
 
     run.events.push(event);
-    this.artifactStore.appendEvent(run.id, event).catch(() => {});
+    // appendEvent is fire-and-forget here (recordEvent is synchronous for
+    // callers), but we must not silently swallow failures — log them with
+    // enough context to correlate with the run. Matches the pattern used in
+    // OrchestratorV2.recordEvent.
+    this.artifactStore.appendEvent(run.id, event).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[orchestrator] appendEvent failed (runId=${run.id} type=${type} phaseId=${phaseId}): ${message}`
+      );
+    });
   }
 
   private recordEvidence(run: HarnessRun, record: EvidenceRecord): void {

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -606,7 +606,12 @@ export class TicketScheduler {
     ticketId: string,
     proposedCommands: string[],
     allowlistedCommands: string[]
-  ): Promise<{ success: boolean; rejected: string[] }> {
+  ): Promise<{
+    success: boolean;
+    rejected: string[];
+    overridden: boolean;
+    substitutedCommands: string[];
+  }> {
     const selection = selectVerificationCommands(
       proposedCommands,
       allowlistedCommands
@@ -625,7 +630,43 @@ export class TicketScheduler {
       success = success && entry.result.exitCode === 0;
     }
 
-    return { success, rejected: selection.rejected };
+    const substitutedCommands = selection.overridden ? [...selection.commandsToRun] : [];
+
+    // Surface the override via the channel feed so users don't see
+    // "verification passed" when the agent's proposed commands were all
+    // swapped out for allowlisted substitutes. Best-effort — a feed write
+    // failure must not halt verification.
+    if (selection.overridden && run.channelId && this.channelStore) {
+      this.channelStore
+        .postEntry(run.channelId, {
+          type: "status_update",
+          fromAgentId: null,
+          fromDisplayName: "Verifier",
+          content:
+            `Verification override: agent's proposed commands were not on the allowlist; ` +
+            `ran allowlisted substitutes instead.`,
+          metadata: {
+            runId: run.id,
+            ticketId,
+            verification: success ? "passed-with-override" : "failed-with-override",
+            rejectedCommands: selection.rejected,
+            substitutedCommands
+          }
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(
+            `[scheduler] verification-override feed post failed (runId=${run.id} ticketId=${ticketId}): ${message}`
+          );
+        });
+    }
+
+    return {
+      success,
+      rejected: selection.rejected,
+      overridden: selection.overridden,
+      substitutedCommands
+    };
   }
 
   private updateBlockedTickets(run: HarnessRun): void {

--- a/test/cli/pr-watcher-factory.test.ts
+++ b/test/cli/pr-watcher-factory.test.ts
@@ -136,6 +136,87 @@ describe("createPrWatcherFactory", () => {
     infoSpy.mockRestore();
   });
 
+  it("posts a channel-level warning entry when GITHUB_TOKEN is absent", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const execGit: ExecGit = vi.fn();
+
+    // Seed a channel and pass its id to the factory so the warning has a
+    // home. Without `defaultChannelId` (and `run.channelId`) there is no
+    // channel to post to — that case is intentionally silent, covered by
+    // the stdout info message above.
+    const channel = await channelStore.createChannel({
+      name: "#test",
+      description: "missing-token test"
+    });
+
+    const factory = createPrWatcherFactory({
+      channelStore,
+      repoRoot: "/irrelevant",
+      defaultChannelId: channel.channelId,
+      execGit
+    });
+
+    factory({
+      run: minimalRun(),
+      scheduler: stubScheduler() as TicketScheduler
+    });
+
+    // Let the fire-and-forget postEntry settle. postEntry awaits mkdir,
+    // appendFile, and touchChannel (which re-reads + writes channel.json),
+    // so a real timer flush is more reliable than microtask pumping.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const entries = await channelStore.readFeed(channel.channelId);
+    const warning = entries.find(
+      (e) =>
+        e.type === "status_update" &&
+        e.metadata.warning === "missing_github_token"
+    );
+    expect(warning).toBeDefined();
+    expect(warning!.fromDisplayName).toBe("PR Watcher");
+    expect(warning!.content).toContain("GITHUB_TOKEN not set");
+    expect(warning!.metadata.component).toBe("pr-watcher");
+
+    infoSpy.mockRestore();
+  });
+
+  it("posts the missing-token warning only once per channel per process", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const execGit: ExecGit = vi.fn();
+
+    const channel = await channelStore.createChannel({
+      name: "#test-dedupe",
+      description: "dedupe test"
+    });
+
+    const factory = createPrWatcherFactory({
+      channelStore,
+      repoRoot: "/irrelevant",
+      defaultChannelId: channel.channelId,
+      execGit
+    });
+
+    // Invoke the factory three times — simulating three back-to-back runs.
+    for (let i = 0; i < 3; i += 1) {
+      factory({
+        run: minimalRun(),
+        scheduler: stubScheduler() as TicketScheduler
+      });
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const entries = await channelStore.readFeed(channel.channelId);
+    const warnings = entries.filter(
+      (e) =>
+        e.type === "status_update" &&
+        e.metadata.warning === "missing_github_token"
+    );
+    expect(warnings).toHaveLength(1);
+
+    infoSpy.mockRestore();
+  });
+
   it("returns a no-op handle when git remote resolution fails", async () => {
     process.env.GITHUB_TOKEN = "fake-token";
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/test/orchestrator/dispatch-error-surface.test.ts
+++ b/test/orchestrator/dispatch-error-surface.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks must be declared at module scope (hoisted by vitest). We mock the
+// orchestrator so `orchestrator.run()` rejects; dispatch should then surface
+// the failure to the channel feed instead of silently swallowing it.
+const runRejection = new Error("synthetic orchestrator failure");
+runRejection.stack = [
+  "Error: synthetic orchestrator failure",
+  "    at frame 1",
+  "    at frame 2",
+  "    at frame 3",
+  "    at frame 4"
+].join("\n");
+
+vi.mock("../../src/orchestrator/orchestrator-v2.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/orchestrator/orchestrator-v2.js")
+  >("../../src/orchestrator/orchestrator-v2.js");
+  class MockOrchestratorV2 {
+    attachPoller(): void {
+      /* no-op */
+    }
+    async run(): Promise<never> {
+      throw runRejection;
+    }
+  }
+  return {
+    ...actual,
+    OrchestratorV2: MockOrchestratorV2
+  };
+});
+
+// Prevent the real agent factory from shelling out.
+vi.mock("../../src/agents/factory.js", () => ({
+  createLiveAgents: () => [],
+  registerAgentNames: async () => {
+    /* no-op */
+  }
+}));
+
+// Pin the storage factory to a tmp-backed FileHarnessStore so dispatch's call
+// to getHarnessStore() doesn't touch ~/.relay.
+const storeRoots: string[] = [];
+vi.mock("../../src/storage/factory.js", async () => {
+  const { FileHarnessStore } = await import("../../src/storage/file-store.js");
+  const root = await mkdtemp(join(tmpdir(), "dispatch-err-hs-"));
+  storeRoots.push(root);
+  const store = new FileHarnessStore(root);
+  return {
+    getHarnessStore: () => store,
+    buildHarnessStore: () => store
+  };
+});
+
+describe("dispatch surfaces fire-and-forget orchestrator errors", () => {
+  let tmpHome: string;
+  const ORIGINAL_HOME = process.env.HOME;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "dispatch-err-home-"));
+    process.env.HOME = tmpHome;
+    const { __resetRelayDirCacheForTests } = await import("../../src/cli/paths.js");
+    __resetRelayDirCacheForTests();
+  });
+
+  afterEach(async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+    const { __resetRelayDirCacheForTests } = await import("../../src/cli/paths.js");
+    __resetRelayDirCacheForTests();
+    while (storeRoots.length > 0) {
+      const r = storeRoots.pop();
+      if (r) await rm(r, { recursive: true, force: true });
+    }
+  });
+
+  it("posts a feed entry describing the failure when the background run rejects", async () => {
+    const { dispatch } = await import("../../src/orchestrator/dispatch.js");
+    const { ChannelStore } = await import("../../src/channels/channel-store.js");
+
+    const result = await dispatch({
+      featureRequest: "Test feature",
+      repoPath: "/irrelevant/repo"
+    });
+
+    expect(result.status).toBe("dispatched");
+    expect(result.channelId).toBeDefined();
+
+    // Allow the background .catch handler to run and post the feed entry.
+    // postEntry awaits mkdir + appendFile + touchChannel (channel read+write);
+    // a real timer flush is more reliable than microtask pumping.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const store = new ChannelStore();
+    const entries = await store.readFeed(result.channelId);
+
+    const failure = entries.find(
+      (e) => e.type === "status_update" && e.content.startsWith("Run failed:")
+    );
+    expect(failure).toBeDefined();
+    expect(failure!.content).toContain("synthetic orchestrator failure");
+    expect(failure!.metadata.runId).toBe(result.runId);
+    expect(failure!.metadata.channelId).toBe(result.channelId);
+    expect(failure!.metadata.error).toBe("true");
+    expect(failure!.metadata.errorMessage).toContain("synthetic orchestrator failure");
+    // Stack trace is included, truncated to <= 20 lines.
+    expect(failure!.metadata.errorStack).toBeDefined();
+    const stackStr = String(failure!.metadata.errorStack);
+    expect(stackStr.split("\n").length).toBeLessThanOrEqual(20);
+    expect(stackStr).toContain("frame 1");
+  });
+});

--- a/test/orchestrator/verification-override-feed.test.ts
+++ b/test/orchestrator/verification-override-feed.test.ts
@@ -1,0 +1,195 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NodeCommandInvoker } from "../../src/agents/command-invoker.js";
+import { createLiveAgents } from "../../src/agents/factory.js";
+import { AgentRegistry } from "../../src/agents/registry.js";
+import type {
+  AgentResult,
+  WorkRequest
+} from "../../src/domain/agent.js";
+import type { HarnessRun } from "../../src/domain/run.js";
+import {
+  initializeTicketLedger,
+  parseTicketPlan,
+  type TicketDefinition
+} from "../../src/domain/ticket.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+import { VerificationRunner } from "../../src/execution/verification-runner.js";
+import { TicketScheduler } from "../../src/orchestrator/ticket-scheduler.js";
+import { ScriptedInvoker } from "../../src/simulation/scripted-invoker.js";
+
+const RETRY_POLICY = { maxAgentAttempts: 1, maxTestFixLoops: 1 } as const;
+
+function buildTicket(
+  id: string,
+  verificationCommands: string[]
+): TicketDefinition {
+  return {
+    id,
+    title: `Ticket ${id}`,
+    objective: `Do ${id}`,
+    specialty: "general",
+    acceptanceCriteria: ["Complete the work"],
+    allowedCommands: [],
+    verificationCommands,
+    docsToUpdate: [],
+    dependsOn: [],
+    retryPolicy: { ...RETRY_POLICY }
+  };
+}
+
+function buildRun(
+  repoRoot: string,
+  tickets: TicketDefinition[],
+  channelId: string
+): HarnessRun {
+  const now = new Date().toISOString();
+  const ticketPlan = parseTicketPlan({
+    version: 1,
+    task: {
+      title: "Test run",
+      featureRequest: "Test feature",
+      repoRoot
+    },
+    classification: {
+      tier: "feature_small",
+      rationale: "test",
+      suggestedSpecialties: ["general"],
+      estimatedTicketCount: tickets.length,
+      needsDesignDoc: false,
+      needsUserApproval: false
+    },
+    tickets,
+    finalVerification: { commands: [] },
+    docsToUpdate: []
+  });
+
+  return {
+    id: "run-ver-override",
+    featureRequest: "Test feature",
+    state: "TICKETS_EXECUTING",
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    channelId,
+    classification: ticketPlan.classification,
+    plan: null,
+    ticketPlan,
+    events: [],
+    evidence: [],
+    artifacts: [],
+    phaseLedger: [],
+    phaseLedgerPath: null,
+    ticketLedger: initializeTicketLedger(tickets),
+    ticketLedgerPath: null,
+    runIndexPath: null
+  };
+}
+
+describe("TicketScheduler verification override surfaces to channel feed", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "ver-override-feed-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("posts a 'verification override' status entry when the agent proposes a non-allowlisted command", async () => {
+    const channelStore = new ChannelStore(join(tmp, "channels"));
+    const channel = await channelStore.createChannel({
+      name: "#ver-override",
+      description: "override test"
+    });
+
+    const registry = new AgentRegistry();
+    for (const agent of createLiveAgents({
+      cwd: tmp,
+      invoker: new ScriptedInvoker(tmp)
+    })) {
+      registry.register(agent);
+    }
+
+    const artifactStore = new LocalArtifactStore(
+      join(tmp, "artifacts"),
+      new FileHarnessStore(join(tmp, "__hs__"))
+    );
+    const verificationRunner = new VerificationRunner(
+      new NodeCommandInvoker(),
+      artifactStore
+    );
+
+    // The tester dispatch proposes a command that is not on the ticket's
+    // allowlist. The scheduler must (a) fall back to the allowlist for
+    // execution and (b) post an override entry to the channel feed.
+    const dispatch = async (
+      _run: HarnessRun,
+      req: Omit<WorkRequest, "runId">
+    ): Promise<AgentResult> => {
+      if (req.kind === "run_checks") {
+        return {
+          summary: "proposed bogus commands",
+          evidence: [],
+          proposedCommands: ["rm -rf /tmp/nope"],
+          blockers: []
+        };
+      }
+      return {
+        summary: `ok:${req.kind}`,
+        evidence: [],
+        proposedCommands: [],
+        blockers: []
+      };
+    };
+
+    const scheduler = new TicketScheduler(
+      tmp,
+      artifactStore,
+      verificationRunner,
+      registry,
+      dispatch,
+      () => {
+        /* no-op recordEvent */
+      },
+      { maxConcurrency: 1, channelStore }
+    );
+
+    const run = buildRun(
+      tmp,
+      [buildTicket("t_override", ["echo allowlisted"])],
+      channel.channelId
+    );
+
+    await scheduler.executeAll(run);
+
+    // Let the fire-and-forget postEntry settle — postEntry awaits mkdir +
+    // appendFile + touchChannel (channel read+write), more than microtask
+    // pumping reliably drains.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const entries = await channelStore.readFeed(channel.channelId);
+    const override = entries.find(
+      (e) =>
+        e.type === "status_update" &&
+        e.content.startsWith("Verification override")
+    );
+    expect(override).toBeDefined();
+    expect(override!.fromDisplayName).toBe("Verifier");
+    expect(override!.metadata.runId).toBe(run.id);
+    expect(override!.metadata.ticketId).toBe("t_override");
+    // The verifier tag encodes both the pass/fail state and the override.
+    expect(String(override!.metadata.verification)).toMatch(
+      /passed-with-override|failed-with-override/
+    );
+    expect(override!.metadata.rejectedCommands).toEqual(["rm -rf /tmp/nope"]);
+    expect(override!.metadata.substitutedCommands).toEqual(["echo allowlisted"]);
+  }, 30_000);
+});

--- a/test/verification-override.test.ts
+++ b/test/verification-override.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { CommandInvocation, CommandInvoker } from "../src/agents/command-invoker.js";
+import { LocalArtifactStore } from "../src/execution/artifact-store.js";
+import { FileHarnessStore } from "../src/storage/file-store.js";
+import {
+  selectVerificationCommands,
+  VerificationRunner
+} from "../src/execution/verification-runner.js";
+
+describe("selectVerificationCommands override signal", () => {
+  it("flags override=true when all proposed commands are rejected", () => {
+    const result = selectVerificationCommands(
+      ["rm -rf /tmp/nope", "curl evil.com"],
+      ["pnpm test", "pnpm typecheck"]
+    );
+    expect(result.overridden).toBe(true);
+    expect(result.commandsToRun).toEqual(["pnpm test", "pnpm typecheck"]);
+    expect(result.rejected).toEqual(["rm -rf /tmp/nope", "curl evil.com"]);
+  });
+
+  it("flags override=false when at least one proposed command is approved", () => {
+    const result = selectVerificationCommands(
+      ["pnpm test", "rm -rf /tmp/nope"],
+      ["pnpm test", "pnpm typecheck"]
+    );
+    expect(result.overridden).toBe(false);
+    expect(result.commandsToRun).toEqual(["pnpm test"]);
+    expect(result.rejected).toEqual(["rm -rf /tmp/nope"]);
+  });
+
+  it("flags override=false when the agent proposed nothing (default path)", () => {
+    const result = selectVerificationCommands([], ["pnpm typecheck"]);
+    expect(result.overridden).toBe(false);
+    expect(result.commandsToRun).toEqual(["pnpm typecheck"]);
+    expect(result.rejected).toEqual([]);
+  });
+});
+
+describe("VerificationRunner surfaces override in run() result", () => {
+  it("marks overridden=true and records substitutedCommands when the agent's proposals are rejected", async () => {
+    const artifactRoot = await mkdtemp(join(tmpdir(), "ver-override-art-"));
+    const storeRoot = await mkdtemp(join(tmpdir(), "ver-override-hs-"));
+    const artifactStore = new LocalArtifactStore(
+      artifactRoot,
+      new FileHarnessStore(storeRoot)
+    );
+    const runner = new VerificationRunner(new FakeCommandInvoker(), artifactStore);
+
+    try {
+      const result = await runner.run({
+        runId: "run-override",
+        phaseId: "phase-1",
+        repoRoot: process.cwd(),
+        proposedCommands: ["rm -rf /tmp/nope"],
+        allowlistedCommands: ["pnpm test", "pnpm typecheck"]
+      });
+
+      expect(result.overridden).toBe(true);
+      expect(result.substitutedCommands).toEqual(["pnpm test", "pnpm typecheck"]);
+      expect(result.rejected).toEqual(["rm -rf /tmp/nope"]);
+      expect(result.success).toBe(true);
+      expect(result.executed).toHaveLength(2);
+    } finally {
+      await rm(artifactRoot, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps overridden=false and substitutedCommands empty on the happy path", async () => {
+    const artifactRoot = await mkdtemp(join(tmpdir(), "ver-override-art-"));
+    const storeRoot = await mkdtemp(join(tmpdir(), "ver-override-hs-"));
+    const artifactStore = new LocalArtifactStore(
+      artifactRoot,
+      new FileHarnessStore(storeRoot)
+    );
+    const runner = new VerificationRunner(new FakeCommandInvoker(), artifactStore);
+
+    try {
+      const result = await runner.run({
+        runId: "run-clean",
+        phaseId: "phase-1",
+        repoRoot: process.cwd(),
+        proposedCommands: ["pnpm test"],
+        allowlistedCommands: ["pnpm test", "pnpm typecheck"]
+      });
+
+      expect(result.overridden).toBe(false);
+      expect(result.substitutedCommands).toEqual([]);
+      expect(result.rejected).toEqual([]);
+      expect(result.success).toBe(true);
+    } finally {
+      await rm(artifactRoot, { recursive: true, force: true });
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+class FakeCommandInvoker implements CommandInvoker {
+  async exec(invocation: CommandInvocation) {
+    return {
+      stdout: `simulated ${invocation.args.join(" ")}`,
+      stderr: "",
+      exitCode: 0
+    };
+  }
+}

--- a/test/verification-runner.test.ts
+++ b/test/verification-runner.test.ts
@@ -21,14 +21,16 @@ describe("verification command selection", () => {
       )
     ).toEqual({
       commandsToRun: ["pnpm test", "pnpm typecheck"],
-      rejected: ["rm -rf /tmp/nope"]
+      rejected: ["rm -rf /tmp/nope"],
+      overridden: false
     });
   });
 
   it("falls back to allowlisted commands when tester proposes none", () => {
     expect(selectVerificationCommands([], ["pnpm typecheck"])).toEqual({
       commandsToRun: ["pnpm typecheck"],
-      rejected: []
+      rejected: [],
+      overridden: false
     });
   });
 });


### PR DESCRIPTION
## Summary

Three related observability gaps where failures were disappearing without any signal to the user:

- **Gap #4 — fire-and-forget orchestrator errors.** `dispatch.ts` already posted a feed entry on rejection, but the nested `postEntry.catch(() => {})` swallowed the secondary failure. It now logs the nested failure and the primary feed entry carries `runId`, `channelId`, `workspaceId`, `errorMessage`, and a 20-line-max stack trace. `orchestrator.ts:483` `appendEvent` failures now log `runId`/`type`/`phaseId` instead of a bare `.catch(() => {})`, matching the pattern already in `OrchestratorV2.recordEvent`.
- **Gap #9 — verification runner silent fallback.** Picked option (B) from the ticket: `selectVerificationCommands` now returns `overridden`, `VerificationRunner.run` returns `overridden` + `substitutedCommands`, and `TicketScheduler.executeVerificationCommands` posts a "Verification override" `status_update` to the channel feed (once per override, best-effort) whenever the agent's proposed commands were all rejected and the allowlist ran in their place. The override metadata carries `verification: "passed-with-override" | "failed-with-override"`, `rejectedCommands`, and `substitutedCommands` so users can see exactly what happened.
- **Gap #10 — PR watcher silently disabled.** `pr-watcher-factory.ts` now posts a one-shot `status_update` warning to the channel feed when `GITHUB_TOKEN` is missing (dedup'd by `channelId` per process so repeated factory invocations don't spam). The stdout `console.info` line is preserved for CLI-only users.

Four new / updated vitest suites cover:
- A rejecting background orchestrator run → feed entry surfaces `runId`, `channelId`, stack trace ≤ 20 lines.
- The override signal at both the selector and the runner layers.
- The feed-level override post from the scheduler's happy path.
- The dedup'd missing-token warning (one entry across three factory invocations).

Docs updated in the same PR (`docs/getting-started.md` troubleshooting table).

No dep changes. Total diff ~660 LOC (under the 800 bar).

## Test plan

- [x] `pnpm test` — 390 passed | 22 skipped
- [x] `pnpm typecheck`
- [x] `pnpm build`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>