### PR TITLE
OSS-14: Package correctness (zod in deps, .env gitignore) + top-level rly --help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ gui/tsconfig.tsbuildinfo
 # on demand by `pnpm tauri icon`.
 gui/src-tauri/icons/android/
 gui/src-tauri/icons/ios/
+# Local env files — never commit. The tracked template stays.
+.env
+.env.*
+config.env
+config.env.*
+!config.env.template

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "@types/node": "^22.15.30",
     "@types/pg": "^8.20.0",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4",
-    "zod": "^3.24.4"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@aoagents/ao-core": "0.2.5",
@@ -52,6 +51,7 @@
     "@aoagents/ao-plugin-tracker-github": "0.2.5",
     "@aoagents/ao-plugin-tracker-linear": "0.2.5",
     "pg": "^8.20.0",
-    "tsx": "^4.20.6"
+    "tsx": "^4.20.6",
+    "zod": "^3.24.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.15.30
@@ -39,9 +42,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
-      zod:
-        specifier: ^3.24.4
-        version: 3.25.76
 
 packages:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,34 @@ import { getWorkspaceDir } from "./cli/workspace-registry.js";
 
 export async function main(): Promise<void> {
   const cwd = process.cwd();
-  const command = process.argv[2] ?? "run";
+  const rawCommand = process.argv[2];
   const args = process.argv.slice(3);
   const live = process.env.HARNESS_LIVE === "1";
+
+  // Top-level help / version short-circuit. These run BEFORE workspace
+  // bootstrap so `rly --help` / `rly --version` on a fresh machine print
+  // cleanly without creating a `~/.relay/` tree or a `.relay/` in cwd.
+  if (
+    rawCommand === undefined ||
+    rawCommand === "--help" ||
+    rawCommand === "-h" ||
+    rawCommand === "help"
+  ) {
+    await printTopLevelHelp();
+    return;
+  }
+
+  if (
+    rawCommand === "--version" ||
+    rawCommand === "-v" ||
+    rawCommand === "version"
+  ) {
+    const version = await readPackageVersion();
+    console.log(`rly v${version}`);
+    return;
+  }
+
+  const command = rawCommand;
   const packageVersion = await readPackageVersion();
   const workspace = await ensureHarnessWorkspace(cwd, packageVersion);
   const artifactStore = new LocalArtifactStore(workspace.paths.artifactsDir, getHarnessStore());
@@ -81,7 +106,7 @@ export async function main(): Promise<void> {
     return;
   }
 
-  if (command === "list-workspaces") {
+  if (command === "list-workspaces" || command === "workspaces") {
     await printWorkspaces(args);
     return;
   }
@@ -1912,6 +1937,39 @@ async function readPackageVersion(): Promise<string> {
   ) as { version?: string };
 
   return packageJson.version ?? "0.0.0";
+}
+
+async function printTopLevelHelp(): Promise<void> {
+  const version = await readPackageVersion();
+  const lines = [
+    `rly v${version} — Relay CLI`,
+    "",
+    "Usage: rly <command> [options]",
+    "",
+    "Commands:",
+    "  run <request>            Classify + plan + execute a feature request",
+    "  channel <subcommand>     Manage channels (list/create/feed/archive/update)",
+    "  session <subcommand>     Manage sessions",
+    "  board <channelId>        Kanban view of tickets",
+    "  decisions <channelId>    List decisions",
+    "  chat <subcommand>        Chat utilities (rewind-snapshot/rewind-apply/...)",
+    "  config <subcommand>      Manage global config",
+    "  pr-watch <pr>            Track a GitHub PR",
+    "  pr-status                List tracked PRs",
+    "  serve                    Run the MCP server",
+    "  workspaces               List registered workspaces",
+    "  up                       Register current repo as a workspace",
+    "  welcome                  Interactive first-run walkthrough",
+    "  tui                      Launch the ratatui dashboard",
+    "  gui                      Launch the Tauri desktop app",
+    "  rebuild                  Rebuild native artifacts (tui/gui)",
+    "  inspect-mcp              Print MCP tool definitions",
+    "  version | --version      Print version",
+    "",
+    "Run `rly <command> --help` for command-specific help.",
+    "Docs: https://github.com/jcast90/relay#readme"
+  ];
+  console.log(lines.join("\n"));
 }
 
 function resolveCliEntrypoint(): string {


### PR DESCRIPTION
## Summary

- **`zod` -> `dependencies`.** Nine files under `src/domain/*` and `src/crosslink/types.ts` import zod at runtime, and `package.json` ships `src/` via `files[]`, so `npm install --omit=dev` would give a broken package. Lockfile regenerated.
- **`.env` family added to `.gitignore`.** `.env`, `.env.*`, `config.env`, `config.env.*` — with `!config.env.template` kept tracked. Prevents a dev's local env from slipping in via `git add -A`.
- **Top-level `rly --help` / `rly help` / `rly -h` / `rly` (no args).** Prints every command with a one-line description. Routed BEFORE `ensureHarnessWorkspace` so a fresh machine doesn't get a `.relay/` directory just from asking for help.
- **`rly --version` / `rly version` / `rly -v`.** Prints `rly v<version>` read from `package.json`.
- **`rly workspaces` alias.** Maps to the existing `list-workspaces` handler so the command name advertised in the help text resolves.

## `rly --help` output

```
rly v0.1.0 — Relay CLI

Usage: rly <command> [options]

Commands:
  run <request>            Classify + plan + execute a feature request
  channel <subcommand>     Manage channels (list/create/feed/archive/update)
  session <subcommand>     Manage sessions
  board <channelId>        Kanban view of tickets
  decisions <channelId>    List decisions
  chat <subcommand>        Chat utilities (rewind-snapshot/rewind-apply/...)
  config <subcommand>      Manage global config
  pr-watch <pr>            Track a GitHub PR
  pr-status                List tracked PRs
  serve                    Run the MCP server
  workspaces               List registered workspaces
  up                       Register current repo as a workspace
  welcome                  Interactive first-run walkthrough
  tui                      Launch the ratatui dashboard
  gui                      Launch the Tauri desktop app
  rebuild                  Rebuild native artifacts (tui/gui)
  inspect-mcp              Print MCP tool definitions
  version | --version      Print version

Run `rly <command> --help` for command-specific help.
Docs: https://github.com/jcast90/relay#readme
```

## Test plan

- [x] `pnpm install --frozen-lockfile` passes with zod in `dependencies`
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (438 passed, 21 skipped)
- [x] `pnpm build` passes
- [x] `./bin/rly.mjs` (no args) prints the help
- [x] `./bin/rly.mjs --help` prints the help
- [x] `./bin/rly.mjs -h` prints the help
- [x] `./bin/rly.mjs help` prints the help
- [x] `./bin/rly.mjs --version` prints `rly v0.1.0`
- [x] `./bin/rly.mjs version` prints `rly v0.1.0`
- [x] `grep -E "\.env|\.env\." .gitignore` shows the new patterns