### PR TITLE
feat(channels): read-only Linear ticket mirror on the channel board

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Right pane shows repo assignments (with `PRIMARY` badge), pinned refs, and — w
 | `rly channel <id>` | Show channel details + recent feed |
 | `rly channel feed <id> [--limit N]` | Raw feed entries |
 | `rly channel post <id> <content> [--from <name>] [--type <type>]` | Post to the feed |
+| `rly channel link-linear <id> <linearProjectId>` | Bind a Linear project to the channel + do a first read-only mirror of its issues onto the ticket board (requires `LINEAR_API_KEY`) |
+| `rly channel linear-sync <id>` | Re-run the Linear → channel-board mirror for a channel already linked |
 | `rly running` | Active tasks across every workspace |
 | `rly board <channelId>` | Kanban view of the ticket board |
 | `rly decisions <channelId>` | Decision history |

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -63,6 +63,20 @@ pub struct TicketLedgerEntry {
     /// before per-repo routing existed still deserialize.
     #[serde(default)]
     pub assigned_alias: Option<String>,
+    /// Provenance of the ticket. Omitted / "relay" = Relay-produced;
+    /// "linear" = read-only mirror of a Linear issue. All
+    /// `#[serde(default)]` for back-compat with ticket files written before
+    /// the Linear mirror existed.
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub linear_issue_id: Option<String>,
+    #[serde(default)]
+    pub linear_identifier: Option<String>,
+    #[serde(default)]
+    pub linear_state: Option<String>,
+    #[serde(default)]
+    pub linear_url: Option<String>,
 }
 
 // --- Channel ---
