### PR TITLE
OSS-06: Streaming tool-use parity (CLI inline, TUI richer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,15 @@ rly list-runs [--workspace <id>]
 rly doctor                      # diagnostics
 ```
 
+During `HARNESS_LIVE=1 rly run` with the Claude provider, tool-use events stream inline on stderr — each tool call appears as `⚙ [HH:MM:SS] [agent] Reading foo.ts`. Pass `--quiet` (or set `RELAY_QUIET=1`) to silence the feed without affecting stdout.
+
 ### TUI (ratatui)
 
 ```bash
 rly tui                         # auto-builds on first run (~1 min)
 ```
 
-Vertical channel sidebar · feed · task board · decisions · agents. Keyboard-driven, fast.
+Vertical channel sidebar · feed · task board · decisions · agents. Keyboard-driven, fast. While a Claude session is streaming, the chat pane shows a live tool-use stack (newest tool call, recent history, and a `last update …` timestamp) — matching the GUI's activity card.
 
 ### GUI (Tauri desktop app)
 
@@ -356,6 +358,7 @@ Both sit behind the same interface; the orchestrator doesn't care which one is l
 | `GITHUB_TOKEN` | GitHub issues + PR watcher |
 | `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) | Linear issues |
 | `CLAUDE_BIN` | Override the `claude` binary path (default: `claude` on `$PATH`) |
+| `RELAY_QUIET=1` / `--quiet` / `--silent` | Suppress inline tool-use activity during `rly run` |
 | `--sequential` | Use the v1 sequential orchestrator instead of v2 ticket-based |
 | `--no-harness-mcp` | Launch Claude/Codex without attaching the Relay MCP server |
 

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+pub mod tool_activity;
+
 // --- Workspace Registry ---
 
 #[derive(Debug, Deserialize)]

--- a/crates/harness-data/src/tool_activity.rs
+++ b/crates/harness-data/src/tool_activity.rs
@@ -1,0 +1,141 @@
+//! Shared tool-use activity rendering for the GUI (src-tauri), the TUI, and
+//! any other Rust surface that needs to turn a Claude stream-json `tool_use`
+//! block into a one-line skimmable description.
+//!
+//! The CLI has a parallel TypeScript implementation in
+//! `src/domain/tool-activity.ts` — keep the two in sync when adding cases.
+//! These two sources are the cross-dashboard contract for tool-use
+//! visualization parity (ticket OSS-06).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Max number of activity entries to retain per stream. Matches the GUI's
+/// `ACTIVITY_STACK_MAX` so cap-before-append behavior is identical across
+/// surfaces.
+pub const ACTIVITY_STACK_MAX: usize = 20;
+
+/// Default number of newest activity entries to show when the stack is
+/// collapsed. Matches the GUI's `ACTIVITY_TOP_N`.
+pub const ACTIVITY_TOP_N: usize = 3;
+
+/// One entry in a streaming activity stack. Matches the shape used by the
+/// GUI's `ActivityEntry` and the TUI's `ActivityStack.entries`, serialized as
+/// camelCase so it round-trips with the TS side if we ever persist it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolActivityEntry {
+    /// Human-readable one-liner (e.g. "Reading foo.ts" or "$ pnpm test").
+    pub text: String,
+    /// Unix epoch milliseconds. The TUI stores a formatted time string; this
+    /// field is the canonical numeric form used by the GUI/CLI.
+    pub ts: i64,
+}
+
+/// Build a human-readable one-liner describing what a `tool_use` block from
+/// Claude's stream-json output is doing. Deliberately short — the goal is a
+/// skimmable feed, not a full payload dump.
+///
+/// Keep this mirrored with `describeToolUse` in `src/domain/tool-activity.ts`
+/// (the CLI/TS side). Adding a new case? Add it there too.
+pub fn describe_tool_use(name: &str, input: &Value) -> String {
+    let get_str = |k: &str| {
+        input
+            .get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    let basename = |p: &str| p.rsplit('/').next().unwrap_or(p).to_string();
+
+    match name {
+        "Read" => format!("Reading {}", basename(&get_str("file_path"))),
+        "Edit" => format!("Editing {}", basename(&get_str("file_path"))),
+        "Write" => format!("Writing {}", basename(&get_str("file_path"))),
+        "Bash" => format!("$ {}", truncate_chars(&get_str("command"), 60)),
+        "Grep" => format!("Searching '{}'", truncate_chars(&get_str("pattern"), 40)),
+        "Glob" => format!("Finding {}", get_str("pattern")),
+        "Agent" => {
+            let desc = get_str("description");
+            if desc.is_empty() {
+                "Spawning agent".to_string()
+            } else {
+                format!("Agent: {}", desc)
+            }
+        }
+        "WebSearch" => format!("Web search: {}", truncate_chars(&get_str("query"), 40)),
+        "WebFetch" => format!("Fetching {}", truncate_chars(&get_str("url"), 50)),
+        "LSP" => format!("LSP {}", get_str("method")),
+        "Skill" => format!("/{}", get_str("skill")),
+        _ => name.to_string(),
+    }
+}
+
+/// Truncate a string to `n` chars (not bytes), appending `…` when clipped.
+/// Unicode-safe: uses `chars().count()` / `chars().take()` so multibyte
+/// sequences aren't split mid-codepoint.
+fn truncate_chars(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(n).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn read_uses_basename() {
+        let d = describe_tool_use("Read", &json!({ "file_path": "/abs/path/src/foo.ts" }));
+        assert_eq!(d, "Reading foo.ts");
+    }
+
+    #[test]
+    fn bash_truncates_long_commands() {
+        let cmd = "a".repeat(200);
+        let d = describe_tool_use("Bash", &json!({ "command": cmd }));
+        // $ + 60 chars + ellipsis
+        assert!(d.starts_with("$ "));
+        assert!(d.ends_with('…'));
+        assert_eq!(d.chars().count(), 2 + 60 + 1);
+    }
+
+    #[test]
+    fn unknown_tool_falls_back_to_name() {
+        let d = describe_tool_use("Mystery", &json!({}));
+        assert_eq!(d, "Mystery");
+    }
+
+    #[test]
+    fn skill_formats_with_slash() {
+        let d = describe_tool_use("Skill", &json!({ "skill": "review-pr" }));
+        assert_eq!(d, "/review-pr");
+    }
+
+    #[test]
+    fn truncate_handles_multibyte() {
+        // Smoke test: 100 ✓ chars, truncate to 5 — must not panic on UTF-8
+        // boundary and must preserve full codepoints.
+        let s = "✓".repeat(100);
+        let t = truncate_chars(&s, 5);
+        assert_eq!(t.chars().count(), 6); // 5 + ellipsis
+    }
+
+    #[test]
+    fn activity_entry_roundtrips_camelcase() {
+        let e = ToolActivityEntry {
+            text: "Reading foo.ts".into(),
+            ts: 1_700_000_000_000,
+        };
+        let s = serde_json::to_string(&e).unwrap();
+        assert!(s.contains("\"text\""));
+        assert!(s.contains("\"ts\""));
+        let back: ToolActivityEntry = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.text, "Reading foo.ts");
+    }
+}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -305,37 +305,8 @@ enum ChatEvent {
     Error { stream_id: u64, message: String },
 }
 
