### PR TITLE
OSS-17: Constant-time MCP token compare + ChannelStore segment validation (defense-in-depth)

### DIFF
--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -19,6 +19,7 @@ import { buildDecisionId, type Decision } from "../domain/decision.js";
 import type { TrackedPrRow } from "../domain/pr-row.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
 import { buildHarnessStore } from "../storage/factory.js";
+import { assertSafeSegment } from "../storage/file-store.js";
 import { STORE_NS } from "../storage/namespaces.js";
 import type { HarnessStore } from "../storage/store.js";
 
@@ -143,6 +144,7 @@ export class ChannelStore {
   }
 
   async getChannel(channelId: string): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     try {
       const raw = await readFile(
         join(this.channelsDir, `${channelId}.json`),
@@ -192,6 +194,7 @@ export class ChannelStore {
       >
     >
   ): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
 
@@ -259,6 +262,7 @@ export class ChannelStore {
   }
 
   async archiveChannel(channelId: string): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     return this.updateChannel(channelId, { status: "archived" });
   }
 
@@ -278,6 +282,7 @@ export class ChannelStore {
   // --- Members ---
 
   async joinChannel(channelId: string, member: Omit<ChannelMember, "joinedAt" | "status">): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
 
@@ -311,6 +316,7 @@ export class ChannelStore {
   }
 
   async leaveChannel(channelId: string, agentId: string): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
 
@@ -344,6 +350,7 @@ export class ChannelStore {
       metadata: Record<string, unknown>;
     }
   ): Promise<ChannelEntry> {
+    assertSafeSegment(channelId, "channelId");
     const feedDir = join(this.channelsDir, channelId);
     await mkdir(feedDir, { recursive: true });
 
@@ -386,6 +393,7 @@ export class ChannelStore {
       metadata?: Record<string, unknown>;
     }
   ): Promise<string> {
+    assertSafeSegment(channelId, "channelId");
     const entry = await this.postEntry(channelId, {
       type: options?.type ?? "message",
       fromAgentId: options?.fromAgentId ?? null,
@@ -397,6 +405,7 @@ export class ChannelStore {
   }
 
   async readFeed(channelId: string, limit?: number): Promise<ChannelEntry[]> {
+    assertSafeSegment(channelId, "channelId");
     const path = join(this.channelsDir, channelId, "feed.jsonl");
 
     try {
@@ -426,6 +435,7 @@ export class ChannelStore {
   // --- References ---
 
   async addRef(channelId: string, ref: Omit<ChannelRef, "addedAt">): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
 
@@ -446,6 +456,7 @@ export class ChannelStore {
   }
 
   async removeRef(channelId: string, targetId: string): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
 
@@ -459,6 +470,9 @@ export class ChannelStore {
   // --- Run linking ---
 
   async linkRun(channelId: string, runId: string, workspaceId: string): Promise<void> {
+    assertSafeSegment(channelId, "channelId");
+    assertSafeSegment(runId, "runId");
+    assertSafeSegment(workspaceId, "workspaceId");
     const runsDir = join(this.channelsDir, channelId);
     await mkdir(runsDir, { recursive: true });
 
@@ -480,6 +494,7 @@ export class ChannelStore {
   }
 
   async readRunLinks(channelId: string): Promise<ChannelRunLink[]> {
+    assertSafeSegment(channelId, "channelId");
     try {
       const raw = await readFile(
         join(this.channelsDir, channelId, "runs.json"),
@@ -501,6 +516,7 @@ export class ChannelStore {
   // command when no active watcher is present.
 
   async readTrackedPrs(channelId: string): Promise<TrackedPrRow[]> {
+    assertSafeSegment(channelId, "channelId");
     const path = join(this.channelsDir, channelId, "tracked-prs.json");
     try {
       const raw = await readFile(path, "utf8");
@@ -522,6 +538,7 @@ export class ChannelStore {
     channelId: string,
     rows: TrackedPrRow[]
   ): Promise<void> {
+    assertSafeSegment(channelId, "channelId");
     const channelDir = join(this.channelsDir, channelId);
     await mkdir(channelDir, { recursive: true });
     const path = join(channelDir, "tracked-prs.json");
@@ -546,6 +563,7 @@ export class ChannelStore {
    * don't silently overwrite real data via `upsertChannelTickets`.
    */
   async readChannelTickets(channelId: string): Promise<TicketLedgerEntry[]> {
+    assertSafeSegment(channelId, "channelId");
     const path = join(this.channelsDir, channelId, "tickets.json");
     let content: string;
 
@@ -589,6 +607,7 @@ export class ChannelStore {
     channelId: string,
     tickets: TicketLedgerEntry[]
   ): Promise<void> {
+    assertSafeSegment(channelId, "channelId");
     const channelDir = join(this.channelsDir, channelId);
     await mkdir(channelDir, { recursive: true });
 
@@ -642,6 +661,7 @@ export class ChannelStore {
     channelId: string,
     incoming: TicketLedgerEntry[]
   ): Promise<TicketLedgerEntry[]> {
+    assertSafeSegment(channelId, "channelId");
     const merged = await this.withChannelLock(channelId, async () => {
       const existing = await this.readChannelTickets(channelId);
       const byId = new Map(existing.map((t) => [t.ticketId, t]));
@@ -731,6 +751,7 @@ export class ChannelStore {
     channelId: string,
     input: Omit<Decision, "decisionId" | "channelId" | "createdAt">
   ): Promise<Decision> {
+    assertSafeSegment(channelId, "channelId");
     const decisionsDir = join(this.channelsDir, channelId, "decisions");
     await mkdir(decisionsDir, { recursive: true });
 
@@ -785,6 +806,8 @@ export class ChannelStore {
   }
 
   async getDecision(channelId: string, decisionId: string): Promise<Decision | null> {
+    assertSafeSegment(channelId, "channelId");
+    assertSafeSegment(decisionId, "decisionId");
     try {
       const raw = await readFile(
         join(this.channelsDir, channelId, "decisions", `${decisionId}.json`),
@@ -797,6 +820,7 @@ export class ChannelStore {
   }
 
   async listDecisions(channelId: string): Promise<Decision[]> {
+    assertSafeSegment(channelId, "channelId");
     const decisionsDir = join(this.channelsDir, channelId, "decisions");
     const files = await this.safeReaddir(decisionsDir);
     const decisions: Decision[] = [];

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import { URL } from "node:url";
 
 import type { JsonRpcMessage, McpMessageHandler } from "./server.js";
@@ -326,11 +326,29 @@ function authorizeRequest(
     return false;
   }
   const provided = header.slice("Bearer ".length).trim();
-  if (provided !== expected) {
+  if (!compareTokens(provided, expected)) {
     respondJson(res, 401, { error: "unauthorized" });
     return false;
   }
   return true;
+}
+
+/**
+ * Constant-time bearer-token compare. A naive `provided !== expected` leaks
+ * the token bit-by-bit over slow / non-loopback links because JavaScript's
+ * string comparison short-circuits on the first mismatching byte — an
+ * attacker measures per-byte response latency and recovers the secret. We
+ * compare in fixed time via `timingSafeEqual`, which requires equal-length
+ * buffers (it throws otherwise — itself a side channel), so we guard with
+ * an explicit length check first. The length check is unavoidable; an
+ * attacker who can probe lengths still learns only the length, not the
+ * bytes.
+ */
+export function compareTokens(provided: string, expected: string): boolean {
+  const p = Buffer.from(provided, "utf8");
+  const e = Buffer.from(expected, "utf8");
+  if (p.length !== e.length) return false;
+  return timingSafeEqual(p, e);
 }
 
 function respondJson(res: ServerResponse, status: number, body: unknown): void {

--- a/src/storage/file-store.ts
+++ b/src/storage/file-store.ts
@@ -47,12 +47,15 @@ let tmpCounter = 0;
 /**
  * Reject path segments that could escape `rootDir` via traversal (`..`),
  * collapse to the parent (`.`), pierce a directory boundary (`/`, `\`), or
- * trip the kernel's null-byte guard. Called on every `ns` and `id` at the
- * entry of every public method — a malicious caller controlling either
- * would otherwise be able to read/write arbitrary files under the process's
- * uid.
+ * trip the kernel's null-byte guard. Called on every path-segment input at
+ * the entry of every public method that path-joins caller-controlled data —
+ * a malicious caller controlling the segment would otherwise be able to
+ * read/write arbitrary files under the process's uid.
+ *
+ * `kind` is only used in the error message; callers pass whatever label
+ * identifies the segment in their API (`"ns"`, `"id"`, `"channelId"`, …).
  */
-export function assertSafeSegment(segment: string, kind: "ns" | "id"): void {
+export function assertSafeSegment(segment: string, kind: string): void {
   if (
     segment === "" ||
     segment === "." ||

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -431,4 +431,134 @@ describe("channel store", () => {
       }
     });
   });
+
+  describe("path-segment validation", () => {
+    // Every public method that takes a `channelId` and path-joins it must
+    // reject path-traversal inputs before touching the filesystem. Invariants
+    // further up the stack (CLI / MCP layer) should already be preventing
+    // these, but the store is the last line of defense — if a caller ever
+    // lets caller-controlled input through, these guards keep a malicious
+    // value from escaping `channelsDir`.
+    const badChannelIds = [
+      { label: "parent traversal", value: "../foo" },
+      { label: "directory boundary", value: "foo/bar" },
+      { label: "null byte", value: "foo\0bar" },
+      { label: "empty", value: "" },
+      { label: "dot", value: "." },
+      { label: "dot-dot", value: ".." },
+      { label: "backslash", value: "foo\\bar" }
+    ];
+
+    for (const { label, value } of badChannelIds) {
+      it(`rejects ${label} (${JSON.stringify(value)}) across every public method`, async () => {
+        const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+        const store = new ChannelStore(dir);
+        try {
+          // Sanity: create a good channel so any method that would otherwise
+          // succeed by finding a record has something to find — a reject here
+          // must come from the guard, not from a missing channel.
+          await store.createChannel({ name: "#ok", description: "ok" });
+
+          const expectThrow = async (fn: () => Promise<unknown>): Promise<void> => {
+            await expect(fn()).rejects.toThrow(/Unsafe path segment/);
+          };
+
+          await expectThrow(() => store.getChannel(value));
+          await expectThrow(() =>
+            store.updateChannel(value, { name: "x" })
+          );
+          await expectThrow(() => store.archiveChannel(value));
+          await expectThrow(() =>
+            store.joinChannel(value, {
+              agentId: "a",
+              displayName: "A",
+              role: "planner",
+              provider: "claude",
+              sessionId: null
+            })
+          );
+          await expectThrow(() => store.leaveChannel(value, "a"));
+          await expectThrow(() =>
+            store.postEntry(value, {
+              type: "message",
+              fromAgentId: null,
+              fromDisplayName: null,
+              content: "hi",
+              metadata: {}
+            })
+          );
+          await expectThrow(() => store.post(value, "hi"));
+          await expectThrow(() => store.readFeed(value));
+          await expectThrow(() =>
+            store.addRef(value, { type: "repo", targetId: "x", label: "x" })
+          );
+          await expectThrow(() => store.removeRef(value, "x"));
+          await expectThrow(() => store.linkRun(value, "run-1", "ws-1"));
+          await expectThrow(() => store.readRunLinks(value));
+          await expectThrow(() => store.readTrackedPrs(value));
+          await expectThrow(() => store.writeTrackedPrs(value, []));
+          await expectThrow(() => store.readChannelTickets(value));
+          await expectThrow(() => store.writeChannelTickets(value, []));
+          await expectThrow(() => store.upsertChannelTickets(value, []));
+          await expectThrow(() =>
+            store.recordDecision(value, {
+              runId: null,
+              ticketId: null,
+              title: "t",
+              description: "d",
+              rationale: "r",
+              alternatives: [],
+              decidedBy: "a",
+              decidedByName: "A",
+              linkedArtifacts: []
+            })
+          );
+          await expectThrow(() => store.getDecision(value, "d"));
+          await expectThrow(() => store.listDecisions(value));
+        } finally {
+          await rm(dir, { recursive: true, force: true });
+        }
+      });
+    }
+
+    it("linkRun also validates runId and workspaceId", async () => {
+      // linkRun path-joins channelId only, but runId/workspaceId are
+      // user-controlled in the general case (e.g. a scheduler seeded from a
+      // tracker payload) — guard them too so the store never embeds an
+      // unsafe value in JSON written to disk, even when the channelId is
+      // well-formed.
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#r",
+          description: "r"
+        });
+        await expect(
+          store.linkRun(channel.channelId, "../bad-run", "ws-1")
+        ).rejects.toThrow(/Unsafe path segment/);
+        await expect(
+          store.linkRun(channel.channelId, "run-1", "../bad-ws")
+        ).rejects.toThrow(/Unsafe path segment/);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("getDecision also validates decisionId", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "#d",
+          description: "d"
+        });
+        await expect(
+          store.getDecision(channel.channelId, "../escape")
+        ).rejects.toThrow(/Unsafe path segment/);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/test/mcp/http-transport.test.ts
+++ b/test/mcp/http-transport.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { BodyTooLargeError, startHttpMcpServer } from "../../src/mcp/http-transport.js";
+import {
+  BodyTooLargeError,
+  compareTokens,
+  startHttpMcpServer
+} from "../../src/mcp/http-transport.js";
 import type { JsonRpcMessage, McpMessageHandler } from "../../src/mcp/server.js";
 
 /**
@@ -299,5 +303,44 @@ describe("startHttpMcpServer", () => {
     expect(err.name).toBe("BodyTooLargeError");
     expect(err.byteCount).toBe(1_500_000);
     expect(err.limit).toBe(1_000_000);
+  });
+});
+
+describe("compareTokens", () => {
+  it("returns true for byte-identical tokens", () => {
+    expect(compareTokens("s3cret-token", "s3cret-token")).toBe(true);
+  });
+
+  it("returns false for tokens that differ in a single byte", () => {
+    expect(compareTokens("s3cret-tokeN", "s3cret-token")).toBe(false);
+  });
+
+  it("returns false for tokens of different length without throwing", () => {
+    // Guard against timingSafeEqual's different-length throw: the helper
+    // short-circuits on length mismatch and returns false cleanly.
+    expect(compareTokens("short", "much-longer-token")).toBe(false);
+    expect(compareTokens("much-longer-token", "short")).toBe(false);
+  });
+
+  it("returns false when either side is empty", () => {
+    expect(compareTokens("", "s3cret")).toBe(false);
+    expect(compareTokens("s3cret", "")).toBe(false);
+  });
+
+  it("treats two empty strings as equal", () => {
+    // `authorizeRequest` never calls compareTokens with an unset expected
+    // token (the caller short-circuits on `!expected` first), so this case
+    // is purely for the helper's own correctness.
+    expect(compareTokens("", "")).toBe(true);
+  });
+
+  it("handles multibyte UTF-8 content correctly", () => {
+    // Tokens could contain non-ASCII if a user decides to be creative; the
+    // helper compares bytes, not code points, so the UTF-8 encoded length
+    // is what matters for the mismatch short-circuit.
+    const a = "tökén-\u{1F510}";
+    const b = "tökén-\u{1F510}";
+    expect(compareTokens(a, b)).toBe(true);
+    expect(compareTokens(a, a + "x")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two defense-in-depth security fixes. Neither is a live exploit under the current caller set, but both close an entire class of future mistakes.

- **Constant-time bearer-token compare** (`src/mcp/http-transport.ts`): replace the naive `provided !== expected` with `crypto.timingSafeEqual` wrapped in a `compareTokens` helper. The old compare short-circuits on the first mismatching byte and leaks the token bit-by-bit via per-byte latency over slow / non-loopback links. `timingSafeEqual` throws on different-length buffers (itself a side channel), so the helper length-guards first and returns `false` cleanly.
- **`assertSafeSegment` in `ChannelStore`** (`src/channels/channel-store.ts`): every public method that path-joins `channelId` (and a handful that join `runId` / `workspaceId` / `decisionId`) now calls `assertSafeSegment` at entry. Widened the helper's `kind` parameter from `"ns" | "id"` to `string` so new call-sites can label their segment kind without forcing `as any`.

## Files touched

- `src/mcp/http-transport.ts` — export `compareTokens`, call it from `authorizeRequest`, import `timingSafeEqual`.
- `src/channels/channel-store.ts` — add `assertSafeSegment` guard to every public method that path-joins caller-controlled data.
- `src/storage/file-store.ts` — widen `assertSafeSegment(segment, kind)` to accept any string label; the `kind` was only ever used in the error message.
- `test/mcp/http-transport.test.ts` — new `describe("compareTokens")` block covering equal / unequal / different-length / empty / multibyte inputs.
- `test/channel-store.test.ts` — new `describe("path-segment validation")` block exhaustively walking every public method with traversal-style inputs (`../foo`, `foo/bar`, `\0`, empty, `.`, `..`, `\\`), plus targeted tests for the `runId` / `workspaceId` / `decisionId` guards.

## Test plan

- [x] `pnpm test` — 453 passed, 21 skipped
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Existing tests unaffected
- [x] New tests cover both fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)