### PR TITLE
OSS-11: Fix 3 failing tests on main (orchestrator-v2 ENOTEMPTY, verification-override-feed assertion)

### DIFF
--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -35,6 +35,15 @@ const channelTicketLocks: Map<string, Promise<void>> = new Map();
 // collide on the tmp file used by writeChannelTickets.
 let channelTicketsTmpCounter = 0;
 
+// Same rationale for the channel manifest (`channels/<id>.json`): two
+// concurrent `touchChannel` calls (e.g. an orchestrator transition and an
+// agent dispatch both firing `postEntry` → `touchChannel` in the same tick)
+// would otherwise both compute `${path}.tmp.${process.pid}`, and the second
+// rename would hit ENOENT because the first rename already consumed the tmp.
+// This surfaces as noisy `channel post failed` stderr even though the post
+// semantically succeeded. A per-call counter eliminates the collision.
+let channelManifestTmpCounter = 0;
+
 /**
  * Ticket-board coordination record stored on the `HarnessStore` at
  * `(channel-tickets, <channelId>)`. The ticket data itself continues to live
@@ -812,7 +821,7 @@ export class ChannelStore {
   private async writeChannel(channel: Channel): Promise<void> {
     await mkdir(this.channelsDir, { recursive: true });
     const path = join(this.channelsDir, `${channel.channelId}.json`);
-    const tmpPath = `${path}.tmp.${process.pid}`;
+    const tmpPath = `${path}.tmp.${process.pid}.${channelManifestTmpCounter++}`;
     await writeFile(tmpPath, JSON.stringify(channel, null, 2));
     await rename(tmpPath, path);
   }

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -67,6 +67,18 @@ export class OrchestratorV2 {
 
   private readonly executor: AgentExecutor | null;
 
+  /**
+   * In-flight best-effort channel writes (postEntry / appendEvent) tracked so
+   * `run()` can await them before returning. Previously these were
+   * fire-and-forget via `.postEntry(...).catch(...)`, which caused teardown
+   * races in tests: `afterEach`/`finally` would `rm` the tmp dir while the
+   * orchestrator's atomic tmp-rename was still in flight, producing
+   * ENOENT/ENOTEMPTY errors on Linux CI. Tracking them here preserves the
+   * "non-blocking, log-and-continue" semantic during the run while still
+   * guaranteeing the writes settle before the caller moves on.
+   */
+  private pendingWrites: Promise<unknown>[] = [];
+
   constructor(
     private readonly registry: AgentRegistry,
     private readonly repoRoot: string,
@@ -267,6 +279,7 @@ export class OrchestratorV2 {
       if (!approvalResult) {
         // No approval yet — persist and return. Caller resumes after approval.
         await this.persistRunIndex(run);
+        await this.waitForPendingWrites();
         return run;
       }
 
@@ -275,6 +288,7 @@ export class OrchestratorV2 {
         run.completedAt = new Date().toISOString();
         run.updatedAt = run.completedAt;
         await this.persistRunIndex(run);
+        await this.waitForPendingWrites();
         return run;
       }
 
@@ -310,17 +324,19 @@ export class OrchestratorV2 {
     await this.persistRunIndex(run);
 
     if (run.channelId && this.channelStore) {
-      await this.channelStore
-        .postEntry(run.channelId, {
+      await this.trackChannelPost(
+        run,
+        this.channelStore.postEntry(run.channelId, {
           type: "run_completed",
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `Run completed: ${run.state}`,
           metadata: { runId: run.id, state: run.state }
         })
-        .catch((err: unknown) => this.warnChannelPostFailed(run, err));
+      );
     }
 
+    await this.waitForPendingWrites();
     return run;
   }
 
@@ -387,17 +403,19 @@ export class OrchestratorV2 {
     await this.persistRunIndex(run);
 
     if (run.channelId && this.channelStore) {
-      await this.channelStore
-        .postEntry(run.channelId, {
+      await this.trackChannelPost(
+        run,
+        this.channelStore.postEntry(run.channelId, {
           type: "run_completed",
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `Run completed: ${run.state}`,
           metadata: { runId: run.id, state: run.state }
         })
-        .catch((err: unknown) => this.warnChannelPostFailed(run, err));
+      );
     }
 
+    await this.waitForPendingWrites();
     return run;
   }
 
@@ -463,15 +481,16 @@ export class OrchestratorV2 {
       });
 
       if (run.channelId && this.channelStore) {
-        this.channelStore
-          .postEntry(run.channelId, {
+        this.trackChannelPost(
+          run,
+          this.channelStore.postEntry(run.channelId, {
             type: "message",
             fromAgentId: agent.id,
             fromDisplayName: agent.name,
             content: `Dispatched for ${input.kind}: ${input.title}`,
             metadata: { attempt: String(attempt) }
           })
-          .catch((err: unknown) => this.warnChannelPostFailed(run, err));
+        );
       }
 
       try {
@@ -536,15 +555,16 @@ export class OrchestratorV2 {
     await this.persistRunIndex(run);
 
     if (run.channelId && this.channelStore) {
-      this.channelStore
-        .postEntry(run.channelId, {
+      this.trackChannelPost(
+        run,
+        this.channelStore.postEntry(run.channelId, {
           type: "status_update",
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `${eventType} → ${run.state}`,
           metadata: { runId: run.id, state: run.state, event: eventType }
         })
-        .catch((err: unknown) => this.warnChannelPostFailed(run, err));
+      );
     }
   }
 
@@ -562,12 +582,16 @@ export class OrchestratorV2 {
     };
 
     run.events.push(event);
-    this.artifactStore.appendEvent(run.id, event).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[orchestrator] appendEvent failed (runId=${run.id} type=${type}): ${message}`
-      );
-    });
+    // Track the append so teardown doesn't race it — same rationale as
+    // channel writes (see trackChannelPost / waitForPendingWrites).
+    this.pendingWrites.push(
+      this.artifactStore.appendEvent(run.id, event).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[orchestrator] appendEvent failed (runId=${run.id} type=${type}): ${message}`
+        );
+      })
+    );
   }
 
   private recordEvidence(run: HarnessRun, record: EvidenceRecord): void {
@@ -615,6 +639,38 @@ export class OrchestratorV2 {
     console.warn(
       `[orchestrator] channel post failed (runId=${run.id} channelId=${run.channelId}): ${message}`
     );
+  }
+
+  /**
+   * Register a best-effort async write (typically a `postEntry`) so
+   * {@link waitForPendingWrites} can drain it at run completion. The returned
+   * promise never rejects — failures are logged via `warnChannelPostFailed`
+   * but never halt the run. This preserves the historical log-and-continue
+   * semantic while preventing teardown races in tests and real callers who
+   * tear down the artifacts dir immediately after `run()` returns.
+   */
+  private trackChannelPost(
+    run: HarnessRun,
+    promise: Promise<unknown>
+  ): Promise<void> {
+    const tracked: Promise<void> = promise.then(
+      () => undefined,
+      (err: unknown) => this.warnChannelPostFailed(run, err)
+    );
+    this.pendingWrites.push(tracked);
+    return tracked;
+  }
+
+  /**
+   * Drain all tracked best-effort writes. Uses `allSettled` so a single
+   * failure never short-circuits the drain. Clears the tracker on exit so
+   * a second invocation doesn't re-await already-settled promises.
+   */
+  private async waitForPendingWrites(): Promise<void> {
+    if (this.pendingWrites.length === 0) return;
+    const pending = this.pendingWrites;
+    this.pendingWrites = [];
+    await Promise.allSettled(pending);
   }
 }
 

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -78,6 +78,20 @@ export class TicketScheduler {
   private readonly channelStore: ChannelStore | undefined;
 
   /**
+   * In-flight best-effort channel writes tracked so `executeAll` / `enqueue`
+   * can drain them before returning. Previously the scheduler fired these
+   * post-calls with `.catch(...)` and never awaited the resulting promise —
+   * tests that tore down the tmp channels dir immediately after
+   * `scheduler.executeAll(run)` would race the atomic tmp-rename inside
+   * `postEntry`, causing visible-before-readable flakes on the
+   * verification-override assertion and ENOENT warnings in the
+   * orchestrator-v2 stderr. Tracking them preserves "best-effort, log and
+   * continue" during the run while guaranteeing visibility before the
+   * caller moves on.
+   */
+  private pendingWrites: Promise<unknown>[] = [];
+
+  /**
    * Effective dispatch callback. When the caller supplies an `AgentExecutor`
    * via options, this is the adapter built in {@link buildExecutorDispatch}
    * that routes to `executor.start().wait()` and maps the `ExecutionResult`
@@ -260,7 +274,22 @@ export class TicketScheduler {
         this.activeRun = null;
         this.wakeResolve = null;
       }
+      // Drain tracked best-effort writes (verification-override feed posts,
+      // etc.) so readers see the final state before the caller proceeds.
+      await this.waitForPendingWrites();
     }
+  }
+
+  /**
+   * Drain all tracked best-effort writes. Uses `allSettled` so a single
+   * failure never short-circuits the drain, and clears the tracker on exit
+   * so a second invocation doesn't re-await already-settled promises.
+   */
+  private async waitForPendingWrites(): Promise<void> {
+    if (this.pendingWrites.length === 0) return;
+    const pending = this.pendingWrites;
+    this.pendingWrites = [];
+    await Promise.allSettled(pending);
   }
 
   /**
@@ -323,6 +352,7 @@ export class TicketScheduler {
     });
 
     await next;
+    await this.waitForPendingWrites();
   }
 
   private async drain(run: HarnessRun): Promise<boolean> {
@@ -637,28 +667,34 @@ export class TicketScheduler {
     // swapped out for allowlisted substitutes. Best-effort — a feed write
     // failure must not halt verification.
     if (selection.overridden && run.channelId && this.channelStore) {
-      this.channelStore
-        .postEntry(run.channelId, {
-          type: "status_update",
-          fromAgentId: null,
-          fromDisplayName: "Verifier",
-          content:
-            `Verification override: agent's proposed commands were not on the allowlist; ` +
-            `ran allowlisted substitutes instead.`,
-          metadata: {
-            runId: run.id,
-            ticketId,
-            verification: success ? "passed-with-override" : "failed-with-override",
-            rejectedCommands: selection.rejected,
-            substitutedCommands
-          }
-        })
-        .catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.warn(
-            `[scheduler] verification-override feed post failed (runId=${run.id} ticketId=${ticketId}): ${message}`
-          );
-        });
+      // Track but don't await — the scheduler keeps moving so the run doesn't
+      // stall on a feed-write blip. The tracked promise is drained at
+      // `executeAll` completion so observers see the override entry before
+      // the caller inspects the feed (or tears down tmp dirs in tests).
+      this.pendingWrites.push(
+        this.channelStore
+          .postEntry(run.channelId, {
+            type: "status_update",
+            fromAgentId: null,
+            fromDisplayName: "Verifier",
+            content:
+              `Verification override: agent's proposed commands were not on the allowlist; ` +
+              `ran allowlisted substitutes instead.`,
+            metadata: {
+              runId: run.id,
+              ticketId,
+              verification: success ? "passed-with-override" : "failed-with-override",
+              rejectedCommands: selection.rejected,
+              substitutedCommands
+            }
+          })
+          .catch((err: unknown) => {
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(
+              `[scheduler] verification-override feed post failed (runId=${run.id} ticketId=${ticketId}): ${message}`
+            );
+          })
+      );
     }
 
     return {

--- a/test/orchestrator-v2.test.ts
+++ b/test/orchestrator-v2.test.ts
@@ -14,6 +14,15 @@ import { VerificationRunner } from "../src/execution/verification-runner.js";
 import { OrchestratorV2 } from "../src/orchestrator/orchestrator-v2.js";
 import { ScriptedInvoker } from "../src/simulation/scripted-invoker.js";
 
+// Defensive tmp-dir cleanup. `force: true` alone swallows ENOENT but not
+// ENOTEMPTY, which can surface on Linux CI when an atomic tmp-rename lands
+// between rmdir's readdir scan and unlink. `maxRetries: 3` re-scans the
+// directory so any late-arriving file gets unlinked on the next pass. The
+// orchestrator now awaits its in-flight best-effort writes before returning
+// (see OrchestratorV2.waitForPendingWrites), so this is belt-and-suspenders
+// for the non-orchestrator writers (poller, scheduler tail, filesystem lag).
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 } as const;
+
 function buildOrchestrator(
   cwd: string,
   artifactsDir: string,
@@ -80,7 +89,7 @@ describe("OrchestratorV2 integration", () => {
       expect(eventTypes).toContain("PlanGenerated");
       expect(eventTypes).toContain("TicketsCreated");
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 
@@ -103,7 +112,7 @@ describe("OrchestratorV2 integration", () => {
       expect(eventTypes).toContain("ClassificationComplete");
       expect(eventTypes).toContain("TicketsCreated");
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 
@@ -125,7 +134,7 @@ describe("OrchestratorV2 integration", () => {
       expect(run.classification!.tier).toBe("feature_small");
       expect(run.state).not.toBe("AWAITING_APPROVAL");
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 
@@ -155,7 +164,7 @@ describe("OrchestratorV2 integration", () => {
       const runs = await artifactStore.readRunsIndex();
       expect(runs.some((r) => r.runId === run.id)).toBe(true);
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 
@@ -184,7 +193,7 @@ describe("OrchestratorV2 integration", () => {
       const ledgerIds = run.ticketLedger.map((t) => t.ticketId).sort();
       expect(boardIds).toEqual(ledgerIds);
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 
@@ -207,7 +216,7 @@ describe("OrchestratorV2 integration", () => {
       expect(boardTickets.length).toBeGreaterThan(0);
       expect(boardTickets[0].runId).toBe(run.id);
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 
@@ -240,7 +249,7 @@ describe("OrchestratorV2 integration", () => {
       const boardTickets = await channelStore.readChannelTickets(run.channelId!);
       expect(boardTickets).toEqual([]);
     } finally {
-      await rm(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, RM_OPTS);
     }
   }, 30_000);
 });

--- a/test/orchestrator/verification-override-feed.test.ts
+++ b/test/orchestrator/verification-override-feed.test.ts
@@ -100,7 +100,10 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
   });
 
   afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true });
+    // Same cleanup hardening as orchestrator-v2.test.ts — the scheduler
+    // drains its own tracked writes in executeAll, but a retrying rm is
+    // cheap insurance against kernel-level tmpdir timing on CI (ENOTEMPTY).
+    await rm(tmp, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
   });
 
   it("posts a 'verification override' status entry when the agent proposes a non-allowlisted command", async () => {
@@ -170,11 +173,9 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
 
     await scheduler.executeAll(run);
 
-    // Let the fire-and-forget postEntry settle — postEntry awaits mkdir +
-    // appendFile + touchChannel (channel read+write), more than microtask
-    // pumping reliably drains.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
+    // `executeAll` drains the scheduler's tracked best-effort writes before
+    // returning (see TicketScheduler.waitForPendingWrites), so the override
+    // feed entry is visible here without a sleep workaround.
     const entries = await channelStore.readFeed(channel.channelId);
     const override = entries.find(
       (e) =>


### PR DESCRIPTION
## Summary

Three failing tests on `main` all had the same root cause: fire-and-forget
channel writes (`.postEntry(...).catch(...)`) in the orchestrator and
scheduler that continued after `run()` / `executeAll()` returned, racing
test teardown and readback.

- **orchestrator-v2.test.ts (x2 ENOTEMPTY on tmp cleanup):** the per-test
  `finally { rm(tmpDir, { recursive: true, force: true }) }` fired while
  tracked-but-untracked atomic tmp-rename calls from `postEntry` were
  still in flight. `force: true` swallows ENOENT but not ENOTEMPTY —
  hence the Linux CI failures.
- **verification-override-feed.test.ts:184 (`expected undefined to be
  defined`):** scheduler's verification-override `postEntry` had not yet
  durably written when the test called `readFeed`. The pre-existing 50 ms
  sleep hid the race on most machines but not under CI load.

## Fix

- `OrchestratorV2` now tracks every best-effort `postEntry` +
  `appendEvent` in a `pendingWrites[]` and drains via `Promise.allSettled`
  before every exit from `run()` (normal completion, awaiting-approval
  early return, rejected-plan early return).
- `TicketScheduler` tracks the verification-override `postEntry` the same
  way and drains in `executeAll.finally` / after `enqueue`.
- `channel-store.writeChannel` tmp path gained a monotonic counter. Two
  concurrent `touchChannel` calls previously both computed
  `${path}.tmp.${process.pid}` (no counter) and the second rename
  ENOENT'd — source of the stderr "channel post failed" spam even though
  the post was semantically correct.
- `verification-override-feed.test.ts` drops the 50 ms sleep workaround;
  the scheduler now drains deterministically.
- `orchestrator-v2.test.ts` tmp cleanup uses `{ maxRetries: 3, retryDelay:
  50 }` as belt-and-suspenders for kernel-level tmpdir timing on CI.

## Test plan

- [x] `pnpm test` — 438 passing, 21 skipped (no count change vs. main)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] Targeted tests re-run 3x, no flakes
- [x] "channel post failed" / ENOENT stderr warnings eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)