@@ -95,6 +109,10 @@ pub struct Channel {
     /// `repo_assignments`.
     #[serde(default)]
     pub primary_workspace_id: Option<String>,
+    /// Linear project ID mirrored onto this channel's board. Read-only.
+    /// Absence means no Linear mirror is configured.
+    #[serde(default)]
+    pub linear_project_id: Option<String>,
     /// ISO 8601 timestamps. Optional for back-compat with channel files
     /// written before these fields were tracked.
     #[serde(default)]
@@ -818,6 +836,82 @@ mod tests {
         assert_eq!(t.depends_on, vec!["T-0"]);
         assert_eq!(t.assigned_alias.as_deref(), Some("ui"));
         assert!(t.assigned_agent_id.is_none());
+    }
+
+    #[test]
+    fn ticket_ledger_entry_with_linear_mirror_fields() {
+        let json = r#"{
+            "ticketId":"linear:abc-123",
+            "title":"mirrored issue",
+            "specialty":"general",
+            "status":"ready",
+            "dependsOn":[],
+            "verification":"pending",
+            "attempt":0,
+            "source":"linear",
+            "linearIssueId":"abc-123",
+            "linearIdentifier":"ENG-42",
+            "linearState":"open",
+            "linearUrl":"https://linear.app/acme/issue/ENG-42"
+        }"#;
+        let t: TicketLedgerEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(t.source.as_deref(), Some("linear"));
+        assert_eq!(t.linear_identifier.as_deref(), Some("ENG-42"));
+        assert_eq!(t.linear_state.as_deref(), Some("open"));
+        assert_eq!(
+            t.linear_url.as_deref(),
+            Some("https://linear.app/acme/issue/ENG-42")
+        );
+    }
+
+    #[test]
+    fn ticket_ledger_entry_back_compat_without_linear_fields() {
+        // A Relay-authored ticket written before the mirror existed must
+        // still parse cleanly with all Linear fields absent.
+        let json = r#"{
+            "ticketId":"T-9",
+            "title":"x",
+            "specialty":"general",
+            "status":"ready",
+            "dependsOn":[],
+            "verification":"pending",
+            "attempt":0
+        }"#;
+        let t: TicketLedgerEntry = serde_json::from_str(json).unwrap();
+        assert!(t.source.is_none());
+        assert!(t.linear_issue_id.is_none());
+        assert!(t.linear_identifier.is_none());
+        assert!(t.linear_state.is_none());
+        assert!(t.linear_url.is_none());
+    }
+
+    #[test]
+    fn channel_with_linear_project_id() {
+        let json = r#"{
+            "channelId":"c-1",
+            "name":"x",
+            "description":"",
+            "status":"active",
+            "members":[],
+            "pinnedRefs":[],
+            "linearProjectId":"proj-uuid-abc"
+        }"#;
+        let ch: Channel = serde_json::from_str(json).unwrap();
+        assert_eq!(ch.linear_project_id.as_deref(), Some("proj-uuid-abc"));
+    }
+
+    #[test]
+    fn channel_back_compat_without_linear_project_id() {
+        let json = r#"{
+            "channelId":"c-1",
+            "name":"x",
+            "description":"",
+            "status":"active",
+            "members":[],
+            "pinnedRefs":[]
+        }"#;
+        let ch: Channel = serde_json::from_str(json).unwrap();
+        assert!(ch.linear_project_id.is_none());
     }
 
     #[test]

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -179,6 +179,7 @@ export class ChannelStore {
         | "workspaceIds"
         | "repoAssignments"
         | "primaryWorkspaceId"
+        | "linearProjectId"
       >
     >
   ): Promise<Channel | null> {

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -66,6 +66,13 @@ export interface Channel {
    * primary/associated model existed.
    */
   primaryWorkspaceId?: string;
+  /**
+   * Linear project ID this channel mirrors onto its ticket board. Read-only
+   * mirror — tickets created from Linear issues are tagged with
+   * `source: "linear"` and are never scheduled by the orchestrator. Absence
+   * means no mirror is configured; Relay still functions normally.
+   */
+  linearProjectId?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/domain/ticket.ts
+++ b/src/domain/ticket.ts
@@ -92,6 +92,18 @@ export interface TicketLedgerEntry {
    * with ticket files written before per-repo routing existed.
    */
   assignedAlias?: string;
+  /**
+   * Provenance of the ticket. Omitted / "relay" = produced by the
+   * orchestrator pipeline (decomposer). "linear" = read-only mirror of a
+   * Linear issue, created by `linear-mirror.ts`. The scheduler only picks
+   * up tickets it itself placed on the run ledger; mirror tickets live on
+   * the channel board only and are inert from the scheduler's POV.
+   */
+  source?: "relay" | "linear";
+  linearIssueId?: string;
+  linearIdentifier?: string;
+  linearState?: string;
+  linearUrl?: string;
 }
 
 export function initializeTicketLedger(

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ import {
   getActiveWatcher
 } from "./cli/pr-watcher-factory.js";
 import type { HarnessPR } from "./integrations/scm.js";
+import {
+  fetchLinearProject,
+  mirrorLinearProject
+} from "./integrations/linear-mirror.js";
 import { handleCrosslinkCommand } from "./crosslink/cli.js";
 import { startDashboard } from "./tui/dashboard.js";
 import { SessionStore } from "./cli/session-store.js";
@@ -648,6 +652,16 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (sub === "link-linear") {
+    await handleChannelLinkLinear(store, args);
+    return;
+  }
+
+  if (sub === "linear-sync") {
+    await handleChannelLinearSync(store, args);
+    return;
+  }
+
   if (sub === "feed") {
     const channelId = args[1];
     const limit = Number(parseNamedArg(args, "--limit") ?? "50");
@@ -740,6 +754,141 @@ async function handleChannelCommand(args: string[]): Promise<void> {
       const from = entry.fromDisplayName ?? "system";
       console.log(`  [${entry.type}] ${from}: ${entry.content.slice(0, 120)}`);
     }
+  }
+}
+
+function getLinearApiKey(): string | null {
+  return process.env.LINEAR_API_KEY ?? null;
+}
+
+async function handleChannelLinkLinear(
+  store: ChannelStore,
+  args: string[]
+): Promise<void> {
+  const channelId = args[1];
+  const projectId = args[2];
+  if (!channelId || !projectId) {
+    console.error(
+      "Usage: rly channel link-linear <channelId> <linearProjectId>"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const apiKey = getLinearApiKey();
+  if (!apiKey) {
+    console.error(
+      "LINEAR_API_KEY is not set. Add it to ~/.relay/config.env and re-source."
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const channel = await store.getChannel(channelId);
+  if (!channel) {
+    console.error(`Channel not found: ${channelId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  let project;
+  try {
+    project = await fetchLinearProject(projectId, { apiKey });
+  } catch (err) {
+    console.error(
+      `Failed to validate Linear project: ${err instanceof Error ? err.message : String(err)}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (!project) {
+    console.error(`Linear project not found: ${projectId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  await store.updateChannel(channelId, { linearProjectId: project.id });
+
+  const result = await mirrorLinearProject(channelId, project.id, {
+    store,
+    apiKey
+  });
+
+  await store.postEntry(channelId, {
+    type: "event",
+    fromAgentId: null,
+    fromDisplayName: "system",
+    content: `Linked Linear project "${project.name}" — mirrored ${result.fetched} issue${result.fetched === 1 ? "" : "s"} onto the channel board.`,
+    metadata: {
+      linearProjectId: project.id,
+      linearProjectName: project.name,
+      fetched: result.fetched
+    }
+  });
+
+  if (args.includes("--json")) {
+    jsonOut({
+      channelId,
+      linearProjectId: project.id,
+      linearProjectName: project.name,
+      fetched: result.fetched,
+      mirrored: result.mirrored.length
+    });
+  } else {
+    console.log(
+      `Linked "${project.name}" (${project.id}) — mirrored ${result.fetched} issues.`
+    );
+  }
+}
+
+async function handleChannelLinearSync(
+  store: ChannelStore,
+  args: string[]
+): Promise<void> {
+  const channelId = args[1];
+  if (!channelId) {
+    console.error("Usage: rly channel linear-sync <channelId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const apiKey = getLinearApiKey();
+  if (!apiKey) {
+    console.error("LINEAR_API_KEY is not set.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const channel = await store.getChannel(channelId);
+  if (!channel) {
+    console.error(`Channel not found: ${channelId}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!channel.linearProjectId) {
+    console.error(
+      `Channel ${channelId} has no Linear project linked. Run: rly channel link-linear ${channelId} <linearProjectId>`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await mirrorLinearProject(channelId, channel.linearProjectId, {
+    store,
+    apiKey
+  });
+
+  if (args.includes("--json")) {
+    jsonOut({
+      channelId,
+      linearProjectId: channel.linearProjectId,
+      fetched: result.fetched,
+      mirrored: result.mirrored.length
+    });
+  } else {
+    console.log(
+      `Synced Linear project ${channel.linearProjectId} — mirrored ${result.fetched} issues.`
+    );
   }
 }
 

--- a/src/integrations/linear-mirror.ts
+++ b/src/integrations/linear-mirror.ts
@@ -1,0 +1,207 @@
+/**
+ * Read-only mirror of a Linear project onto a channel's ticket board.
+ *
+ * Each Linear issue in the configured project becomes a `TicketLedgerEntry`
+ * with `source: "linear"` and a stable id of `linear:<issue.id>`. The
+ * orchestrator scheduler never touches these — it only picks up tickets it
+ * itself placed on a run's ledger. Mirror tickets live on the channel
+ * board for display only.
+ *
+ * The mirror talks to Linear directly via GraphQL using `LINEAR_API_KEY`.
+ * We do not route through `@aoagents/ao-plugin-tracker-linear` because its
+ * `listIssues` surface filters by team, not by project — the unit this
+ * mirror is scoped to. Keep the query surface minimal and explicit here.
+ */
+import type { ChannelStore } from "../channels/channel-store.js";
+import type { TicketLedgerEntry, TicketStatus } from "../domain/ticket.js";
+import type { AgentSpecialty } from "../domain/specialty.js";
+
+const LINEAR_API_URL = "https://api.linear.app/graphql";
+const MIRROR_TICKET_PREFIX = "linear:";
+
+export interface LinearIssueNode {
+  id: string;
+  identifier: string;
+  title: string;
+  url: string;
+  state: { type: string; name: string };
+  updatedAt: string;
+}
+
+export interface LinearProjectNode {
+  id: string;
+  name: string;
+}
+
+export interface LinearMirrorDeps {
+  store: ChannelStore;
+  apiKey: string;
+  /**
+   * Injectable fetch so tests can stub the network. Defaults to the global
+   * `fetch`. The mirror only ever POSTs to `LINEAR_API_URL`.
+   */
+  fetch?: typeof fetch;
+}
+
+export interface LinearSyncResult {
+  fetched: number;
+  mirrored: TicketLedgerEntry[];
+}
+
+/** Raw GraphQL POST. Throws on network error, HTTP error, or `errors` array. */
+async function linearGraphql<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  deps: Pick<LinearMirrorDeps, "apiKey" | "fetch">
+): Promise<T> {
+  const fetchImpl = deps.fetch ?? fetch;
+  const res = await fetchImpl(LINEAR_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: deps.apiKey
+    },
+    body: JSON.stringify({ query, variables })
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Linear API HTTP ${res.status}: ${body.slice(0, 200)}`
+    );
+  }
+  const payload = (await res.json()) as {
+    data?: T;
+    errors?: Array<{ message: string }>;
+  };
+  if (payload.errors && payload.errors.length > 0) {
+    throw new Error(`Linear API error: ${payload.errors[0].message}`);
+  }
+  if (!payload.data) {
+    throw new Error("Linear API returned no data");
+  }
+  return payload.data;
+}
+
+/**
+ * Confirm the given project exists and return its display name. Called by
+ * `rly channel link-linear` before persisting `linearProjectId` on the
+ * channel so we don't stamp a stale / malformed id onto a channel.
+ *
+ * Returns `null` when Linear reports no project with that id — lets the
+ * CLI print a targeted error instead of a generic "API error".
+ */
+export async function fetchLinearProject(
+  projectId: string,
+  deps: Pick<LinearMirrorDeps, "apiKey" | "fetch">
+): Promise<LinearProjectNode | null> {
+  const data = await linearGraphql<{ project: LinearProjectNode | null }>(
+    `query($id: String!) { project(id: $id) { id name } }`,
+    { id: projectId },
+    deps
+  );
+  return data.project ?? null;
+}
+
+/**
+ * Fetch up to 100 issues belonging to the project. Linear paginates but
+ * 100 is the API's hard per-page cap and covers the typical project. A
+ * follow-up can add cursor-paging if projects routinely run larger.
+ */
+export async function fetchProjectIssues(
+  projectId: string,
+  deps: Pick<LinearMirrorDeps, "apiKey" | "fetch">
+): Promise<LinearIssueNode[]> {
+  const data = await linearGraphql<{ issues: { nodes: LinearIssueNode[] } }>(
+    `query($projectId: ID!) {
+      issues(filter: { project: { id: { eq: $projectId } } }, first: 100) {
+        nodes {
+          id
+          identifier
+          title
+          url
+          state { type name }
+          updatedAt
+        }
+      }
+    }`,
+    { projectId },
+    deps
+  );
+  return data.issues.nodes;
+}
+
+/**
+ * Map a Linear state.type onto the nearest Relay ticket status. Preserves
+ * meaningful kanban columns (open → ready, started → executing, completed
+ * → completed, canceled → failed). Because mirror tickets carry
+ * `source: "linear"`, dashboards can distinguish them from Relay-native
+ * tickets if the mapping feels lossy.
+ */
+export function mapLinearStateToStatus(stateType: string): TicketStatus {
+  switch (stateType) {
+    case "started":
+      return "executing";
+    case "completed":
+      return "completed";
+    case "canceled":
+      return "failed";
+    case "triage":
+    case "backlog":
+    case "unstarted":
+    default:
+      return "ready";
+  }
+}
+
+export function mirrorTicketId(issueId: string): string {
+  return `${MIRROR_TICKET_PREFIX}${issueId}`;
+}
+
+export function toMirrorTicket(
+  issue: LinearIssueNode,
+  now: string
+): TicketLedgerEntry {
+  return {
+    ticketId: mirrorTicketId(issue.id),
+    title: `${issue.identifier} ${issue.title}`,
+    specialty: "general" as AgentSpecialty,
+    status: mapLinearStateToStatus(issue.state.type),
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: issue.state.type === "completed" ? issue.updatedAt : null,
+    updatedAt: now,
+    runId: null,
+    source: "linear",
+    linearIssueId: issue.id,
+    linearIdentifier: issue.identifier,
+    linearState: issue.state.name,
+    linearUrl: issue.url
+  };
+}
+
+/**
+ * One-shot sync: fetch issues for the channel's Linear project and upsert
+ * them onto the channel board. Existing Relay-native tickets are left
+ * untouched because `upsertChannelTickets` is additive per `ticketId`.
+ */
+export async function mirrorLinearProject(
+  channelId: string,
+  projectId: string,
+  deps: LinearMirrorDeps
+): Promise<LinearSyncResult> {
+  const issues = await fetchProjectIssues(projectId, deps);
+  const now = new Date().toISOString();
+  const mirrors = issues.map((issue) => toMirrorTicket(issue, now));
+  const merged = await deps.store.upsertChannelTickets(channelId, mirrors);
+  return {
+    fetched: issues.length,
+    mirrored: merged.filter((t) => t.source === "linear")
+  };
+}

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -402,4 +402,33 @@ describe("channel store", () => {
       }
     });
   });
+
+  describe("linearProjectId patching", () => {
+    it("persists linearProjectId via updateChannel and clears it on undefined", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({
+          name: "linked",
+          description: "test"
+        });
+        expect(channel.linearProjectId).toBeUndefined();
+
+        const linked = await store.updateChannel(channel.channelId, {
+          linearProjectId: "proj-uuid-abc"
+        });
+        expect(linked!.linearProjectId).toBe("proj-uuid-abc");
+
+        const reloaded = await store.getChannel(channel.channelId);
+        expect(reloaded!.linearProjectId).toBe("proj-uuid-abc");
+
+        const cleared = await store.updateChannel(channel.channelId, {
+          linearProjectId: undefined
+        });
+        expect(cleared!.linearProjectId).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/test/integrations/linear-mirror.test.ts
+++ b/test/integrations/linear-mirror.test.ts
@@ -1,0 +1,280 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import {
+  fetchLinearProject,
+  mapLinearStateToStatus,
+  mirrorLinearProject,
+  mirrorTicketId,
+  toMirrorTicket,
+  type LinearIssueNode
+} from "../../src/integrations/linear-mirror.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+/**
+ * Tests for the read-only Linear → channel-board mirror.
+ *
+ * Network is stubbed via an injected `fetch`. Each test sets up a real
+ * `ChannelStore` in a tmp dir so the upsert-merge path is exercised end to
+ * end against the on-disk shape Rust consumers expect.
+ */
+
+function stubFetch(responses: Array<unknown>): typeof fetch {
+  let i = 0;
+  return vi.fn(async () => {
+    const body = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  }) as unknown as typeof fetch;
+}
+
+function issue(
+  overrides: Partial<LinearIssueNode> & Pick<LinearIssueNode, "id" | "identifier">
+): LinearIssueNode {
+  return {
+    title: "Sample issue",
+    url: `https://linear.app/acme/issue/${overrides.identifier}`,
+    state: { type: "unstarted", name: "Todo" },
+    updatedAt: "2026-04-21T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+async function withStore<T>(fn: (store: ChannelStore, dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "linear-mirror-"));
+  try {
+    const store = new ChannelStore(dir, new FileHarnessStore(dir));
+    return await fn(store, dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("linear-mirror", () => {
+  it("maps Linear state.type onto Relay ticket statuses", () => {
+    expect(mapLinearStateToStatus("started")).toBe("executing");
+    expect(mapLinearStateToStatus("completed")).toBe("completed");
+    expect(mapLinearStateToStatus("canceled")).toBe("failed");
+    expect(mapLinearStateToStatus("backlog")).toBe("ready");
+    expect(mapLinearStateToStatus("triage")).toBe("ready");
+    // Unknown types fall through to "ready" so a new Linear state doesn't
+    // orphan mirror tickets into an invalid status enum.
+    expect(mapLinearStateToStatus("future-state")).toBe("ready");
+  });
+
+  it("builds a mirror ticket with source=linear and namespaced id", () => {
+    const t = toMirrorTicket(
+      issue({
+        id: "issue-uuid-1",
+        identifier: "ENG-42",
+        title: "Rate-limit search",
+        state: { type: "started", name: "In Progress" }
+      }),
+      "2026-04-21T10:00:00.000Z"
+    );
+    expect(t.ticketId).toBe(mirrorTicketId("issue-uuid-1"));
+    expect(t.source).toBe("linear");
+    expect(t.status).toBe("executing");
+    expect(t.linearIdentifier).toBe("ENG-42");
+    expect(t.linearState).toBe("In Progress");
+    expect(t.title).toBe("ENG-42 Rate-limit search");
+    expect(t.dependsOn).toEqual([]);
+    expect(t.runId).toBeNull();
+  });
+
+  it("stamps completedAt only when the Linear issue is completed", () => {
+    const open = toMirrorTicket(
+      issue({ id: "a", identifier: "ENG-1" }),
+      "2026-04-21T00:00:00.000Z"
+    );
+    expect(open.completedAt).toBeNull();
+
+    const done = toMirrorTicket(
+      issue({
+        id: "b",
+        identifier: "ENG-2",
+        state: { type: "completed", name: "Done" },
+        updatedAt: "2026-04-20T00:00:00.000Z"
+      }),
+      "2026-04-21T00:00:00.000Z"
+    );
+    expect(done.completedAt).toBe("2026-04-20T00:00:00.000Z");
+  });
+
+  it("fetchLinearProject returns null when Linear reports no such project", async () => {
+    const fetchImpl = stubFetch([{ data: { project: null } }]);
+    const out = await fetchLinearProject("missing", {
+      apiKey: "lin_api_x",
+      fetch: fetchImpl
+    });
+    expect(out).toBeNull();
+  });
+
+  it("surfaces Linear GraphQL errors so the CLI can stop before writing", async () => {
+    const fetchImpl = stubFetch([
+      { errors: [{ message: "Invalid project id" }] }
+    ]);
+    await expect(
+      fetchLinearProject("bad", { apiKey: "k", fetch: fetchImpl })
+    ).rejects.toThrow(/Invalid project id/);
+  });
+
+  it("mirrors issues onto the channel board and preserves existing Relay tickets", async () => {
+    await withStore(async (store) => {
+      const channel = await store.createChannel({
+        name: "mirror-test",
+        description: "test"
+      });
+
+      // Seed a Relay-authored ticket so we can prove the mirror is additive.
+      await store.upsertChannelTickets(channel.channelId, [
+        {
+          ticketId: "T-1",
+          title: "relay ticket",
+          specialty: "general",
+          status: "ready",
+          dependsOn: [],
+          assignedAgentId: null,
+          assignedAgentName: null,
+          crosslinkSessionId: null,
+          verification: "pending",
+          lastClassification: null,
+          chosenNextAction: null,
+          attempt: 0,
+          startedAt: null,
+          completedAt: null,
+          updatedAt: "2026-04-21T00:00:00.000Z",
+          runId: null
+        }
+      ]);
+
+      const fetchImpl = stubFetch([
+        {
+          data: {
+            issues: {
+              nodes: [
+                issue({ id: "li-1", identifier: "ENG-1" }),
+                issue({
+                  id: "li-2",
+                  identifier: "ENG-2",
+                  state: { type: "started", name: "In Progress" }
+                })
+              ]
+            }
+          }
+        }
+      ]);
+
+      const result = await mirrorLinearProject(
+        channel.channelId,
+        "proj-uuid",
+        { store, apiKey: "lin_api_x", fetch: fetchImpl }
+      );
+
+      expect(result.fetched).toBe(2);
+      expect(result.mirrored).toHaveLength(2);
+
+      const board = await store.readChannelTickets(channel.channelId);
+      const ids = board.map((t) => t.ticketId);
+      // Relay ticket survives alongside the two mirrors.
+      expect(ids).toContain("T-1");
+      expect(ids).toContain(mirrorTicketId("li-1"));
+      expect(ids).toContain(mirrorTicketId("li-2"));
+
+      const relay = board.find((t) => t.ticketId === "T-1");
+      expect(relay?.source).toBeUndefined();
+
+      const mirrors = board.filter((t) => t.source === "linear");
+      expect(mirrors).toHaveLength(2);
+    });
+  });
+
+  it("re-syncing overwrites mirror rows with fresh state from Linear", async () => {
+    await withStore(async (store) => {
+      const channel = await store.createChannel({
+        name: "resync",
+        description: "test"
+      });
+
+      const firstFetch = stubFetch([
+        {
+          data: {
+            issues: {
+              nodes: [
+                issue({
+                  id: "li-1",
+                  identifier: "ENG-7",
+                  state: { type: "unstarted", name: "Todo" }
+                })
+              ]
+            }
+          }
+        }
+      ]);
+      await mirrorLinearProject(channel.channelId, "proj", {
+        store,
+        apiKey: "k",
+        fetch: firstFetch
+      });
+
+      const secondFetch = stubFetch([
+        {
+          data: {
+            issues: {
+              nodes: [
+                issue({
+                  id: "li-1",
+                  identifier: "ENG-7",
+                  state: { type: "completed", name: "Done" },
+                  updatedAt: "2026-04-22T00:00:00.000Z"
+                })
+              ]
+            }
+          }
+        }
+      ]);
+      await mirrorLinearProject(channel.channelId, "proj", {
+        store,
+        apiKey: "k",
+        fetch: secondFetch
+      });
+
+      const board = await store.readChannelTickets(channel.channelId);
+      const row = board.find((t) => t.ticketId === mirrorTicketId("li-1"));
+      expect(row?.status).toBe("completed");
+      expect(row?.linearState).toBe("Done");
+      expect(row?.completedAt).toBe("2026-04-22T00:00:00.000Z");
+    });
+  });
+
+  it("raises on non-2xx HTTP so callers never silently drop data", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("rate limited", {
+          status: 429,
+          headers: { "content-type": "text/plain" }
+        })
+    ) as unknown as typeof fetch;
+
+    await withStore(async (store) => {
+      const channel = await store.createChannel({
+        name: "err",
+        description: "test"
+      });
+      await expect(
+        mirrorLinearProject(channel.channelId, "proj", {
+          store,
+          apiKey: "k",
+          fetch: fetchImpl
+        })
+      ).rejects.toThrow(/HTTP 429/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `rly channel link-linear <channelId> <linearProjectId>` binds a Linear project to a channel and does an immediate first sync. `rly channel linear-sync <channelId>` re-syncs on demand. Both commands require `LINEAR_API_KEY`; they fail loudly (no silent-pass) when it's unset, when Linear returns errors, or when the project id is bogus.
- New `src/integrations/linear-mirror.ts` talks to Linear's GraphQL directly (`issues(filter: { project: { id: { eq: $projectId }}})`), maps each issue → `TicketLedgerEntry` with `source: "linear"`, `ticketId: "linear:<issue.id>"`, and a state-preserving kanban mapping (`started → executing`, `completed → completed`, `canceled → failed`, else `ready`). `upsertChannelTickets` is additive per ticket id, so Relay-authored tickets keep living alongside the mirror rows.
- TS domain: `Channel.linearProjectId?`, `TicketLedgerEntry.source?`/`linearIssueId?`/`linearIdentifier?`/`linearState?`/`linearUrl?`.
- Rust `crates/harness-data` mirrors each new field with `#[serde(default)]` for back-compat + 4 new schema-drift tests. Dashboards (TUI/GUI) already read these structs, so no code there has to change to start seeing the new fields; visual polish (dedicated "Linear" badge + link-out) is a follow-up.
- `ChannelStore.updateChannel` patch type extended to include `linearProjectId`.

## What's intentionally **not** here (follow-ups)
- No background polling loop — sync is explicit via the CLI. A `setInterval`-based poller modeled on `pr-poller.ts` can land next.
- No dashboard UI changes — mirror tickets show up on the board with `source: "linear"` and Linear URL/identifier on the record, but `rly board` / TUI / GUI still render them with the default ticket template. Follow-up PR will add a Linear badge + link-out.
- Write-back to Linear is out of scope (read-only in v1).

## Test plan
- [x] `pnpm test` — 447 pass, 21 skipped (+9 new: 8 `linear-mirror`, 1 `channel-store`)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `cargo check --workspace` clean (harness-data, TUI, GUI)
- [x] `cargo test -p harness-data` — 41 pass (+4 new schema-drift tests: ticket mirror fields present / absent, channel.linearProjectId present / absent)
- [ ] Manual end-to-end with a real Linear account:
  - `rly channel link-linear <channelId> <real-project-id>` prints `Linked "<name>" — mirrored N issues.`
  - Board shows the mirror rows alongside any existing Relay tickets
  - `rly channel linear-sync <channelId>` keeps the board up to date after the underlying issue states change in Linear
  - (Recommended before merge; I don't have a Linear test workspace to exercise the live path here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)