### PR TITLE
OSS-16: README tagline refresh + docs sync (tool counts, storage, lint, HARNESS_QUIET, Linux prereqs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ gui/src-tauri/icons/ios/
 config.env
 config.env.*
 !config.env.template
+.claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Prefer multiple small commits with coherent titles over one `"wip"` blob squashe
 ## Style
 
 - Two-space indent, double quotes, semicolons, trailing commas where the language allows them.
-- No linter config is enforced in CI. Run your editor's built-in formatter on files you touch; leave untouched files alone (no drive-by reformats in a feature PR).
+- Prettier is enforced in CI via the `format-check` job. Run `pnpm format` before pushing (or `pnpm format:check` to verify). Leave files you didn't otherwise touch alone — no drive-by reformats in a feature PR.
 - Keep imports tidy — no unused, grouped roughly as node-builtin / dep / local.
 
 ## Changes that span the dashboards

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 <h1 align="center">Relay</h1>
 
 <p align="center">
-  <b>Local-first orchestration for coding agents.</b><br/>
-  Classify a request, decompose it into parallel tickets, dispatch Claude / Codex to execute, verify, and track PRs —
-  all while you supervise from a dashboard.
+  <b>Orchestrate coding agents across repos. Local-first, self-hosted, runs inside your existing Claude / Codex CLI.</b><br/>
+  Relay turns a single request into a plan, decomposes it into tickets, dispatches them to agents across one or more repos, tracks long-running work, and keeps a durable decision log — all on your machine, with no hosted service required.
 </p>
 
 <p align="center">
@@ -22,13 +21,18 @@
 
 Relay turns a sentence, a GitHub issue URL, or a Linear ticket into a **running plan of AI-coded work** — with tickets, verification loops, live PR tracking, and optional human approval gates. Sessions run inside your normal Claude or Codex CLI; Relay wraps them with an MCP server that records everything into Slack-style **channels** you can query later.
 
-The core idea: **you shouldn't keep agents' context in your head.** Plans, tickets, decisions, and cross-session messages all live in `~/.relay/` as JSON files + optional Postgres, readable by the CLI, the terminal TUI, and the desktop GUI.
+**Suitable for individual developers and for teams working inside a company.** Relay runs entirely on your machine (or on infrastructure you control). There is no hosted Relay service, no telemetry, and no phone-home — state stays in `~/.relay/` on disk (optionally backed by your own Postgres). What it's built for:
+
+- **Agent orchestration** — classify, plan, decompose, dispatch, and verify. One request turns into a supervised workflow.
+- **Multi-repo coordination** — sessions running in different repos can discover each other, message, and share context via the crosslink MCP tools.
+- **Long-running work** — background PR tracking, plan-approval gates, and a durable decision log so you can step away and come back.
 
 CLI: **`rly`**.
 
 ## Table of contents
 
 - [Install](#install)
+  - [Install prerequisites (platform notes)](#install-prerequisites-platform-notes)
 - [Quickstart](#quickstart)
 - [How it works](#how-it-works)
 - [Key concepts](#key-concepts)
@@ -85,6 +89,26 @@ Download the `.dmg` / `.AppImage` / `.deb` / `.msi` from the [latest release](ht
 ```bash
 pnpm install && pnpm build && pnpm link --global
 ```
+
+### Install prerequisites (platform notes)
+
+**macOS**: Xcode Command Line Tools (`xcode-select --install`). Nothing else required.
+
+**Ubuntu / Debian** (needed for `--with-gui`): install the Tauri system deps first —
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libglib2.0-dev \
+  libgtk-3-dev \
+  libwebkit2gtk-4.1-dev \
+  libsoup-3.0-dev \
+  libjavascriptcoregtk-4.1-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev
+```
+
+**Windows**: no extra system deps for the CLI. The GUI needs [WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/) (usually pre-installed on Windows 11).
 
 ### How `rly` finds the source
 
@@ -377,7 +401,7 @@ Verification commands run through an `Executor` abstraction (`src/execution/exec
 | `GITHUB_TOKEN` | GitHub issues + PR watcher |
 | `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) | Linear issues |
 | `CLAUDE_BIN` | Override the `claude` binary path (default: `claude` on `$PATH`) |
-| `RELAY_QUIET=1` / `--quiet` / `--silent` | Suppress inline tool-use activity during `rly run` |
+| `RELAY_QUIET=1` / `HARNESS_QUIET=1` / `--quiet` / `--silent` | Suppress inline tool-use activity during `rly run` (both env vars honored) |
 | `--sequential` | Use the v1 sequential orchestrator instead of v2 ticket-based |
 | `--no-harness-mcp` | Launch Claude/Codex without attaching the Relay MCP server |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ Ten concrete steps. Assumes `GITHUB_TOKEN`, `HARNESS_LIVE=1`, and `RELAY_AUTO_AP
 
 1. **`cd /path/to/your/repo && rly up`** — registers the repo in `~/.relay/workspace-registry.json`. Expect: `registered workspace <hash> → <path>`.
 2. **`rly doctor`** — checks tokens, MCP wiring, binary paths. Expect a grid of green check marks. A red line here means stop and fix before step 3.
-3. **`rly claude`** — launches Claude with the Relay MCP server attached. Expect: Claude's banner, then the MCP toolbar showing 18 tools (6 harness / 7 channel / 5 crosslink).
+3. **`rly claude`** — launches Claude with the Relay MCP server attached. Expect: Claude's banner, then the MCP toolbar showing 17 tools (8 harness / 6 channel / 3 crosslink — run `rly inspect-mcp` for the live source of truth).
 4. **Paste a GitHub issue URL** as your first message — e.g. `https://github.com/your-org/your-repo/issues/42`. Expect: the classifier prints `resolved: <title>`, `tier: feature_small`, `suggestedBranch: feat/42-…`.
 5. **Planner runs** — you see a phased plan in the feed (`phase 1: scaffold`, `phase 2: wire`, `phase 3: tests`). No approval prompt on `feature_small`; `feature_large`/`architectural` would pause here.
 6. **Decomposer emits tickets** — watch the feed print `T-1 … T-4 ready`. Tickets with no `dependsOn` go `ready` immediately; others stay `blocked`.

--- a/docs/storage-injection.md
+++ b/docs/storage-injection.md
@@ -1,9 +1,14 @@
 # Storage Injection
 
 Relay's persistent state lives behind a single interface, `HarnessStore`
-(`src/storage/store.ts`). Today the only implementation is
-`FileHarnessStore`, rooted at `~/.relay/`. A Postgres backend is planned for
-the cloud/pod deployment path and will slot in without touching call sites.
+(`src/storage/store.ts`). Two implementations ship today:
+
+- **`FileHarnessStore`** — rooted at `~/.relay/`, atomic JSON/JSONL writes. The
+  default, and the right choice for solo dev, CI, and single-host deployments.
+- **`PostgresHarnessStore`** — backed by your own Postgres. Use this for
+  multi-agent deployments where `LISTEN/NOTIFY` broadcasts and row-locked
+  decision writes matter. Select it via `HARNESS_STORE=postgres` +
+  `HARNESS_POSTGRES_URL`.
 
 ## Goal
 


### PR DESCRIPTION
## Summary
- **Tagline**: "Orchestrate coding agents across repos. Local-first, self-hosted, runs inside your existing Claude / Codex CLI."  Re-frames Relay as work-appropriate (was reading anti-corporate); emphasizes local-first + no telemetry.
- Added a three-bullet positioning section (agent orchestration / multi-repo coordination / long-running work).
- docs/getting-started.md MCP tool count drift fixed (17, not 18; 8/6/3).
- docs/storage-injection.md: documents Postgres as shipped (not "planned").
- CONTRIBUTING.md: prettier is enforced in CI now (OSS-18).
- README env-vars: HARNESS_QUIET alias documented.
- README install: platform-specific prereqs (macOS / Ubuntu-Debian / Windows).

## Test plan
- [ ] All `.md` files render cleanly on GitHub
- [ ] `rg '18 tools|6 harness' docs/` returns zero
- [ ] `rg 'Postgres backend is planned'` returns zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)