### PR TITLE
feat(dashboards): render Linear mirror tickets distinctly in CLI/TUI/GUI

### DIFF
--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -826,6 +826,7 @@ function TicketDetailModal({
                     href={ticket.linearUrl}
                     target="_blank"
                     rel="noopener noreferrer"
+                    className="tracked-pr-link"
                   >
                     Open in Linear
                   </a>

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -698,30 +698,41 @@ function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
               {label} ({grouped[status].length})
             </h4>
             <div className="board-column-body">
-              {grouped[status].map((t) => (
-                <div
-                  key={t.ticketId}
-                  className="ticket clickable"
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => setSelected(t)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      setSelected(t);
-                    }
-                  }}
-                >
-                  <div>{t.title}</div>
-                  {t.assignedAlias && (
-                    <div className="ticket-alias-chip">@{t.assignedAlias}</div>
-                  )}
-                  <div className="ticket-meta">
-                    {t.specialty} · attempt {t.attempt}
-                    {t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""}
+              {grouped[status].map((t) => {
+                const isLinear = t.source === "linear";
+                return (
+                  <div
+                    key={t.ticketId}
+                    className={`ticket clickable${isLinear ? " ticket-linear" : ""}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => setSelected(t)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelected(t);
+                      }
+                    }}
+                  >
+                    {isLinear && t.linearIdentifier && (
+                      <div className="ticket-linear-chip">
+                        Linear · {t.linearIdentifier}
+                      </div>
+                    )}
+                    <div>{t.title}</div>
+                    {t.assignedAlias && (
+                      <div className="ticket-alias-chip">@{t.assignedAlias}</div>
+                    )}
+                    <div className="ticket-meta">
+                      {isLinear
+                        ? t.linearState ?? "linear mirror"
+                        : `${t.specialty} · attempt ${t.attempt}${
+                            t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""
+                          }`}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         ))}
@@ -793,6 +804,34 @@ function TicketDetailModal({
               <span className="detail-label">Assigned to</span>
               <span>@{ticket.assignedAlias}</span>
             </div>
+          )}
+          {ticket.source === "linear" && (
+            <>
+              {ticket.linearIdentifier && (
+                <div className="detail-row">
+                  <span className="detail-label">Linear</span>
+                  <span>{ticket.linearIdentifier}</span>
+                </div>
+              )}
+              {ticket.linearState && (
+                <div className="detail-row">
+                  <span className="detail-label">Linear state</span>
+                  <span>{ticket.linearState}</span>
+                </div>
+              )}
+              {ticket.linearUrl && (
+                <div className="detail-row">
+                  <span className="detail-label">Link</span>
+                  <a
+                    href={ticket.linearUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open in Linear
+                  </a>
+                </div>
+              )}
+            </>
           )}
           {deps.length > 0 && (
             <div className="detail-row detail-row-block">

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -319,6 +319,25 @@ button.primary { background: var(--accent-dim); border-color: var(--accent); }
   color: var(--text);
 }
 
+/* Linear mirror tickets: a magenta-ish border + "Linear · ENG-42" chip so
+   read-only mirror rows are distinguishable from Relay-scheduled tickets. */
+.ticket.ticket-linear {
+  border-left: 3px solid #c678dd;
+}
+
+.ticket-linear-chip {
+  display: inline-block;
+  margin-bottom: 4px;
+  padding: 1px 6px;
+  font-size: 10px;
+  line-height: 1.4;
+  border-radius: 10px;
+  background: rgba(198, 120, 221, 0.15);
+  color: #c678dd;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 /* PRIMARY tag — rendered next to the selected primary row in the new-channel
    modal and in the right pane's repo list. Mauve keeps it distinct from the
    alias chip (sapphire) and from the accent-blue used for active channels. */

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -101,6 +101,13 @@ export type TicketLedgerEntry = {
   // Alias of the channel repo assignment this ticket is routed to.
   // Optional; absent on tickets written before per-repo routing existed.
   assignedAlias?: string;
+  // Provenance. Absent = Relay-authored. "linear" = read-only mirror of
+  // a Linear issue surfaced by the Linear → channel-board poller.
+  source?: "relay" | "linear";
+  linearIssueId?: string;
+  linearIdentifier?: string;
+  linearState?: string;
+  linearUrl?: string;
 };
 
 export type Decision = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1299,7 +1299,14 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
 
   // Delegates to resolveBoardTickets so CLI + MCP tool + GUI all read the
   // channel board through the same unified-then-fallback policy.
-  const board: Record<string, Array<{ ticketId: string; title: string }>> = {};
+  interface BoardRow {
+    ticketId: string;
+    title: string;
+    source?: "relay" | "linear";
+    linearIdentifier?: string;
+    linearUrl?: string;
+  }
+  const board: Record<string, BoardRow[]> = {};
   const resolved = await resolveBoardTickets(store, channelId, async (
     workspaceId,
     runId
@@ -1313,7 +1320,13 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
 
   for (const { entry } of resolved) {
     if (!board[entry.status]) board[entry.status] = [];
-    board[entry.status].push({ ticketId: entry.ticketId, title: entry.title });
+    board[entry.status].push({
+      ticketId: entry.ticketId,
+      title: entry.title,
+      source: entry.source,
+      linearIdentifier: entry.linearIdentifier,
+      linearUrl: entry.linearUrl
+    });
   }
 
   if (args.includes("--json")) {
@@ -1329,7 +1342,12 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
   for (const [status, tickets] of Object.entries(board)) {
     console.log(`[${status.toUpperCase()}] (${tickets.length})`);
     for (const t of tickets) {
-      console.log(`  ${t.ticketId}: ${t.title}`);
+      if (t.source === "linear" && t.linearIdentifier) {
+        const tail = t.linearUrl ? `  ${t.linearUrl}` : "";
+        console.log(`  [linear ${t.linearIdentifier}] ${t.title}${tail}`);
+      } else {
+        console.log(`  ${t.ticketId}: ${t.title}`);
+      }
     }
     console.log("");
   }

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -564,11 +564,29 @@ fn draw_board(frame: &mut Frame, app: &App, channel_name: &str, area: Rect) {
             Style::default()
         };
 
-        lines.push(Line::from(vec![
-            Span::styled(indicator, Style::default().fg(Color::Cyan)),
-            Span::styled(&ticket.title, title_style),
-            Span::styled(format!(" [{}]", agent), Style::default().fg(Color::DarkGray)),
-        ]));
+        let is_linear = ticket.source.as_deref() == Some("linear");
+        let mut spans = vec![Span::styled(indicator, Style::default().fg(Color::Cyan))];
+        if is_linear {
+            if let Some(id) = ticket.linear_identifier.as_deref() {
+                spans.push(Span::styled(
+                    format!("[{}] ", id),
+                    Style::default().fg(Color::Magenta),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    "[linear] ",
+                    Style::default().fg(Color::Magenta),
+                ));
+            }
+        }
+        spans.push(Span::styled(&ticket.title, title_style));
+        if !is_linear {
+            spans.push(Span::styled(
+                format!(" [{}]", agent),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        lines.push(Line::from(spans));
 
         flat_index += 1;
     }
@@ -1573,7 +1591,8 @@ fn detail_content<'a>(app: &'a App) -> (String, Vec<Line<'a>>) {
                     let ticket = &app.tickets[idx];
                     let agent = ticket.assigned_agent_name.as_deref().unwrap_or("unassigned");
                     let status_clr = status_color(&ticket.status);
-                    let lines = vec![
+                    let is_linear = ticket.source.as_deref() == Some("linear");
+                    let mut lines = vec![
                         Line::from(vec![
                             Span::styled("Title: ", Style::default().fg(Color::DarkGray)),
                             Span::styled(&ticket.title, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
@@ -1602,16 +1621,41 @@ fn detail_content<'a>(app: &'a App) -> (String, Vec<Line<'a>>) {
                             Span::styled("Ticket ID: ", Style::default().fg(Color::DarkGray)),
                             Span::styled(&ticket.ticket_id, Style::default().fg(Color::DarkGray)),
                         ]),
-                        Line::raw(""),
-                        Line::from(vec![
-                            Span::styled("Dependencies: ", Style::default().fg(Color::DarkGray)),
-                            Span::raw(if ticket.depends_on.is_empty() {
-                                "none".to_string()
-                            } else {
-                                ticket.depends_on.join(", ")
-                            }),
-                        ]),
                     ];
+                    if is_linear {
+                        lines.push(Line::raw(""));
+                        lines.push(Line::from(vec![Span::styled(
+                            "── Linear (read-only mirror) ──",
+                            Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                        )]));
+                        if let Some(id) = ticket.linear_identifier.as_deref() {
+                            lines.push(Line::from(vec![
+                                Span::styled("Identifier: ", Style::default().fg(Color::DarkGray)),
+                                Span::styled(id, Style::default().fg(Color::Magenta)),
+                            ]));
+                        }
+                        if let Some(s) = ticket.linear_state.as_deref() {
+                            lines.push(Line::from(vec![
+                                Span::styled("Linear state: ", Style::default().fg(Color::DarkGray)),
+                                Span::raw(s),
+                            ]));
+                        }
+                        if let Some(url) = ticket.linear_url.as_deref() {
+                            lines.push(Line::from(vec![
+                                Span::styled("URL: ", Style::default().fg(Color::DarkGray)),
+                                Span::styled(url, Style::default().fg(Color::Blue)),
+                            ]));
+                        }
+                    }
+                    lines.push(Line::raw(""));
+                    lines.push(Line::from(vec![
+                        Span::styled("Dependencies: ", Style::default().fg(Color::DarkGray)),
+                        Span::raw(if ticket.depends_on.is_empty() {
+                            "none".to_string()
+                        } else {
+                            ticket.depends_on.join(", ")
+                        }),
+                    ]));
                     (format!("Ticket: {}", ticket.title), lines)
                 } else {
                     ("No ticket".to_string(), vec![])


### PR DESCRIPTION
Successor to #60 (auto-closed when the #57 base branch was deleted on merge). Same diff, rebased onto main + must-fix addressed from the earlier review: "Open in Linear" link now uses `.tracked-pr-link` for WCAG AA contrast on the dark background.

## Summary
- `rly board`: mirror rows (tickets with `source: "linear"`) render as `[linear ENG-42] <title>  <url>`.
- TUI: magenta `[ENG-42]` prefix in the board list + a dedicated "Linear (read-only mirror)" section in the detail panel.
- GUI: "Linear · ENG-42" chip + left-border accent on cards; detail modal adds identifier, Linear state, and a styled "Open in Linear" link.
- `gui/src/types.ts` picks up the five optional Linear fields.

## Test plan
- [x] `pnpm test` — 447 pass (unchanged — UI-only)
- [x] `pnpm typecheck`, `pnpm build` clean
- [x] `cargo check --workspace` clean
- [x] `cd gui && pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)