-fn describe_tool_use(name: &str, input: &serde_json::Value) -> String {
-    let s = |k: &str| {
-        input
-            .get(k)
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string()
-    };
-    let basename = |p: &str| p.rsplit('/').next().unwrap_or(p).to_string();
-    let trunc = |s: String, n: usize| {
-        if s.chars().count() <= n {
-            s
-        } else {
-            let mut out: String = s.chars().take(n).collect();
-            out.push('…');
-            out
-        }
-    };
-    match name {
-        "Read" => format!("Reading {}", basename(&s("file_path"))),
-        "Edit" => format!("Editing {}", basename(&s("file_path"))),
-        "Write" => format!("Writing {}", basename(&s("file_path"))),
-        "Bash" => format!("$ {}", trunc(s("command"), 60)),
-        "Grep" => format!("Searching '{}'", trunc(s("pattern"), 40)),
-        "Glob" => format!("Finding {}", s("pattern")),
-        "WebSearch" => format!("Web search: {}", trunc(s("query"), 40)),
-        "WebFetch" => format!("Fetching {}", trunc(s("url"), 50)),
-        "Skill" => format!("/{}", s("skill")),
-        _ => name.to_string(),
-    }
-}
+// `describe_tool_use` lives in the shared `harness_data::tool_activity`
+// module so the GUI, TUI, and CLI render identical one-liners. See OSS-06.
 
 #[tauri::command]
 fn start_chat(
@@ -527,7 +498,9 @@ fn start_chat(
                                         "chat-event",
                                         ChatEvent::Activity {
                                             stream_id,
-                                            text: describe_tool_use(name, input),
+                                            text: data::tool_activity::describe_tool_use(
+                                                name, input,
+                                            ),
                                         },
                                     );
                                 }

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -22,6 +22,15 @@ interface CliAgentOptions {
   cwd: string;
   model?: string;
   invoker: CommandInvoker;
+  /**
+   * Optional streaming observer — when supplied (and the invoker exposes
+   * `spawn`), the Claude adapter switches from buffered `--output-format
+   * json` to `stream-json --verbose` and feeds every stdout line to this
+   * callback so the CLI can render tool-use activity inline as it happens.
+   * The TUI and GUI have their own streaming paths; this is how `rly run`
+   * achieves the same parity. (OSS-06)
+   */
+  onStreamLine?: (line: string) => void;
 }
 
 interface ParsedProviderResult {
@@ -44,6 +53,7 @@ abstract class CliAgentBase implements Agent {
   protected readonly cwd: string;
   protected readonly model?: string;
   protected readonly invoker: CommandInvoker;
+  protected readonly onStreamLine?: (line: string) => void;
 
   constructor(options: CliAgentOptions) {
     this.id = options.id;
@@ -53,6 +63,7 @@ abstract class CliAgentBase implements Agent {
     this.cwd = options.cwd;
     this.model = options.model;
     this.invoker = options.invoker;
+    this.onStreamLine = options.onStreamLine;
   }
 
   async run(request: WorkRequest) {
@@ -158,6 +169,15 @@ export class ClaudeCliAgent extends CliAgentBase {
       process.env.RELAY_AUTO_APPROVE === "true" ||
       process.env.RELAY_AUTO_APPROVE === "yes";
 
+    // Streaming path: only reachable when the caller wired an onStreamLine
+    // hook AND the invoker exposes `spawn`. ScriptedInvoker doesn't
+    // implement spawn; live test runs that want streaming must use
+    // NodeCommandInvoker. We fall back to the buffered path otherwise so
+    // no call site breaks just because streaming wasn't configured.
+    if (this.onStreamLine && typeof this.invoker.spawn === "function") {
+      return this.invokeStreaming(prompt, autoApprove);
+    }
+
     const args = [
       "-p",
       "--output-format",
@@ -192,6 +212,106 @@ export class ClaudeCliAgent extends CliAgentBase {
     return {
       rawResponse: result.stdout,
       parsed: this.normalizePayload(JSON.parse(result.stdout))
+    };
+  }
+
+  /**
+   * Stream-json variant of the Claude call. Drives the onStreamLine hook on
+   * every newline so CLI renderers can visualise tool_use blocks live. The
+   * final agent-result JSON (schema-shaped) is reassembled from the
+   * concatenated text blocks emitted before the stream closes — this mirrors
+   * the TUI worker's logic in tui/src/main.rs.
+   */
+  private async invokeStreaming(
+    prompt: string,
+    autoApprove: boolean
+  ): Promise<ParsedProviderResult> {
+    const args: string[] = [
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--json-schema",
+      JSON.stringify(agentResultJsonSchema)
+    ];
+    if (autoApprove) args.push("--dangerously-skip-permissions");
+    else args.push("--permission-mode", "default");
+    if (this.model) args.push("--model", this.model);
+    args.push(prompt);
+
+    const spawnFn = this.invoker.spawn!;
+    const handle = spawnFn({
+      command: "claude",
+      args,
+      cwd: this.cwd,
+      timeoutMs: 300_000
+    });
+
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let accumText = "";
+    let resultText: string | null = null;
+    const onLine = this.onStreamLine!;
+
+    const processLine = (line: string) => {
+      if (!line) return;
+      onLine(line);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (!parsed || typeof parsed !== "object") return;
+      const obj = parsed as Record<string, unknown>;
+      if (obj.type === "assistant") {
+        const msg = obj.message as { content?: unknown } | undefined;
+        const blocks = Array.isArray(msg?.content) ? msg?.content : null;
+        if (!blocks) return;
+        for (const block of blocks) {
+          if (block && typeof block === "object") {
+            const b = block as Record<string, unknown>;
+            if (b.type === "text" && typeof b.text === "string") {
+              accumText += b.text;
+            }
+          }
+        }
+      } else if (obj.type === "result" && typeof obj.result === "string") {
+        resultText = obj.result;
+      }
+    };
+
+    handle.onStdout((chunk) => {
+      stdoutBuf += chunk;
+      let newlineIdx: number;
+      while ((newlineIdx = stdoutBuf.indexOf("\n")) >= 0) {
+        const line = stdoutBuf.slice(0, newlineIdx).trim();
+        stdoutBuf = stdoutBuf.slice(newlineIdx + 1);
+        if (line) processLine(line);
+      }
+    });
+    handle.onStderr((chunk) => {
+      stderrBuf += chunk;
+    });
+
+    const exitCode: number = await new Promise((resolve, reject) => {
+      handle.onError((err) => reject(err));
+      handle.onExit((code) => resolve(code ?? 1));
+    });
+    const tail = stdoutBuf.trim();
+    if (tail) processLine(tail);
+
+    if (exitCode !== 0) {
+      throw new Error(stderrBuf || stdoutBuf || "Claude execution failed.");
+    }
+
+    const raw = resultText ?? accumText;
+    if (!raw) {
+      throw new Error("Claude stream produced no parseable JSON body.");
+    }
+    return {
+      rawResponse: raw,
+      parsed: this.normalizePayload(JSON.parse(raw))
     };
   }
 }

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -53,6 +53,13 @@ interface AgentFactoryOptions {
   defaultProvider?: AgentProvider;
   defaultModel?: string;
   overrides?: Record<string, { provider?: AgentProvider; model?: string }>;
+  /**
+   * Per-agent streaming hook. When supplied, the factory will pass it to each
+   * Claude-provider agent so stdout lines can be fed to the CLI activity
+   * renderer. The factory calls this for every spec so callers can scope the
+   * renderer per-agent (e.g. label it with the agent's displayName).
+   */
+  onStreamLineFor?: (spec: AgentSpec) => ((line: string) => void) | undefined;
 }
 
 export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
@@ -64,6 +71,10 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
     const provider = override?.provider ?? spec.provider ?? defaultProvider;
     const model = override?.model ?? spec.model ?? options.defaultModel;
     const AgentClass = provider === "codex" ? CodexCliAgent : ClaudeCliAgent;
+    // Only Claude supports tool_use stream-json today — passing this to
+    // CodexCliAgent is harmless but ignored there.
+    const onStreamLine =
+      provider === "claude" ? options.onStreamLineFor?.(spec) : undefined;
 
     return new AgentClass({
       id: spec.id,
@@ -75,7 +86,8 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
       },
       cwd: options.cwd,
       model,
-      invoker
+      invoker,
+      onStreamLine
     });
   });
 }

--- a/src/cli/stream-activity-renderer.ts
+++ b/src/cli/stream-activity-renderer.ts
@@ -1,0 +1,133 @@
+import {
+  ACTIVITY_STACK_MAX,
+  appendActivityCapped,
+  parseClaudeStreamLine,
+  type ToolActivityEntry,
+} from "../domain/tool-activity.js";
+
+/**
+ * Inline CLI renderer for streaming tool-use events. Keeps parity with the
+ * GUI's activity stack and the TUI's activity pane — tool name + one-line
+ * argument preview, rendered as the stream arrives so operators running
+ * `rly run` can see what their agents are doing live.
+ *
+ * Output format (on stderr so it doesn't pollute stdout pipelines):
+ *
+ *   ⚙ [12:34:56] [@alias] Reading foo.ts
+ *   ⚙ [12:34:57] [@alias] $ pnpm test
+ *
+ * Respects quiet mode (either `RELAY_QUIET=1` or `--quiet` in CLI args).
+ * When quiet, the renderer silently drops activity but still parses the
+ * stream so callers can still collect the final result.
+ */
+
+export interface StreamActivityRendererOptions {
+  /** Prefix (rendered inside brackets) so multi-agent runs stay identifiable. */
+  label?: string;
+  /** Override for test assertions / piping into non-TTY sinks. */
+  write?: (line: string) => void;
+  /** When false, the renderer is a no-op. Default: enabled. */
+  enabled?: boolean;
+  /** Debounce in ms. Consecutive activities arriving within this window are
+   *  coalesced so a burst of 30 tool_use events doesn't spam the terminal. */
+  debounceMs?: number;
+}
+
+export interface StreamActivityRenderer {
+  /** Feed one stream-json line (trimmed or raw). Safe to call with any string. */
+  onLine(line: string): void;
+  /** Force-flush any debounced pending render. Call before exit. */
+  flush(): void;
+  /** Most-recent entries, newest last. Mostly for tests. */
+  snapshot(): ToolActivityEntry[];
+}
+
+/**
+ * Decide whether the renderer should actually print. Quiet mode wins when
+ * either RELAY_QUIET / HARNESS_QUIET env is set OR the caller passed --quiet
+ * / --silent / -q on the CLI. The TTY check is intentional: when stderr is a
+ * pipe (e.g. `rly run ... 2>log`), we still stream so the log is useful.
+ */
+export function isQuietMode(argv: string[] = []): boolean {
+  if (argv.includes("--quiet") || argv.includes("--silent")) {
+    return true;
+  }
+  const env = process.env.RELAY_QUIET ?? process.env.HARNESS_QUIET;
+  return env === "1" || env === "true" || env === "yes";
+}
+
+export function createStreamActivityRenderer(
+  options: StreamActivityRendererOptions = {}
+): StreamActivityRenderer {
+  const enabled = options.enabled !== false;
+  const write = options.write ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const label = options.label ? ` [${options.label}]` : "";
+  const debounceMs = options.debounceMs ?? 40;
+
+  let stack: ToolActivityEntry[] = [];
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingIdx = 0; // index into stack of the oldest unrendered entry
+
+  const emit = () => {
+    if (!enabled) {
+      pendingIdx = stack.length;
+      return;
+    }
+    for (; pendingIdx < stack.length; pendingIdx++) {
+      const entry = stack[pendingIdx];
+      const ts = formatTime(entry.ts);
+      write(`${dim("⚙")} ${dim(`[${ts}]`)}${dim(label)} ${entry.text}`);
+    }
+    pendingTimer = null;
+  };
+
+  const scheduleEmit = () => {
+    if (pendingTimer) return;
+    pendingTimer = setTimeout(emit, debounceMs);
+  };
+
+  return {
+    onLine(line: string): void {
+      const text = parseClaudeStreamLine(line);
+      if (!text) return;
+      // Cap BEFORE appending so a spike of events can't ever overshoot the
+      // retained stack size. Matches the GUI and TUI's append policy.
+      const entry: ToolActivityEntry = { text, ts: Date.now() };
+      const before = stack.length;
+      stack = appendActivityCapped(stack, entry, ACTIVITY_STACK_MAX);
+      if (stack.length < before + 1) {
+        // We dropped an older entry to make room. Keep pendingIdx pointing at
+        // the newest unrendered entry so we don't re-render already-flushed
+        // lines after a cap-trim.
+        pendingIdx = Math.max(0, pendingIdx - (before + 1 - stack.length));
+      }
+      scheduleEmit();
+    },
+    flush(): void {
+      if (pendingTimer) {
+        clearTimeout(pendingTimer);
+        pendingTimer = null;
+      }
+      emit();
+    },
+    snapshot(): ToolActivityEntry[] {
+      return stack.slice();
+    },
+  };
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+function dim(s: string): string {
+  // ANSI dim. If NO_COLOR is set or the sink isn't a TTY we leave the string
+  // unwrapped so log captures stay clean.
+  if (process.env.NO_COLOR) return s;
+  if (!process.stderr.isTTY) return s;
+  return `\x1b[2m${s}\x1b[0m`;
+}

--- a/src/domain/tool-activity.ts
+++ b/src/domain/tool-activity.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared tool-use activity model for the CLI streaming renderer.
+ *
+ * The GUI (gui/src-tauri/src/lib.rs) and the TUI (tui/src/main.rs) already
+ * ship an identical Rust implementation in `crates/harness-data/src/tool_activity.rs`.
+ * This module is the TypeScript mirror — add new tool cases to both sides so
+ * the three surfaces stay in sync (OSS-06 parity contract).
+ */
+
+/** Max entries retained in the activity stack. Matches the Rust/GUI cap. */
+export const ACTIVITY_STACK_MAX = 20;
+
+/** Default number of newest entries shown when the stack is collapsed. */
+export const ACTIVITY_TOP_N = 3;
+
+export interface ToolActivityEntry {
+  /** Short human-readable description (e.g. "Reading foo.ts" or "$ pnpm test"). */
+  text: string;
+  /** Unix epoch milliseconds at the time the event arrived. */
+  ts: number;
+}
+
+/**
+ * Build a skimmable one-liner describing a Claude `tool_use` block. The
+ * output format deliberately mirrors the Rust side — keep them aligned.
+ */
+export function describeToolUse(
+  name: string,
+  input: Record<string, unknown> | null | undefined
+): string {
+  const getStr = (key: string): string => {
+    if (!input) return "";
+    const v = (input as Record<string, unknown>)[key];
+    return typeof v === "string" ? v : "";
+  };
+  const basename = (p: string): string => {
+    const idx = p.lastIndexOf("/");
+    return idx < 0 ? p : p.slice(idx + 1);
+  };
+
+  switch (name) {
+    case "Read":
+      return `Reading ${basename(getStr("file_path"))}`;
+    case "Edit":
+      return `Editing ${basename(getStr("file_path"))}`;
+    case "Write":
+      return `Writing ${basename(getStr("file_path"))}`;
+    case "Bash":
+      return `$ ${truncateChars(getStr("command"), 60)}`;
+    case "Grep":
+      return `Searching '${truncateChars(getStr("pattern"), 40)}'`;
+    case "Glob":
+      return `Finding ${getStr("pattern")}`;
+    case "Agent": {
+      const desc = getStr("description");
+      return desc ? `Agent: ${desc}` : "Spawning agent";
+    }
+    case "WebSearch":
+      return `Web search: ${truncateChars(getStr("query"), 40)}`;
+    case "WebFetch":
+      return `Fetching ${truncateChars(getStr("url"), 50)}`;
+    case "LSP":
+      return `LSP ${getStr("method")}`;
+    case "Skill":
+      return `/${getStr("skill")}`;
+    default:
+      return name;
+  }
+}
+
+/**
+ * Parse a single line of Claude `stream-json --verbose` stdout into an
+ * activity description (or `null` if the line isn't a `tool_use` block we
+ * want to visualise).
+ *
+ * Returns `null` for text chunks, result blocks, malformed JSON, or anything
+ * else — callers should treat a null return as "skip, not an error".
+ */
+export function parseClaudeStreamLine(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!json || typeof json !== "object") return null;
+  const obj = json as Record<string, unknown>;
+  if (obj.type !== "assistant") return null;
+
+  const message = obj.message;
+  if (!message || typeof message !== "object") return null;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return null;
+
+  // Claude can emit multiple content blocks per assistant event. We return the
+  // first tool_use block; if more than one tool_use appears in the same event
+  // the caller can re-scan (rare in practice).
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as Record<string, unknown>;
+    if (b.type !== "tool_use") continue;
+    const name = typeof b.name === "string" ? b.name : "tool";
+    const inputRaw = b.input;
+    const input =
+      inputRaw && typeof inputRaw === "object"
+        ? (inputRaw as Record<string, unknown>)
+        : undefined;
+    return describeToolUse(name, input);
+  }
+  return null;
+}
+
+/**
+ * Append an entry to an existing stack, capping BEFORE the push so a burst of
+ * tool_use events can't momentarily exceed the cap (gap #12 lesson — don't
+ * append-then-trim).
+ */
+export function appendActivityCapped(
+  stack: ToolActivityEntry[],
+  entry: ToolActivityEntry,
+  cap: number = ACTIVITY_STACK_MAX
+): ToolActivityEntry[] {
+  const next = stack.length >= cap ? stack.slice(stack.length - cap + 1) : stack.slice();
+  next.push(entry);
+  return next;
+}
+
+function truncateChars(s: string, n: number): string {
+  // Use Array.from so surrogate-paired emoji count as a single unit instead of
+  // being split mid-codepoint.
+  const chars = Array.from(s);
+  if (chars.length <= n) return s;
+  return `${chars.slice(0, n).join("")}…`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ import { AgentRegistry } from "./agents/registry.js";
 import { launchGui, launchTui, parseGuiFlags } from "./cli/launch-gui-tui.js";
 import { parseRebuildFlags, runRebuild } from "./cli/rebuild.js";
 import { launchInteractiveCommand } from "./cli/launcher.js";
+import {
+  createStreamActivityRenderer,
+  isQuietMode
+} from "./cli/stream-activity-renderer.js";
 import { hasOnboarded, parseWelcomeFlags, runWelcome } from "./cli/welcome.js";
 import {
   ensureHarnessWorkspace,
@@ -254,11 +258,25 @@ export async function main(): Promise<void> {
   const agentOverrides = parseAgentOverrides();
   await registerAgentNames({ defaultProvider, overrides: agentOverrides });
   const registry = new AgentRegistry();
+
+  // Inline tool-use activity (OSS-06). Active only for live Claude runs where
+  // stderr is a TTY and the user hasn't opted out via --quiet / RELAY_QUIET.
+  // Scripted runs don't hit the Claude CLI so there's nothing to stream.
+  const streamQuiet = isQuietMode(args);
+  const streamRendererEnabled = live && !streamQuiet;
+  const streamRenderers = new Map<string, ReturnType<typeof createStreamActivityRenderer>>();
   const agents = createLiveAgents({
     cwd,
     invoker: live ? undefined : new ScriptedInvoker(cwd),
     defaultProvider,
-    overrides: agentOverrides
+    overrides: agentOverrides,
+    onStreamLineFor: streamRendererEnabled
+      ? (spec) => {
+          const renderer = createStreamActivityRenderer({ label: spec.id });
+          streamRenderers.set(spec.id, renderer);
+          return (line: string) => renderer.onLine(line);
+        }
+      : undefined
   });
 
   for (const agent of agents) {
@@ -306,6 +324,9 @@ export async function main(): Promise<void> {
       run = await orchestratorV2.run(featureRequest, runId);
     }
   } catch (error) {
+    // Flush any pending streaming activity before surfacing the failure so
+    // the last few tool calls aren't lost when a burst was still in flight.
+    for (const r of streamRenderers.values()) r.flush();
     console.error("Orchestrator failed:", error instanceof Error ? error.message : error);
 
     // Mark the run as FAILED in the index so the dashboard doesn't show it as active
@@ -327,6 +348,7 @@ export async function main(): Promise<void> {
     process.exitCode = 1;
     return;
   }
+  for (const r of streamRenderers.values()) r.flush();
   const recentRuns = await artifactStore.readRunsIndex();
 
   console.log(`Run id: ${run.id}`);

--- a/test/stream-activity-renderer.test.ts
+++ b/test/stream-activity-renderer.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createStreamActivityRenderer,
+  isQuietMode
+} from "../src/cli/stream-activity-renderer.js";
+
+describe("isQuietMode", () => {
+  const originalQuiet = process.env.RELAY_QUIET;
+  afterEach(() => {
+    if (originalQuiet === undefined) delete process.env.RELAY_QUIET;
+    else process.env.RELAY_QUIET = originalQuiet;
+  });
+
+  it("returns true when --quiet is in argv", () => {
+    expect(isQuietMode(["run", "--quiet"])).toBe(true);
+    expect(isQuietMode(["run", "--silent"])).toBe(true);
+  });
+
+  it("returns true when RELAY_QUIET=1", () => {
+    process.env.RELAY_QUIET = "1";
+    expect(isQuietMode([])).toBe(true);
+  });
+
+  it("returns false by default", () => {
+    delete process.env.RELAY_QUIET;
+    delete process.env.HARNESS_QUIET;
+    expect(isQuietMode([])).toBe(false);
+    expect(isQuietMode(["run", "feature-request"])).toBe(false);
+  });
+});
+
+describe("createStreamActivityRenderer", () => {
+  const captured: string[] = [];
+  const write = (line: string) => captured.push(line);
+
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  const claudeLine = (toolUse: { name: string; input: Record<string, unknown> }) =>
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", ...toolUse }]
+      }
+    });
+
+  it("renders tool_use events through the write sink", () => {
+    const r = createStreamActivityRenderer({ write, debounceMs: 0 });
+    r.onLine(claudeLine({ name: "Read", input: { file_path: "src/foo.ts" } }));
+    r.flush();
+    expect(captured.length).toBe(1);
+    expect(captured[0]).toContain("Reading foo.ts");
+  });
+
+  it("includes the label when provided", () => {
+    const r = createStreamActivityRenderer({ write, debounceMs: 0, label: "pixel" });
+    r.onLine(claudeLine({ name: "Bash", input: { command: "pnpm test" } }));
+    r.flush();
+    expect(captured[0]).toContain("[pixel]");
+    expect(captured[0]).toContain("$ pnpm test");
+  });
+
+  it("skips text-only assistant events", () => {
+    const r = createStreamActivityRenderer({ write, debounceMs: 0 });
+    r.onLine(
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "thinking" }] }
+      })
+    );
+    r.flush();
+    expect(captured.length).toBe(0);
+  });
+
+  it("respects enabled=false as a no-op sink", () => {
+    const r = createStreamActivityRenderer({ write, debounceMs: 0, enabled: false });
+    r.onLine(claudeLine({ name: "Read", input: { file_path: "a.ts" } }));
+    r.flush();
+    expect(captured.length).toBe(0);
+  });
+
+  it("caps retained snapshot at the shared limit without momentary overshoot", () => {
+    const r = createStreamActivityRenderer({ write, debounceMs: 0 });
+    // Push 30 events — 10 above the cap.
+    for (let i = 0; i < 30; i++) {
+      r.onLine(claudeLine({ name: "Read", input: { file_path: `f${i}.ts` } }));
+    }
+    r.flush();
+    expect(r.snapshot().length).toBe(20);
+    // Oldest retained should be f10, newest f29 (LIFO after capping).
+    expect(r.snapshot()[0].text).toBe("Reading f10.ts");
+    expect(r.snapshot()[19].text).toBe("Reading f29.ts");
+  });
+});

