### PR TITLE
OSS-15: Purge all personal/private references before OSS launch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at uruguay90@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders by opening a [private security advisory](https://github.com/jcast90/relay/security/advisories/new) (GitHub's private-reporting channel — used here because it's the only private inbox this project exposes). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,4 +84,4 @@ The templates ask the questions we'll otherwise have to ask you anyway — filli
 
 ## Security issues
 
-If you think you've found a security issue, **don't open a public issue**. Email `uruguay90@gmail.com` with the details and we'll triage privately before any disclosure.
+If you think you've found a security issue, **don't open a public issue**. Use GitHub's [private vulnerability reporting](https://github.com/jcast90/relay/security/advisories/new) and we'll triage privately before any disclosure. See [`SECURITY.md`](./SECURITY.md) for the full policy.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ rly gui --dev                   # hot-reload Vite + Tauri window
 rly gui --rebuild               # force rebuild
 ```
 
-Catppuccin Mocha theme (matches the CMUX ghostty config). Three tabs per channel:
+Catppuccin Mocha theme. Three tabs per channel:
 
 - **Chat** — live streaming with thinking previews + tool-call rail + pulsing accent indicator
 - **Board** — kanban with empty columns hidden, per-column scroll, click-any-ticket detail modal with dependency tree
@@ -480,5 +480,5 @@ MIT — see [`LICENSE`](./LICENSE).
 ## Acknowledgements
 
 - [Composio](https://github.com/ComposioHQ/agent-orchestrator) for `@aoagents/ao-core` and the tracker / SCM plugin surface.
-- [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) palette (via the CMUX ghostty theme).
+- [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) palette.
 - [Tauri](https://tauri.app/), [Ratatui](https://ratatui.rs/), [vitest](https://vitest.dev/), [tsx](https://tsx.is/) — the foundations everything rests on.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Relay is a personal open-source project, not a corporate product. This policy is
 
 ## Reporting a vulnerability
 
-Email **uruguay90@gmail.com** with:
+Please use GitHub's [private vulnerability reporting](https://github.com/jcast90/relay/security/advisories/new) to open a draft advisory. Include:
 
 - Affected version — a commit hash, or the output of `rly --version`.
 - A reproduction — minimal steps or a small script. Private repro repos are fine.

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -255,7 +255,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
               autoFocus
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. proposal-pilot"
+              placeholder="e.g. my-project"
             />
           </label>
           <label>

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1,8 +1,7 @@
 :root {
-  /* Catppuccin Mocha — matches the CMUX ghostty theme.
+  /* Catppuccin Mocha palette.
      Mantle for sidebars is darker than base so the center pane sits a touch
-     elevated; alt surfaces stay sunken (same aesthetic as the old Tokyo Night
-     theme, just different hues). */
+     elevated; alt surfaces stay sunken. */
   --bg: #1e1e2e;            /* base */
   --bg-alt: #181825;        /* mantle — sunken card / entry surface */
   --bg-panel: #11111b;      /* crust — darker sidebars */

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { getRelayDir } from "./paths.js";
 
 export interface HarnessGlobalConfig {
-  /** Directories to scan for git repos (e.g. ["~/projects", "~/turingon/Dev"]) */
+  /** Directories to scan for git repos (e.g. ["~/projects", "~/work"]) */
   projectDirs: string[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,13 +219,13 @@ export async function main(): Promise<void> {
     const autoApprove = isAutoApproveEnabled(args);
     const userArgs = stripAutoApproveFlags(stripHarnessMcpOptOut(args));
 
-    // For claude-* variants (e.g. claude-turingon), use the base binary
+    // For claude-* variants (e.g. claude-myproject), use the base binary
     // with CLAUDE_CONFIG_DIR set to ~/.claude-<variant>
     const isVariant = command.startsWith("claude-") || command.startsWith("codex-");
     const baseBinary = isVariant ? command.split("-")[0] : command;
     const variantEnv: Record<string, string> = {};
     if (isVariant) {
-      const variantName = command; // e.g. "claude-turingon"
+      const variantName = command; // e.g. "claude-myproject"
       const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
       variantEnv.CLAUDE_CONFIG_DIR = `${home}/.${variantName}`;
     }


### PR DESCRIPTION
## Summary

Scrub every leaked personal or private reference from the repo before OSS launch. No behavioural changes — pure comment / copy / placeholder edits plus swapping a personal email for GitHub's private vulnerability reporting flow.

User-reported hotspots, plus a repo-wide discovery sweep for: `turingon`, `cmux`, `ghostty`, `jonathanlancaster`, `uruguay90`, `@gmail.com` / `@icloud.com` / `@me.com`, `/Users/jonathanlancaster`, and other internal project names (`proposal-pilot`, `capture-pilot`, `outrank`).

## File-by-file diff (before / after)

### High-priority

**`src/index.ts:222`**
- before: `// For claude-* variants (e.g. claude-turingon), use the base binary`
- after:  `// For claude-* variants (e.g. claude-myproject), use the base binary`

**`src/index.ts:228`**
- before: `const variantName = command; // e.g. "claude-turingon"`
- after:  `const variantName = command; // e.g. "claude-myproject"`

**`src/cli/config.ts:8`**
- before: `  /** Directories to scan for git repos (e.g. ["~/projects", "~/turingon/Dev"]) */`
- after:  `  /** Directories to scan for git repos (e.g. ["~/projects", "~/work"]) */`

**`README.md:233`**
- before: `Catppuccin Mocha theme (matches the CMUX ghostty config). Three tabs per channel:`
- after:  `Catppuccin Mocha theme. Three tabs per channel:`

**`README.md:483`**
- before: `- [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) palette (via the CMUX ghostty theme).`
- after:  `- [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) palette.`

**`gui/src/styles.css:2–5`**
- before:
  ```
  /* Catppuccin Mocha — matches the CMUX ghostty theme.
     Mantle for sidebars is darker than base so the center pane sits a touch
     elevated; alt surfaces stay sunken (same aesthetic as the old Tokyo Night
     theme, just different hues). */
  ```
- after:
  ```
  /* Catppuccin Mocha palette.
     Mantle for sidebars is darker than base so the center pane sits a touch
     elevated; alt surfaces stay sunken. */
  ```

### Discovery-pass finds (not on the original list)

**`gui/src/components/NewChannelModal.tsx:258`** — a placeholder referencing the internal "proposal-pilot" product.
- before: `placeholder="e.g. proposal-pilot"`
- after:  `placeholder="e.g. my-project"`

### Medium-priority (email swap)

No project inbox exists yet, so all three docs point at GitHub's private vulnerability reporting flow: `https://github.com/jcast90/relay/security/advisories/new`.

**`SECURITY.md:5–13`**
- before: `## Reporting a vulnerability` followed by `Email **uruguay90@gmail.com** with:` and the three bullets.
- after:  `## Reporting a vulnerability` followed by `Please use GitHub's [private vulnerability reporting](https://github.com/jcast90/relay/security/advisories/new) to open a draft advisory. Include:` and the same three bullets.

**`CONTRIBUTING.md:87`**
- before: `If you think you've found a security issue, **don't open a public issue**. Email ` + "`uruguay90@gmail.com`" + ` with the details and we'll triage privately before any disclosure.`
- after:  `If you think you've found a security issue, **don't open a public issue**. Use GitHub's [private vulnerability reporting](https://github.com/jcast90/relay/security/advisories/new) and we'll triage privately before any disclosure. See [` + "`SECURITY.md`" + `](./SECURITY.md) for the full policy.`

**`CODE_OF_CONDUCT.md:39`**
- before: `Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at uruguay90@gmail.com. All complaints will be reviewed and investigated promptly and fairly.`
- after:  `Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders by opening a [private security advisory](https://github.com/jcast90/relay/security/advisories/new) (GitHub's private-reporting channel — used here because it's the only private inbox this project exposes). All complaints will be reviewed and investigated promptly and fairly.`

## Kept intentionally

- **`LICENSE:3`** — `Copyright (c) 2026 Jonathan Lancaster`. Standard MIT copyright line; required for the license to function.
- **`package.json:10,12,14`** — `https://github.com/jcast90/relay[.git|#readme|/issues]`. Legitimate public repo URLs.
- **`.github/CODEOWNERS:1`** — `*       @jcast90`. Legitimate code owner.
- **Test fixtures using `/home/user/...` and `/home/test`** (`test/workspace-registry.test.ts`, `test/workspace-registry-harness-store.test.ts`, `test/fixtures/legacy-workspace-registry/workspace-registry.json`, `test/command-invoker.test.ts`, `gui/src-tauri/src/lib.rs`) — these are generic POSIX test paths, not personal ones.
- **`example.com` URLs in `test/integrations/ao-notifier.test.ts` and `test/mcp/serve-validation.test.ts`** — intentional RFC-reserved example domain.

## Verification

```
rg -i 'turingon|cmux|uruguay90|jonathanlancaster|ghostty' .  # zero matches
rg '/Users/jonathanlancaster' .                              # zero matches
rg '@gmail\.com|@icloud\.com|@me\.com' .                     # zero matches
pnpm typecheck                                                # pass
pnpm test                                                     # 438 passed, 21 skipped (2 test files skipped)
pnpm build                                                    # pass
```

## Ambiguous cases for reviewer confirmation

- **`SECURITY.md` + `CONTRIBUTING.md` + `CODE_OF_CONDUCT.md`** — I routed abuse/security reports through the GitHub private advisory flow since no project inbox exists. If you'd rather set up `security@relay.dev` (or similar) before the OSS launch, this should be updated to point there instead.
- **`LICENSE` copyright line** kept as-is. Let me know if you'd prefer that replaced with something like "the Relay authors".

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Verification greps (see above) all return zero matches
- [ ] Manual eyeball pass by user over each before/after above

🤖 Generated with [Claude Code](https://claude.com/claude-code)