--- a/test/tool-activity.test.ts
+++ b/test/tool-activity.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVITY_STACK_MAX,
+  ACTIVITY_TOP_N,
+  appendActivityCapped,
+  describeToolUse,
+  parseClaudeStreamLine
+} from "../src/domain/tool-activity.js";
+
+describe("describeToolUse", () => {
+  it("renders Read with basename", () => {
+    expect(describeToolUse("Read", { file_path: "/abs/path/src/foo.ts" })).toBe(
+      "Reading foo.ts"
+    );
+  });
+
+  it("renders Edit with basename", () => {
+    expect(describeToolUse("Edit", { file_path: "bar.ts" })).toBe("Editing bar.ts");
+  });
+
+  it("truncates long Bash commands to 60 chars plus ellipsis", () => {
+    const cmd = "a".repeat(200);
+    const out = describeToolUse("Bash", { command: cmd });
+    expect(out.startsWith("$ ")).toBe(true);
+    expect(out.endsWith("…")).toBe(true);
+    // "$ " + 60 chars + "…"
+    expect(Array.from(out).length).toBe(2 + 60 + 1);
+  });
+
+  it("falls back to the tool name for unknown tools", () => {
+    expect(describeToolUse("Mystery", {})).toBe("Mystery");
+  });
+
+  it("handles missing input gracefully", () => {
+    expect(describeToolUse("Read", null)).toBe("Reading ");
+    expect(describeToolUse("Bash", undefined)).toBe("$ ");
+  });
+
+  it("handles multibyte truncation without splitting codepoints", () => {
+    const s = "✓".repeat(100);
+    const out = describeToolUse("Bash", { command: s });
+    // $ + 60 check-marks + ellipsis
+    expect(Array.from(out).length).toBe(2 + 60 + 1);
+  });
+
+  it("formats Skill as /name", () => {
+    expect(describeToolUse("Skill", { skill: "review-pr" })).toBe("/review-pr");
+  });
+});
+
+describe("parseClaudeStreamLine", () => {
+  it("returns null for text chunks", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "hello" }] }
+    });
+    expect(parseClaudeStreamLine(line)).toBeNull();
+  });
+
+  it("extracts the first tool_use block as a description", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "let me look" },
+          { type: "tool_use", name: "Read", input: { file_path: "src/foo.ts" } }
+        ]
+      }
+    });
+    expect(parseClaudeStreamLine(line)).toBe("Reading foo.ts");
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseClaudeStreamLine("{not json")).toBeNull();
+    expect(parseClaudeStreamLine("")).toBeNull();
+  });
+
+  it("ignores non-assistant types", () => {
+    const line = JSON.stringify({ type: "result", result: "done" });
+    expect(parseClaudeStreamLine(line)).toBeNull();
+  });
+});
+
+describe("appendActivityCapped", () => {
+  it("caps BEFORE appending (no momentary overshoot)", () => {
+    const full = Array.from({ length: ACTIVITY_STACK_MAX }, (_, i) => ({
+      text: `x${i}`,
+      ts: i
+    }));
+    const next = appendActivityCapped(full, { text: "new", ts: 99 });
+    expect(next.length).toBe(ACTIVITY_STACK_MAX);
+    expect(next[next.length - 1].text).toBe("new");
+    // Oldest entry got evicted.
+    expect(next[0].text).toBe("x1");
+  });
+
+  it("doesn't mutate the input", () => {
+    const input = [{ text: "a", ts: 1 }];
+    const next = appendActivityCapped(input, { text: "b", ts: 2 });
+    expect(input.length).toBe(1);
+    expect(next.length).toBe(2);
+  });
+
+  it("constants match the Rust side", () => {
+    expect(ACTIVITY_STACK_MAX).toBe(20);
+    expect(ACTIVITY_TOP_N).toBe(3);
+  });
+});

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -754,18 +754,21 @@ impl App {
                 self.chat_streaming = true;
             }
             WorkerEvent::Activity(desc) => {
-                // Push to activity stack for this alias
+                use data::tool_activity::{ACTIVITY_STACK_MAX, ACTIVITY_TOP_N};
+                let now = now_time();
+                // Cap BEFORE appending so a burst of tool_use blocks can't spike
+                // the stack past the limit even for a single frame (mirrors the
+                // fix being shipped in OSS-02 / gap #12).
                 let stack = self.activity_stacks
                     .entry(alias.clone())
                     .or_insert_with(|| ActivityStack {
                         entries: Vec::new(),
                         agent_alias: alias.clone(),
                     });
-                stack.entries.push((desc.clone(), now_time()));
-                // Keep max 20 entries
-                if stack.entries.len() > 20 {
+                while stack.entries.len() >= ACTIVITY_STACK_MAX {
                     stack.entries.remove(0);
                 }
+                stack.entries.push((desc.clone(), now.clone()));
 
                 // Remove previous activity message for this alias if it's the last message
                 if let Some(last) = self.chat_messages.last() {
@@ -780,28 +783,42 @@ impl App {
                     }
                 }
 
-                // Build stacked activity content — show top 3
+                // Build stacked activity content. Top-N newest visible (most
+                // recent last — natural reading order), each prefixed with a
+                // wall-clock timestamp so the user can see how fast tool calls
+                // are firing. Matches the GUI's stacked card layout.
                 let stack = self.activity_stacks.get(&alias).unwrap();
-                let top_n = if self.activity_expanded { stack.entries.len() } else { 3 };
-                let recent: Vec<&str> = stack.entries.iter()
-                    .rev()
-                    .take(top_n)
-                    .map(|(d, _)| d.as_str())
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .rev()
-                    .collect();
+                let top_n = if self.activity_expanded { stack.entries.len() } else { ACTIVITY_TOP_N };
                 let total = stack.entries.len();
-                let content = if total > top_n {
-                    format!("{}\n  +{} more", recent.join("\n"), total - top_n)
-                } else {
-                    recent.join("\n")
-                };
+                let start = total.saturating_sub(top_n);
+                let mut lines: Vec<String> = Vec::with_capacity(top_n + 2);
+
+                // First line is the header-adjacent status ("N actions · thinking")
+                // so the UI layer always has something to pair with the alias
+                // badge, mirroring the GUI's `stream-status` span.
+                let action_label = if total == 1 { "action" } else { "actions" };
+                lines.push(format!(
+                    "{} {} · {}",
+                    total,
+                    action_label,
+                    if self.chat_streaming { "writing response" } else { "thinking" },
+                ));
+
+                for (d, ts) in &stack.entries[start..] {
+                    lines.push(format!("[{}] {}", ts, d));
+                }
+                let hidden = total.saturating_sub(top_n);
+                if hidden > 0 {
+                    lines.push(format!("  +{} more", hidden));
+                }
+                if let Some((_, last_ts)) = stack.entries.last() {
+                    lines.push(format!("last update {}", last_ts));
+                }
 
                 self.chat_messages.push(ChatMessage {
                     role: ChatRole::Activity,
-                    content,
-                    timestamp: now_time(),
+                    content: lines.join("\n"),
+                    timestamp: now,
                     agent_alias: alias.clone(),
                 });
                 self.chat_scroll = usize::MAX;
@@ -2379,7 +2396,7 @@ fn spawn_claude_worker_with_session(
                                                         Some("tool_use") => {
                                                             let tool_name = block.get("name").and_then(|v| v.as_str()).unwrap_or("tool");
                                                             let input = block.get("input").unwrap_or(&serde_json::Value::Null);
-                                                            let desc = describe_tool_use(tool_name, input);
+                                                            let desc = data::tool_activity::describe_tool_use(tool_name, input);
                                                             let _ = evt_tx.send(WorkerEvent::Activity(desc));
                                                         }
                                                         _ => {}
@@ -2437,65 +2454,8 @@ fn spawn_claude_worker_with_session(
     (cmd_tx, evt_rx)
 }
 
-/// Build a human-readable one-liner describing what a tool call is doing.
-fn describe_tool_use(name: &str, input: &serde_json::Value) -> String {
-    let get_str = |key: &str| input.get(key).and_then(|v| v.as_str()).unwrap_or("");
-
-    match name {
-        "Read" => {
-            let path = get_str("file_path");
-            let short = path.rsplit('/').next().unwrap_or(path);
-            format!("Reading {}", short)
-        }
-        "Edit" => {
-            let path = get_str("file_path");
-            let short = path.rsplit('/').next().unwrap_or(path);
-            format!("Editing {}", short)
-        }
-        "Write" => {
-            let path = get_str("file_path");
-            let short = path.rsplit('/').next().unwrap_or(path);
-            format!("Writing {}", short)
-        }
-        "Bash" => {
-            let cmd = get_str("command");
-            format!("$ {}", truncate_str(cmd, 50))
-        }
-        "Grep" => {
-            let pattern = get_str("pattern");
-            format!("Searching for '{}'", truncate_str(pattern, 40))
-        }
-        "Glob" => {
-            let pattern = get_str("pattern");
-            format!("Finding files: {}", pattern)
-        }
-        "Agent" => {
-            let desc = get_str("description");
-            if desc.is_empty() {
-                "Spawning agent".to_string()
-            } else {
-                format!("Agent: {}", desc)
-            }
-        }
-        "WebSearch" => {
-            let query = get_str("query");
-            format!("Web search: {}", truncate_str(query, 40))
-        }
-        "WebFetch" => {
-            let url = get_str("url");
-            format!("Fetching {}", truncate_str(url, 40))
-        }
-        "LSP" => {
-            let method = get_str("method");
-            format!("LSP {}", method)
-        }
-        "Skill" => {
-            let skill = get_str("skill");
-            format!("/{}", skill)
-        }
-        _ => name.to_string(),
-    }
-}
+// `describe_tool_use` now lives in `harness_data::tool_activity` so the GUI
+// (src-tauri) and the TUI render identical one-liners. See OSS-06.
 
 fn prompt_auto_approve() -> bool {
     use std::io::Write;

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -369,45 +369,85 @@ fn draw_chat(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
             }
             ChatRole::Activity => {
-                // Stacked activity: content may have multiple lines
+                // Stacked activity layout — mirrors the GUI's ActivityStreamCard.
+                // First content line is a status header ("N actions · thinking"),
+                // subsequent lines are per-tool entries formatted "[HH:MM:SS] desc",
+                // and trailing "+N more" / "last update" lines are de-emphasised.
                 let activity_lines: Vec<&str> = msg.content.lines().collect();
-                let alias_label = msg.agent_alias.as_ref().map(|a| format!("@{}", a)).unwrap_or_else(|| "agent".to_string());
+                let alias_label = msg
+                    .agent_alias
+                    .as_ref()
+                    .map(|a| format!("@{}", a))
+                    .unwrap_or_else(|| "agent".to_string());
+                let last_idx = activity_lines.len().saturating_sub(1);
+                let mut newest_shown = false;
                 for (li, aline) in activity_lines.iter().enumerate() {
                     if li == 0 {
-                        // First line: show agent badge + icon
-                        let mut spans = vec![
+                        // Header: agent badge + live status
+                        let spans = vec![
                             Span::styled("    ", Style::default()),
                             Span::styled(
                                 format!(" {} ", alias_label),
                                 Style::default().fg(Color::Black).bg(Color::Rgb(80, 80, 100)),
                             ),
-                            Span::styled(" ", Style::default()),
-                        ];
-                        // Prefix icon for the newest (first) entry
-                        spans.push(Span::styled(
-                            "⚙ ",
-                            Style::default().fg(Color::Rgb(120, 120, 150)),
-                        ));
-                        spans.push(Span::styled(
-                            aline.to_string(),
-                            Style::default().fg(Color::Rgb(120, 120, 150)).add_modifier(Modifier::ITALIC),
-                        ));
-                        lines.push(Line::from(spans));
-                    } else {
-                        // Subsequent stacked entries (indented)
-                        let prefix = if aline.starts_with("  +") {
-                            // "+N more" summary
-                            "      "
-                        } else {
-                            "      ⚙ "
-                        };
-                        lines.push(Line::from(vec![
+                            Span::raw("  "),
                             Span::styled(
-                                format!("{}{}", prefix, aline),
-                                Style::default().fg(Color::Rgb(80, 80, 100)).add_modifier(Modifier::ITALIC),
+                                if app.chat_streaming { "● " } else { "○ " },
+                                Style::default().fg(if app.chat_streaming {
+                                    Color::Green
+                                } else {
+                                    Color::DarkGray
+                                }),
                             ),
-                        ]));
+                            Span::styled(
+                                aline.to_string(),
+                                Style::default()
+                                    .fg(Color::Rgb(160, 160, 180))
+                                    .add_modifier(Modifier::ITALIC),
+                            ),
+                        ];
+                        lines.push(Line::from(spans));
+                        continue;
                     }
+
+                    let is_meta = aline.starts_with("  +") || aline.starts_with("last update ");
+                    if is_meta {
+                        lines.push(Line::from(vec![Span::styled(
+                            format!("      {}", aline.trim_start()),
+                            Style::default()
+                                .fg(Color::Rgb(80, 80, 100))
+                                .add_modifier(Modifier::ITALIC),
+                        )]));
+                        continue;
+                    }
+
+                    // Entry line. The last entry line (just before the meta lines
+                    // if any) is the newest — highlight it so the user can track
+                    // what's happening *right now*, matching the GUI's `newest`
+                    // class treatment.
+                    let is_newest = !newest_shown
+                        && (li == last_idx
+                            || (li + 1 <= last_idx
+                                && {
+                                    let next = activity_lines[li + 1];
+                                    next.starts_with("  +") || next.starts_with("last update ")
+                                }));
+                    if is_newest {
+                        newest_shown = true;
+                    }
+                    let (entry_color, icon_color) = if is_newest {
+                        (Color::Rgb(180, 180, 200), Color::Rgb(150, 150, 200))
+                    } else {
+                        (Color::Rgb(100, 100, 120), Color::Rgb(90, 90, 110))
+                    };
+                    lines.push(Line::from(vec![
+                        Span::raw("      "),
+                        Span::styled("⚙ ", Style::default().fg(icon_color)),
+                        Span::styled(
+                            aline.to_string(),
+                            Style::default().fg(entry_color).add_modifier(Modifier::ITALIC),
+                        ),
+                    ]));
                 }
             }
             ChatRole::System => {


### PR DESCRIPTION
## Summary

Brings CLI and TUI tool-use visualization up to parity with the GUI's stacked activity card (gap #15 from the parity audit). The core de-duplication is moving `describe_tool_use` out of two Rust files into a shared crate module, and adding a TypeScript mirror so `rly run` can render the same one-liners inline.

- **Shared data model.** `crates/harness-data::tool_activity` now owns `describe_tool_use`, `ToolActivityEntry { text, ts }`, and the cap constants. The GUI Tauri side and the TUI both call into it instead of maintaining their own copies — three-way drift is now a structural impossibility. The TS mirror in `src/domain/tool-activity.ts` keeps the CLI side synced (add a new tool case? update both).
- **CLI inline renderer (new).** `src/cli/stream-activity-renderer.ts` parses Claude `stream-json --verbose` lines and emits dimmed `⚙ [HH:MM:SS] [@label] …` lines on stderr. Respects quiet mode (`--quiet` / `--silent` / `RELAY_QUIET=1`) and strips color when stderr isn't a TTY or when `NO_COLOR` is set. Cap-before-append on the internal stack so a burst of tool_use events can't overshoot the cap even for a frame (gap #12 / OSS-02 lesson).
- **ClaudeCliAgent streaming path.** Opt-in via a new `onStreamLine` constructor option. When wired, the agent switches from buffered `--output-format json` to `stream-json --verbose`, feeds every line to the hook, and reassembles the final schema-shaped JSON from the `result` block or concatenated `text` blocks (mirrors the TUI worker). Scripted tests are unaffected — `ScriptedInvoker` doesn't implement `spawn`, so the agent falls back to the buffered path automatically.
- **`rly run` wiring.** `createLiveAgents` now accepts `onStreamLineFor(spec)`, and `rly run` creates one renderer per agent spec when the run is live + non-quiet, flushing pending entries on both success and the orchestrator-error path.
- **TUI richer pane.** The activity card now shows the header status line (`N actions · thinking / writing response`), per-entry wall-clock timestamps, a `last update HH:MM:SS` meta, and highlights the newest entry — matching the GUI's card layout. Existing collapse/expand behavior and cap preserved. Cap-before-append applied here too.

### Example CLI output

```
$ HARNESS_LIVE=1 rly run "Add rate limiting to the auth endpoint"
Tip: `rly welcome` walks through channels, …
⚙ [14:22:11] [atlas] Reading auth.ts
⚙ [14:22:12] [atlas] Reading rate-limit.ts
⚙ [14:22:13] [pixel] Editing auth.ts
⚙ [14:22:15] [probe] $ pnpm test auth
⚙ [14:22:42] [lens] Reading auth.ts
Run id: run-…
Run state: COMPLETED
```

Lines are rendered dim on TTYs (ANSI `\x1b[2m`); pipes and `NO_COLOR=1` get plain text.

### Example TUI layout (text sketch)

```
  @atlas    ● 4 actions · writing response
      [14:22:11] ⚙ Reading auth.ts
      [14:22:12] ⚙ Reading rate-limit.ts
      [14:22:13] ⚙ Editing auth.ts
      +1 more
      last update 14:22:13
```

The newest entry gets a brighter foreground; older entries dim into the background. `●` vs `○` in the header tracks live/idle state, same palette family as the GUI.

## Test plan

- [x] `pnpm test` — 403 passed (22 new), 22 skipped
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `cargo check --workspace`
- [x] `cargo test -p harness-data` — 6 new Rust tests pass
- [x] `cd gui && pnpm build` — GUI bundle still builds (safety check, GUI source unchanged aside from the describe_tool_use call-site dedup)
- [ ] Manual: `HARNESS_LIVE=1 rly run "…"` against a real Claude install, confirm inline activity lines flow
- [ ] Manual: `RELAY_QUIET=1 HARNESS_LIVE=1 rly run "…"` — no activity lines, stdout unchanged
- [ ] Manual: `rly tui` during a streaming session — header + timestamps + meta line render

## Not in scope

- Codex provider streaming. Codex CLI's output doesn't expose `tool_use` events the same way; adding parity there is a separate ticket.
- Persisting the activity stack to `~/.relay/`. Activity remains transient (as in the GUI today) — no file-layout or `harness-data` schema changes other than the new helper module.
- Extending beyond the GUI's existing feature set (no "gold-plating").

🤖 Generated with [Claude Code](https://claude.com/claude-code)