### PR TITLE
OSS-18: Prettier reset + make format-check blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
   format-check:
     name: format-check
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,4 +102,4 @@ jobs:
           node-version: 22
 
       - name: Prettier check
-        run: pnpm dlx prettier --check 'src/**/*.{ts,tsx}' 'gui/src/**/*.{ts,tsx}' '*.md'
+        run: pnpm dlx prettier --check 'src/**/*.{ts,tsx}' 'test/**/*.{ts,tsx}' 'gui/src/**/*.{ts,tsx}' 'scripts/**/*.{ts,mts}' '*.md' 'docs/**/*.md'

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ config.env
 config.env.*
 !config.env.template
 .claude/
+.agent-harness/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,15 @@
+dist/
+node_modules/
+.claude/
+.relay/
+gui/dist/
+gui/src-tauri/target/
+tui/target/
+target/
+Cargo.lock
+pnpm-lock.yaml
+gui/pnpm-lock.yaml
+*.min.js
+*.min.css
+.changeset/
+CHANGELOG.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "arrowParens": "always"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ cd gui && pnpm build
 ## Code style
 
 - Two-space indent, double quotes, semicolons, trailing commas where the language allows them.
-- **No linter is enforced in CI.** Run your editor's built-in formatter on files you touch.
+- **Prettier is enforced in CI.** Run `pnpm format` before pushing (or `pnpm format:check` to verify). The `format-check` CI job blocks merges on drift.
 - **No drive-by reformats** of files you didn't otherwise touch. Keep the diff focused on the change.
 - Imports grouped roughly as node-builtin / dep / local. No unused imports.
 

--- a/CI.md
+++ b/CI.md
@@ -28,11 +28,11 @@ need external services. Two triggers:
 
 ### Jobs and what they need
 
-| Job | Unskip flag | External service | Secret required |
-|---|---|---|---|
-| `postgres-integration` | `HARNESS_TEST_POSTGRES_URL` | Postgres 16 service container | none — provisioned inline |
-| `git-worktree-integration` | `RELAY_TEST_REAL_GIT=1` | system `git` | none |
-| `pr-watcher-live` | `GITHUB_TOKEN`, `HARNESS_LIVE=1` | github.com | `INTEGRATION_GITHUB_TOKEN` (fine-grained read token) |
+| Job                        | Unskip flag                      | External service              | Secret required                                      |
+| -------------------------- | -------------------------------- | ----------------------------- | ---------------------------------------------------- |
+| `postgres-integration`     | `HARNESS_TEST_POSTGRES_URL`      | Postgres 16 service container | none — provisioned inline                            |
+| `git-worktree-integration` | `RELAY_TEST_REAL_GIT=1`          | system `git`                  | none                                                 |
+| `pr-watcher-live`          | `GITHUB_TOKEN`, `HARNESS_LIVE=1` | github.com                    | `INTEGRATION_GITHUB_TOKEN` (fine-grained read token) |
 
 Jobs whose secret isn't set print a skip notice and exit 0 — the workflow
 stays green until an admin provisions them. Grep the workflow file for

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,19 +10,19 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 Examples of behavior that contributes to a positive environment for our community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 

--- a/README.md
+++ b/README.md
@@ -176,14 +176,14 @@ Relay's classifier picks it up, plans the work, and either executes or asks for 
 
 ### Complexity tiers
 
-| Tier | Behavior |
-|---|---|
-| `trivial` | Heuristic match (typo, rename, lint) — single ticket, skip planning |
-| `bugfix` | Heuristic match — debug-first flow |
-| `feature_small` | LLM classification — lightweight plan, no approval |
-| `feature_large` | Full plan + **user approval required** via MCP |
-| `architectural` | Design-doc phase → plan → approval |
-| `multi_repo` | Like `feature_large` + crosslink coordination across repos |
+| Tier            | Behavior                                                            |
+| --------------- | ------------------------------------------------------------------- |
+| `trivial`       | Heuristic match (typo, rename, lint) — single ticket, skip planning |
+| `bugfix`        | Heuristic match — debug-first flow                                  |
+| `feature_small` | LLM classification — lightweight plan, no approval                  |
+| `feature_large` | Full plan + **user approval required** via MCP                      |
+| `architectural` | Design-doc phase → plan → approval                                  |
+| `multi_repo`    | Like `feature_large` + crosslink coordination across repos          |
 
 ## Key concepts
 
@@ -284,43 +284,43 @@ Right pane shows repo assignments (with `PRIMARY` badge), pinned refs, and — w
 
 ## CLI reference
 
-| Command | What it does |
-|---|---|
-| `rly welcome` | 6-step interactive tour (pass `--reset` to replay) |
-| `rly up` | Register the current repo in the global workspace |
-| `rly status` | Workspace paths + recent runs |
-| `rly list-runs` | Recent persisted runs across workspaces |
-| `rly list-workspaces` | All registered workspaces |
-| `rly claude` | Launch Claude with Relay MCP attached |
-| `rly codex` | Launch Codex with Relay MCP attached |
-| `rly channels` | List channels (most-recently-active first) |
-| `rly channel create <name> [--repos alias:wsId:path,...] [--primary <alias>]` | Create a channel |
-| `rly channel update <id> [--repos ...] [--primary <alias>]` | Update repos / primary |
-| `rly channel archive <id>` | Archive a channel |
-| `rly channel <id>` | Show channel details + recent feed |
-| `rly channel feed <id> [--limit N]` | Raw feed entries |
-| `rly channel post <id> <content> [--from <name>] [--type <type>]` | Post to the feed |
-| `rly channel link-linear <id> <linearProjectId>` | Bind a Linear project to the channel + do a first read-only mirror of its issues onto the ticket board (requires `LINEAR_API_KEY`) |
-| `rly channel linear-sync <id>` | Re-run the Linear → channel-board mirror for a channel already linked |
-| `rly running` | Active tasks across every workspace |
-| `rly board <channelId>` | Kanban view of the ticket board |
-| `rly decisions <channelId>` | Decision history |
-| `rly pr-watch <url-or-#> [--branch <b>] [--ticket <id>] [--channel <id>]` | Manually track a PR |
-| `rly pr-status [--channel <id>] [--json]` | List tracked PRs with CI + review state (reads the on-disk mirror when no orchestrator is running) |
-| `rly approve <runId>` | Approve a pending plan (same code path as `harness_approve_plan` MCP tool) |
-| `rly reject <runId> [--feedback "…"]` | Reject a pending plan |
-| `rly pending-plans [--json]` | List runs awaiting plan-approval decisions |
-| `rly chat rewind --channel <id> --session <id> [--to <iso> \| --interactive]` | Roll repos + session transcript back to a rewindable user turn |
-| `rly crosslink status` | Active cross-session chatter |
-| `rly tui` | Terminal dashboard (auto-builds on first run) |
-| `rly gui [--dev] [--rebuild]` | Desktop dashboard |
-| `rly rebuild [--all] [--dist] [--tui] [--gui] [--skip-install]` | Rebuild artifacts (runs `pnpm install` first unless skipped) |
-| `rly doctor` | Diagnostics: paths, MCP wiring, token presence |
-| `rly session <create\|list\|get\|delete\|...>` | Session-transcript management |
-| `rly chat <system-prompt\|resolve-refs\|mcp-config>` | Chat plumbing used by the TUI/GUI |
-| `rly config <add-project-dir\|remove-project-dir>` | Global config |
-| `rly mcp-server --workspace <path>` | Run the MCP server (invoked by Claude/Codex automatically) |
-| `rly inspect-mcp` | Show the live MCP tool catalogue |
+| Command                                                                       | What it does                                                                                                                       |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `rly welcome`                                                                 | 6-step interactive tour (pass `--reset` to replay)                                                                                 |
+| `rly up`                                                                      | Register the current repo in the global workspace                                                                                  |
+| `rly status`                                                                  | Workspace paths + recent runs                                                                                                      |
+| `rly list-runs`                                                               | Recent persisted runs across workspaces                                                                                            |
+| `rly list-workspaces`                                                         | All registered workspaces                                                                                                          |
+| `rly claude`                                                                  | Launch Claude with Relay MCP attached                                                                                              |
+| `rly codex`                                                                   | Launch Codex with Relay MCP attached                                                                                               |
+| `rly channels`                                                                | List channels (most-recently-active first)                                                                                         |
+| `rly channel create <name> [--repos alias:wsId:path,...] [--primary <alias>]` | Create a channel                                                                                                                   |
+| `rly channel update <id> [--repos ...] [--primary <alias>]`                   | Update repos / primary                                                                                                             |
+| `rly channel archive <id>`                                                    | Archive a channel                                                                                                                  |
+| `rly channel <id>`                                                            | Show channel details + recent feed                                                                                                 |
+| `rly channel feed <id> [--limit N]`                                           | Raw feed entries                                                                                                                   |
+| `rly channel post <id> <content> [--from <name>] [--type <type>]`             | Post to the feed                                                                                                                   |
+| `rly channel link-linear <id> <linearProjectId>`                              | Bind a Linear project to the channel + do a first read-only mirror of its issues onto the ticket board (requires `LINEAR_API_KEY`) |
+| `rly channel linear-sync <id>`                                                | Re-run the Linear → channel-board mirror for a channel already linked                                                              |
+| `rly running`                                                                 | Active tasks across every workspace                                                                                                |
+| `rly board <channelId>`                                                       | Kanban view of the ticket board                                                                                                    |
+| `rly decisions <channelId>`                                                   | Decision history                                                                                                                   |
+| `rly pr-watch <url-or-#> [--branch <b>] [--ticket <id>] [--channel <id>]`     | Manually track a PR                                                                                                                |
+| `rly pr-status [--channel <id>] [--json]`                                     | List tracked PRs with CI + review state (reads the on-disk mirror when no orchestrator is running)                                 |
+| `rly approve <runId>`                                                         | Approve a pending plan (same code path as `harness_approve_plan` MCP tool)                                                         |
+| `rly reject <runId> [--feedback "…"]`                                         | Reject a pending plan                                                                                                              |
+| `rly pending-plans [--json]`                                                  | List runs awaiting plan-approval decisions                                                                                         |
+| `rly chat rewind --channel <id> --session <id> [--to <iso> \| --interactive]` | Roll repos + session transcript back to a rewindable user turn                                                                     |
+| `rly crosslink status`                                                        | Active cross-session chatter                                                                                                       |
+| `rly tui`                                                                     | Terminal dashboard (auto-builds on first run)                                                                                      |
+| `rly gui [--dev] [--rebuild]`                                                 | Desktop dashboard                                                                                                                  |
+| `rly rebuild [--all] [--dist] [--tui] [--gui] [--skip-install]`               | Rebuild artifacts (runs `pnpm install` first unless skipped)                                                                       |
+| `rly doctor`                                                                  | Diagnostics: paths, MCP wiring, token presence                                                                                     |
+| `rly session <create\|list\|get\|delete\|...>`                                | Session-transcript management                                                                                                      |
+| `rly chat <system-prompt\|resolve-refs\|mcp-config>`                          | Chat plumbing used by the TUI/GUI                                                                                                  |
+| `rly config <add-project-dir\|remove-project-dir>`                            | Global config                                                                                                                      |
+| `rly mcp-server --workspace <path>`                                           | Run the MCP server (invoked by Claude/Codex automatically)                                                                         |
+| `rly inspect-mcp`                                                             | Show the live MCP tool catalogue                                                                                                   |
 
 ## MCP tools
 
@@ -393,17 +393,17 @@ Verification commands run through an `Executor` abstraction (`src/execution/exec
 
 ### Environment flags
 
-| Var / flag | Effect |
-|---|---|
-| `HARNESS_LIVE=1` | Use real Claude/Codex adapters instead of the scripted demo |
-| `RELAY_AUTO_APPROVE=1` / `--auto-approve` / `--yolo` | Unattended mode — no permission prompts. Required for multi-hour runs |
-| `RELAY_USE_DIST=1` | Run pre-built `dist/cli.js` instead of live source via `tsx`. Marginally faster startup; stale until `rly rebuild` |
-| `GITHUB_TOKEN` | GitHub issues + PR watcher |
-| `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) | Linear issues |
-| `CLAUDE_BIN` | Override the `claude` binary path (default: `claude` on `$PATH`) |
-| `RELAY_QUIET=1` / `HARNESS_QUIET=1` / `--quiet` / `--silent` | Suppress inline tool-use activity during `rly run` (both env vars honored) |
-| `--sequential` | Use the v1 sequential orchestrator instead of v2 ticket-based |
-| `--no-harness-mcp` | Launch Claude/Codex without attaching the Relay MCP server |
+| Var / flag                                                   | Effect                                                                                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `HARNESS_LIVE=1`                                             | Use real Claude/Codex adapters instead of the scripted demo                                                        |
+| `RELAY_AUTO_APPROVE=1` / `--auto-approve` / `--yolo`         | Unattended mode — no permission prompts. Required for multi-hour runs                                              |
+| `RELAY_USE_DIST=1`                                           | Run pre-built `dist/cli.js` instead of live source via `tsx`. Marginally faster startup; stale until `rly rebuild` |
+| `GITHUB_TOKEN`                                               | GitHub issues + PR watcher                                                                                         |
+| `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`)                     | Linear issues                                                                                                      |
+| `CLAUDE_BIN`                                                 | Override the `claude` binary path (default: `claude` on `$PATH`)                                                   |
+| `RELAY_QUIET=1` / `HARNESS_QUIET=1` / `--quiet` / `--silent` | Suppress inline tool-use activity during `rly run` (both env vars honored)                                         |
+| `--sequential`                                               | Use the v1 sequential orchestrator instead of v2 ticket-based                                                      |
+| `--no-harness-mcp`                                           | Launch Claude/Codex without attaching the Relay MCP server                                                         |
 
 ### File layout
 
@@ -482,12 +482,12 @@ cargo check --workspace       # all three Rust crates
 
 Per-area quick loops:
 
-| What | Loop |
-|---|---|
-| Edit TS source, see CLI change | Just save — `rly` reads `src/` live via `tsx` (no rebuild) |
-| Edit Rust TUI | `rly rebuild --tui` |
-| Edit Tauri GUI | `rly gui --dev` (hot reload) |
-| After `git pull` pulled new deps | `rly rebuild` (runs `pnpm install` first) |
+| What                             | Loop                                                       |
+| -------------------------------- | ---------------------------------------------------------- |
+| Edit TS source, see CLI change   | Just save — `rly` reads `src/` live via `tsx` (no rebuild) |
+| Edit Rust TUI                    | `rly rebuild --tui`                                        |
+| Edit Tauri GUI                   | `rly gui --dev` (hot reload)                               |
+| After `git pull` pulled new deps | `rly rebuild` (runs `pnpm install` first)                  |
 
 ### Testing conventions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ You can expect an acknowledgement within **72 hours**. Please do not open a publ
 
 - Vulnerabilities in Claude Code, Codex, or the `@aoagents/*` packages — please report those to their respective maintainers.
 - Issues in your own code that Relay dispatches agents to operate on. Relay doesn't protect you from yourself when running with `RELAY_AUTO_APPROVE=1`; that's by design.
-- Social-engineering a user into running a malicious issue URL / prompt. Prompt injection surfaces inside the agent's own trust boundary; see *Known-and-accepted risks* below.
+- Social-engineering a user into running a malicious issue URL / prompt. Prompt injection surfaces inside the agent's own trust boundary; see _Known-and-accepted risks_ below.
 
 ## Known-and-accepted risks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,12 +37,12 @@ Paste this into a fresh `rly claude` session:
 https://github.com/acme/api/issues/42
 ```
 
-where issue #42 says *"Rate-limit `/api/search` to 60 req/min per API key, return 429 with `Retry-After` header."*
+where issue #42 says _"Rate-limit `/api/search` to 60 req/min per API key, return 429 with `Retry-After` header."_
 
 What happens, in order:
 
 1. **Classifier** hits GitHub, pulls title + body + labels (`enhancement`, `api`, `backend`). Emits `tier: feature_small`, `suggestedBranch: feat/42-rate-limit-search`.
-2. **Planner** writes a 3-phase plan: *(1) add middleware + token-bucket store, (2) wire into `/api/search` route, (3) tests + error-shape*. Feed entry `plan_created`.
+2. **Planner** writes a 3-phase plan: _(1) add middleware + token-bucket store, (2) wire into `/api/search` route, (3) tests + error-shape_. Feed entry `plan_created`.
 3. **Decomposer** fans out: `T-1 add rate-limit middleware (general)`, `T-2 wire into /api/search (api_crud, depends on T-1)`, `T-3 integration test for 429 + Retry-After (testing, depends on T-2)`, `T-4 update OpenAPI spec (general, depends on T-2)`. Ticket board is live in `rly board <channelId>`.
 4. **Scheduler** starts T-1 (the only `ready` ticket). T-2/T-3/T-4 sit `blocked`. As T-1 completes and verifies, T-2 unblocks, then T-3 + T-4 run in parallel. Max-concurrency defaults to 3 — you can watch the `executing` column fill up.
 5. **Each ticket** spawns its own Claude subprocess with a scoped prompt, runs verification commands (test / lint / typecheck) through the `Executor` abstraction, retries up to `maxTestFixLoops` on failure.
@@ -111,7 +111,7 @@ For when you want to see the pipeline at a glance:
 
 ## `~/.relay/` file layout
 
-All three dashboards (CLI / TUI / GUI) read the same files. No synchronisation layer — the filesystem *is* the state.
+All three dashboards (CLI / TUI / GUI) read the same files. No synchronisation layer — the filesystem _is_ the state.
 
 ```
 ~/.relay/
@@ -140,20 +140,20 @@ Opting in to Postgres (`PostgresHarnessStore`) keeps the same on-disk layout and
 
 ## Troubleshooting
 
-| Symptom | Likely cause / fix |
-|---|---|
-| `GITHUB_TOKEN not set — PR watching disabled` | Expected if you didn't set the token; PRs won't auto-track. Also posted once per channel to the feed (visible in TUI/GUI) so you see it even if you closed the terminal. |
-| Classifier can't resolve a Linear key like `ABC-123` | `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) not set, or the key doesn't match any issue visible to your token. |
-| Claude keeps prompting for permissions | Set `RELAY_AUTO_APPROVE=1` or pass `--yolo` / `--auto-approve`. |
-| Tickets stuck in `blocked` forever | Check `dependsOn` chain — a failed upstream ticket blocks everything downstream. `rly board <id>` shows the edges. |
-| Ticket retries exhausted (`failed`) | Verification commands kept failing past `maxTestFixLoops`. Feed shows the last verification output; fix manually, mark the ticket `completed`, and the scheduler unblocks downstream. |
-| `Verification override` in feed | The agent proposed commands that weren't on the ticket's allowlist, so the scheduler ran the allowlist instead. The feed entry lists `rejectedCommands` and `substitutedCommands` — if the substitution is wrong, update the ticket's `allowedCommands` / `verificationCommands`. |
-| `rly` runs stale code after `git pull` | Default reads current source via `tsx`, so this shouldn't happen. If you set `RELAY_USE_DIST=1`, run `rly rebuild`. |
-| `rly tui` / `rly gui` fails on first run | Install `cargo` (rustup). The auto-build needs it. |
-| TUI shows no channels | Register at least one workspace with `rly up` and create a channel (or launch a session, which creates one). |
-| GUI shows stale data | `rly gui --rebuild` to refresh the bundle after a code change. |
-| Crosslink `no_session` when spawning an associated agent | The GUI spawns a terminal tab on macOS/Linux/Windows. If spawn fails (no supported terminal detected), a system entry lands in the channel feed — run `rly claude` in the repo manually and crosslink will pick it up. |
-| PR watcher never updates | Check `rly pr-status` for errors. Usually a scoping issue on `GITHUB_TOKEN` (needs `repo` scope for private repos). |
+| Symptom                                                  | Likely cause / fix                                                                                                                                                                                                                                                                |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN not set — PR watching disabled`            | Expected if you didn't set the token; PRs won't auto-track. Also posted once per channel to the feed (visible in TUI/GUI) so you see it even if you closed the terminal.                                                                                                          |
+| Classifier can't resolve a Linear key like `ABC-123`     | `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) not set, or the key doesn't match any issue visible to your token.                                                                                                                                                                       |
+| Claude keeps prompting for permissions                   | Set `RELAY_AUTO_APPROVE=1` or pass `--yolo` / `--auto-approve`.                                                                                                                                                                                                                   |
+| Tickets stuck in `blocked` forever                       | Check `dependsOn` chain — a failed upstream ticket blocks everything downstream. `rly board <id>` shows the edges.                                                                                                                                                                |
+| Ticket retries exhausted (`failed`)                      | Verification commands kept failing past `maxTestFixLoops`. Feed shows the last verification output; fix manually, mark the ticket `completed`, and the scheduler unblocks downstream.                                                                                             |
+| `Verification override` in feed                          | The agent proposed commands that weren't on the ticket's allowlist, so the scheduler ran the allowlist instead. The feed entry lists `rejectedCommands` and `substitutedCommands` — if the substitution is wrong, update the ticket's `allowedCommands` / `verificationCommands`. |
+| `rly` runs stale code after `git pull`                   | Default reads current source via `tsx`, so this shouldn't happen. If you set `RELAY_USE_DIST=1`, run `rly rebuild`.                                                                                                                                                               |
+| `rly tui` / `rly gui` fails on first run                 | Install `cargo` (rustup). The auto-build needs it.                                                                                                                                                                                                                                |
+| TUI shows no channels                                    | Register at least one workspace with `rly up` and create a channel (or launch a session, which creates one).                                                                                                                                                                      |
+| GUI shows stale data                                     | `rly gui --rebuild` to refresh the bundle after a code change.                                                                                                                                                                                                                    |
+| Crosslink `no_session` when spawning an associated agent | The GUI spawns a terminal tab on macOS/Linux/Windows. If spawn fails (no supported terminal detected), a system entry lands in the channel feed — run `rly claude` in the repo manually and crosslink will pick it up.                                                            |
+| PR watcher never updates                                 | Check `rly pr-status` for errors. Usually a scoping issue on `GITHUB_TOKEN` (needs `repo` scope for private repos).                                                                                                                                                               |
 
 ## Next
 

--- a/docs/storage-injection.md
+++ b/docs/storage-injection.md
@@ -33,11 +33,11 @@ global side-effect.
 
 ## Environment
 
-| `HARNESS_STORE` | Behavior |
-| --- | --- |
-| unset / `file` | `FileHarnessStore` at `getRelayDir()` (usually `~/.relay/`) |
-| `postgres` | Throws `NotImplementedError` until T-402 lands |
-| `sqlite` | Throws `NotImplementedError` (no tracking ticket yet) |
+| `HARNESS_STORE` | Behavior                                                    |
+| --------------- | ----------------------------------------------------------- |
+| unset / `file`  | `FileHarnessStore` at `getRelayDir()` (usually `~/.relay/`) |
+| `postgres`      | Throws `NotImplementedError` until T-402 lands              |
+| `sqlite`        | Throws `NotImplementedError` (no tracking ticket yet)       |
 
 ## Legacy stores (unmigrated)
 
@@ -45,13 +45,13 @@ These five modules still import `node:fs/promises` directly. They predate
 `HarnessStore` and migrate one ticket at a time so each PR stays
 reviewable:
 
-| File | Ticket |
-| --- | --- |
-| `src/channels/channel-store.ts` | T-101 (partial) |
-| `src/cli/workspace-registry.ts` | T-102 (partial) |
-| `src/cli/session-store.ts` | T-102 (partial) |
-| `src/execution/artifact-store.ts` | T-103 |
-| `src/crosslink/store.ts` | T-104 |
+| File                              | Ticket          |
+| --------------------------------- | --------------- |
+| `src/channels/channel-store.ts`   | T-101 (partial) |
+| `src/cli/workspace-registry.ts`   | T-102 (partial) |
+| `src/cli/session-store.ts`        | T-102 (partial) |
+| `src/execution/artifact-store.ts` | T-103           |
+| `src/crosslink/store.ts`          | T-104           |
 
 Until those tickets land, these files are exempt from a "no direct fs in
 storage code" lint. The canonical list lives as a comment in

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -21,12 +21,10 @@ import type {
 export const api = {
   listWorkspaces: () => invoke<WorkspaceEntry[]>("list_workspaces"),
   listChannels: () => invoke<Channel[]>("list_channels"),
-  getChannel: (channelId: string) =>
-    invoke<Channel | null>("get_channel", { channelId }),
+  getChannel: (channelId: string) => invoke<Channel | null>("get_channel", { channelId }),
   listFeed: (channelId: string, limit = 200) =>
     invoke<ChannelEntry[]>("list_feed", { channelId, limit }),
-  listSessions: (channelId: string) =>
-    invoke<ChatSession[]>("list_sessions", { channelId }),
+  listSessions: (channelId: string) => invoke<ChatSession[]>("list_sessions", { channelId }),
   loadSession: (channelId: string, sessionId: string, limit = 500) =>
     invoke<PersistedChatMessage[]>("load_session", {
       channelId,
@@ -39,22 +37,20 @@ export const api = {
     invoke<Decision[]>("list_channel_decisions", { channelId }),
   listChannelRuns: (channelId: string) =>
     invoke<ChannelRunLink[]>("list_channel_runs", { channelId }),
-  listRuns: (workspaceId: string) =>
-    invoke<RunIndexEntry[]>("list_runs", { workspaceId }),
+  listRuns: (workspaceId: string) => invoke<RunIndexEntry[]>("list_runs", { workspaceId }),
   listTicketLedger: (workspaceId: string, runId: string) =>
     invoke<TicketLedgerEntry[]>("list_ticket_ledger", { workspaceId, runId }),
   listAgentNames: () => invoke<AgentNameEntry[]>("list_agent_names"),
   runCli: (args: string[]) =>
-    invoke<{ success: boolean; stdout: string; stderr: string; code: number | null }>(
-      "run_cli",
-      { args },
-    ),
+    invoke<{ success: boolean; stdout: string; stderr: string; code: number | null }>("run_cli", {
+      args,
+    }),
 
   createChannel: (
     name: string,
     description: string,
     repos: { alias: string; workspaceId: string; repoPath: string }[],
-    primaryWorkspaceId?: string,
+    primaryWorkspaceId?: string
   ) =>
     invoke<{ channelId: string }>("create_channel", {
       name,
@@ -62,19 +58,12 @@ export const api = {
       repos,
       primaryWorkspaceId,
     }),
-  archiveChannel: (channelId: string) =>
-    invoke<unknown>("archive_channel", { channelId }),
+  archiveChannel: (channelId: string) => invoke<unknown>("archive_channel", { channelId }),
   updateChannelRepos: (
     channelId: string,
-    repos: { alias: string; workspaceId: string; repoPath: string }[],
-  ) =>
-    invoke<unknown>("update_channel_repos", { channelId, repos }),
-  postToChannel: (
-    channelId: string,
-    content: string,
-    from?: string,
-    entryType?: string,
-  ) =>
+    repos: { alias: string; workspaceId: string; repoPath: string }[]
+  ) => invoke<unknown>("update_channel_repos", { channelId, repos }),
+  postToChannel: (channelId: string, content: string, from?: string, entryType?: string) =>
     invoke<unknown>("post_to_channel", {
       channelId,
       content,
@@ -91,7 +80,7 @@ export const api = {
     role: string,
     content: string,
     agentAlias?: string,
-    metadata?: Record<string, string>,
+    metadata?: Record<string, string>
   ) =>
     invoke<unknown>("append_session_message", {
       channelId,
@@ -104,12 +93,7 @@ export const api = {
 
   rewindSnapshot: (channelId: string, sessionId: string) =>
     invoke<RewindSnapshot>("rewind_snapshot", { channelId, sessionId }),
-  rewindApply: (
-    channelId: string,
-    sessionId: string,
-    key: string,
-    messageTimestamp: string,
-  ) =>
+  rewindApply: (channelId: string, sessionId: string, key: string, messageTimestamp: string) =>
     invoke<RewindResult>("rewind_apply", {
       channelId,
       sessionId,
@@ -132,8 +116,7 @@ export const api = {
   // persisting the assistant message. Called by the rewind flow BEFORE
   // truncating the session log so the stream can't race truncation and
   // append a stale assistant turn afterwards.
-  cancelChatStream: (streamId: number) =>
-    invoke<void>("cancel_chat_stream", { streamId }),
+  cancelChatStream: (streamId: number) => invoke<void>("cancel_chat_stream", { streamId }),
 
   // Task #24 contract. These invoke wrappers are thin passthroughs that
   // assume the Rust side registers `spawn_agent`, `list_spawns`, and
@@ -143,19 +126,16 @@ export const api = {
   // spawn UI rather than crashing the app.
   spawnAgent: (channelId: string, alias: string, repoPath: string) =>
     invoke<Spawn>("spawn_agent", { channelId, alias, repoPath }),
-  listSpawns: (channelId: string) =>
-    invoke<Spawn[]>("list_spawns", { channelId }),
+  listSpawns: (channelId: string) => invoke<Spawn[]>("list_spawns", { channelId }),
   killSpawnedAgent: (channelId: string, alias: string) =>
     invoke<void>("kill_spawned_agent", { channelId, alias }),
 
   // OSS-05: Parity commands — tracked-PR mirror + plan approval. These
   // shell out to the same `rly approve` / `rly reject` commands the CLI
   // uses, so there's exactly one code path that writes approval records.
-  listTrackedPrs: (channelId: string) =>
-    invoke<TrackedPrRow[]>("list_tracked_prs", { channelId }),
+  listTrackedPrs: (channelId: string) => invoke<TrackedPrRow[]>("list_tracked_prs", { channelId }),
   listPendingPlans: () => invoke<PendingPlan[]>("list_pending_plans"),
-  approvePlan: (runId: string) =>
-    invoke<unknown>("approve_plan", { runId }),
+  approvePlan: (runId: string) => invoke<unknown>("approve_plan", { runId }),
   rejectPlan: (runId: string, feedback?: string) =>
     invoke<unknown>("reject_plan", { runId, feedback }),
 };
@@ -168,8 +148,6 @@ export type ChatEvent =
   | { kind: "done"; streamId: number; finalText: string }
   | { kind: "error"; streamId: number; message: string };
 
-export function subscribeChatEvents(
-  cb: (event: ChatEvent) => void,
-): Promise<UnlistenFn> {
+export function subscribeChatEvents(cb: (event: ChatEvent) => void): Promise<UnlistenFn> {
   return listen<ChatEvent>("chat-event", (e) => cb(e.payload));
 }

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -44,9 +44,7 @@ export function CenterPane({
   const [feed, setFeed] = useState<ChannelEntry[]>([]);
   const [tickets, setTickets] = useState<TicketLedgerEntry[]>([]);
   const [decisions, setDecisions] = useState<Decision[]>([]);
-  const [sessionMessages, setSessionMessages] = useState<PersistedChatMessage[]>(
-    [],
-  );
+  const [sessionMessages, setSessionMessages] = useState<PersistedChatMessage[]>([]);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [stream, setStream] = useState<ActiveStream | null>(null);
 
@@ -89,9 +87,7 @@ export function CenterPane({
       if (event.kind === "done" || event.kind === "error") {
         // Refresh persisted messages so the stored assistant text shows up.
         onRefresh();
-        setStream((current) =>
-          current && current.streamId === event.streamId ? null : current,
-        );
+        setStream((current) => (current && current.streamId === event.streamId ? null : current));
       }
     }).then((u) => (unlisten = u));
     return () => {
@@ -111,22 +107,12 @@ export function CenterPane({
 
   return (
     <div className="panel">
-      <PendingPlanCta
-        channel={channel}
-        refreshTick={refreshTick}
-        onChanged={onRefresh}
-      />
+      <PendingPlanCta channel={channel} refreshTick={refreshTick} onChanged={onRefresh} />
       <div className="tabs">
-        <div
-          className={`tab ${tab === "chat" ? "active" : ""}`}
-          onClick={() => setTab("chat")}
-        >
+        <div className={`tab ${tab === "chat" ? "active" : ""}`} onClick={() => setTab("chat")}>
           Chat
         </div>
-        <div
-          className={`tab ${tab === "board" ? "active" : ""}`}
-          onClick={() => setTab("board")}
-        >
+        <div className={`tab ${tab === "board" ? "active" : ""}`} onClick={() => setTab("board")}>
           Board ({tickets.length})
         </div>
         <div
@@ -230,9 +216,7 @@ function ChatView({
         {stream && (
           <ActivityStreamCard
             stream={stream}
-            onToggleExpanded={() =>
-              onStartStream({ ...stream, expanded: !stream.expanded })
-            }
+            onToggleExpanded={() => onStartStream({ ...stream, expanded: !stream.expanded })}
           />
         )}
       </div>
@@ -265,9 +249,7 @@ function ActivityStreamCard({
   return (
     <div className="feed-entry role-assistant streaming">
       <div className="feed-header">
-        <span className="feed-author">
-          {stream.alias ? `@${stream.alias}` : "assistant"}
-        </span>
+        <span className="feed-author">{stream.alias ? `@${stream.alias}` : "assistant"}</span>
         <span className="stream-status">
           <span className="stream-dot" />
           {stream.accum ? "writing response" : "thinking"}
@@ -293,29 +275,19 @@ function ActivityStreamCard({
                   className={`stream-activity-line ${isNewest ? "newest" : ""}`}
                   title={new Date(entry.ts).toLocaleTimeString()}
                 >
-                  {isNewest && (
-                    <span className="activity-badge">{agentBadge}</span>
-                  )}
+                  {isNewest && <span className="activity-badge">{agentBadge}</span>}
                   <span className="activity-icon">⚙</span>
                   <span className="activity-text">{entry.text}</span>
                 </div>
               );
             })}
             {hiddenCount > 0 && (
-              <button
-                type="button"
-                className="stream-activity-more"
-                onClick={onToggleExpanded}
-              >
+              <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
                 +{hiddenCount} more
               </button>
             )}
             {stream.expanded && total > ACTIVITY_TOP_N && (
-              <button
-                type="button"
-                className="stream-activity-more"
-                onClick={onToggleExpanded}
-              >
+              <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
                 collapse
               </button>
             )}
@@ -347,25 +319,18 @@ function SessionMessages({
   streamId: number | null;
   onRewound: () => void;
 }) {
-  const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(
-    null,
-  );
+  const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(null);
 
-
-  if (messages.length === 0)
-    return <div className="empty">No messages in this session yet</div>;
+  if (messages.length === 0) return <div className="empty">No messages in this session yet</div>;
   return (
     <>
       {messages.map((m, i) => {
         const rewindKey = m.metadata?.rewindKey;
-        const canRewind =
-          m.role === "user" && !!rewindKey && !streaming;
+        const canRewind = m.role === "user" && !!rewindKey && !streaming;
         return (
           <div key={i} className={`feed-entry role-${m.role}`}>
             <div className="feed-header">
-              <span className="feed-author">
-                {m.agentAlias ? `@${m.agentAlias}` : m.role}
-              </span>
+              <span className="feed-author">{m.agentAlias ? `@${m.agentAlias}` : m.role}</span>
               <span className="feed-header-right">
                 {formatTime(m.timestamp)}
                 {m.role === "user" && rewindKey && (
@@ -443,12 +408,7 @@ function RewindConfirmModal({
           console.warn("[rewind] cancelChatStream failed:", e);
         }
       }
-      await api.rewindApply(
-        channel.channelId,
-        sessionId,
-        rewindKey,
-        target.timestamp,
-      );
+      await api.rewindApply(channel.channelId, sessionId, rewindKey, target.timestamp);
       onDone();
     } catch (e) {
       setError(String(e));
@@ -463,10 +423,9 @@ function RewindConfirmModal({
         <div className="modal-header">Rewind to this turn?</div>
         <div className="modal-body">
           <p>
-            Each repo in this channel will be reset to the commit captured
-            before this message. All messages at or after this turn will be
-            removed from the session, and Claude session IDs will be cleared
-            so the next message starts a fresh conversation.
+            Each repo in this channel will be reset to the commit captured before this message. All
+            messages at or after this turn will be removed from the session, and Claude session IDs
+            will be cleared so the next message starts a fresh conversation.
           </p>
           <div className="rewind-repo-list">
             {channel.repoAssignments.map((r) => (
@@ -477,10 +436,9 @@ function RewindConfirmModal({
             ))}
           </div>
           <p className="rewind-warning">
-            <strong>Warning:</strong> this runs <code>git reset --hard</code>.
-            Any uncommitted changes in these repos will be lost. Shell side
-            effects (API calls, spawned processes, database writes) are{" "}
-            <strong>not</strong> undone.
+            <strong>Warning:</strong> this runs <code>git reset --hard</code>. Any uncommitted
+            changes in these repos will be lost. Shell side effects (API calls, spawned processes,
+            database writes) are <strong>not</strong> undone.
           </p>
           {error && <div className="composer-error">{error}</div>}
         </div>
@@ -488,12 +446,7 @@ function RewindConfirmModal({
           <button type="button" onClick={onClose} disabled={busy}>
             Cancel
           </button>
-          <button
-            type="button"
-            className="primary"
-            onClick={apply}
-            disabled={busy || !rewindKey}
-          >
+          <button type="button" className="primary" onClick={apply} disabled={busy || !rewindKey}>
             {busy ? "Rewinding…" : "Rewind"}
           </button>
         </div>
@@ -548,13 +501,10 @@ function Composer({
       // Parse @alias prefix to route to a repo.
       const aliases = channel.repoAssignments.map((r) => r.alias);
       const { alias, body } = parseAliasPrefix(raw, aliases);
-      const repo = alias
-        ? channel.repoAssignments.find((r) => r.alias === alias)
-        : null;
+      const repo = alias ? channel.repoAssignments.find((r) => r.alias === alias) : null;
       const cwd = repo?.repoPath;
       const aliasKey = alias ?? "general";
-      const claudeSessionId =
-        activeSession?.claudeSessionIds?.[aliasKey] ?? undefined;
+      const claudeSessionId = activeSession?.claudeSessionIds?.[aliasKey] ?? undefined;
 
       let activeId = sessionId;
       if (!activeId) {
@@ -636,11 +586,7 @@ function Composer({
           />
           auto-approve
         </label>
-        <button
-          className="primary"
-          onClick={send}
-          disabled={disabled || !text.trim()}
-        >
+        <button className="primary" onClick={send} disabled={disabled || !text.trim()}>
           {streaming ? "…" : "Send"}
         </button>
       </div>
@@ -650,7 +596,7 @@ function Composer({
 
 function parseAliasPrefix(
   message: string,
-  aliases: string[],
+  aliases: string[]
 ): { alias: string | null; body: string } {
   const match = message.match(/^@([a-zA-Z0-9_-]+)\s+([\s\S]*)$/);
   if (!match) return { alias: null, body: message };
@@ -675,19 +621,14 @@ const BOARD_COLUMNS: Array<{ status: string; label: string }> = [
 function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
   const [selected, setSelected] = useState<TicketLedgerEntry | null>(null);
 
-  if (tickets.length === 0)
-    return <div className="empty">No tickets in this channel</div>;
+  if (tickets.length === 0) return <div className="empty">No tickets in this channel</div>;
 
   const grouped: Record<string, TicketLedgerEntry[]> = {};
   for (const t of tickets) {
-    const key = BOARD_COLUMNS.some((c) => c.status === t.status)
-      ? t.status
-      : "pending";
+    const key = BOARD_COLUMNS.some((c) => c.status === t.status) ? t.status : "pending";
     (grouped[key] ||= []).push(t);
   }
-  const visible = BOARD_COLUMNS.filter(
-    (c) => (grouped[c.status]?.length ?? 0) > 0,
-  );
+  const visible = BOARD_COLUMNS.filter((c) => (grouped[c.status]?.length ?? 0) > 0);
 
   return (
     <>
@@ -715,17 +656,13 @@ function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
                     }}
                   >
                     {isLinear && t.linearIdentifier && (
-                      <div className="ticket-linear-chip">
-                        Linear · {t.linearIdentifier}
-                      </div>
+                      <div className="ticket-linear-chip">Linear · {t.linearIdentifier}</div>
                     )}
                     <div>{t.title}</div>
-                    {t.assignedAlias && (
-                      <div className="ticket-alias-chip">@{t.assignedAlias}</div>
-                    )}
+                    {t.assignedAlias && <div className="ticket-alias-chip">@{t.assignedAlias}</div>}
                     <div className="ticket-meta">
                       {isLinear
-                        ? t.linearState ?? "linear mirror"
+                        ? (t.linearState ?? "linear mirror")
                         : `${t.specialty} · attempt ${t.attempt}${
                             t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""
                           }`}
@@ -738,11 +675,7 @@ function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
         ))}
       </div>
       {selected && (
-        <TicketDetailModal
-          ticket={selected}
-          tickets={tickets}
-          onClose={() => setSelected(null)}
-        />
+        <TicketDetailModal ticket={selected} tickets={tickets} onClose={() => setSelected(null)} />
       )}
     </>
   );
@@ -767,10 +700,7 @@ function TicketDetailModal({
   });
   return (
     <div className="modal-backdrop" onClick={onClose}>
-      <div
-        className="modal ticket-modal"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="modal ticket-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">{ticket.title}</div>
         <div className="modal-body">
           <div className="detail-row">
@@ -836,14 +766,11 @@ function TicketDetailModal({
           )}
           {deps.length > 0 && (
             <div className="detail-row detail-row-block">
-              <span className="detail-label">
-                Depends on ({deps.length})
-              </span>
+              <span className="detail-label">Depends on ({deps.length})</span>
               <ul className="dep-list">
                 {deps.map((d) => (
                   <li key={d.id}>
-                    <code>{d.id}</code>{" "}
-                    <span className="dep-status">{d.status}</span>
+                    <code>{d.id}</code> <span className="dep-status">{d.status}</span>
                     <div className="dep-title">{d.title}</div>
                   </li>
                 ))}
@@ -862,8 +789,7 @@ function TicketDetailModal({
 }
 
 function DecisionsView({ decisions }: { decisions: Decision[] }) {
-  if (decisions.length === 0)
-    return <div className="empty">No decisions recorded</div>;
+  if (decisions.length === 0) return <div className="empty">No decisions recorded</div>;
   return (
     <>
       {decisions.map((d) => (
@@ -933,7 +859,7 @@ function PendingPlanCta({
   }, [refreshTick]);
 
   const relevant = plans.filter((p) =>
-    channel ? !p.channelId || p.channelId === channel.channelId : true,
+    channel ? !p.channelId || p.channelId === channel.channelId : true
   );
   if (relevant.length === 0) return null;
 
@@ -962,9 +888,7 @@ function PendingPlanCta({
         <div key={p.runId} className="plan-cta-row">
           <div className="plan-cta-body">
             <strong>Plan awaiting approval</strong>
-            <span className="plan-cta-feature">
-              {p.featureRequest.slice(0, 80)}
-            </span>
+            <span className="plan-cta-feature">{p.featureRequest.slice(0, 80)}</span>
             <span className="plan-cta-meta">
               run {p.runId.slice(0, 12)}… · workspace {p.workspaceId}
             </span>
@@ -978,11 +902,7 @@ function PendingPlanCta({
             >
               {busyRunId === p.runId ? "…" : "Approve"}
             </button>
-            <button
-              type="button"
-              disabled={busyRunId === p.runId}
-              onClick={() => act(p, "reject")}
-            >
+            <button type="button" disabled={busyRunId === p.runId} onClick={() => act(p, "reject")}>
               Reject
             </button>
           </div>

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -33,9 +33,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
   // first row, at which point we auto-set to that row. If the current
   // primary is later unchecked, we reassign to the earliest still-
   // selected row (by master-array order, not visible order).
-  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(
-    null,
-  );
+  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(null);
   const filterRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -54,7 +52,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
           selected: false,
           alias: defaultAlias(w.repoPath),
           spawn: false,
-        })),
+        }))
       );
     });
   }, [open]);
@@ -68,11 +66,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
       .map((r, origIndex) => ({ row: r, origIndex }))
       .filter(({ row }) => {
         if (tokens.length === 0) return true;
-        const haystack = [
-          row.workspace.repoPath,
-          row.workspace.workspaceId,
-          row.alias,
-        ]
+        const haystack = [row.workspace.repoPath, row.workspace.workspaceId, row.alias]
           .join(" ")
           .toLowerCase();
         return tokens.every((tok) => haystack.includes(tok));
@@ -128,9 +122,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
     // Radio-click: assumes the row is already selected (the radio is only
     // rendered on selected rows). Defensive: verify and no-op otherwise.
     setRepos((prev) => {
-      const match = prev.find(
-        (r) => r.workspace.workspaceId === workspaceId && r.selected,
-      );
+      const match = prev.find((r) => r.workspace.workspaceId === workspaceId && r.selected);
       if (!match) return prev;
       setPrimaryWorkspaceId(workspaceId);
       return prev;
@@ -139,16 +131,12 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
 
   const toggleSpawn = (origIndex: number) => {
     setRepos((prev) =>
-      prev.map((row, j) =>
-        j === origIndex ? { ...row, spawn: !row.spawn } : row,
-      ),
+      prev.map((row, j) => (j === origIndex ? { ...row, spawn: !row.spawn } : row))
     );
   };
 
   const updateAlias = (origIndex: number, alias: string) => {
-    setRepos((prev) =>
-      prev.map((row, j) => (j === origIndex ? { ...row, alias } : row)),
-    );
+    setRepos((prev) => prev.map((row, j) => (j === origIndex ? { ...row, alias } : row)));
   };
 
   const onFilterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -198,7 +186,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
         name.trim(),
         description.trim(),
         selected,
-        effectivePrimary,
+        effectivePrimary
       );
 
       // Spawn all non-primary rows that were opted-in. Run in parallel; a
@@ -206,31 +194,25 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
       // the channel was created successfully, and the user can still
       // launch agents later from the right pane.
       const toSpawn = selectedRows.filter(
-        (r) =>
-          r.spawn &&
-          r.workspace.workspaceId !== effectivePrimary,
+        (r) => r.spawn && r.workspace.workspaceId !== effectivePrimary
       );
       if (toSpawn.length > 0) {
         const results = await Promise.all(
           toSpawn.map(async (r) => {
             const alias = r.alias.trim() || defaultAlias(r.workspace.repoPath);
             try {
-              await api.spawnAgent(
-                result.channelId,
-                alias,
-                r.workspace.repoPath,
-              );
+              await api.spawnAgent(result.channelId, alias, r.workspace.repoPath);
               return { alias, ok: true as const };
             } catch (e) {
               return { alias, ok: false as const, error: String(e) };
             }
-          }),
+          })
         );
         const failures = results.filter((x) => !x.ok);
         if (failures.length > 0) {
           setSpawnWarning(
             `Channel created, but ${failures.length}/${results.length} spawn(s) failed: ` +
-              failures.map((f) => `@${f.alias}`).join(", "),
+              failures.map((f) => `@${f.alias}`).join(", ")
           );
         }
       }
@@ -274,9 +256,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
               </span>
             </div>
             {repos.length === 0 ? (
-              <div className="empty">
-                No registered workspaces. Run `rly up` in a repo first.
-              </div>
+              <div className="empty">No registered workspaces. Run `rly up` in a repo first.</div>
             ) : (
               <>
                 <input
@@ -293,8 +273,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                   ) : (
                     visible.map(({ row, origIndex }, i) => {
                       const isPrimary =
-                        row.selected &&
-                        primaryWorkspaceId === row.workspace.workspaceId;
+                        row.selected && primaryWorkspaceId === row.workspace.workspaceId;
                       return (
                         <div
                           key={row.workspace.workspaceId}
@@ -307,14 +286,9 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                             onChange={() => toggleSelected(origIndex)}
                             title="Include this repo in the channel"
                           />
-                          <span
-                            className="repo-path"
-                            title={row.workspace.repoPath}
-                          >
+                          <span className="repo-path" title={row.workspace.repoPath}>
                             {basename(row.workspace.repoPath)}
-                            {isPrimary && (
-                              <span className="primary-badge">PRIMARY</span>
-                            )}
+                            {isPrimary && <span className="primary-badge">PRIMARY</span>}
                           </span>
                           <input
                             className="alias-input"
@@ -335,9 +309,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                                 type="radio"
                                 name="primary-workspace"
                                 checked={isPrimary}
-                                onChange={() =>
-                                  setPrimary(row.workspace.workspaceId)
-                                }
+                                onChange={() => setPrimary(row.workspace.workspaceId)}
                               />
                               primary
                             </label>
@@ -392,5 +364,8 @@ function basename(p: string): string {
 }
 
 function defaultAlias(repoPath: string): string {
-  return basename(repoPath).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(0, 12);
+  return basename(repoPath)
+    .replace(/[^a-z0-9-]/gi, "")
+    .toLowerCase()
+    .slice(0, 12);
 }

--- a/gui/src/components/RightPane.tsx
+++ b/gui/src/components/RightPane.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
-import type {
-  Channel,
-  ChannelRunLink,
-  RunIndexEntry,
-  Spawn,
-  TrackedPrRow,
-} from "../types";
+import type { Channel, ChannelRunLink, RunIndexEntry, Spawn, TrackedPrRow } from "../types";
 import { SessionList } from "./SessionList";
 
 type Props = {
@@ -16,12 +10,7 @@ type Props = {
   refreshTick: number;
 };
 
-export function RightPane({
-  channel,
-  sessionId,
-  onSelectSession,
-  refreshTick,
-}: Props) {
+export function RightPane({ channel, sessionId, onSelectSession, refreshTick }: Props) {
   const [runs, setRuns] = useState<RunInfo[]>([]);
 
   useEffect(() => {
@@ -37,7 +26,7 @@ export function RightPane({
           const ws = await api.listRuns(link.workspaceId);
           const match = ws.find((r) => r.runId === link.runId);
           return match ? { run: match, workspaceId: link.workspaceId } : null;
-        }),
+        })
       );
       if (cancelled) return;
       setRuns(all.filter((x): x is RunInfo => x !== null));
@@ -76,8 +65,7 @@ export function RightPane({
         <h4>Repos ({channel.repoAssignments.length})</h4>
         {channel.repoAssignments.map((r) => {
           const isPrimary =
-            channel.primaryWorkspaceId &&
-            r.workspaceId === channel.primaryWorkspaceId;
+            channel.primaryWorkspaceId && r.workspaceId === channel.primaryWorkspaceId;
           return (
             <div key={r.workspaceId} className="row">
               <span>
@@ -116,13 +104,7 @@ export function RightPane({
  * narrow right pane: state / CI / review get a colored dot instead of
  * text (kept accessible via `title`).
  */
-function TrackedPrs({
-  channelId,
-  refreshTick,
-}: {
-  channelId: string;
-  refreshTick: number;
-}) {
+function TrackedPrs({ channelId, refreshTick }: { channelId: string; refreshTick: number }) {
   const [rows, setRows] = useState<TrackedPrRow[]>([]);
 
   useEffect(() => {
@@ -164,10 +146,7 @@ function TrackedPrs({
               className={`pr-dot pr-state-${r.prState ?? "unknown"}`}
               title={`state: ${r.prState ?? "-"}`}
             />
-            <span
-              className={`pr-dot pr-ci-${r.ci ?? "unknown"}`}
-              title={`ci: ${r.ci ?? "-"}`}
-            />
+            <span className={`pr-dot pr-ci-${r.ci ?? "unknown"}`} title={`ci: ${r.ci ?? "-"}`} />
             <span
               className={`pr-dot pr-review-${r.review ?? "unknown"}`}
               title={`review: ${r.review ?? "-"}`}
@@ -191,13 +170,7 @@ type RunInfo = { run: RunIndexEntry; workspaceId: string };
  * surfaces trigger spawns. Kill is optimistic: we drop the row from
  * local state before the async call resolves, then rollback if it fails.
  */
-function SpawnedAgents({
-  channelId,
-  refreshTick,
-}: {
-  channelId: string;
-  refreshTick: number;
-}) {
+function SpawnedAgents({ channelId, refreshTick }: { channelId: string; refreshTick: number }) {
   const [spawns, setSpawns] = useState<Spawn[]>([]);
   const [killError, setKillError] = useState<string | null>(null);
 

--- a/gui/src/components/SessionList.tsx
+++ b/gui/src/components/SessionList.tsx
@@ -9,12 +9,7 @@ type Props = {
   refreshTick: number;
 };
 
-export function SessionList({
-  channelId,
-  selectedSessionId,
-  onSelect,
-  refreshTick,
-}: Props) {
+export function SessionList({ channelId, selectedSessionId, onSelect, refreshTick }: Props) {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [busy, setBusy] = useState(false);
 
@@ -56,9 +51,7 @@ export function SessionList({
       {sessions.map((s) => (
         <div
           key={s.sessionId}
-          className={`session-row ${
-            s.sessionId === selectedSessionId ? "active" : ""
-          }`}
+          className={`session-row ${s.sessionId === selectedSessionId ? "active" : ""}`}
           onClick={() => onSelect(s.sessionId)}
         >
           <div className="session-title">{s.title}</div>

--- a/gui/src/main.tsx
+++ b/gui/src/main.tsx
@@ -6,5 +6,5 @@ import "./styles.css";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "test": "vitest run",
     "changeset": "changeset",
     "changeset-version": "changeset version && node scripts/sync-versions.mjs",
-    "changeset-publish": "pnpm build && changeset publish"
+    "changeset-publish": "pnpm build && changeset publish",
+    "format": "prettier --write \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\" \"gui/src/**/*.{ts,tsx}\" \"scripts/**/*.{ts,mts}\" \"*.md\" \"docs/**/*.md\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\" \"gui/src/**/*.{ts,tsx}\" \"scripts/**/*.{ts,mts}\" \"*.md\" \"docs/**/*.md\""
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/scripts/seed-plan-tickets.ts
+++ b/scripts/seed-plan-tickets.ts
@@ -23,7 +23,7 @@ import { initializeTicketLedger } from "../src/domain/ticket.js";
 import {
   getWorkspaceDir,
   resolveWorkspaceForRepo,
-  registerWorkspace
+  registerWorkspace,
 } from "../src/cli/workspace-registry.js";
 import { buildRunId } from "../src/orchestrator/orchestrator-v2.js";
 import { join } from "node:path";
@@ -55,10 +55,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "src/storage/store.ts exports the interface with full types",
       "FileHarnessStore passes unit tests covering all methods",
-      "LocalArtifactStore remains untouched this ticket"
+      "LocalArtifactStore remains untouched this ticket",
     ],
     specialty: "general",
-    dependsOn: []
+    dependsOn: [],
   },
   {
     id: "T-002",
@@ -70,10 +70,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "pnpm build && pnpm test pass",
       "grep of node:fs/promises outside src/storage returns only an explicit allowlist",
-      "Env var HARNESS_STORE=file selects FileHarnessStore"
+      "Env var HARNESS_STORE=file selects FileHarnessStore",
     ],
     specialty: "general",
-    dependsOn: ["T-001"]
+    dependsOn: ["T-001"],
   },
   {
     id: "T-003",
@@ -85,10 +85,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Types compile across the repo",
       "Existing orchestrator + scheduler tests unchanged and passing",
-      "A test double AgentExecutor is available for unit tests"
+      "A test double AgentExecutor is available for unit tests",
     ],
     specialty: "general",
-    dependsOn: []
+    dependsOn: [],
   },
   {
     id: "T-101",
@@ -100,10 +100,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "All existing channel tests pass",
       "A migration test reads fixtures written by the pre-migration code and validates round-trip",
-      "GUI + Rust TUI continue to parse the feed correctly"
+      "GUI + Rust TUI continue to parse the feed correctly",
     ],
     specialty: "general",
-    dependsOn: ["T-001", "T-002"]
+    dependsOn: ["T-001", "T-002"],
   },
   {
     id: "T-102",
@@ -115,10 +115,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "rly up / rly status / rly list-workspaces all work unchanged",
       "Pre-migration workspace registry JSON still reads successfully",
-      "Tests updated to inject a store"
+      "Tests updated to inject a store",
     ],
     specialty: "general",
-    dependsOn: ["T-101"]
+    dependsOn: ["T-101"],
   },
   {
     id: "T-103",
@@ -130,10 +130,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "End-to-end `pnpm demo` produces an equivalent artifact tree",
       "Orchestrator + scheduler tests unchanged",
-      "Artifacts round-trip via readCommandResult / readFailureClassification"
+      "Artifacts round-trip via readCommandResult / readFailureClassification",
     ],
     specialty: "general",
-    dependsOn: ["T-101"]
+    dependsOn: ["T-101"],
   },
   {
     id: "T-104",
@@ -145,10 +145,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "rly crosslink status, rly decisions, named agents all work",
       "No new hardcoded homedir() calls introduced",
-      "Unit tests updated to inject store"
+      "Unit tests updated to inject store",
     ],
     specialty: "general",
-    dependsOn: ["T-101"]
+    dependsOn: ["T-101"],
   },
   {
     id: "T-105",
@@ -160,10 +160,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Orchestrator runs and chat sessions produce indistinguishable ticket entries on the channel board",
       "rly board and GUI Board render identical contents",
-      "Legacy per-run-ledger readers fall back cleanly when channel board is empty"
+      "Legacy per-run-ledger readers fall back cleanly when channel board is empty",
     ],
     specialty: "general",
-    dependsOn: []
+    dependsOn: [],
   },
   {
     id: "T-201",
@@ -175,10 +175,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Two concurrent tickets on the same repo use separate worktrees",
       "Killing mid-ticket leaves worktree + .relay-state.json on disk",
-      "Worktrees are removed after successful completion"
+      "Worktrees are removed after successful completion",
     ],
     specialty: "general",
-    dependsOn: ["T-003"]
+    dependsOn: ["T-003"],
   },
   {
     id: "T-202",
@@ -190,10 +190,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "TicketScheduler constructed with AgentExecutor instead of dispatch callback",
       "All orchestrator tests pass",
-      "Stream yields at least start/stdout/exit events"
+      "Stream yields at least start/stdout/exit events",
     ],
     specialty: "general",
-    dependsOn: ["T-003", "T-201"]
+    dependsOn: ["T-003", "T-201"],
   },
   {
     id: "T-203",
@@ -205,10 +205,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "kill -9 during a ticket -> restart -> ticket resumes and completes",
       "Recovered tickets surface in rly board",
-      "Integration test covers kill-restart-complete cycle"
+      "Integration test covers kill-restart-complete cycle",
     ],
     specialty: "general",
-    dependsOn: ["T-202", "T-103", "T-105"]
+    dependsOn: ["T-202", "T-103", "T-105"],
   },
   {
     id: "T-204",
@@ -220,10 +220,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Two concurrent runs with 3 tickets each + cap=4 -> max 4 in-flight agents",
       "Cap respects hot-reload of the config value",
-      "Metric/log line on block/unblock"
+      "Metric/log line on block/unblock",
     ],
     specialty: "general",
-    dependsOn: ["T-202"]
+    dependsOn: ["T-202"],
   },
   {
     id: "T-301",
@@ -235,10 +235,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "A simulated hang fires stuck_agent within threshold + 10s",
       "Threshold configurable per ticket/run",
-      "Event posted to channel feed"
+      "Event posted to channel feed",
     ],
     specialty: "general",
-    dependsOn: ["T-202"]
+    dependsOn: ["T-202"],
   },
   {
     id: "T-302",
@@ -250,10 +250,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Single hang recovers by retry",
       "Repeated hang escalates via harness_escalate",
-      "Ticket ledger ends in failed_stuck status when exhausted"
+      "Ticket ledger ends in failed_stuck status when exhausted",
     ],
     specialty: "general",
-    dependsOn: ["T-301"]
+    dependsOn: ["T-301"],
   },
   {
     id: "T-303",
@@ -265,10 +265,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Three integration tests, one per severity",
       "Channel always receives an escalation post",
-      "Webhook/pager endpoints configurable at runtime"
+      "Webhook/pager endpoints configurable at runtime",
     ],
     specialty: "general",
-    dependsOn: ["T-101", "T-105"]
+    dependsOn: ["T-101", "T-105"],
   },
   {
     id: "T-304",
@@ -280,10 +280,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "rly board renders stuck + escalated tickets distinctly",
       "Rust TUI and Tauri GUI show the new statuses",
-      "Status changes propagate within a render tick"
+      "Status changes propagate within a render tick",
     ],
     specialty: "general",
-    dependsOn: ["T-301", "T-303"]
+    dependsOn: ["T-301", "T-303"],
   },
   {
     id: "T-401",
@@ -295,10 +295,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "External Claude session with remote MCP URL can call harness_list_runs",
       "Auth: missing/invalid token rejected",
-      "Existing stdio path unchanged"
+      "Existing stdio path unchanged",
     ],
     specialty: "general",
-    dependsOn: ["T-002"]
+    dependsOn: ["T-002"],
   },
   {
     id: "T-402",
@@ -310,10 +310,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "pnpm demo works end-to-end against Postgres",
       "Two harness processes on the same DB don't corrupt state",
-      "Migrations run idempotently"
+      "Migrations run idempotently",
     ],
     specialty: "general",
-    dependsOn: ["T-001"]
+    dependsOn: ["T-001"],
   },
   {
     id: "T-403",
@@ -325,10 +325,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "2-ticket demo against a kind cluster completes",
       "Artifacts land in the configured HarnessStore",
-      "Failed pods leave logs + PVC preserved for inspection"
+      "Failed pods leave logs + PVC preserved for inspection",
     ],
     specialty: "devops",
-    dependsOn: ["T-202", "T-401"]
+    dependsOn: ["T-202", "T-401"],
   },
   {
     id: "T-404",
@@ -340,10 +340,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "docker compose up boots a working relay over HTTP backed by Postgres",
       "Image is reproducible (no host mounts required)",
-      "README quickstart section added"
+      "README quickstart section added",
     ],
     specialty: "devops",
-    dependsOn: ["T-401", "T-402"]
+    dependsOn: ["T-401", "T-402"],
   },
   {
     id: "T-501",
@@ -355,10 +355,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Plugin off: harness behavior unchanged",
       "Plugin on: planner classification pulls graph results instead of grep for architecture queries",
-      "Graph rebuild triggered on branch switch inside the sandbox worktree, not the user's repo"
+      "Graph rebuild triggered on branch switch inside the sandbox worktree, not the user's repo",
     ],
     specialty: "general",
-    dependsOn: ["T-401", "T-102"]
+    dependsOn: ["T-401", "T-102"],
   },
   {
     id: "T-502",
@@ -370,10 +370,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Adding hooks-overrides/atlas.json affects only Atlas sessions",
       "Merge precedence matches docs: base -> role -> workspace+role",
-      "No regression to existing single-settings callers"
+      "No regression to existing single-settings callers",
     ],
     specialty: "general",
-    dependsOn: ["T-102"]
+    dependsOn: ["T-102"],
   },
   {
     id: "T-503",
@@ -385,10 +385,10 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "Atlas can DM an implementer; recipient sees message on next tool call",
       "Mail survives restarts",
-      "Tests cover send / check / unread counting"
+      "Tests cover send / check / unread counting",
     ],
     specialty: "general",
-    dependsOn: ["T-101"]
+    dependsOn: ["T-101"],
   },
   {
     id: "T-504",
@@ -400,11 +400,11 @@ const PLAN: PlanItem[] = [
     acceptanceCriteria: [
       "A formula TOML is discovered and selectable by the planner",
       "Selected formula produces a deterministic ticket plan",
-      "At least one shipped formula exercised by the demo"
+      "At least one shipped formula exercised by the demo",
     ],
     specialty: "general",
-    dependsOn: ["T-304", "T-204"]
-  }
+    dependsOn: ["T-304", "T-204"],
+  },
 ];
 
 async function main(): Promise<void> {
@@ -421,8 +421,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const workspace =
-    (await resolveWorkspaceForRepo(REPO)) ?? (await registerWorkspace(REPO));
+  const workspace = (await resolveWorkspaceForRepo(REPO)) ?? (await registerWorkspace(REPO));
   const artifactsDir = join(getWorkspaceDir(workspace.workspaceId), "artifacts");
   const artifactStore = new LocalArtifactStore(artifactsDir, getHarnessStore());
 
@@ -439,7 +438,7 @@ async function main(): Promise<void> {
     verificationCommands: [],
     docsToUpdate: [],
     dependsOn: item.dependsOn,
-    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
   }));
 
   const ticketLedger = initializeTicketLedger(tickets, runId);
@@ -451,7 +450,7 @@ async function main(): Promise<void> {
     suggestedSpecialties: ["general", "devops"] as string[],
     estimatedTicketCount: tickets.length,
     needsDesignDoc: false,
-    needsUserApproval: true
+    needsUserApproval: true,
   };
 
   const run: HarnessRun = {
@@ -471,12 +470,12 @@ async function main(): Promise<void> {
         title: "Pluggable Relay refactor",
         featureRequest:
           "Pluggable Relay: storage + executor + MCP transport; adopt select Gas Town concepts; optional graphify plugin",
-        repoRoot: REPO
+        repoRoot: REPO,
       },
       classification,
       tickets,
       finalVerification: { commands: ["pnpm build", "pnpm test"] },
-      docsToUpdate: ["README.md"]
+      docsToUpdate: ["README.md"],
     },
     events: [],
     evidence: [],
@@ -485,7 +484,7 @@ async function main(): Promise<void> {
     phaseLedgerPath: null,
     ticketLedger,
     ticketLedgerPath: null,
-    runIndexPath: null
+    runIndexPath: null,
   };
 
   // Per-run snapshot (immutable decomposition record).
@@ -503,8 +502,8 @@ async function main(): Promise<void> {
       updatedAt: now,
       completedAt: null,
       phaseLedgerPath: null,
-      artifactsRoot: join(artifactsDir, runId)
-    }
+      artifactsRoot: join(artifactsDir, runId),
+    },
   });
 
   // Unified live ticket board — rly board + GUI both read this.
@@ -518,7 +517,7 @@ async function main(): Promise<void> {
         channelId,
         workspaceId: workspace.workspaceId,
         ticketCount: tickets.length,
-        artifactsDir: join(artifactsDir, runId)
+        artifactsDir: join(artifactsDir, runId),
       },
       null,
       2

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -9,7 +9,7 @@ import {
   type AgentCapability,
   type FailureClassification,
   type AgentProvider,
-  type WorkRequest
+  type WorkRequest,
 } from "../domain/agent.js";
 import { parsePhasePlan, type PhasePlan } from "../domain/phase-plan.js";
 import type { CommandInvoker } from "./command-invoker.js";
@@ -80,7 +80,7 @@ const CLAUDE_PASS_ENV: readonly string[] = [
   // legacy alias. Keep both so users on either convention work.
   "GOOGLE_CLOUD_PROJECT",
   "GOOGLE_CLOUD_QUOTA_PROJECT",
-  "CLOUDSDK_CORE_PROJECT"
+  "CLOUDSDK_CORE_PROJECT",
 ];
 
 /**
@@ -100,7 +100,7 @@ const CODEX_PASS_ENV: readonly string[] = [
   "AZURE_OPENAI_API_VERSION",
   "AZURE_OPENAI_DEPLOYMENT",
   "AZURE_OPENAI_DEPLOYMENT_NAME",
-  "CODEX_HOME"
+  "CODEX_HOME",
 ];
 
 abstract class CliAgentBase implements Agent {
@@ -129,7 +129,7 @@ abstract class CliAgentBase implements Agent {
 
     return {
       ...response.parsed,
-      rawResponse: response.rawResponse
+      rawResponse: response.rawResponse,
     };
   }
 
@@ -142,9 +142,7 @@ abstract class CliAgentBase implements Agent {
       proposedCommands: baseResult.proposedCommands,
       blockers: baseResult.blockers,
       failureClassification: baseResult.failureClassification,
-      phasePlan: baseResult.phasePlan
-        ? parsePhasePlan(baseResult.phasePlan)
-        : undefined
+      phasePlan: baseResult.phasePlan ? parsePhasePlan(baseResult.phasePlan) : undefined,
     };
   }
 
@@ -178,7 +176,7 @@ export class CodexCliAgent extends CliAgentBase {
         "--output-schema",
         schemaPath,
         "-o",
-        outputPath
+        outputPath,
       ];
 
       if (autoApprove) {
@@ -199,7 +197,7 @@ export class CodexCliAgent extends CliAgentBase {
         // Codex authenticates via its own config or API key env vars. The
         // invoker strips secrets by default (OSS-03); opt these back in so
         // users who rely on env-based auth aren't silently broken.
-        passEnv: [...CODEX_PASS_ENV]
+        passEnv: [...CODEX_PASS_ENV],
       });
 
       if (result.exitCode !== 0) {
@@ -210,12 +208,12 @@ export class CodexCliAgent extends CliAgentBase {
 
       return {
         rawResponse,
-        parsed: this.normalizePayload(JSON.parse(rawResponse))
+        parsed: this.normalizePayload(JSON.parse(rawResponse)),
       };
     } finally {
       await rm(tempDir, {
         recursive: true,
-        force: true
+        force: true,
       });
     }
   }
@@ -245,7 +243,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       "--output-format",
       "json",
       "--json-schema",
-      JSON.stringify(agentResultJsonSchema)
+      JSON.stringify(agentResultJsonSchema),
     ];
 
     if (autoApprove) {
@@ -268,7 +266,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       // Claude CLI authenticates via its own config dir or API key env vars.
       // The invoker strips secrets by default (OSS-03); opt these back in so
       // users who rely on env-based auth aren't silently broken.
-      passEnv: [...CLAUDE_PASS_ENV]
+      passEnv: [...CLAUDE_PASS_ENV],
     });
 
     if (result.exitCode !== 0) {
@@ -277,7 +275,7 @@ export class ClaudeCliAgent extends CliAgentBase {
 
     return {
       rawResponse: result.stdout,
-      parsed: this.normalizePayload(JSON.parse(result.stdout))
+      parsed: this.normalizePayload(JSON.parse(result.stdout)),
     };
   }
 
@@ -298,7 +296,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       "stream-json",
       "--verbose",
       "--json-schema",
-      JSON.stringify(agentResultJsonSchema)
+      JSON.stringify(agentResultJsonSchema),
     ];
     if (autoApprove) args.push("--dangerously-skip-permissions");
     else args.push("--permission-mode", "default");
@@ -310,7 +308,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       command: "claude",
       args,
       cwd: this.cwd,
-      timeoutMs: 300_000
+      timeoutMs: 300_000,
     });
 
     let stdoutBuf = "";
@@ -377,7 +375,7 @@ export class ClaudeCliAgent extends CliAgentBase {
     }
     return {
       rawResponse: raw,
-      parsed: this.normalizePayload(JSON.parse(raw))
+      parsed: this.normalizePayload(JSON.parse(raw)),
     };
   }
 }
@@ -433,7 +431,7 @@ function buildPrompt(agentName: string, request: WorkRequest): string {
     "If this is classification work (kind=classify_request), return a classification object with: tier (trivial|bugfix|feature_small|feature_large|architectural|multi_repo), rationale, suggestedSpecialties, estimatedTicketCount, needsDesignDoc, needsUserApproval.",
     "If this is ticket decomposition work (kind=decompose_tickets), return a ticketPlan object with parallelizable tickets and dependsOn edges.",
     "If this is design doc work (kind=generate_design_doc), provide the design document in your summary.",
-    "Otherwise, omit phasePlan, classification, and ticketPlan."
+    "Otherwise, omit phasePlan, classification, and ticketPlan.",
   ];
 
   return lines.join("\n");

--- a/src/agents/command-invoker.ts
+++ b/src/agents/command-invoker.ts
@@ -47,7 +47,7 @@ export const DEFAULT_ENV_WHITELIST: ReadonlySet<string> = new Set([
   "TMP",
   "TERM",
   "PWD",
-  "NODE_ENV"
+  "NODE_ENV",
 ]);
 
 /**
@@ -55,11 +55,7 @@ export const DEFAULT_ENV_WHITELIST: ReadonlySet<string> = new Set([
  * full locale family; `HARNESS_*` / `RELAY_*` are the harness's own namespace
  * for wiring workspace paths + feature flags into dispatched subprocesses.
  */
-const DEFAULT_PREFIX_WHITELIST: readonly string[] = [
-  "LC_",
-  "HARNESS_",
-  "RELAY_"
-];
+const DEFAULT_PREFIX_WHITELIST: readonly string[] = ["LC_", "HARNESS_", "RELAY_"];
 
 /**
  * Matches env var names that look like credentials. Covers suffix forms
@@ -113,10 +109,7 @@ export function sanitizeEnv(
   opts: SanitizeEnvOptions = {}
 ): Record<string, string> {
   const passEnvSet = new Set(opts.passEnv ?? []);
-  const explicitKeys = new Set<string>([
-    ...passEnvSet,
-    ...Object.keys(opts.env ?? {})
-  ]);
+  const explicitKeys = new Set<string>([...passEnvSet, ...Object.keys(opts.env ?? {})]);
   const result: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(parentEnv)) {
@@ -153,7 +146,7 @@ export function sanitizeEnv(
 function buildChildEnv(invocation: CommandInvocation): Record<string, string> {
   return sanitizeEnv(process.env, {
     passEnv: invocation.passEnv,
-    env: invocation.env
+    env: invocation.env,
   });
 }
 
@@ -179,9 +172,7 @@ export interface SpawnedProcess {
   /** Subscribe to stderr chunks as the child emits them. */
   onStderr(listener: (chunk: string) => void): void;
   /** Fires exactly once when the child exits (code/signal per Node semantics). */
-  onExit(
-    listener: (exitCode: number | null, signal: NodeJS.Signals | null) => void
-  ): void;
+  onExit(listener: (exitCode: number | null, signal: NodeJS.Signals | null) => void): void;
   /** Fires when the spawn itself fails (e.g. ENOENT for a missing binary). */
   onError(listener: (error: Error) => void): void;
   /**
@@ -217,15 +208,11 @@ export interface CommandInvoker {
 export class NodeCommandInvoker implements CommandInvoker {
   async exec(invocation: CommandInvocation): Promise<CommandResult> {
     return new Promise((resolve, reject) => {
-      const child: ChildProcessWithoutNullStreams = spawn(
-        invocation.command,
-        invocation.args,
-        {
-          cwd: invocation.cwd,
-          env: buildChildEnv(invocation),
-          stdio: "pipe"
-        }
-      );
+      const child: ChildProcessWithoutNullStreams = spawn(invocation.command, invocation.args, {
+        cwd: invocation.cwd,
+        env: buildChildEnv(invocation),
+        stdio: "pipe",
+      });
 
       let stdout = "";
       let stderr = "";
@@ -260,7 +247,7 @@ export class NodeCommandInvoker implements CommandInvoker {
         resolve({
           stdout,
           stderr,
-          exitCode: code ?? 1
+          exitCode: code ?? 1,
         });
       });
 
@@ -285,15 +272,11 @@ export class NodeCommandInvoker implements CommandInvoker {
    * same child.
    */
   spawn(invocation: CommandInvocation): SpawnedProcess {
-    const child: ChildProcessWithoutNullStreams = spawn(
-      invocation.command,
-      invocation.args,
-      {
-        cwd: invocation.cwd,
-        env: buildChildEnv(invocation),
-        stdio: "pipe"
-      }
-    );
+    const child: ChildProcessWithoutNullStreams = spawn(invocation.command, invocation.args, {
+      cwd: invocation.cwd,
+      env: buildChildEnv(invocation),
+      stdio: "pipe",
+    });
 
     if (invocation.stdin) {
       child.stdin.write(invocation.stdin);
@@ -319,7 +302,7 @@ export class NodeCommandInvoker implements CommandInvoker {
       },
       kill(signal) {
         return child.kill(signal);
-      }
+      },
     };
   }
 }

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -19,32 +19,32 @@ const AGENT_SPECS: AgentSpec[] = [
     id: "atlas",
     displayName: "Atlas (Planner)",
     role: "planner",
-    specialties: ["general"]
+    specialties: ["general"],
   },
   {
     id: "pixel",
     displayName: "Pixel (UI Engineer)",
     role: "implementer",
-    specialties: ["ui", "general"]
+    specialties: ["ui", "general"],
   },
   {
     id: "forge",
     displayName: "Forge (Backend Engineer)",
     role: "implementer",
-    specialties: ["api_crud", "business_logic", "general"]
+    specialties: ["api_crud", "business_logic", "general"],
   },
   {
     id: "lens",
     displayName: "Lens (Code Reviewer)",
     role: "reviewer",
-    specialties: ["general", "ui", "business_logic", "api_crud"]
+    specialties: ["general", "ui", "business_logic", "api_crud"],
   },
   {
     id: "probe",
     displayName: "Probe (Test Engineer)",
     role: "tester",
-    specialties: ["general", "ui", "business_logic", "api_crud"]
-  }
+    specialties: ["general", "ui", "business_logic", "api_crud"],
+  },
 ];
 
 interface AgentFactoryOptions {
@@ -73,8 +73,7 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
     const AgentClass = provider === "codex" ? CodexCliAgent : ClaudeCliAgent;
     // Only Claude supports tool_use stream-json today — passing this to
     // CodexCliAgent is harmless but ignored there.
-    const onStreamLine =
-      provider === "claude" ? options.onStreamLineFor?.(spec) : undefined;
+    const onStreamLine = provider === "claude" ? options.onStreamLineFor?.(spec) : undefined;
 
     return new AgentClass({
       id: spec.id,
@@ -82,12 +81,12 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
       provider,
       capability: {
         role: spec.role,
-        specialties: spec.specialties
+        specialties: spec.specialties,
       },
       cwd: options.cwd,
       model,
       invoker,
-      onStreamLine
+      onStreamLine,
     });
   });
 }

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -1,9 +1,4 @@
-import {
-  type Agent,
-  type AgentRole,
-  type WorkRequest,
-  roleForWork
-} from "../domain/agent.js";
+import { type Agent, type AgentRole, type WorkRequest, roleForWork } from "../domain/agent.js";
 import type { AgentSpecialty } from "../domain/specialty.js";
 
 export class AgentRegistry {
@@ -19,7 +14,7 @@ export class AgentRegistry {
       .filter((agent) => agent.capability.role === requiredRole)
       .map((agent) => ({
         agent,
-        score: scoreAgent(agent.capability.role, agent.capability.specialties, request.specialty)
+        score: scoreAgent(agent.capability.role, agent.capability.specialties, request.specialty),
       }))
       .sort((left, right) => right.score - left.score);
 

--- a/src/channels/ao-notifier.ts
+++ b/src/channels/ao-notifier.ts
@@ -1,9 +1,4 @@
-import type {
-  Notifier,
-  NotifyAction,
-  NotifyContext,
-  OrchestratorEvent
-} from "@aoagents/ao-core";
+import type { Notifier, NotifyAction, NotifyContext, OrchestratorEvent } from "@aoagents/ao-core";
 
 import type { ChannelStore } from "./channel-store.js";
 
@@ -30,15 +25,12 @@ export class HarnessChannelNotifier implements Notifier {
     await this.channelStore.post(this.defaultChannelId, this.formatEventMessage(event), {
       type: "event",
       fromDisplayName: "orchestrator",
-      metadata: this.buildEventMetadata(event)
+      metadata: this.buildEventMetadata(event),
     });
   }
 
   /** Push a notification with actionable links appended to the body. */
-  async notifyWithActions(
-    event: OrchestratorEvent,
-    actions: NotifyAction[]
-  ): Promise<void> {
+  async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
     const base = this.formatEventMessage(event);
     const actionLines = actions
       .map((a) => {
@@ -52,7 +44,7 @@ export class HarnessChannelNotifier implements Notifier {
     await this.channelStore.post(this.defaultChannelId, content, {
       type: "event",
       fromDisplayName: "orchestrator",
-      metadata: this.buildEventMetadata(event)
+      metadata: this.buildEventMetadata(event),
     });
   }
 
@@ -72,7 +64,7 @@ export class HarnessChannelNotifier implements Notifier {
     return this.channelStore.post(channelId, message, {
       type: "message",
       fromDisplayName: "orchestrator",
-      metadata
+      metadata,
     });
   }
 
@@ -91,7 +83,7 @@ export class HarnessChannelNotifier implements Notifier {
       timestamp: event.timestamp.toISOString(),
       // Preserve the event payload — the channel store will JSON-serialize
       // this so downstream readers keep seeing string-valued metadata.
-      data: event.data
+      data: event.data,
     };
   }
 }

--- a/src/channels/board-resolver.ts
+++ b/src/channels/board-resolver.ts
@@ -42,7 +42,7 @@ export async function resolveBoardTickets(
   if (channelTickets.length > 0) {
     return channelTickets.map((entry) => ({
       entry,
-      runId: entry.runId ?? null
+      runId: entry.runId ?? null,
     }));
   }
 

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -13,7 +13,7 @@ import {
   type ChannelRef,
   type ChannelRunLink,
   type ChannelStatus,
-  type RepoAssignment
+  type RepoAssignment,
 } from "../domain/channel.js";
 import { buildDecisionId, type Decision } from "../domain/decision.js";
 import type { TrackedPrRow } from "../domain/pr-row.js";
@@ -134,7 +134,7 @@ export class ChannelStore {
       repoAssignments: assignments,
       primaryWorkspaceId,
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
     };
 
     await this.writeChannel(channel);
@@ -146,10 +146,7 @@ export class ChannelStore {
   async getChannel(channelId: string): Promise<Channel | null> {
     assertSafeSegment(channelId, "channelId");
     try {
-      const raw = await readFile(
-        join(this.channelsDir, `${channelId}.json`),
-        "utf8"
-      );
+      const raw = await readFile(join(this.channelsDir, `${channelId}.json`), "utf8");
       return JSON.parse(raw) as Channel;
     } catch {
       return null;
@@ -164,9 +161,7 @@ export class ChannelStore {
       if (!file.endsWith(".json")) continue;
 
       try {
-        const raw = JSON.parse(
-          await readFile(join(this.channelsDir, file), "utf8")
-        ) as Channel;
+        const raw = JSON.parse(await readFile(join(this.channelsDir, file), "utf8")) as Channel;
 
         if (!status || raw.status === status) {
           channels.push(raw);
@@ -201,7 +196,7 @@ export class ChannelStore {
     const updated: Channel = {
       ...channel,
       ...patch,
-      updatedAt: new Date().toISOString()
+      updatedAt: new Date().toISOString(),
     };
 
     // Reconcile primaryWorkspaceId against the (possibly updated) repo list.
@@ -221,8 +216,7 @@ export class ChannelStore {
     const assignments = updated.repoAssignments ?? [];
     const currentPrimary = updated.primaryWorkspaceId;
     const primaryStillValid =
-      !!currentPrimary &&
-      assignments.some((a) => a.workspaceId === currentPrimary);
+      !!currentPrimary && assignments.some((a) => a.workspaceId === currentPrimary);
 
     if (primaryExplicitlyCleared) {
       updated.primaryWorkspaceId = undefined;
@@ -252,9 +246,7 @@ export class ChannelStore {
     }
 
     if (channel.primaryWorkspaceId) {
-      const match = assignments.find(
-        (a) => a.workspaceId === channel.primaryWorkspaceId
-      );
+      const match = assignments.find((a) => a.workspaceId === channel.primaryWorkspaceId);
       if (match) return match;
     }
 
@@ -281,7 +273,10 @@ export class ChannelStore {
 
   // --- Members ---
 
-  async joinChannel(channelId: string, member: Omit<ChannelMember, "joinedAt" | "status">): Promise<Channel | null> {
+  async joinChannel(
+    channelId: string,
+    member: Omit<ChannelMember, "joinedAt" | "status">
+  ): Promise<Channel | null> {
     assertSafeSegment(channelId, "channelId");
     const channel = await this.getChannel(channelId);
     if (!channel) return null;
@@ -292,7 +287,7 @@ export class ChannelStore {
     const fullMember: ChannelMember = {
       ...member,
       joinedAt: now,
-      status: "active"
+      status: "active",
     };
 
     if (existing >= 0) {
@@ -309,7 +304,7 @@ export class ChannelStore {
       fromAgentId: member.agentId,
       fromDisplayName: member.displayName,
       content: `${member.displayName} joined the channel.`,
-      metadata: { role: member.role, provider: member.provider }
+      metadata: { role: member.role, provider: member.provider },
     });
 
     return channel;
@@ -332,7 +327,7 @@ export class ChannelStore {
       fromAgentId: agentId,
       fromDisplayName: member.displayName,
       content: `${member.displayName} left the channel.`,
-      metadata: {}
+      metadata: {},
     });
 
     return channel;
@@ -362,13 +357,10 @@ export class ChannelStore {
       fromDisplayName: input.fromDisplayName,
       content: input.content,
       metadata: normalizeMetadata(input.metadata),
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
     };
 
-    await appendFile(
-      join(feedDir, "feed.jsonl"),
-      JSON.stringify(entry) + "\n"
-    );
+    await appendFile(join(feedDir, "feed.jsonl"), JSON.stringify(entry) + "\n");
 
     // Bump channel-level activity so sorts by updatedAt reflect feed writes.
     await this.touchChannel(channelId);
@@ -399,7 +391,7 @@ export class ChannelStore {
       fromAgentId: options?.fromAgentId ?? null,
       fromDisplayName: options?.fromDisplayName ?? "system",
       content,
-      metadata: options?.metadata ?? {}
+      metadata: options?.metadata ?? {},
     });
     return entry.entryId;
   }
@@ -416,9 +408,7 @@ export class ChannelStore {
         .filter(Boolean)
         .map((line) => {
           const entry = JSON.parse(line) as ChannelEntry;
-          entry.metadata = denormalizeMetadata(
-            entry.metadata as Record<string, string>
-          );
+          entry.metadata = denormalizeMetadata(entry.metadata as Record<string, string>);
           return entry;
         });
 
@@ -449,7 +439,7 @@ export class ChannelStore {
       fromAgentId: null,
       fromDisplayName: null,
       content: `Reference added: ${ref.label} (${ref.type}: ${ref.targetId})`,
-      metadata: { refType: ref.type, targetId: ref.targetId }
+      metadata: { refType: ref.type, targetId: ref.targetId },
     });
 
     return channel;
@@ -489,17 +479,14 @@ export class ChannelStore {
       fromAgentId: null,
       fromDisplayName: null,
       content: `Run ${runId} linked to channel.`,
-      metadata: { runId, workspaceId }
+      metadata: { runId, workspaceId },
     });
   }
 
   async readRunLinks(channelId: string): Promise<ChannelRunLink[]> {
     assertSafeSegment(channelId, "channelId");
     try {
-      const raw = await readFile(
-        join(this.channelsDir, channelId, "runs.json"),
-        "utf8"
-      );
+      const raw = await readFile(join(this.channelsDir, channelId, "runs.json"), "utf8");
       return JSON.parse(raw) as ChannelRunLink[];
     } catch {
       return [];
@@ -527,17 +514,12 @@ export class ChannelStore {
       // Any other failure surfaces so a corrupt file isn't silently
       // overwritten by the next snapshot.
       throw new Error(
-        `Failed to read tracked-prs at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Failed to read tracked-prs at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }
 
-  async writeTrackedPrs(
-    channelId: string,
-    rows: TrackedPrRow[]
-  ): Promise<void> {
+  async writeTrackedPrs(channelId: string, rows: TrackedPrRow[]): Promise<void> {
     assertSafeSegment(channelId, "channelId");
     const channelDir = join(this.channelsDir, channelId);
     await mkdir(channelDir, { recursive: true });
@@ -545,11 +527,7 @@ export class ChannelStore {
     const tmpPath = `${path}.tmp.${process.pid}.${channelTicketsTmpCounter++}`;
     await writeFile(
       tmpPath,
-      JSON.stringify(
-        { updatedAt: new Date().toISOString(), rows },
-        null,
-        2
-      )
+      JSON.stringify({ updatedAt: new Date().toISOString(), rows }, null, 2)
     );
     await rename(tmpPath, path);
   }
@@ -603,10 +581,7 @@ export class ChannelStore {
    * `upsertChannelTickets` — this method is primarily for seeders and
    * full-board rewrites.
    */
-  async writeChannelTickets(
-    channelId: string,
-    tickets: TicketLedgerEntry[]
-  ): Promise<void> {
+  async writeChannelTickets(channelId: string, tickets: TicketLedgerEntry[]): Promise<void> {
     assertSafeSegment(channelId, "channelId");
     const channelDir = join(this.channelsDir, channelId);
     await mkdir(channelDir, { recursive: true });
@@ -621,7 +596,7 @@ export class ChannelStore {
       JSON.stringify(
         {
           updatedAt: new Date().toISOString(),
-          tickets
+          tickets,
         },
         null,
         2
@@ -697,22 +672,15 @@ export class ChannelStore {
     // this executes under `pg_advisory_xact_lock`, on FileHarnessStore it
     // serializes through the in-process key-lock. Purely advisory —
     // nothing reads this record today; T-402 consumers layer on top.
-    await this.store.mutate<TicketLockRecord>(
-      STORE_NS.channelTickets,
-      channelId,
-      () => ({
-        updatedAt: new Date().toISOString(),
-        count: merged.length
-      })
-    );
+    await this.store.mutate<TicketLockRecord>(STORE_NS.channelTickets, channelId, () => ({
+      updatedAt: new Date().toISOString(),
+      count: merged.length,
+    }));
 
     return merged;
   }
 
-  private async withChannelLock<T>(
-    channelId: string,
-    fn: () => Promise<T>
-  ): Promise<T> {
+  private async withChannelLock<T>(channelId: string, fn: () => Promise<T>): Promise<T> {
     const prev = channelTicketLocks.get(channelId) ?? Promise.resolve();
     let resolveCurrent!: () => void;
     const current = new Promise<void>((resolve) => {
@@ -759,7 +727,7 @@ export class ChannelStore {
       decisionId: buildDecisionId(),
       channelId,
       ...input,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
     };
 
     const path = join(decisionsDir, `${decision.decisionId}.json`);
@@ -798,8 +766,8 @@ export class ChannelStore {
       metadata: {
         decisionId: decision.decisionId,
         ...(input.runId ? { runId: input.runId } : {}),
-        ...(input.ticketId ? { ticketId: input.ticketId } : {})
-      }
+        ...(input.ticketId ? { ticketId: input.ticketId } : {}),
+      },
     });
 
     return decision;
@@ -829,9 +797,7 @@ export class ChannelStore {
       if (!file.endsWith(".json")) continue;
 
       try {
-        const raw = JSON.parse(
-          await readFile(join(decisionsDir, file), "utf8")
-        ) as Decision;
+        const raw = JSON.parse(await readFile(join(decisionsDir, file), "utf8")) as Decision;
         decisions.push(raw);
       } catch {
         // skip
@@ -881,9 +847,7 @@ const JSON_TAG = "__ah_meta_json::";
  * `JSON_TAG` is also JSON-tagged on write so `denormalizeMetadata` restores
  * the exact original string instead of treating it as a serialized payload.
  */
-function normalizeMetadata(
-  metadata: Record<string, unknown>
-): Record<string, string> {
+function normalizeMetadata(metadata: Record<string, unknown>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(metadata)) {
     if (value === undefined || value === null) continue;
@@ -891,9 +855,7 @@ function normalizeMetadata(
       // Normal case: strings pass through verbatim. The rare string that
       // coincidentally starts with the tag must be tagged too, otherwise
       // the reader would mis-parse it.
-      out[key] = value.startsWith(JSON_TAG)
-        ? JSON_TAG + JSON.stringify(value)
-        : value;
+      out[key] = value.startsWith(JSON_TAG) ? JSON_TAG + JSON.stringify(value) : value;
     } else {
       out[key] = JSON_TAG + JSON.stringify(value);
     }

--- a/src/cli/agent-wrapper.ts
+++ b/src/cli/agent-wrapper.ts
@@ -9,7 +9,7 @@ export async function ensureClaudeMcpConfig(input: {
   paths: HarnessWorkspacePaths;
 }): Promise<string> {
   await mkdir(input.paths.rootDir, {
-    recursive: true
+    recursive: true,
   });
 
   const path = join(input.paths.rootDir, "claude.mcp.json");
@@ -17,20 +17,15 @@ export async function ensureClaudeMcpConfig(input: {
     mcpServers: {
       relay: {
         command: process.execPath,
-        args: [
-          input.cliEntrypoint,
-          "mcp-server",
-          "--workspace",
-          input.cwd
-        ],
+        args: [input.cliEntrypoint, "mcp-server", "--workspace", input.cwd],
         env: {
           RELAY_HOME: input.paths.rootDir,
           RELAY_ARTIFACTS_DIR: input.paths.artifactsDir,
           RELAY_RUNS_INDEX: input.paths.runsIndexPath,
-          RELAY_PROVIDER: "claude"
-        }
-      }
-    }
+          RELAY_PROVIDER: "claude",
+        },
+      },
+    },
   };
 
   await writeFile(path, JSON.stringify(config, null, 2));
@@ -49,7 +44,7 @@ const HARNESS_SYSTEM_PROMPT = [
   "- crosslink_register: Update your session description so others know what you're working on.",
   "",
   "When you receive a crosslink message (prefixed with [CROSSLINK INBOUND]), read it carefully and use crosslink_reply to respond.",
-  "If you need information from another repo, use crosslink_discover to find the right session, then crosslink_send to ask."
+  "If you need information from another repo, use crosslink_discover to find the right session, then crosslink_send to ask.",
 ].join("\n");
 
 /**
@@ -79,7 +74,7 @@ export function buildClaudeLaunchArgs(input: {
     "--mcp-config",
     input.mcpConfigPath,
     "--append-system-prompt",
-    HARNESS_SYSTEM_PROMPT
+    HARNESS_SYSTEM_PROMPT,
   ];
   if (input.autoApprove) {
     // Claude Code's flag for unattended runs. No per-tool prompts.
@@ -102,10 +97,10 @@ export function buildCodexLaunchArgs(input: {
       input.cliEntrypoint,
       "mcp-server",
       "--workspace",
-      input.cwd
+      input.cwd,
     ])}`,
     "-c",
-    `mcp_servers.relay.env.RELAY_PROVIDER=${tomlString("codex")}`
+    `mcp_servers.relay.env.RELAY_PROVIDER=${tomlString("codex")}`,
   ];
   if (input.autoApprove) {
     // Codex CLI's unattended mode. If your codex version rejects this flag,

--- a/src/cli/chat-context.ts
+++ b/src/cli/chat-context.ts
@@ -20,7 +20,7 @@ function collectRepoContext(repoPath: string): string {
       return execFileSync("git", ["-C", repoPath, ...args], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
-        timeout: 2000
+        timeout: 2000,
       }).trim();
     } catch {
       return null;
@@ -71,11 +71,7 @@ export function readAgentsMdSummary(repoPath: string, limit = 40): string | null
     const path = join(repoPath, name);
     if (!existsSync(path)) continue;
     try {
-      const head = readFileSync(path, "utf8")
-        .split("\n")
-        .slice(0, limit)
-        .join("\n")
-        .trimEnd();
+      const head = readFileSync(path, "utf8").split("\n").slice(0, limit).join("\n").trimEnd();
       return head.length > 0 ? head : null;
     } catch {
       return null;
@@ -129,9 +125,7 @@ export async function buildSystemPrompt(input: {
     // default unprefixed chat continues to speak from the primary repo.
     const isAssociated = Boolean(
       input.alias &&
-        assignments.some(
-          (r) => r.alias === input.alias && r.workspaceId !== primary.workspaceId
-        )
+      assignments.some((r) => r.alias === input.alias && r.workspaceId !== primary.workspaceId)
     );
 
     if (isAssociated) {
@@ -151,8 +145,7 @@ export async function buildSystemPrompt(input: {
       const selfCtx = collectRepoContext(self.repoPath);
       if (selfCtx) {
         parts.push(
-          "\nYour repo context (read at session start — may be stale after long runs):\n" +
-            selfCtx
+          "\nYour repo context (read at session start — may be stale after long runs):\n" + selfCtx
         );
       }
 
@@ -194,7 +187,7 @@ export async function buildSystemPrompt(input: {
         const blocks: string[] = [
           `\n### Associated repos`,
           `These repos are attached to the channel but you do NOT work in them directly. ` +
-            `An associated agent is (or can be) attached to each one.`
+            `An associated agent is (or can be) attached to each one.`,
         ];
         for (const r of associated) {
           const aName = r.repoPath.split("/").pop() ?? r.repoPath;
@@ -255,26 +248,26 @@ export async function buildSystemPrompt(input: {
 
   parts.push(
     `\n\n## Shared Ticket Board & Decisions\n\n` +
-    `Ticket board: \`${ticketsPath}\`\n` +
-    `Decisions dir: \`${decisionsDir}/\`\n\n` +
-    `IMPORTANT: When asked about tickets, always READ \`${ticketsPath}\` first. ` +
-    `Do not guess or say tickets don't exist without checking the file.\n\n` +
-    `This file is the unified board shared by chat and orchestrator runs. ` +
-    `When creating tickets, write to \`${ticketsPath}\` as JSON: ` +
-    `\`{"updatedAt": "<ISO-8601>", "tickets": [<TicketLedgerEntry>...]}\`. ` +
-    `Each ticket must use the full TicketLedgerEntry shape: ` +
-    `\`{"ticketId": "T-1", "title": "...", "specialty": "general"|"ui"|"business_logic"|"api_crud"|"devops"|"testing", ` +
-    `"status": "pending"|"blocked"|"ready"|"executing"|"verifying"|"retry"|"completed"|"failed", ` +
-    `"dependsOn": [], "assignedAgentId": null, "assignedAgentName": null, "crosslinkSessionId": null, ` +
-    `"verification": "pending"|"running"|"passed"|"failed_recoverable"|"failed_terminal", ` +
-    `"lastClassification": null, "chosenNextAction": null, "attempt": 0, ` +
-    `"startedAt": null, "completedAt": null, "updatedAt": "<ISO-8601>", "runId": null}\`.\n\n` +
-    `Set \`runId\` to null for chat-created tickets; the orchestrator fills it for run-decomposed tickets. ` +
-    `When starting a ticket set \`status\` to \`executing\` and \`startedAt\` to now; ` +
-    `when done set \`completed\`/\`failed\` and populate \`completedAt\`. ` +
-    `Always read-modify-write the whole file and refresh \`updatedAt\` on every write.\n\n` +
-    `Decisions: write as JSON files in \`${decisionsDir}/\` with ` +
-    `decisionId, title, description, rationale, alternatives, decidedByName, createdAt.`
+      `Ticket board: \`${ticketsPath}\`\n` +
+      `Decisions dir: \`${decisionsDir}/\`\n\n` +
+      `IMPORTANT: When asked about tickets, always READ \`${ticketsPath}\` first. ` +
+      `Do not guess or say tickets don't exist without checking the file.\n\n` +
+      `This file is the unified board shared by chat and orchestrator runs. ` +
+      `When creating tickets, write to \`${ticketsPath}\` as JSON: ` +
+      `\`{"updatedAt": "<ISO-8601>", "tickets": [<TicketLedgerEntry>...]}\`. ` +
+      `Each ticket must use the full TicketLedgerEntry shape: ` +
+      `\`{"ticketId": "T-1", "title": "...", "specialty": "general"|"ui"|"business_logic"|"api_crud"|"devops"|"testing", ` +
+      `"status": "pending"|"blocked"|"ready"|"executing"|"verifying"|"retry"|"completed"|"failed", ` +
+      `"dependsOn": [], "assignedAgentId": null, "assignedAgentName": null, "crosslinkSessionId": null, ` +
+      `"verification": "pending"|"running"|"passed"|"failed_recoverable"|"failed_terminal", ` +
+      `"lastClassification": null, "chosenNextAction": null, "attempt": 0, ` +
+      `"startedAt": null, "completedAt": null, "updatedAt": "<ISO-8601>", "runId": null}\`.\n\n` +
+      `Set \`runId\` to null for chat-created tickets; the orchestrator fills it for run-decomposed tickets. ` +
+      `When starting a ticket set \`status\` to \`executing\` and \`startedAt\` to now; ` +
+      `when done set \`completed\`/\`failed\` and populate \`completedAt\`. ` +
+      `Always read-modify-write the whole file and refresh \`updatedAt\` on every write.\n\n` +
+      `Decisions: write as JSON files in \`${decisionsDir}/\` with ` +
+      `decisionId, title, description, rationale, alternatives, decidedByName, createdAt.`
   );
 
   return parts.join("\n");
@@ -296,9 +289,7 @@ export async function resolveChannelRefs(input: {
       continue;
     }
 
-    const refName = word
-      .slice(1)
-      .replace(/[.,;:!?]+$/, "");
+    const refName = word.slice(1).replace(/[.,;:!?]+$/, "");
 
     if (!refName || seen.has(refName)) {
       continue;
@@ -307,8 +298,7 @@ export async function resolveChannelRefs(input: {
     const refLower = refName.toLowerCase();
     const channel = channels.find(
       (ch) =>
-        ch.name.toLowerCase() === refLower ||
-        ch.name.toLowerCase().replace(/ /g, "-") === refLower
+        ch.name.toLowerCase() === refLower || ch.name.toLowerCase().replace(/ /g, "-") === refLower
     );
 
     if (!channel) {
@@ -351,9 +341,8 @@ export async function resolveChannelRefs(input: {
       if (existsSync(ticketsPath)) {
         try {
           const ticketContent = readFileSync(ticketsPath, "utf8");
-          const truncated = ticketContent.length > 2000
-            ? ticketContent.slice(0, 2000) + "..."
-            : ticketContent;
+          const truncated =
+            ticketContent.length > 2000 ? ticketContent.slice(0, 2000) + "..." : ticketContent;
 
           contextBlocks.push(
             `\n## Tickets from #${channel.name}\n\`\`\`json\n${truncated}\n\`\`\`\n`
@@ -365,9 +354,8 @@ export async function resolveChannelRefs(input: {
     }
   }
 
-  const resolved = contextBlocks.length > 0
-    ? `${input.message}\n${contextBlocks.join("\n")}`
-    : input.message;
+  const resolved =
+    contextBlocks.length > 0 ? `${input.message}\n${contextBlocks.join("\n")}` : input.message;
 
   return { resolved, refs };
 }

--- a/src/cli/chat-rewind.ts
+++ b/src/cli/chat-rewind.ts
@@ -54,14 +54,8 @@ export interface RewindApplyResult {
  */
 export interface RewindDeps {
   channelStore: Pick<ChannelStore, "getChannel">;
-  sessionStore: Pick<
-    SessionStore,
-    "truncateBeforeTimestamp" | "clearClaudeSessionIds"
-  >;
-  gitExec: (
-    args: string[],
-    opts: { cwd: string }
-  ) => Promise<{ stdout: string; stderr: string }>;
+  sessionStore: Pick<SessionStore, "truncateBeforeTimestamp" | "clearClaudeSessionIds">;
+  gitExec: (args: string[], opts: { cwd: string }) => Promise<{ stdout: string; stderr: string }>;
   /** Injectable clock for deterministic test keys. Defaults to `Date.now`. */
   now?: () => number;
 }
@@ -70,7 +64,7 @@ export function defaultRewindDeps(): RewindDeps {
   return {
     channelStore: new ChannelStore(undefined, getHarnessStore()),
     sessionStore: new SessionStore(),
-    gitExec: async (args, opts) => execFileAsync("git", args, { cwd: opts.cwd })
+    gitExec: async (args, opts) => execFileAsync("git", args, { cwd: opts.cwd }),
   };
 }
 
@@ -99,22 +93,20 @@ export async function rewindSnapshot(
   for (const assignment of repos) {
     const refName = rewindRefName(sessionId, key);
     const { stdout: shaOut } = await deps.gitExec(["rev-parse", "HEAD"], {
-      cwd: assignment.repoPath
+      cwd: assignment.repoPath,
     });
     const sha = shaOut.trim();
     if (!sha) {
-      throw new Error(
-        `git rev-parse HEAD produced empty output in ${assignment.repoPath}`
-      );
+      throw new Error(`git rev-parse HEAD produced empty output in ${assignment.repoPath}`);
     }
     await deps.gitExec(["update-ref", refName, sha], {
-      cwd: assignment.repoPath
+      cwd: assignment.repoPath,
     });
     snapshots.push({
       alias: assignment.alias,
       repoPath: assignment.repoPath,
       sha,
-      ref: refName
+      ref: refName,
     });
   }
   return { key, snapshots };
@@ -149,10 +141,9 @@ export async function rewindApply(
   for (const assignment of repos) {
     let sha: string;
     try {
-      const { stdout } = await deps.gitExec(
-        ["rev-parse", "--verify", `${refName}^{commit}`],
-        { cwd: assignment.repoPath }
-      );
+      const { stdout } = await deps.gitExec(["rev-parse", "--verify", `${refName}^{commit}`], {
+        cwd: assignment.repoPath,
+      });
       sha = stdout.trim();
     } catch (err) {
       throw new Error(
@@ -170,7 +161,7 @@ export async function rewindApply(
     let porcelain: string;
     try {
       const { stdout } = await deps.gitExec(["status", "--porcelain"], {
-        cwd: assignment.repoPath
+        cwd: assignment.repoPath,
       });
       porcelain = stdout;
     } catch (err) {
@@ -196,7 +187,7 @@ export async function rewindApply(
     reset.push({
       alias: assignment.alias,
       repoPath: assignment.repoPath,
-      sha
+      sha,
     });
   }
 
@@ -209,10 +200,7 @@ export async function rewindApply(
     sessionId,
     messageTimestamp
   );
-  const cleared = await deps.sessionStore.clearClaudeSessionIds(
-    channelId,
-    sessionId
-  );
+  const cleared = await deps.sessionStore.clearClaudeSessionIds(channelId, sessionId);
 
   return { reset, removedMessages, clearedClaudeSessions: cleared !== null };
 }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -27,9 +27,7 @@ export async function readConfig(): Promise<HarnessGlobalConfig> {
   try {
     const raw = JSON.parse(await readFile(configPath(), "utf8")) as Partial<HarnessGlobalConfig>;
     return {
-      projectDirs: Array.isArray(raw.projectDirs)
-        ? raw.projectDirs.map(expandHome)
-        : []
+      projectDirs: Array.isArray(raw.projectDirs) ? raw.projectDirs.map(expandHome) : [],
     };
   } catch {
     return { projectDirs: [] };

--- a/src/cli/launch-gui-tui.ts
+++ b/src/cli/launch-gui-tui.ts
@@ -14,11 +14,7 @@ function resolveRepoRoot(): string {
   return fileURLToPath(new URL("../..", import.meta.url));
 }
 
-async function runTool(
-  command: string,
-  args: string[],
-  cwd: string
-): Promise<number> {
+async function runTool(command: string, args: string[], cwd: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { cwd, stdio: "inherit" });
     child.on("error", reject);
@@ -54,11 +50,7 @@ export async function launchTui(userCwd: string): Promise<number> {
   if (!existsSync(tuiBinary)) {
     console.log("[rly tui] building release binary (first run — takes ~1 min)…");
     await requireCargo();
-    const buildExit = await runTool(
-      "cargo",
-      ["build", "--release", "-p", "relay-tui"],
-      repoRoot
-    );
+    const buildExit = await runTool("cargo", ["build", "--release", "-p", "relay-tui"], repoRoot);
     if (buildExit !== 0) {
       console.error("[rly tui] build failed — aborting launch.");
       return buildExit;
@@ -70,7 +62,7 @@ export async function launchTui(userCwd: string): Promise<number> {
     command: tuiBinary,
     args: [],
     cwd: userCwd,
-    env: { CLAUDE_BIN: claudeBin }
+    env: { CLAUDE_BIN: claudeBin },
   });
 }
 
@@ -107,19 +99,10 @@ export async function launchGui(options: LaunchGuiOptions = {}): Promise<number>
   // Cargo workspace target, same as relay-tui — gui/src-tauri is a workspace
   // member, so Tauri's bundle lands under <root>/target, not
   // <root>/gui/src-tauri/target.
-  const appPath = join(
-    repoRoot,
-    "target",
-    "release",
-    "bundle",
-    "macos",
-    "Relay.app"
-  );
+  const appPath = join(repoRoot, "target", "release", "bundle", "macos", "Relay.app");
 
   if (options.rebuild || !existsSync(appPath)) {
-    console.log(
-      "[rly gui] building release bundle (first run — takes ~2-3 min)…"
-    );
+    console.log("[rly gui] building release bundle (first run — takes ~2-3 min)…");
     await requireCargo();
     const buildExit = await runTool("pnpm", ["gui:build"], repoRoot);
     if (buildExit !== 0) {
@@ -144,13 +127,11 @@ export function parseGuiFlags(args: string[]): LaunchGuiOptions {
   const known = new Set(["--dev", "--rebuild"]);
   for (const arg of args) {
     if (arg.startsWith("--") && !known.has(arg)) {
-      console.warn(
-        `[rly gui] ignoring unknown flag ${arg}. Supported: --dev, --rebuild.`
-      );
+      console.warn(`[rly gui] ignoring unknown flag ${arg}. Supported: --dev, --rebuild.`);
     }
   }
   return {
     dev: args.includes("--dev"),
-    rebuild: args.includes("--rebuild")
+    rebuild: args.includes("--rebuild"),
   };
 }

--- a/src/cli/launcher.ts
+++ b/src/cli/launcher.ts
@@ -11,9 +11,9 @@ export async function launchInteractiveCommand(input: {
       cwd: input.cwd,
       env: {
         ...process.env,
-        ...input.env
+        ...input.env,
       },
-      stdio: "inherit"
+      stdio: "inherit",
     });
 
     child.on("error", (error) => {

--- a/src/cli/pr-watcher-factory.ts
+++ b/src/cli/pr-watcher-factory.ts
@@ -25,23 +25,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import type { ChannelStore } from "../channels/channel-store.js";
-import {
-  createScm,
-  wrapScm,
-  type HarnessProject,
-  type HarnessScm
-} from "../integrations/scm.js";
-import {
-  PrPoller,
-  type TrackedPr,
-  type TrackedPrSnapshot
-} from "../integrations/pr-poller.js";
+import { createScm, wrapScm, type HarnessProject, type HarnessScm } from "../integrations/scm.js";
+import { PrPoller, type TrackedPr, type TrackedPrSnapshot } from "../integrations/pr-poller.js";
 import type { TrackedPrRow } from "../domain/pr-row.js";
 import { SchedulerFollowUpDispatcher } from "../integrations/scheduler-follow-up-dispatcher.js";
-import type {
-  PollerFactory,
-  PollerHandle
-} from "../orchestrator/orchestrator-v2.js";
+import type { PollerFactory, PollerHandle } from "../orchestrator/orchestrator-v2.js";
 
 // execFile (argv-based) is used deliberately instead of exec (shell string)
 // so repo paths can never be shell-interpreted.
@@ -130,8 +118,7 @@ export function __resetActiveWatcherForTests(): void {
  * Default git runner: `git -C <repoRoot> <...args>`. Kept outside the factory
  * so tests can substitute a mock via `opts.execGit`.
  */
-const defaultExecGit: ExecGit = (repoRoot, args) =>
-  execFileAsync("git", ["-C", repoRoot, ...args]);
+const defaultExecGit: ExecGit = (repoRoot, args) => execFileAsync("git", ["-C", repoRoot, ...args]);
 
 /**
  * Parse both HTTPS and SSH GitHub remotes:
@@ -183,10 +170,7 @@ async function detectRepo(
  * and then at the run-level classification's suggestedBranch. Returns null
  * when nothing plausible is found — we'd rather skip a ticket than guess.
  */
-function branchHintFor(
-  ticketId: string,
-  run: Parameters<PollerFactory>[0]["run"]
-): string | null {
+function branchHintFor(ticketId: string, run: Parameters<PollerFactory>[0]["run"]): string | null {
   // TicketDefinition doesn't carry branchName today, but the classifier does
   // populate `suggestedBranch` on the run-level ClassificationResult when the
   // request came from an issue URL. That branch applies to the whole run, so
@@ -241,8 +225,8 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
               runId: run.id,
               channelId,
               warning: "missing_github_token",
-              component: "pr-watcher"
-            }
+              component: "pr-watcher",
+            },
           })
           .catch((err: unknown) => {
             const message = err instanceof Error ? err.message : String(err);
@@ -256,12 +240,13 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
 
     // Lazy repo detection with memoized result. `undefined` means "not tried",
     // `null` means "tried and failed".
-    const repoPromise = cachedRepo === undefined
-      ? detectRepo(opts.repoRoot, execGit).then((r) => {
-          cachedRepo = r;
-          return r;
-        })
-      : Promise.resolve(cachedRepo);
+    const repoPromise =
+      cachedRepo === undefined
+        ? detectRepo(opts.repoRoot, execGit).then((r) => {
+            cachedRepo = r;
+            return r;
+          })
+        : Promise.resolve(cachedRepo);
 
     // Build the SCM + poller eagerly with a placeholder project; we'll
     // short-circuit `start()` if repo detection failed. This keeps the handle
@@ -287,7 +272,7 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
           const project: HarnessProject = {
             owner: repo.owner,
             name: repo.name,
-            path: opts.repoRoot
+            path: opts.repoRoot,
           };
 
           // The no-token overload of createScm is synchronous; the plugin
@@ -306,7 +291,7 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
               // doesn't back up the poller. The channel dir is created on
               // demand by ChannelStore.writeTrackedPrs.
               void persistSnapshot(opts.channelStore, rows);
-            }
+            },
           });
           poller.start();
 
@@ -319,7 +304,7 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
             },
             listTracked() {
               return poller?.listTracked() ?? [];
-            }
+            },
           };
           if (activeWatcher && activeWatcher.handle !== handle) {
             console.warn(
@@ -341,7 +326,7 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
               scm,
               poller: poller!,
               defaultChannelId: opts.defaultChannelId,
-              autoTracked
+              autoTracked,
             }).catch(() => {
               /* detection must never crash the run */
             });
@@ -353,7 +338,7 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
             scm,
             poller: poller!,
             defaultChannelId: opts.defaultChannelId,
-            autoTracked
+            autoTracked,
           }).catch(() => {});
         });
       },
@@ -367,7 +352,7 @@ export function createPrWatcherFactory(opts: CreateFactoryOpts): PollerFactory {
         if (activeWatcher?.handle === handle) {
           activeWatcher = null;
         }
-      }
+      },
     };
 
     return handle;
@@ -381,7 +366,7 @@ function noopHandle(): PollerHandle {
     },
     stop(): void {
       /* intentional no-op */
-    }
+    },
   };
 }
 
@@ -426,7 +411,7 @@ async function scanCompletedTickets(input: {
         ticketId: entry.ticketId,
         channelId,
         pr,
-        repo: input.repo
+        repo: input.repo,
       });
       input.autoTracked.add(entry.ticketId);
     } catch {
@@ -466,7 +451,7 @@ async function persistSnapshot(
       ci: row.last?.ci ?? null,
       review: row.last?.review ?? null,
       prState: row.last?.prState ?? null,
-      updatedAt: now
+      updatedAt: now,
     });
     grouped.set(row.channelId, list);
   }
@@ -475,10 +460,7 @@ async function persistSnapshot(
       try {
         await channelStore.writeTrackedPrs(channelId, list);
       } catch (err) {
-        console.warn(
-          `[pr-watcher] failed to persist tracked-prs for ${channelId}:`,
-          err
-        );
+        console.warn(`[pr-watcher] failed to persist tracked-prs for ${channelId}:`, err);
       }
     })
   );

--- a/src/cli/rebuild.ts
+++ b/src/cli/rebuild.ts
@@ -10,11 +10,7 @@ function resolveRepoRoot(): string {
   return fileURLToPath(new URL("../..", import.meta.url));
 }
 
-async function runTool(
-  command: string,
-  args: string[],
-  cwd: string
-): Promise<number> {
+async function runTool(command: string, args: string[], cwd: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { cwd, stdio: "inherit" });
     child.on("error", reject);
@@ -40,13 +36,7 @@ export function parseRebuildFlags(args: string[]): RebuildOptions {
   const explicitDist = args.includes("--dist");
   const anyExplicit = explicitTui || explicitGui || explicitDist;
 
-  const known = new Set([
-    "--all",
-    "--tui",
-    "--gui",
-    "--dist",
-    "--skip-install"
-  ]);
+  const known = new Set(["--all", "--tui", "--gui", "--dist", "--skip-install"]);
   for (const arg of args) {
     if (arg.startsWith("--") && !known.has(arg)) {
       console.warn(
@@ -59,7 +49,7 @@ export function parseRebuildFlags(args: string[]): RebuildOptions {
     dist: all || explicitDist || !anyExplicit,
     tui: all || explicitTui,
     gui: all || explicitGui,
-    skipInstall: args.includes("--skip-install")
+    skipInstall: args.includes("--skip-install"),
   };
 }
 
@@ -97,11 +87,7 @@ export async function runRebuild(options: RebuildOptions): Promise<number> {
 
   if (options.tui) {
     console.log("[rly rebuild] TUI — cargo build --release -p relay-tui");
-    const exit = await runTool(
-      "cargo",
-      ["build", "--release", "-p", "relay-tui"],
-      repoRoot
-    );
+    const exit = await runTool("cargo", ["build", "--release", "-p", "relay-tui"], repoRoot);
     if (exit !== 0) {
       console.error("[rly rebuild] TUI build failed — stopping.");
       return exit;

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -3,11 +3,7 @@ import { appendFile, mkdir, readFile, rename, rm, unlink, writeFile } from "node
 import { join } from "node:path";
 import { promisify } from "node:util";
 
-import {
-  buildSessionId,
-  type ChatSession,
-  type PersistedChatMessage
-} from "../domain/session.js";
+import { buildSessionId, type ChatSession, type PersistedChatMessage } from "../domain/session.js";
 import { buildHarnessStore } from "../storage/factory.js";
 import { STORE_NS } from "../storage/namespaces.js";
 import type { HarnessStore } from "../storage/store.js";
@@ -86,16 +82,10 @@ export class SessionStore {
    * the Rust/GUI reader expects the path layout documented on
    * `SessionLockRecord`. Only coordination primitives migrate.
    */
-  constructor(
-    channelsDir?: string,
-    store?: HarnessStore,
-    gitExec?: SessionStoreGitExec
-  ) {
+  constructor(channelsDir?: string, store?: HarnessStore, gitExec?: SessionStoreGitExec) {
     this.channelsDir = channelsDir ?? join(getRelayDir(), "channels");
     this.store = store ?? buildHarnessStore();
-    this.gitExec =
-      gitExec ??
-      (async (args, opts) => execFileAsync("git", args, { cwd: opts.cwd }));
+    this.gitExec = gitExec ?? (async (args, opts) => execFileAsync("git", args, { cwd: opts.cwd }));
   }
 
   private sessionsDir(channelId: string): string {
@@ -118,7 +108,7 @@ export class SessionStore {
       createdAt: now,
       updatedAt: now,
       messageCount: 0,
-      claudeSessionIds: {}
+      claudeSessionIds: {},
     };
 
     await mkdir(this.sessionsDir(channelId), { recursive: true });
@@ -160,9 +150,7 @@ export class SessionStore {
       return sessions;
     } catch (err) {
       throw new Error(
-        `Corrupt sessions index at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `Corrupt sessions index at ${path}: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err }
       );
     }
@@ -182,11 +170,7 @@ export class SessionStore {
     }
 
     await this.writeSessions(channelId, sessions);
-    await this.touchLockRecord(
-      channelId,
-      session.sessionId,
-      session.messageCount
-    );
+    await this.touchLockRecord(channelId, session.sessionId, session.messageCount);
   }
 
   async updateClaudeSessionId(
@@ -249,10 +233,7 @@ export class SessionStore {
     // swallow + warn so a coordination-store hiccup doesn't look like a
     // failed session deletion to the caller.
     try {
-      await this.store.deleteDoc(
-        STORE_NS.session,
-        lockRecordId(channelId, sessionId)
-      );
+      await this.store.deleteDoc(STORE_NS.session, lockRecordId(channelId, sessionId));
     } catch (err) {
       console.warn(
         `[session-store] coordination-record delete failed (channelId=${channelId}, sessionId=${sessionId}): ${
@@ -271,11 +252,13 @@ export class SessionStore {
       const prefix = `refs/harness-rewind/${sessionId}/`;
       let refs: string[] = [];
       try {
-        const { stdout } = await this.gitExec(
-          ["for-each-ref", "--format=%(refname)", prefix],
-          { cwd: repoPath }
-        );
-        refs = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+        const { stdout } = await this.gitExec(["for-each-ref", "--format=%(refname)", prefix], {
+          cwd: repoPath,
+        });
+        refs = stdout
+          .split("\n")
+          .map((l) => l.trim())
+          .filter(Boolean);
       } catch (err) {
         console.warn(
           `[session-store] for-each-ref failed in ${repoPath} while pruning rewind refs for session ${sessionId}: ${
@@ -379,7 +362,10 @@ export class SessionStore {
       }
       throw err;
     }
-    const lines = content.trimEnd().split("\n").filter((l) => l.length > 0);
+    const lines = content
+      .trimEnd()
+      .split("\n")
+      .filter((l) => l.length > 0);
     const kept: string[] = [];
     let removed = 0;
     for (const line of lines) {
@@ -419,10 +405,7 @@ export class SessionStore {
    * the next message after a rollback starts a fresh Claude conversation
    * (Claude can't itself be rewound server-side).
    */
-  async clearClaudeSessionIds(
-    channelId: string,
-    sessionId: string
-  ): Promise<ChatSession | null> {
+  async clearClaudeSessionIds(channelId: string, sessionId: string): Promise<ChatSession | null> {
     const session = await this.getSession(channelId, sessionId);
     if (!session) return null;
     session.claudeSessionIds = {};
@@ -440,7 +423,10 @@ export class SessionStore {
 
     try {
       const content = await readFile(path, "utf8");
-      const lines = content.trimEnd().split("\n").filter((l) => l.length > 0);
+      const lines = content
+        .trimEnd()
+        .split("\n")
+        .filter((l) => l.length > 0);
       const messages: PersistedChatMessage[] = [];
 
       // Note on line numbering: `slice(-limit)` means the loop index is the
@@ -519,7 +505,7 @@ export class SessionStore {
         lockRecordId(channelId, sessionId),
         () => ({
           updatedAt: new Date().toISOString(),
-          messageCount
+          messageCount,
         })
       );
     } catch (err) {

--- a/src/cli/welcome.ts
+++ b/src/cli/welcome.ts
@@ -1,12 +1,5 @@
 import { existsSync } from "node:fs";
-import {
-  chmod,
-  copyFile,
-  mkdir,
-  readFile,
-  rename,
-  writeFile
-} from "node:fs/promises";
+import { chmod, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { createInterface, Interface } from "node:readline/promises";
 import { join } from "node:path";
 
@@ -121,7 +114,7 @@ const c = {
   mauve: "\x1b[38;5;183m",
   green: "\x1b[38;5;151m",
   peach: "\x1b[38;5;216m",
-  red: "\x1b[38;5;211m"
+  red: "\x1b[38;5;211m",
 };
 
 export interface WelcomeOptions {
@@ -134,7 +127,7 @@ export interface WelcomeOptions {
 export function parseWelcomeFlags(args: string[]): WelcomeOptions {
   return {
     reset: args.includes("--reset"),
-    nonInteractive: args.includes("--non-interactive") || !process.stdin.isTTY
+    nonInteractive: args.includes("--non-interactive") || !process.stdin.isTTY,
   };
 }
 
@@ -163,9 +156,7 @@ function header(step: number, total: number, title: string): void {
   const bar = `${c.dim}${"─".repeat(66)}${c.reset}`;
   console.log("");
   console.log(bar);
-  console.log(
-    `${c.bold}${c.blue}Step ${step}/${total}${c.reset}  ${c.bold}${title}${c.reset}`
-  );
+  console.log(`${c.bold}${c.blue}Step ${step}/${total}${c.reset}  ${c.bold}${title}${c.reset}`);
   console.log(bar);
 }
 
@@ -197,15 +188,15 @@ const TOKEN_PROMPTS: TokenPrompt[] = [
     label: "GitHub personal access token",
     url: "https://github.com/settings/tokens",
     hint: "scopes: repo (private) or public_repo (public only)",
-    disabledCopy: "GitHub issue ingestion + PR watcher stay off; tickets live on the channel board"
+    disabledCopy: "GitHub issue ingestion + PR watcher stay off; tickets live on the channel board",
   },
   {
     key: "LINEAR_API_KEY",
     label: "Linear API key",
     url: "https://linear.app/settings/api",
     hint: "personal API key — starts with lin_api_",
-    disabledCopy: "Linear issue resolution stays off; tickets live on the channel board"
-  }
+    disabledCopy: "Linear issue resolution stays off; tickets live on the channel board",
+  },
 ];
 
 async function promptForTokens(
@@ -222,13 +213,12 @@ async function promptForTokens(
 
   p("");
   const opener = (
-    await ask(
-      rl,
-      `Add API tokens now? (optional — skip any you don't have) [Y/n]`
-    )
+    await ask(rl, `Add API tokens now? (optional — skip any you don't have) [Y/n]`)
   ).toLowerCase();
   if (opener !== "" && opener !== "y" && opener !== "yes") {
-    p(`  ${c.dim}Skipped — you can edit${c.reset} ${c.bold}~/.relay/config.env${c.reset} ${c.dim}later.${c.reset}`);
+    p(
+      `  ${c.dim}Skipped — you can edit${c.reset} ${c.bold}~/.relay/config.env${c.reset} ${c.dim}later.${c.reset}`
+    );
     return;
   }
 
@@ -303,9 +293,7 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
     // ── 1. Intro ─────────────────────────────────────────────────────────
     header(1, total, "What Relay is");
     p("");
-    p(
-      `${c.bold}Relay${c.reset} is a local-first orchestration layer for coding agents.`
-    );
+    p(`${c.bold}Relay${c.reset} is a local-first orchestration layer for coding agents.`);
     p("It takes a request — a sentence, an issue URL, a vague idea — and:");
     p("");
     p(`  ${c.green}1.${c.reset} classifies the work (trivial / feature / architectural)`);
@@ -324,13 +312,16 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
     const tokens = await readTokensFromConfig();
     const workspaces = await listRegisteredWorkspaces();
 
-    const ok = (b: boolean) =>
-      b ? `${c.green}✓${c.reset}` : `${c.peach}·${c.reset}`;
+    const ok = (b: boolean) => (b ? `${c.green}✓${c.reset}` : `${c.peach}·${c.reset}`);
 
     p("");
     p(`  ${ok(configEnvExists)} ~/.relay/config.env ${configEnvExists ? "present" : "missing"}`);
-    p(`  ${ok(tokens.github)} GITHUB_TOKEN      ${tokens.github ? "set" : "not set — PR watcher + GitHub issues disabled"}`);
-    p(`  ${ok(tokens.linear)} LINEAR_API_KEY    ${tokens.linear ? "set" : "not set — Linear issue ingestion disabled"}`);
+    p(
+      `  ${ok(tokens.github)} GITHUB_TOKEN      ${tokens.github ? "set" : "not set — PR watcher + GitHub issues disabled"}`
+    );
+    p(
+      `  ${ok(tokens.linear)} LINEAR_API_KEY    ${tokens.linear ? "set" : "not set — Linear issue ingestion disabled"}`
+    );
     p(
       `  ${ok(workspaces.length > 0)} repos registered  ${workspaces.length} workspace${workspaces.length === 1 ? "" : "s"}`
     );
@@ -343,10 +334,7 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
     if (!configEnvExists) {
       if (rl) {
         const answer = (
-          await ask(
-            rl,
-            "No ~/.relay/config.env yet — copy the template into place now? [Y/n]"
-          )
+          await ask(rl, "No ~/.relay/config.env yet — copy the template into place now? [Y/n]")
         ).toLowerCase();
         if (answer === "" || answer === "y" || answer === "yes") {
           const result = await scaffoldConfigEnv(relayDir);
@@ -358,7 +346,9 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
             configReady = true;
           } else {
             p(`  ${c.peach}!${c.reset} Template not found at ${result.expectedTemplate}.`);
-            p(`    ${c.dim}Re-run install.sh to drop it in, or create config.env by hand.${c.reset}`);
+            p(
+              `    ${c.dim}Re-run install.sh to drop it in, or create config.env by hand.${c.reset}`
+            );
           }
         } else {
           p(`  ${c.dim}Skipped — when you're ready, run:${c.reset}`);
@@ -375,7 +365,9 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
     if (rl && configReady && (!tokens.github || !tokens.linear)) {
       await promptForTokens(rl, relayDir, tokens);
     } else if (!rl && configReady && !tokens.github) {
-      p(`  ${c.dim}To enable GitHub/Linear, open${c.reset} ${c.bold}~/.relay/config.env${c.reset} ${c.dim}and fill in tokens, then:${c.reset}`);
+      p(
+        `  ${c.dim}To enable GitHub/Linear, open${c.reset} ${c.bold}~/.relay/config.env${c.reset} ${c.dim}and fill in tokens, then:${c.reset}`
+      );
       p(`    source ~/.relay/config.env    ${c.dim}# or add to ~/.zshrc${c.reset}`);
     }
     if (workspaces.length === 0) {

--- a/src/cli/workspace-registry.ts
+++ b/src/cli/workspace-registry.ts
@@ -110,7 +110,7 @@ export class WorkspaceRegistry {
       const raw = JSON.parse(content) as WorkspaceRegistryDoc;
       return {
         updatedAt: raw.updatedAt ?? new Date().toISOString(),
-        workspaces: Array.isArray(raw.workspaces) ? raw.workspaces : []
+        workspaces: Array.isArray(raw.workspaces) ? raw.workspaces : [],
       };
     } catch (err) {
       throw new Error(
@@ -154,14 +154,10 @@ export class WorkspaceRegistry {
     // doesn't look like a failed registry write to the caller. Mirrors the
     // T-101 policy for channel-ticket coordination records.
     try {
-      await this.store.mutate<WorkspaceRegistryLockRecord>(
-        STORE_NS.workspace,
-        "registry",
-        () => ({
-          updatedAt: registry.updatedAt,
-          count: registry.workspaces.length
-        })
-      );
+      await this.store.mutate<WorkspaceRegistryLockRecord>(STORE_NS.workspace, "registry", () => ({
+        updatedAt: registry.updatedAt,
+        count: registry.workspaces.length,
+      }));
     } catch (err) {
       console.warn(
         `[workspace-registry] coordination-record mutate failed (path=${path}, count=${registry.workspaces.length}): ${
@@ -176,9 +172,7 @@ export class WorkspaceRegistry {
     const workspaceId = buildWorkspaceId(repoPath);
     const now = new Date().toISOString();
 
-    const existing = registry.workspaces.find(
-      (w) => w.workspaceId === workspaceId
-    );
+    const existing = registry.workspaces.find((w) => w.workspaceId === workspaceId);
 
     if (existing) {
       existing.lastAccessedAt = now;
@@ -192,7 +186,7 @@ export class WorkspaceRegistry {
       workspaceId,
       repoPath,
       registeredAt: now,
-      lastAccessedAt: now
+      lastAccessedAt: now,
     };
 
     registry.workspaces.push(entry);
@@ -202,14 +196,10 @@ export class WorkspaceRegistry {
     return entry;
   }
 
-  async resolveForRepo(
-    repoPath: string
-  ): Promise<WorkspaceRegistryEntry | null> {
+  async resolveForRepo(repoPath: string): Promise<WorkspaceRegistryEntry | null> {
     const registry = await this.read();
     const workspaceId = buildWorkspaceId(repoPath);
-    return (
-      registry.workspaces.find((w) => w.workspaceId === workspaceId) ?? null
-    );
+    return registry.workspaces.find((w) => w.workspaceId === workspaceId) ?? null;
   }
 
   async list(): Promise<WorkspaceRegistryEntry[]> {
@@ -232,28 +222,20 @@ export async function readRegistry(): Promise<WorkspaceRegistryDoc> {
   return new WorkspaceRegistry(undefined, getHarnessStore()).read();
 }
 
-export async function writeRegistry(
-  registry: WorkspaceRegistryDoc
-): Promise<void> {
+export async function writeRegistry(registry: WorkspaceRegistryDoc): Promise<void> {
   return new WorkspaceRegistry(undefined, getHarnessStore()).write(registry);
 }
 
-export async function registerWorkspace(
-  repoPath: string
-): Promise<WorkspaceRegistryEntry> {
+export async function registerWorkspace(repoPath: string): Promise<WorkspaceRegistryEntry> {
   return new WorkspaceRegistry(undefined, getHarnessStore()).register(repoPath);
 }
 
 export async function resolveWorkspaceForRepo(
   repoPath: string
 ): Promise<WorkspaceRegistryEntry | null> {
-  return new WorkspaceRegistry(undefined, getHarnessStore()).resolveForRepo(
-    repoPath
-  );
+  return new WorkspaceRegistry(undefined, getHarnessStore()).resolveForRepo(repoPath);
 }
 
-export async function listRegisteredWorkspaces(): Promise<
-  WorkspaceRegistryEntry[]
-> {
+export async function listRegisteredWorkspaces(): Promise<WorkspaceRegistryEntry[]> {
   return new WorkspaceRegistry(undefined, getHarnessStore()).list();
 }

--- a/src/cli/workspace.ts
+++ b/src/cli/workspace.ts
@@ -3,11 +3,7 @@ import { join } from "node:path";
 
 import type { RunIndexEntry } from "../domain/run.js";
 import type { LocalArtifactStore } from "../execution/artifact-store.js";
-import {
-  buildWorkspaceId,
-  getWorkspaceDir,
-  registerWorkspace
-} from "./workspace-registry.js";
+import { buildWorkspaceId, getWorkspaceDir, registerWorkspace } from "./workspace-registry.js";
 
 export interface HarnessWorkspacePaths {
   rootDir: string;
@@ -37,7 +33,7 @@ export async function ensureHarnessWorkspace(
   const paths = getHarnessWorkspacePaths(cwd);
 
   await mkdir(paths.artifactsDir, {
-    recursive: true
+    recursive: true,
   });
 
   const existing = await readHarnessServiceStatus(paths.serviceStatusPath);
@@ -49,17 +45,14 @@ export async function ensureHarnessWorkspace(
     artifactsDir: paths.artifactsDir,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
-    version
+    version,
   };
 
-  await writeFile(
-    paths.serviceStatusPath,
-    JSON.stringify(status, null, 2)
-  );
+  await writeFile(paths.serviceStatusPath, JSON.stringify(status, null, 2));
 
   return {
     paths,
-    status
+    status,
   };
 }
 
@@ -71,13 +64,11 @@ export function getHarnessWorkspacePaths(cwd: string): HarnessWorkspacePaths {
     rootDir,
     artifactsDir: join(rootDir, "artifacts"),
     serviceStatusPath: join(rootDir, "service-status.json"),
-    runsIndexPath: join(rootDir, "artifacts", "runs-index.json")
+    runsIndexPath: join(rootDir, "artifacts", "runs-index.json"),
   };
 }
 
-export async function readHarnessServiceStatus(
-  path: string
-): Promise<HarnessServiceStatus | null> {
+export async function readHarnessServiceStatus(path: string): Promise<HarnessServiceStatus | null> {
   try {
     return JSON.parse(await readFile(path, "utf8")) as HarnessServiceStatus;
   } catch {
@@ -96,12 +87,12 @@ export async function readWorkspaceSummary(
   const paths = getHarnessWorkspacePaths(cwd);
   const [status, recentRuns] = await Promise.all([
     readHarnessServiceStatus(paths.serviceStatusPath),
-    artifactStore.readRunsIndex()
+    artifactStore.readRunsIndex(),
   ]);
 
   return {
     paths,
     status,
-    recentRuns
+    recentRuns,
   };
 }

--- a/src/crosslink/cli.ts
+++ b/src/crosslink/cli.ts
@@ -3,10 +3,7 @@ import { CrosslinkStore } from "./store.js";
 import { generateHookScripts, printHookSetupInstructions } from "./hook.js";
 import { buildCrosslinkId } from "./types.js";
 
-export async function handleCrosslinkCommand(
-  subcommand: string,
-  args: string[]
-): Promise<void> {
+export async function handleCrosslinkCommand(subcommand: string, args: string[]): Promise<void> {
   switch (subcommand) {
     case "init":
       return handleInit();
@@ -62,9 +59,7 @@ async function handleCheck(): Promise<void> {
   // In hook context, RELAY_SESSION is not set, so we pick the most recently
   // active session.
   const envSessionId = process.env.RELAY_SESSION;
-  const session = envSessionId
-    ? sessions.find((s) => s.sessionId === envSessionId)
-    : sessions[0];
+  const session = envSessionId ? sessions.find((s) => s.sessionId === envSessionId) : sessions[0];
 
   if (!session) {
     return;
@@ -73,11 +68,11 @@ async function handleCheck(): Promise<void> {
   const messages = await store.pollMessages(session.sessionId);
 
   for (const msg of messages) {
-    const replyHint = msg.type === "question"
-      ? " — use crosslink_reply to respond"
-      : "";
+    const replyHint = msg.type === "question" ? " — use crosslink_reply to respond" : "";
 
-    console.log(`[CROSSLINK INBOUND from=${msg.fromSessionId} messageId=${msg.messageId} type=${msg.type}${replyHint}]`);
+    console.log(
+      `[CROSSLINK INBOUND from=${msg.fromSessionId} messageId=${msg.messageId} type=${msg.type}${replyHint}]`
+    );
     console.log(msg.content);
     console.log("[/CROSSLINK]");
     console.log("");
@@ -100,7 +95,7 @@ async function handleSend(args: string[]): Promise<void> {
     fromSessionId: buildCrosslinkId("cli"),
     toSessionId,
     content: message,
-    type: "question"
+    type: "question",
   });
 
   console.log(`Message sent: ${sent.messageId}`);

--- a/src/crosslink/hook.ts
+++ b/src/crosslink/hook.ts
@@ -185,10 +185,10 @@ export function getClaudeHookConfig(shellScriptPath: string): object {
       UserPromptSubmit: [
         {
           type: "command",
-          command: shellScriptPath
-        }
-      ]
-    }
+          command: shellScriptPath,
+        },
+      ],
+    },
   };
 }
 
@@ -200,5 +200,7 @@ export function printHookSetupInstructions(shellScriptPath: string): void {
   console.log(JSON.stringify(getClaudeHookConfig(shellScriptPath), null, 2));
   console.log("");
   console.log("For Codex, add this system prompt instruction to your codex config:");
-  console.log('  "At the start of each task, call crosslink_poll to check for messages from other sessions."');
+  console.log(
+    '  "At the start of each task, call crosslink_poll to check for messages from other sessions."'
+  );
 }

--- a/src/crosslink/store.ts
+++ b/src/crosslink/store.ts
@@ -12,7 +12,7 @@ import {
   type CrosslinkSession,
   type CrosslinkMessage,
   type MessageStatus,
-  type MessageType
+  type MessageType,
 } from "./types.js";
 
 const STALE_HEARTBEAT_MS = 120_000;
@@ -73,10 +73,7 @@ function warnIfLegacyLayoutPresent(baseDir: string): void {
   const legacySessionsDir = join(legacyRoot, "sessions");
   const legacyMailboxesDir = join(legacyRoot, "mailboxes");
 
-  if (
-    hasNonEmptyDir(legacySessionsDir) ||
-    hasNonEmptyDir(legacyMailboxesDir)
-  ) {
+  if (hasNonEmptyDir(legacySessionsDir) || hasNonEmptyDir(legacyMailboxesDir)) {
     warnedLegacyRoots.add(legacyRoot);
     console.warn(
       `[crosslink] legacy layout detected at ${legacyRoot}. ` +
@@ -151,7 +148,7 @@ export class CrosslinkStore {
       ...session,
       sessionId: buildCrosslinkId("session"),
       registeredAt: now,
-      lastHeartbeat: now
+      lastHeartbeat: now,
     };
 
     await this.store.putDoc(STORE_NS.crosslinkSession, full.sessionId, full);
@@ -171,7 +168,7 @@ export class CrosslinkStore {
     const updated: CrosslinkSession = {
       ...session,
       ...patch,
-      lastHeartbeat: new Date().toISOString()
+      lastHeartbeat: new Date().toISOString(),
     };
 
     await this.store.putDoc(STORE_NS.crosslinkSession, sessionId, updated);
@@ -255,7 +252,7 @@ export class CrosslinkStore {
       status: "pending",
       createdAt: now,
       deliveredAt: null,
-      repliedAt: null
+      repliedAt: null,
     };
 
     await this.store.putDoc(
@@ -375,10 +372,7 @@ export class CrosslinkStore {
   // --- Internal helpers ---
 
   private async readSession(sessionId: string): Promise<CrosslinkSession | null> {
-    const doc = await this.store.getDoc<unknown>(
-      STORE_NS.crosslinkSession,
-      sessionId
-    );
+    const doc = await this.store.getDoc<unknown>(STORE_NS.crosslinkSession, sessionId);
     return doc ? safeParseSession(doc) : null;
   }
 }

--- a/src/crosslink/tools.ts
+++ b/src/crosslink/tools.ts
@@ -28,13 +28,13 @@ export function getCrosslinkToolDefinitions(): object[] {
                 "testing",
                 "documentation",
                 "architecture",
-                "general"
-              ]
+                "general",
+              ],
             },
-            description: "Optional filter: only show sessions with these capabilities."
-          }
-        }
-      }
+            description: "Optional filter: only show sessions with these capabilities.",
+          },
+        },
+      },
     },
     {
       name: "crosslink_send",
@@ -47,19 +47,19 @@ export function getCrosslinkToolDefinitions(): object[] {
         properties: {
           toSessionId: {
             type: "string",
-            description: "The session ID to send the message to."
+            description: "The session ID to send the message to.",
           },
           content: {
             type: "string",
-            description: "The message content (question, information, etc.)."
+            description: "The message content (question, information, etc.).",
           },
           type: {
             type: "string",
             enum: ["question", "notification"],
-            description: "Message type. Defaults to 'question'."
-          }
-        }
-      }
+            description: "Message type. Defaults to 'question'.",
+          },
+        },
+      },
     },
     {
       name: "crosslink_poll",
@@ -68,9 +68,9 @@ export function getCrosslinkToolDefinitions(): object[] {
       inputSchema: {
         type: "object",
         additionalProperties: false,
-        properties: {}
-      }
-    }
+        properties: {},
+      },
+    },
   ];
 }
 
@@ -116,7 +116,7 @@ async function handleRegister(
 
   const updated = await state.store.updateSession(state.sessionId, {
     description,
-    ...(capabilities ? { capabilities } : {})
+    ...(capabilities ? { capabilities } : {}),
   });
 
   if (!updated) {
@@ -126,7 +126,7 @@ async function handleRegister(
   return {
     sessionId: updated.sessionId,
     description: updated.description,
-    capabilities: updated.capabilities
+    capabilities: updated.capabilities,
   };
 }
 
@@ -142,9 +142,7 @@ async function handleDiscover(
 
   if (filterCapabilities && filterCapabilities.length > 0) {
     sessions = sessions.filter((session) =>
-      filterCapabilities.some((cap) =>
-        session.capabilities.includes(cap as CrosslinkCapability)
-      )
+      filterCapabilities.some((cap) => session.capabilities.includes(cap as CrosslinkCapability))
     );
   }
 
@@ -157,8 +155,8 @@ async function handleDiscover(
       capabilities: session.capabilities,
       agentProvider: session.agentProvider,
       status: session.status,
-      isSelf: session.sessionId === state.sessionId
-    }))
+      isSelf: session.sessionId === state.sessionId,
+    })),
   };
 }
 
@@ -172,7 +170,7 @@ async function handleSend(
 
   const toSessionId = String(args.toSessionId ?? "");
   const content = String(args.content ?? "");
-  const type = args.type === "notification" ? "notification" as const : "question" as const;
+  const type = args.type === "notification" ? ("notification" as const) : ("question" as const);
 
   if (!toSessionId || !content) {
     return { error: "toSessionId and content are required." };
@@ -182,7 +180,7 @@ async function handleSend(
     fromSessionId: state.sessionId,
     toSessionId,
     content,
-    type
+    type,
   });
 
   notifyTmux(toSessionId, state.sessionId);
@@ -190,7 +188,7 @@ async function handleSend(
   return {
     messageId: message.messageId,
     toSessionId: message.toSessionId,
-    status: message.status
+    status: message.status,
   };
 }
 
@@ -209,8 +207,8 @@ async function handlePoll(state: CrosslinkToolState): Promise<unknown> {
       type: msg.type,
       content: msg.content,
       inReplyTo: msg.inReplyTo,
-      createdAt: msg.createdAt
-    }))
+      createdAt: msg.createdAt,
+    })),
   };
 }
 
@@ -241,7 +239,7 @@ async function handleReply(
     toSessionId: original.fromSessionId,
     content,
     type: "reply",
-    inReplyTo: messageId
+    inReplyTo: messageId,
   });
 
   await state.store.updateMessageStatus(state.sessionId, messageId, "replied");
@@ -251,7 +249,7 @@ async function handleReply(
   return {
     replyMessageId: reply.messageId,
     toSessionId: original.fromSessionId,
-    inReplyTo: messageId
+    inReplyTo: messageId,
   };
 }
 
@@ -273,10 +271,11 @@ function notifyTmux(targetSessionId: string, fromSessionId: string): void {
   }
 
   try {
-    execFileSync("tmux", [
-      "display-message",
-      `Crosslink: message from ${fromSessionId} → ${targetSessionId}`
-    ], { stdio: "ignore", timeout: 2000 });
+    execFileSync(
+      "tmux",
+      ["display-message", `Crosslink: message from ${fromSessionId} → ${targetSessionId}`],
+      { stdio: "ignore", timeout: 2000 }
+    );
   } catch {
     // tmux not available or failed
   }
@@ -288,7 +287,7 @@ const VALID_CAPABILITIES = new Set([
   "testing",
   "documentation",
   "architecture",
-  "general"
+  "general",
 ]);
 
 function isValidCapability(value: string): value is CrosslinkCapability {

--- a/src/crosslink/types.ts
+++ b/src/crosslink/types.ts
@@ -10,7 +10,7 @@ export const CrosslinkCapabilitySchema = z.enum([
   "testing",
   "documentation",
   "architecture",
-  "general"
+  "general",
 ]);
 
 export type CrosslinkCapability = z.infer<typeof CrosslinkCapabilitySchema>;
@@ -34,7 +34,7 @@ export const CrosslinkSessionSchema = z.object({
   agentProvider: AgentProviderSchema,
   registeredAt: z.string(),
   lastHeartbeat: z.string(),
-  status: SessionStatusSchema
+  status: SessionStatusSchema,
 });
 
 export type CrosslinkSession = z.infer<typeof CrosslinkSessionSchema>;
@@ -43,12 +43,7 @@ export const MessageTypeSchema = z.enum(["question", "reply", "notification"]);
 
 export type MessageType = z.infer<typeof MessageTypeSchema>;
 
-export const MessageStatusSchema = z.enum([
-  "pending",
-  "delivered",
-  "replied",
-  "expired"
-]);
+export const MessageStatusSchema = z.enum(["pending", "delivered", "replied", "expired"]);
 
 export type MessageStatus = z.infer<typeof MessageStatusSchema>;
 
@@ -62,7 +57,7 @@ export const CrosslinkMessageSchema = z.object({
   status: MessageStatusSchema,
   createdAt: z.string(),
   deliveredAt: z.string().nullable(),
-  repliedAt: z.string().nullable()
+  repliedAt: z.string().nullable(),
 });
 
 export type CrosslinkMessage = z.infer<typeof CrosslinkMessageSchema>;

--- a/src/domain/agent-names.ts
+++ b/src/domain/agent-names.ts
@@ -26,8 +26,7 @@ export interface AgentNameEntry {
  * through the store as a coordination record for Postgres-backed deployments
  * (T-402). Same pattern as T-101's `upsertChannelTickets` coordination doc.
  */
-const namesPath = (dir?: string): string =>
-  join(dir ?? getRelayDir(), "agent-names.json");
+const namesPath = (dir?: string): string => join(dir ?? getRelayDir(), "agent-names.json");
 
 /**
  * Doc id for the `STORE_NS.agentName` coordination record. The registry is
@@ -90,11 +89,7 @@ export async function setAgentName(
   // persisted the data Rust/GUI care about.
   try {
     const store = resolveStore(io);
-    await store.mutate<AgentNameEntry[]>(
-      STORE_NS.agentName,
-      REGISTRY_DOC_ID,
-      () => entries
-    );
+    await store.mutate<AgentNameEntry[]>(STORE_NS.agentName, REGISTRY_DOC_ID, () => entries);
   } catch (err) {
     // Never let a mirror failure shadow a successful primary write. The
     // Rust-visible file is already on disk; a future caller's `setAgentName`
@@ -108,21 +103,14 @@ export async function setAgentName(
   return entry;
 }
 
-export async function getAgentName(
-  agentId: string,
-  io?: AgentNameIO
-): Promise<string> {
+export async function getAgentName(agentId: string, io?: AgentNameIO): Promise<string> {
   const entries = await listAgentNames(io);
   return entries.find((e) => e.agentId === agentId)?.displayName ?? agentId;
 }
 
-export async function listAgentNames(
-  io?: AgentNameIO
-): Promise<AgentNameEntry[]> {
+export async function listAgentNames(io?: AgentNameIO): Promise<AgentNameEntry[]> {
   try {
-    return JSON.parse(
-      await readFile(namesPath(io?.relayDir), "utf8")
-    ) as AgentNameEntry[];
+    return JSON.parse(await readFile(namesPath(io?.relayDir), "utf8")) as AgentNameEntry[];
   } catch {
     return [];
   }

--- a/src/domain/agent.ts
+++ b/src/domain/agent.ts
@@ -18,18 +18,14 @@ export type WorkKind =
   | "review_changes"
   | "run_checks";
 
-export const FailureCategorySchema = z.enum([
-  "fix_code",
-  "fix_test",
-  "bad_command_plan"
-]);
+export const FailureCategorySchema = z.enum(["fix_code", "fix_test", "bad_command_plan"]);
 
 export type FailureCategory = z.infer<typeof FailureCategorySchema>;
 
 export const FailureClassificationSchema = z.object({
   category: FailureCategorySchema,
   rationale: z.string().min(1),
-  nextAction: z.string().min(1)
+  nextAction: z.string().min(1),
 });
 
 export type FailureClassification = z.infer<typeof FailureClassificationSchema>;
@@ -103,7 +99,7 @@ export const AgentResultSchema = z.object({
   proposedCommands: z.array(z.string()),
   blockers: z.array(z.string()),
   failureClassification: FailureClassificationSchema.optional(),
-  phasePlan: z.unknown().optional()
+  phasePlan: z.unknown().optional(),
 });
 
 export const agentResultJsonSchema = {
@@ -112,19 +108,19 @@ export const agentResultJsonSchema = {
   required: ["summary", "evidence", "proposedCommands", "blockers"],
   properties: {
     summary: {
-      type: "string"
+      type: "string",
     },
     evidence: {
       type: "array",
-      items: { type: "string" }
+      items: { type: "string" },
     },
     proposedCommands: {
       type: "array",
-      items: { type: "string" }
+      items: { type: "string" },
     },
     blockers: {
       type: "array",
-      items: { type: "string" }
+      items: { type: "string" },
     },
     failureClassification: {
       type: "object",
@@ -133,18 +129,18 @@ export const agentResultJsonSchema = {
       properties: {
         category: {
           type: "string",
-          enum: ["fix_code", "fix_test", "bad_command_plan"]
+          enum: ["fix_code", "fix_test", "bad_command_plan"],
         },
         rationale: {
-          type: "string"
+          type: "string",
         },
         nextAction: {
-          type: "string"
-        }
-      }
+          type: "string",
+        },
+      },
     },
     phasePlan: {
-      type: "object"
-    }
-  }
+      type: "object",
+    },
+  },
 } as const;

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -21,7 +21,7 @@ export const ChannelEntryTypeSchema = z.enum([
   "agent_left",
   "ref_added",
   "run_started",
-  "run_completed"
+  "run_completed",
 ]);
 export type ChannelEntryType = z.infer<typeof ChannelEntryTypeSchema>;
 

--- a/src/domain/classification.ts
+++ b/src/domain/classification.ts
@@ -8,7 +8,7 @@ export const ComplexityTierSchema = z.enum([
   "feature_small",
   "feature_large",
   "architectural",
-  "multi_repo"
+  "multi_repo",
 ]);
 
 export type ComplexityTier = z.infer<typeof ComplexityTierSchema>;
@@ -30,7 +30,7 @@ export const ClassificationResultSchema = z.object({
    * was an issue URL or bare Linear identifier. Purely advisory — callers may
    * use it to seed worktree names for downstream tickets.
    */
-  suggestedBranch: z.string().optional()
+  suggestedBranch: z.string().optional(),
 });
 
 export type ClassificationResult = z.infer<typeof ClassificationResultSchema>;
@@ -48,36 +48,29 @@ export const classificationResultJsonSchema = {
     "suggestedSpecialties",
     "estimatedTicketCount",
     "needsDesignDoc",
-    "needsUserApproval"
+    "needsUserApproval",
   ],
   properties: {
     tier: {
       type: "string",
-      enum: [
-        "trivial",
-        "bugfix",
-        "feature_small",
-        "feature_large",
-        "architectural",
-        "multi_repo"
-      ]
+      enum: ["trivial", "bugfix", "feature_small", "feature_large", "architectural", "multi_repo"],
     },
     rationale: { type: "string" },
     suggestedSpecialties: {
       type: "array",
       items: {
         type: "string",
-        enum: ["general", "ui", "business_logic", "api_crud", "devops", "testing"]
-      }
+        enum: ["general", "ui", "business_logic", "api_crud", "devops", "testing"],
+      },
     },
     estimatedTicketCount: {
       type: "integer",
       minimum: 1,
-      maximum: 50
+      maximum: 50,
     },
     needsDesignDoc: { type: "boolean" },
-    needsUserApproval: { type: "boolean" }
-  }
+    needsUserApproval: { type: "boolean" },
+  },
 } as const;
 
 export function tierNeedsApproval(tier: ComplexityTier): boolean {

--- a/src/domain/phase-plan.ts
+++ b/src/domain/phase-plan.ts
@@ -4,7 +4,7 @@ import { AgentSpecialtySchema } from "./specialty.js";
 
 export const RetryPolicySchema = z.object({
   maxAgentAttempts: z.number().int().min(1).max(5),
-  maxTestFixLoops: z.number().int().min(1).max(10)
+  maxTestFixLoops: z.number().int().min(1).max(10),
 });
 
 export const PhaseDefinitionSchema = z.object({
@@ -16,7 +16,7 @@ export const PhaseDefinitionSchema = z.object({
   allowedCommands: z.array(z.string().min(1)).default([]),
   verificationCommands: z.array(z.string().min(1)).default([]),
   docsToUpdate: z.array(z.string().min(1)).default([]),
-  retryPolicy: RetryPolicySchema
+  retryPolicy: RetryPolicySchema,
 });
 
 export const PhasePlanSchema = z.object({
@@ -24,13 +24,13 @@ export const PhasePlanSchema = z.object({
   task: z.object({
     title: z.string().min(1),
     featureRequest: z.string().min(1),
-    repoRoot: z.string().min(1)
+    repoRoot: z.string().min(1),
   }),
   phases: z.array(PhaseDefinitionSchema).min(1),
   finalVerification: z.object({
-    commands: z.array(z.string().min(1)).default([])
+    commands: z.array(z.string().min(1)).default([]),
   }),
-  docsToUpdate: z.array(z.string().min(1)).default([])
+  docsToUpdate: z.array(z.string().min(1)).default([]),
 });
 
 export type RetryPolicy = z.infer<typeof RetryPolicySchema>;
@@ -41,16 +41,13 @@ export function parsePhasePlan(input: unknown): PhasePlan {
   return PhasePlanSchema.parse(input);
 }
 
-export function createSeedPlan(
-  featureRequest: string,
-  repoRoot: string
-): PhasePlan {
+export function createSeedPlan(featureRequest: string, repoRoot: string): PhasePlan {
   return parsePhasePlan({
     version: 1,
     task: {
       title: "Bootstrap harness scaffolding",
       featureRequest,
-      repoRoot
+      repoRoot,
     },
     phases: [
       {
@@ -60,15 +57,15 @@ export function createSeedPlan(
         specialty: "ui",
         acceptanceCriteria: [
           "Create an initial composition root for the harness.",
-          "Keep the file layout simple enough for future API wiring."
+          "Keep the file layout simple enough for future API wiring.",
         ],
         allowedCommands: ["pnpm typecheck"],
         verificationCommands: ["pnpm typecheck"],
         docsToUpdate: ["README.md"],
         retryPolicy: {
           maxAgentAttempts: 2,
-          maxTestFixLoops: 2
-        }
+          maxTestFixLoops: 2,
+        },
       },
       {
         id: "phase_02",
@@ -77,21 +74,21 @@ export function createSeedPlan(
         specialty: "api_crud",
         acceptanceCriteria: [
           "Create seams for future CRUD and business logic flows.",
-          "Keep orchestration independent from provider-specific execution details."
+          "Keep orchestration independent from provider-specific execution details.",
         ],
         allowedCommands: ["pnpm typecheck", "pnpm test"],
         verificationCommands: ["pnpm typecheck", "pnpm test"],
         docsToUpdate: ["README.md"],
         retryPolicy: {
           maxAgentAttempts: 2,
-          maxTestFixLoops: 2
-        }
-      }
+          maxTestFixLoops: 2,
+        },
+      },
     ],
     finalVerification: {
-      commands: ["pnpm typecheck", "pnpm test"]
+      commands: ["pnpm typecheck", "pnpm test"],
     },
-    docsToUpdate: ["README.md"]
+    docsToUpdate: ["README.md"],
   });
 }
 
@@ -102,7 +99,7 @@ export const phasePlanJsonSchema = {
   properties: {
     version: {
       type: "integer",
-      enum: [1]
+      enum: [1],
     },
     task: {
       type: "object",
@@ -111,8 +108,8 @@ export const phasePlanJsonSchema = {
       properties: {
         title: { type: "string" },
         featureRequest: { type: "string" },
-        repoRoot: { type: "string" }
-      }
+        repoRoot: { type: "string" },
+      },
     },
     phases: {
       type: "array",
@@ -129,7 +126,7 @@ export const phasePlanJsonSchema = {
           "allowedCommands",
           "verificationCommands",
           "docsToUpdate",
-          "retryPolicy"
+          "retryPolicy",
         ],
         properties: {
           id: { type: "string" },
@@ -137,24 +134,24 @@ export const phasePlanJsonSchema = {
           goal: { type: "string" },
           specialty: {
             type: "string",
-            enum: ["general", "ui", "business_logic", "api_crud"]
+            enum: ["general", "ui", "business_logic", "api_crud"],
           },
           acceptanceCriteria: {
             type: "array",
             minItems: 1,
-            items: { type: "string" }
+            items: { type: "string" },
           },
           allowedCommands: {
             type: "array",
-            items: { type: "string" }
+            items: { type: "string" },
           },
           verificationCommands: {
             type: "array",
-            items: { type: "string" }
+            items: { type: "string" },
           },
           docsToUpdate: {
             type: "array",
-            items: { type: "string" }
+            items: { type: "string" },
           },
           retryPolicy: {
             type: "object",
@@ -164,17 +161,17 @@ export const phasePlanJsonSchema = {
               maxAgentAttempts: {
                 type: "integer",
                 minimum: 1,
-                maximum: 5
+                maximum: 5,
               },
               maxTestFixLoops: {
                 type: "integer",
                 minimum: 1,
-                maximum: 10
-              }
-            }
-          }
-        }
-      }
+                maximum: 10,
+              },
+            },
+          },
+        },
+      },
     },
     finalVerification: {
       type: "object",
@@ -183,13 +180,13 @@ export const phasePlanJsonSchema = {
       properties: {
         commands: {
           type: "array",
-          items: { type: "string" }
-        }
-      }
+          items: { type: "string" },
+        },
+      },
     },
     docsToUpdate: {
       type: "array",
-      items: { type: "string" }
-    }
-  }
+      items: { type: "string" },
+    },
+  },
 } as const;

--- a/src/domain/pr-lifecycle.ts
+++ b/src/domain/pr-lifecycle.ts
@@ -11,7 +11,7 @@ export const PrStageSchema = z.enum([
   "changes_requested",
   "approved",
   "merged",
-  "closed"
+  "closed",
 ]);
 
 export type PrStage = z.infer<typeof PrStageSchema>;
@@ -19,7 +19,7 @@ export type PrStage = z.infer<typeof PrStageSchema>;
 export const PrEventSchema = z.object({
   stage: PrStageSchema,
   timestamp: z.string(),
-  details: z.record(z.string()).default({})
+  details: z.record(z.string()).default({}),
 });
 
 export type PrEvent = z.infer<typeof PrEventSchema>;
@@ -33,7 +33,7 @@ export const PrLifecycleSchema = z.object({
   currentStage: PrStageSchema,
   events: z.array(PrEventSchema),
   createdAt: z.string(),
-  updatedAt: z.string()
+  updatedAt: z.string(),
 });
 
 export type PrLifecycle = z.infer<typeof PrLifecycleSchema>;
@@ -56,11 +56,11 @@ export function createPrLifecycle(input: {
       {
         stage: "branch_created",
         timestamp: now,
-        details: { branch: input.branch }
-      }
+        details: { branch: input.branch },
+      },
     ],
     createdAt: now,
-    updatedAt: now
+    updatedAt: now,
   };
 }
 
@@ -81,10 +81,10 @@ export function advancePrStage(
       {
         stage,
         timestamp: now,
-        details: details ?? {}
-      }
+        details: details ?? {},
+      },
     ],
-    updatedAt: now
+    updatedAt: now,
   };
 }
 
@@ -99,7 +99,7 @@ const VALID_TRANSITIONS: Record<PrStage, PrStage[]> = {
   changes_requested: ["commits_pushed"],
   approved: ["merged", "checks_running"],
   merged: [],
-  closed: []
+  closed: [],
 };
 
 export function canTransition(from: PrStage, to: PrStage): boolean {

--- a/src/domain/pr-row.ts
+++ b/src/domain/pr-row.ts
@@ -24,14 +24,14 @@ export const TrackedPrRowSchema = z.object({
   ci: z.string().nullable(),
   review: z.string().nullable(),
   prState: z.string().nullable(),
-  updatedAt: z.string()
+  updatedAt: z.string(),
 });
 
 export type TrackedPrRow = z.infer<typeof TrackedPrRowSchema>;
 
 export const TrackedPrFileSchema = z.object({
   updatedAt: z.string(),
-  rows: z.array(TrackedPrRowSchema)
+  rows: z.array(TrackedPrRowSchema),
 });
 
 export type TrackedPrFile = z.infer<typeof TrackedPrFileSchema>;

--- a/src/domain/run.ts
+++ b/src/domain/run.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentProvider,
-  FailureCategory,
-  WorkKind
-} from "./agent.js";
+import type { AgentProvider, FailureCategory, WorkKind } from "./agent.js";
 import type { ClassificationResult } from "./classification.js";
 import type { PhasePlan } from "./phase-plan.js";
 import type { TicketLedgerEntry, TicketPlan } from "./ticket.js";
@@ -95,9 +91,7 @@ export interface FailureClassificationArtifactRecord {
   nextAction: string;
 }
 
-export type ArtifactRecord =
-  | CommandResultArtifactRecord
-  | FailureClassificationArtifactRecord;
+export type ArtifactRecord = CommandResultArtifactRecord | FailureClassificationArtifactRecord;
 
 export type VerificationStatus =
   | "pending"

--- a/src/domain/specialty.ts
+++ b/src/domain/specialty.ts
@@ -6,7 +6,7 @@ export const AgentSpecialtySchema = z.enum([
   "business_logic",
   "api_crud",
   "devops",
-  "testing"
+  "testing",
 ]);
 
 export type AgentSpecialty = z.infer<typeof AgentSpecialtySchema>;

--- a/src/domain/state-machine.ts
+++ b/src/domain/state-machine.ts
@@ -2,69 +2,61 @@ import type { RunEventType, RunState } from "./run.js";
 
 const transitions: Record<RunState, Partial<Record<RunEventType, RunState>>> = {
   CLASSIFYING: {
-    ClassificationComplete: "DRAFT_PLAN"
+    ClassificationComplete: "DRAFT_PLAN",
   },
   DRAFT_PLAN: {
-    PlanGenerated: "PLAN_REVIEW"
+    PlanGenerated: "PLAN_REVIEW",
   },
   PLAN_REVIEW: {
     PlanAccepted: "PHASE_READY",
     PlanAwaitingApproval: "AWAITING_APPROVAL",
-    TicketsCreated: "TICKETS_EXECUTING"
+    TicketsCreated: "TICKETS_EXECUTING",
   },
   AWAITING_APPROVAL: {
     PlanApproved: "TICKETS_EXECUTING",
-    PlanRejected: "DRAFT_PLAN"
+    PlanRejected: "DRAFT_PLAN",
   },
   DESIGN_DOC: {
-    DesignDocGenerated: "AWAITING_APPROVAL"
+    DesignDocGenerated: "AWAITING_APPROVAL",
   },
   PHASE_READY: {
     PhaseStarted: "PHASE_EXECUTE",
-    NoPhasesRemain: "COMPLETE"
+    NoPhasesRemain: "COMPLETE",
   },
   PHASE_EXECUTE: {
     PatchGenerated: "TEST_FIX_LOOP",
-    NoProgressDetected: "BLOCKED"
+    NoProgressDetected: "BLOCKED",
   },
   TEST_FIX_LOOP: {
     ChecksPassed: "REVIEW_FIX_LOOP",
     ChecksFailedRecoverable: "PHASE_EXECUTE",
-    ChecksFailedNonRecoverable: "FAILED"
+    ChecksFailedNonRecoverable: "FAILED",
   },
   REVIEW_FIX_LOOP: {
-    ReviewResolved: "PHASE_READY"
+    ReviewResolved: "PHASE_READY",
   },
   TICKETS_EXECUTING: {
     AllTicketsComplete: "TICKETS_COMPLETE",
-    TicketFailed: "FAILED"
+    TicketFailed: "FAILED",
   },
   TICKETS_COMPLETE: {
     ChecksPassed: "COMPLETE",
-    ChecksFailedNonRecoverable: "FAILED"
+    ChecksFailedNonRecoverable: "FAILED",
   },
   COMPLETE: {},
   BLOCKED: {},
-  FAILED: {}
+  FAILED: {},
 };
 
-export function getNextState(
-  currentState: RunState,
-  eventType: RunEventType
-): RunState | null {
+export function getNextState(currentState: RunState, eventType: RunEventType): RunState | null {
   return transitions[currentState][eventType] ?? null;
 }
 
-export function assertTransition(
-  currentState: RunState,
-  eventType: RunEventType
-): RunState {
+export function assertTransition(currentState: RunState, eventType: RunEventType): RunState {
   const nextState = getNextState(currentState, eventType);
 
   if (!nextState) {
-    throw new Error(
-      `Invalid transition: state=${currentState} event=${eventType}`
-    );
+    throw new Error(`Invalid transition: state=${currentState} event=${eventType}`);
   }
 
   return nextState;

--- a/src/domain/ticket.ts
+++ b/src/domain/ticket.ts
@@ -14,7 +14,7 @@ export const TicketStatusSchema = z.enum([
   "verifying",
   "retry",
   "completed",
-  "failed"
+  "failed",
 ]);
 
 export type TicketStatus = z.infer<typeof TicketStatusSchema>;
@@ -29,7 +29,7 @@ export const TicketDefinitionSchema = z.object({
   verificationCommands: z.array(z.string()).default([]),
   docsToUpdate: z.array(z.string()).default([]),
   dependsOn: z.array(z.string()).default([]),
-  retryPolicy: RetryPolicySchema
+  retryPolicy: RetryPolicySchema,
 });
 
 export type TicketDefinition = z.infer<typeof TicketDefinitionSchema>;
@@ -39,14 +39,14 @@ export const TicketPlanSchema = z.object({
   task: z.object({
     title: z.string().min(1),
     featureRequest: z.string().min(1),
-    repoRoot: z.string().min(1)
+    repoRoot: z.string().min(1),
   }),
   classification: ClassificationResultSchema,
   tickets: z.array(TicketDefinitionSchema).min(1),
   finalVerification: z.object({
-    commands: z.array(z.string()).default([])
+    commands: z.array(z.string()).default([]),
   }),
-  docsToUpdate: z.array(z.string()).default([])
+  docsToUpdate: z.array(z.string()).default([]),
 });
 
 export type TicketPlan = z.infer<typeof TicketPlanSchema>;
@@ -116,7 +116,7 @@ export function initializeTicketLedger(
     ticketId: ticket.id,
     title: ticket.title,
     specialty: ticket.specialty,
-    status: ticket.dependsOn.length > 0 ? "blocked" as const : "ready" as const,
+    status: ticket.dependsOn.length > 0 ? ("blocked" as const) : ("ready" as const),
     dependsOn: ticket.dependsOn,
     assignedAgentId: null,
     assignedAgentName: null,
@@ -128,7 +128,7 @@ export function initializeTicketLedger(
     startedAt: null,
     completedAt: null,
     updatedAt: now,
-    runId
+    runId,
   }));
 }
 
@@ -199,9 +199,7 @@ export function validateTicketDag(tickets: TicketDefinition[]): {
     return { valid: true, order, cycle: null };
   }
 
-  const remaining = tickets
-    .filter((t) => !order.includes(t.id))
-    .map((t) => t.id);
+  const remaining = tickets.filter((t) => !order.includes(t.id)).map((t) => t.id);
 
   return { valid: false, order, cycle: remaining };
 }
@@ -209,7 +207,7 @@ export function validateTicketDag(tickets: TicketDefinition[]): {
 export function linearizeTickets(tickets: TicketDefinition[]): TicketDefinition[] {
   return tickets.map((ticket, index) => ({
     ...ticket,
-    dependsOn: index > 0 ? [tickets[index - 1].id] : []
+    dependsOn: index > 0 ? [tickets[index - 1].id] : [],
   }));
 }
 
@@ -226,21 +224,38 @@ export const ticketPlanJsonSchema = {
       properties: {
         title: { type: "string" },
         featureRequest: { type: "string" },
-        repoRoot: { type: "string" }
-      }
+        repoRoot: { type: "string" },
+      },
     },
     classification: {
       type: "object",
       additionalProperties: false,
-      required: ["tier", "rationale", "suggestedSpecialties", "estimatedTicketCount", "needsDesignDoc", "needsUserApproval"],
+      required: [
+        "tier",
+        "rationale",
+        "suggestedSpecialties",
+        "estimatedTicketCount",
+        "needsDesignDoc",
+        "needsUserApproval",
+      ],
       properties: {
-        tier: { type: "string", enum: ["trivial", "bugfix", "feature_small", "feature_large", "architectural", "multi_repo"] },
+        tier: {
+          type: "string",
+          enum: [
+            "trivial",
+            "bugfix",
+            "feature_small",
+            "feature_large",
+            "architectural",
+            "multi_repo",
+          ],
+        },
         rationale: { type: "string" },
         suggestedSpecialties: { type: "array", items: { type: "string" } },
         estimatedTicketCount: { type: "integer", minimum: 1, maximum: 50 },
         needsDesignDoc: { type: "boolean" },
-        needsUserApproval: { type: "boolean" }
-      }
+        needsUserApproval: { type: "boolean" },
+      },
     },
     tickets: {
       type: "array",
@@ -253,7 +268,10 @@ export const ticketPlanJsonSchema = {
           id: { type: "string" },
           title: { type: "string" },
           objective: { type: "string" },
-          specialty: { type: "string", enum: ["general", "ui", "business_logic", "api_crud", "devops", "testing"] },
+          specialty: {
+            type: "string",
+            enum: ["general", "ui", "business_logic", "api_crud", "devops", "testing"],
+          },
           acceptanceCriteria: { type: "array", minItems: 1, items: { type: "string" } },
           allowedCommands: { type: "array", items: { type: "string" } },
           verificationCommands: { type: "array", items: { type: "string" } },
@@ -265,20 +283,20 @@ export const ticketPlanJsonSchema = {
             required: ["maxAgentAttempts", "maxTestFixLoops"],
             properties: {
               maxAgentAttempts: { type: "integer", minimum: 1, maximum: 5 },
-              maxTestFixLoops: { type: "integer", minimum: 1, maximum: 10 }
-            }
-          }
-        }
-      }
+              maxTestFixLoops: { type: "integer", minimum: 1, maximum: 10 },
+            },
+          },
+        },
+      },
     },
     finalVerification: {
       type: "object",
       additionalProperties: false,
       required: ["commands"],
       properties: {
-        commands: { type: "array", items: { type: "string" } }
-      }
+        commands: { type: "array", items: { type: "string" } },
+      },
     },
-    docsToUpdate: { type: "array", items: { type: "string" } }
-  }
+    docsToUpdate: { type: "array", items: { type: "string" } },
+  },
 } as const;

--- a/src/domain/tool-activity.ts
+++ b/src/domain/tool-activity.ts
@@ -104,9 +104,7 @@ export function parseClaudeStreamLine(line: string): string | null {
     const name = typeof b.name === "string" ? b.name : "tool";
     const inputRaw = b.input;
     const input =
-      inputRaw && typeof inputRaw === "object"
-        ? (inputRaw as Record<string, unknown>)
-        : undefined;
+      inputRaw && typeof inputRaw === "object" ? (inputRaw as Record<string, unknown>) : undefined;
     return describeToolUse(name, input);
   }
   return null;

--- a/src/execution/artifact-store.ts
+++ b/src/execution/artifact-store.ts
@@ -12,7 +12,7 @@ import type {
   HarnessRun,
   PhaseLedgerEntry,
   RunEvent,
-  RunIndexEntry
+  RunIndexEntry,
 } from "../domain/run.js";
 import { buildHarnessStore } from "../storage/factory.js";
 import { STORE_NS } from "../storage/namespaces.js";
@@ -73,13 +73,8 @@ export interface ArtifactStore {
   }): Promise<ArtifactRecord>;
   readCommandResult(path: string): Promise<CommandArtifactContent>;
   readFailureClassification(path: string): Promise<FailureClassificationArtifactContent>;
-  savePhaseLedger(input: {
-    runId: string;
-    phaseLedger: PhaseLedgerEntry[];
-  }): Promise<string>;
-  saveRunsIndex(input: {
-    entry: RunIndexEntry;
-  }): Promise<string>;
+  savePhaseLedger(input: { runId: string; phaseLedger: PhaseLedgerEntry[] }): Promise<string>;
+  saveRunsIndex(input: { entry: RunIndexEntry }): Promise<string>;
   readRunsIndex(): Promise<RunIndexEntry[]>;
   saveRunSnapshot(run: HarnessRun): Promise<string>;
   readRunSnapshot(runId: string): Promise<RunSnapshot | null>;
@@ -89,10 +84,19 @@ export interface ArtifactStore {
   readPrLifecycle(runId: string): Promise<PrLifecycle | null>;
   saveTicketLedger(input: { runId: string; ticketLedger: TicketLedgerEntry[] }): Promise<string>;
   readTicketLedger(runId: string): Promise<TicketLedgerEntry[] | null>;
-  saveClassification(input: { runId: string; classification: ClassificationResult }): Promise<string>;
+  saveClassification(input: {
+    runId: string;
+    classification: ClassificationResult;
+  }): Promise<string>;
   saveDesignDoc(input: { runId: string; content: string }): Promise<string>;
-  saveApprovalRecord(input: { runId: string; decision: "approved" | "rejected"; feedback?: string }): Promise<string>;
-  readApprovalRecord(runId: string): Promise<{ decision: "approved" | "rejected"; feedback?: string; timestamp: string } | null>;
+  saveApprovalRecord(input: {
+    runId: string;
+    decision: "approved" | "rejected";
+    feedback?: string;
+  }): Promise<string>;
+  readApprovalRecord(
+    runId: string
+  ): Promise<{ decision: "approved" | "rejected"; feedback?: string; timestamp: string } | null>;
 }
 
 /**
@@ -148,16 +152,12 @@ function buildBlobUri(id: string): string {
  *   the caller should fall through to the pre-T-103 legacy absolute-path
  *   read. Existing run histories still carry absolute paths in `run.json`.
  */
-function parseBlobUri(
-  uri: string
-): { ns: string; id: string } | null {
+function parseBlobUri(uri: string): { ns: string; id: string } | null {
   if (!uri.startsWith(BLOB_URI_PREFIX)) return null;
   const rest = uri.slice(BLOB_URI_PREFIX.length);
   const slash = rest.indexOf("/");
   if (slash < 0) {
-    throw new Error(
-      `Invalid blob URI (missing '/'): ${uri}`
-    );
+    throw new Error(`Invalid blob URI (missing '/'): ${uri}`);
   }
   const ns = rest.slice(0, slash);
   const id = rest.slice(slash + 1);
@@ -229,9 +229,7 @@ export class LocalArtifactStore implements ArtifactStore {
     this.store = store ?? buildHarnessStore();
   }
 
-  async saveCommandResult(
-    input: SaveCommandArtifactInput
-  ): Promise<ArtifactRecord> {
+  async saveCommandResult(input: SaveCommandArtifactInput): Promise<ArtifactRecord> {
     const artifactId = buildArtifactId();
     const content: CommandArtifactContent = {
       artifactId,
@@ -241,7 +239,7 @@ export class LocalArtifactStore implements ArtifactStore {
       exitCode: input.result.exitCode,
       stdout: input.result.stdout,
       stderr: input.result.stderr,
-      capturedAt: new Date().toISOString()
+      capturedAt: new Date().toISOString(),
     };
 
     const id = blobId(input.runId, input.phaseId, artifactId);
@@ -250,7 +248,7 @@ export class LocalArtifactStore implements ArtifactStore {
       contentType: "application/json",
       runId: input.runId,
       phaseId: input.phaseId,
-      artifactType: "command_result"
+      artifactType: "command_result",
     });
 
     return {
@@ -259,7 +257,7 @@ export class LocalArtifactStore implements ArtifactStore {
       type: "command_result",
       path: buildBlobUri(id),
       command: input.command,
-      exitCode: input.result.exitCode
+      exitCode: input.result.exitCode,
     };
   }
 
@@ -269,7 +267,7 @@ export class LocalArtifactStore implements ArtifactStore {
       const bytes = await this.store.getBlob({
         ns: ref.ns,
         id: ref.id,
-        size: 0
+        size: 0,
       });
       return JSON.parse(new TextDecoder().decode(bytes)) as CommandArtifactContent;
     }
@@ -292,7 +290,7 @@ export class LocalArtifactStore implements ArtifactStore {
       category: input.classification.category,
       rationale: input.classification.rationale,
       nextAction: input.classification.nextAction,
-      capturedAt: new Date().toISOString()
+      capturedAt: new Date().toISOString(),
     };
 
     const id = blobId(input.runId, input.phaseId, artifactId);
@@ -301,7 +299,7 @@ export class LocalArtifactStore implements ArtifactStore {
       contentType: "application/json",
       runId: input.runId,
       phaseId: input.phaseId,
-      artifactType: "failure_classification"
+      artifactType: "failure_classification",
     });
 
     return {
@@ -311,28 +309,22 @@ export class LocalArtifactStore implements ArtifactStore {
       path: buildBlobUri(id),
       category: input.classification.category,
       rationale: input.classification.rationale,
-      nextAction: input.classification.nextAction
+      nextAction: input.classification.nextAction,
     };
   }
 
-  async readFailureClassification(
-    path: string
-  ): Promise<FailureClassificationArtifactContent> {
+  async readFailureClassification(path: string): Promise<FailureClassificationArtifactContent> {
     const ref = parseBlobUri(path);
     if (ref) {
       const bytes = await this.store.getBlob({
         ns: ref.ns,
         id: ref.id,
-        size: 0
+        size: 0,
       });
-      return JSON.parse(
-        new TextDecoder().decode(bytes)
-      ) as FailureClassificationArtifactContent;
+      return JSON.parse(new TextDecoder().decode(bytes)) as FailureClassificationArtifactContent;
     }
     warnLegacyArtifactPath(path);
-    return JSON.parse(
-      await readLegacyArtifactFile(path)
-    ) as FailureClassificationArtifactContent;
+    return JSON.parse(await readLegacyArtifactFile(path)) as FailureClassificationArtifactContent;
   }
 
   async savePhaseLedger(input: {
@@ -342,7 +334,7 @@ export class LocalArtifactStore implements ArtifactStore {
     const runDir = join(this.rootDir, input.runId);
 
     await mkdir(runDir, {
-      recursive: true
+      recursive: true,
     });
 
     const path = join(runDir, "phase-ledger.json");
@@ -353,7 +345,7 @@ export class LocalArtifactStore implements ArtifactStore {
         {
           runId: input.runId,
           updatedAt: new Date().toISOString(),
-          phases: input.phaseLedger
+          phases: input.phaseLedger,
         },
         null,
         2
@@ -364,14 +356,12 @@ export class LocalArtifactStore implements ArtifactStore {
     return path;
   }
 
-  async saveRunsIndex(input: {
-    entry: RunIndexEntry;
-  }): Promise<string> {
+  async saveRunsIndex(input: { entry: RunIndexEntry }): Promise<string> {
     const path = join(this.rootDir, "runs-index.json");
     const existing = await this.readRunsIndex();
     const next = [
       input.entry,
-      ...existing.filter((entry) => entry.runId !== input.entry.runId)
+      ...existing.filter((entry) => entry.runId !== input.entry.runId),
     ].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
 
     await writeFile(
@@ -379,7 +369,7 @@ export class LocalArtifactStore implements ArtifactStore {
       JSON.stringify(
         {
           updatedAt: new Date().toISOString(),
-          runs: next
+          runs: next,
         },
         null,
         2
@@ -403,9 +393,7 @@ export class LocalArtifactStore implements ArtifactStore {
         return [];
       }
       throw new Error(
-        `Failed to read runs index at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Failed to read runs index at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
 
@@ -414,9 +402,7 @@ export class LocalArtifactStore implements ArtifactStore {
       return raw.runs ?? [];
     } catch (err) {
       throw new Error(
-        `Failed to parse runs index at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Failed to parse runs index at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }
@@ -441,7 +427,7 @@ export class LocalArtifactStore implements ArtifactStore {
       artifacts: run.artifacts,
       phaseLedger: run.phaseLedger,
       ticketLedger: run.ticketLedger,
-      eventCount: run.events.length
+      eventCount: run.events.length,
     };
 
     await writeFile(path, JSON.stringify(snapshot, null, 2));
@@ -497,9 +483,7 @@ export class LocalArtifactStore implements ArtifactStore {
         return [];
       }
       throw new Error(
-        `Failed to read event log at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Failed to read event log at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
 
@@ -511,9 +495,7 @@ export class LocalArtifactStore implements ArtifactStore {
         .map((line) => JSON.parse(line) as RunEvent);
     } catch (err) {
       throw new Error(
-        `Failed to parse event log at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Failed to parse event log at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }
@@ -571,18 +553,14 @@ export class LocalArtifactStore implements ArtifactStore {
         {
           runId: input.runId,
           updatedAt: new Date().toISOString(),
-          tickets: input.ticketLedger
+          tickets: input.ticketLedger,
         },
         null,
         2
       )
     );
 
-    await this.writeCoordRecord(
-      input.runId,
-      "ticket-ledger",
-      input.ticketLedger.length
-    );
+    await this.writeCoordRecord(input.runId, "ticket-ledger", input.ticketLedger.length);
     return path;
   }
 
@@ -623,22 +601,19 @@ export class LocalArtifactStore implements ArtifactStore {
     const doc = {
       runId: input.runId,
       ...input.classification,
-      classifiedAt: new Date().toISOString()
+      classifiedAt: new Date().toISOString(),
     };
     await this.store.putDoc(STORE_NS.runArtifacts, id, doc);
     return buildBlobUri(id);
   }
 
-  async saveDesignDoc(input: {
-    runId: string;
-    content: string;
-  }): Promise<string> {
+  async saveDesignDoc(input: { runId: string; content: string }): Promise<string> {
     const id = `${input.runId}__design-doc`;
     const bytes = new TextEncoder().encode(input.content);
     await this.store.putBlob(STORE_NS.runArtifacts, id, bytes, {
       contentType: "text/markdown",
       runId: input.runId,
-      artifactType: "design_doc"
+      artifactType: "design_doc",
     });
     return buildBlobUri(id);
   }
@@ -653,7 +628,7 @@ export class LocalArtifactStore implements ArtifactStore {
       runId: input.runId,
       decision: input.decision,
       feedback: input.feedback ?? null,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
     await this.store.putDoc(STORE_NS.runArtifacts, id, doc);
     return buildBlobUri(id);
@@ -675,7 +650,7 @@ export class LocalArtifactStore implements ArtifactStore {
     return {
       decision: doc.decision,
       feedback: doc.feedback ?? undefined,
-      timestamp: doc.timestamp
+      timestamp: doc.timestamp,
     };
   }
 
@@ -696,7 +671,7 @@ export class LocalArtifactStore implements ArtifactStore {
       () => ({
         kind,
         updatedAt: new Date().toISOString(),
-        ...(count !== undefined ? { count } : {})
+        ...(count !== undefined ? { count } : {}),
       })
     );
   }

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -25,13 +25,7 @@ export interface ExecutionResult {
   stderr: string;
 }
 
-export type ExecutionEventKind =
-  | "start"
-  | "stdout"
-  | "stderr"
-  | "tool_use"
-  | "heartbeat"
-  | "exit";
+export type ExecutionEventKind = "start" | "stdout" | "stderr" | "tool_use" | "heartbeat" | "exit";
 
 export interface ExecutionEvent {
   kind: ExecutionEventKind;

--- a/src/execution/local-child-process-executor.ts
+++ b/src/execution/local-child-process-executor.ts
@@ -3,7 +3,7 @@ import {
   NodeCommandInvoker,
   type CommandInvocation,
   type CommandInvoker,
-  type SpawnedProcess
+  type SpawnedProcess,
 } from "../agents/command-invoker.js";
 import type {
   AgentExecutor,
@@ -11,7 +11,7 @@ import type {
   ExecutionHandle,
   ExecutionResult,
   ExecutionStatus,
-  ExecutorStartOptions
+  ExecutorStartOptions,
 } from "./executor.js";
 import type { SandboxProvider, SandboxRef } from "./sandbox.js";
 
@@ -94,9 +94,7 @@ const POST_KILL_WATCHDOG_MS = 5_000;
 const MAX_HEARTBEAT_COUNT = 120;
 const SUMMARY_PREFIX_LENGTH = 120;
 
-function defaultResolveCommand(
-  ticket: TicketDefinition
-): ResolvedCommand | null {
+function defaultResolveCommand(ticket: TicketDefinition): ResolvedCommand | null {
   const first = ticket.allowedCommands[0];
   if (!first) return null;
   const parts = first.trim().split(/\s+/);
@@ -308,7 +306,7 @@ class LocalExecutionHandle implements ExecutionHandle {
       this.bus.emit({
         kind: "stdout",
         at: new Date().toISOString(),
-        data: chunk
+        data: chunk,
       });
     });
     this.deps.process.onStderr((chunk) => {
@@ -316,7 +314,7 @@ class LocalExecutionHandle implements ExecutionHandle {
       this.bus.emit({
         kind: "stderr",
         at: new Date().toISOString(),
-        data: chunk
+        data: chunk,
       });
     });
     this.deps.process.onError((error) => {
@@ -328,9 +326,7 @@ class LocalExecutionHandle implements ExecutionHandle {
       // those apart. Unknown codes fall through to 1.
       this.stderrBuf += error.message;
       const code = (error as NodeJS.ErrnoException).code;
-      const reason = code
-        ? `${error.message} (code ${code})`
-        : error.message;
+      const reason = code ? `${error.message} (code ${code})` : error.message;
       let exitCode = 1;
       if (code === "ENOENT") {
         exitCode = COMMAND_NOT_FOUND_EXIT_CODE;
@@ -352,8 +348,7 @@ class LocalExecutionHandle implements ExecutionHandle {
       // Unix convention: signal-terminated processes surface as 128+signo so
       // callers can distinguish them from natural exits. We preserve Node's
       // own `code` when present, otherwise fall back to signo arithmetic.
-      const exitCode =
-        code ?? (signal ? 128 + signalToNumber(signal) : 1);
+      const exitCode = code ?? (signal ? 128 + signalToNumber(signal) : 1);
       this.finalize(exitCode);
     });
   }
@@ -381,7 +376,7 @@ class LocalExecutionHandle implements ExecutionHandle {
         this.bus.emit({
           kind: "heartbeat",
           at: new Date().toISOString(),
-          data: "heartbeat-cap-reached"
+          data: "heartbeat-cap-reached",
         });
         if (this.heartbeatHandle) clearInterval(this.heartbeatHandle);
         this.heartbeatHandle = null;
@@ -451,7 +446,7 @@ class LocalExecutionHandle implements ExecutionHandle {
       exitCode,
       summary,
       stdout: this.stdoutBuf,
-      stderr: this.stderrBuf
+      stderr: this.stderrBuf,
     };
 
     if (this.timeoutHandle) clearTimeout(this.timeoutHandle);
@@ -463,7 +458,7 @@ class LocalExecutionHandle implements ExecutionHandle {
       {
         kind: "exit",
         at: new Date().toISOString(),
-        data: String(exitCode)
+        data: String(exitCode),
       },
       true
     );
@@ -487,12 +482,7 @@ class LocalExecutionHandle implements ExecutionHandle {
   }
 }
 
-function buildSummary(
-  stdout: string,
-  stderr: string,
-  exitCode: number,
-  reason?: string
-): string {
+function buildSummary(stdout: string, stderr: string, exitCode: number, reason?: string): string {
   if (reason) return reason;
   if (exitCode === 0 && stderr.trim() === "") {
     return stdout.slice(0, SUMMARY_PREFIX_LENGTH);
@@ -505,13 +495,20 @@ function buildSummary(
 // when Node hands us `signal` without `code`.
 function signalToNumber(signal: NodeJS.Signals): number {
   switch (signal) {
-    case "SIGHUP": return 1;
-    case "SIGINT": return 2;
-    case "SIGQUIT": return 3;
-    case "SIGABRT": return 6;
-    case "SIGKILL": return 9;
-    case "SIGTERM": return 15;
-    default: return 1;
+    case "SIGHUP":
+      return 1;
+    case "SIGINT":
+      return 2;
+    case "SIGQUIT":
+      return 3;
+    case "SIGABRT":
+      return 6;
+    case "SIGKILL":
+      return 9;
+    case "SIGTERM":
+      return 15;
+    default:
+      return 1;
   }
 }
 
@@ -560,10 +557,7 @@ export class LocalChildProcessExecutor implements AgentExecutor {
     }
   }
 
-  async start(
-    ticket: TicketDefinition,
-    opts: ExecutorStartOptions
-  ): Promise<ExecutionHandle> {
+  async start(ticket: TicketDefinition, opts: ExecutorStartOptions): Promise<ExecutionHandle> {
     // Create-per-start sandbox management. We create before validating opts
     // so a mis-typed "remote" ref from the provider path is still caught
     // symmetrically with the caller-supplied path below.
@@ -583,11 +577,10 @@ export class LocalChildProcessExecutor implements AgentExecutor {
           options?: { runId: string; ticketId: string }
         ): Promise<SandboxRef>;
       };
-      sandbox = await provider.create(
-        { root: opts.repoRoot },
-        "main",
-        { runId: opts.runId, ticketId: ticket.id }
-      );
+      sandbox = await provider.create({ root: opts.repoRoot }, "main", {
+        runId: opts.runId,
+        ticketId: ticket.id,
+      });
       ownsSandbox = true;
     } else {
       sandbox = opts.sandbox;
@@ -641,7 +634,7 @@ export class LocalChildProcessExecutor implements AgentExecutor {
       args: resolved.args,
       cwd: ownedSandbox.workdir.path,
       stdin: resolved.stdin,
-      env: { ...opts.env, ...resolved.env }
+      env: { ...opts.env, ...resolved.env },
     };
 
     // Narrowed above by the ctor-time check; `!` here is load-bearing so TS
@@ -669,7 +662,7 @@ export class LocalChildProcessExecutor implements AgentExecutor {
           // waits on the result of this cleanup.
           await providerForCleanup.destroy(ownedSandbox);
         }
-      }
+      },
     });
 
     return handle;

--- a/src/execution/noop-executor.ts
+++ b/src/execution/noop-executor.ts
@@ -5,14 +5,9 @@ import type {
   ExecutionHandle,
   ExecutionResult,
   ExecutionStatus,
-  ExecutorStartOptions
+  ExecutorStartOptions,
 } from "./executor.js";
-import type {
-  DestroyResult,
-  RepoRef,
-  SandboxProvider,
-  SandboxRef
-} from "./sandbox.js";
+import type { DestroyResult, RepoRef, SandboxProvider, SandboxRef } from "./sandbox.js";
 import { resolveLocalPath } from "./sandbox.js";
 
 export class NoopSandboxProvider implements SandboxProvider {
@@ -26,7 +21,7 @@ export class NoopSandboxProvider implements SandboxProvider {
     return {
       id,
       workdir: { kind: "local", path: repo.root },
-      meta: { base }
+      meta: { base },
     };
   }
 
@@ -55,9 +50,7 @@ class NoopExecutionHandle implements ExecutionHandle {
     if (this.cachedResult) {
       // wait() resolved normally; if kill() fires afterward it's a no-op and
       // we stay `exited` per the documented contract on ExecutionHandle.kill.
-      return this.killed && this.cachedResult.exitCode === 137
-        ? "killed"
-        : "exited";
+      return this.killed && this.cachedResult.exitCode === 137 ? "killed" : "exited";
     }
 
     return this.killed ? "killed" : "running";
@@ -92,7 +85,7 @@ class NoopExecutionHandle implements ExecutionHandle {
     yield {
       kind: "exit",
       at: new Date().toISOString(),
-      data: String(result.exitCode)
+      data: String(result.exitCode),
     };
   }
 }
@@ -107,10 +100,7 @@ class NoopExecutionHandle implements ExecutionHandle {
 export class NoopExecutor implements AgentExecutor {
   private counter = 0;
 
-  async start(
-    _ticket: TicketDefinition,
-    opts: ExecutorStartOptions
-  ): Promise<ExecutionHandle> {
+  async start(_ticket: TicketDefinition, opts: ExecutorStartOptions): Promise<ExecutionHandle> {
     const id = `noop-exec-${++this.counter}`;
     // `sandbox` is optional on ExecutorStartOptions so executors that manage
     // their own lifecycle can skip it. NoopExecutor does not create sandboxes;

--- a/src/execution/sandboxes/git-worktree.ts
+++ b/src/execution/sandboxes/git-worktree.ts
@@ -4,12 +4,7 @@ import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 
 import { getRelayDir } from "../../cli/paths.js";
-import type {
-  DestroyResult,
-  RepoRef,
-  SandboxProvider,
-  SandboxRef
-} from "../sandbox.js";
+import type { DestroyResult, RepoRef, SandboxProvider, SandboxRef } from "../sandbox.js";
 export type { DestroyResult } from "../sandbox.js";
 
 // argv-based runner (no shell) keeps repo paths safe from shell expansion.
@@ -34,10 +29,7 @@ export interface RunGitResult {
  * process with argv (no shell). Tests inject a mock so the provider is
  * unit-testable without a real git repo on disk.
  */
-export type RunGit = (
-  args: string[],
-  cwd: string
-) => Promise<RunGitResult>;
+export type RunGit = (args: string[], cwd: string) => Promise<RunGitResult>;
 
 export interface GitWorktreeSandboxOptions {
   /** Parent dir holding all sandboxes for this harness. */
@@ -70,7 +62,7 @@ const DIRTY_STDERR_FRAGMENTS = [
   "contains modified or untracked files",
   "is dirty",
   "has modifications",
-  "use --force to delete it"
+  "use --force to delete it",
 ];
 
 /**
@@ -83,10 +75,7 @@ const DIRTY_STDERR_FRAGMENTS = [
  * {@link ../../storage/file-store.ts} — see the PR review: a tiny local copy
  * is preferable to extracting a shared helper during a review-response commit.
  */
-function assertSafeSegment(
-  segment: string,
-  kind: "runId" | "ticketId"
-): void {
+function assertSafeSegment(segment: string, kind: "runId" | "ticketId"): void {
   if (
     segment === "" ||
     segment === "." ||
@@ -119,13 +108,13 @@ const defaultRunGit: RunGit = async (args, cwd) => {
         stdout: e.stdout ?? "",
         stderr: e.stderr ?? String(err),
         code: 1,
-        spawnCode: e.code
+        spawnCode: e.code,
       };
     }
     return {
       stdout: e.stdout ?? "",
       stderr: e.stderr ?? String(err),
-      code: typeof e.code === "number" ? e.code : 1
+      code: typeof e.code === "number" ? e.code : 1,
     };
   }
 };
@@ -159,15 +148,9 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
    * crash), the worktree and its `.relay-state.json` remain on disk for T-203
    * recovery — deletion is never implicit.
    */
-  async create(
-    repo: RepoRef,
-    base: string,
-    options?: CreateOptions
-  ): Promise<SandboxRef> {
+  async create(repo: RepoRef, base: string, options?: CreateOptions): Promise<SandboxRef> {
     if (!options) {
-      throw new Error(
-        "GitWorktreeSandboxProvider.create requires { runId, ticketId }"
-      );
+      throw new Error("GitWorktreeSandboxProvider.create requires { runId, ticketId }");
     }
     // Validate BEFORE the non-null coerce in requireIds — an empty string
     // should surface as "Unsafe path segment" (not as the lower-priority
@@ -210,7 +193,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
       ticketId,
       createdAt: new Date().toISOString(),
       base,
-      branch
+      branch,
     };
 
     try {
@@ -227,10 +210,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
       console.debug(
         `[git-worktree] state-file write failed at ${sandboxPath}; attempting rollback`
       );
-      const rollback = await this.runGit(
-        ["worktree", "remove", "--force", sandboxPath],
-        repo.root
-      );
+      const rollback = await this.runGit(["worktree", "remove", "--force", sandboxPath], repo.root);
       if (rollback.code !== 0) {
         // eslint-disable-next-line no-console
         console.debug(
@@ -238,9 +218,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
         );
       }
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `Failed to write .relay-state.json at ${sandboxPath}: ${message}`
-      );
+      throw new Error(`Failed to write .relay-state.json at ${sandboxPath}: ${message}`);
     }
 
     this.ownerRepo.set(id, repo.root);
@@ -248,7 +226,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
     return {
       id,
       workdir: { kind: "local", path: sandboxPath },
-      meta: { branch, base, runId, ticketId }
+      meta: { branch, base, runId, ticketId },
     };
   }
 
@@ -265,10 +243,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
    * that a T-203 recovery sweep is expected to salvage. Pass
    * `{ force: true }` to override.
    */
-  async destroy(
-    ref: SandboxRef,
-    opts: DestroyOptions = {}
-  ): Promise<DestroyResult> {
+  async destroy(ref: SandboxRef, opts: DestroyOptions = {}): Promise<DestroyResult> {
     if (ref.workdir.kind !== "local") {
       return { kind: "missing" };
     }
@@ -331,9 +306,7 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
 
 function requireIds(options: CreateOptions | undefined): CreateOptions {
   if (!options?.runId || !options.ticketId) {
-    throw new Error(
-      "GitWorktreeSandboxProvider.create requires { runId, ticketId }"
-    );
+    throw new Error("GitWorktreeSandboxProvider.create requires { runId, ticketId }");
   }
   return options;
 }

--- a/src/execution/verification-runner.ts
+++ b/src/execution/verification-runner.ts
@@ -42,10 +42,7 @@ export class VerificationRunner {
   ) {}
 
   async run(input: VerificationRunInput): Promise<VerificationRunResult> {
-    const selection = selectVerificationCommands(
-      input.proposedCommands,
-      input.allowlistedCommands
-    );
+    const selection = selectVerificationCommands(input.proposedCommands, input.allowlistedCommands);
     const executed: VerificationCommandResult[] = [];
 
     for (const command of selection.commandsToRun) {
@@ -53,13 +50,13 @@ export class VerificationRunner {
         runId: input.runId,
         phaseId: input.phaseId,
         repoRoot: input.repoRoot,
-        command
+        command,
       });
 
       executed.push({
         command,
         result,
-        artifact
+        artifact,
       });
     }
 
@@ -68,7 +65,7 @@ export class VerificationRunner {
       executed,
       rejected: selection.rejected,
       overridden: selection.overridden,
-      substitutedCommands: selection.overridden ? [...selection.commandsToRun] : []
+      substitutedCommands: selection.overridden ? [...selection.commandsToRun] : [],
     };
   }
 
@@ -85,19 +82,19 @@ export class VerificationRunner {
       command: "zsh",
       args: ["-c", input.command],
       cwd: input.repoRoot,
-      timeoutMs: 300_000
+      timeoutMs: 300_000,
     });
     const artifact = await this.artifactStore.saveCommandResult({
       runId: input.runId,
       phaseId: input.phaseId,
       command: input.command,
       result,
-      cwd: input.repoRoot
+      cwd: input.repoRoot,
     });
 
     return {
       result,
-      artifact
+      artifact,
     };
   }
 }
@@ -132,7 +129,7 @@ export function selectVerificationCommands(
         ? approvedProposed
         : uniqueNormalizedCommands(allowlistedCommands),
     rejected,
-    overridden
+    overridden,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,27 +11,21 @@ import {
   hasHarnessMcpOptOut,
   isAutoApproveEnabled,
   stripAutoApproveFlags,
-  stripHarnessMcpOptOut
+  stripHarnessMcpOptOut,
 } from "./cli/agent-wrapper.js";
 import { AgentRegistry } from "./agents/registry.js";
 import { launchGui, launchTui, parseGuiFlags } from "./cli/launch-gui-tui.js";
 import { parseRebuildFlags, runRebuild } from "./cli/rebuild.js";
 import { launchInteractiveCommand } from "./cli/launcher.js";
-import {
-  createStreamActivityRenderer,
-  isQuietMode
-} from "./cli/stream-activity-renderer.js";
+import { createStreamActivityRenderer, isQuietMode } from "./cli/stream-activity-renderer.js";
 import { hasOnboarded, parseWelcomeFlags, runWelcome } from "./cli/welcome.js";
 import {
   ensureHarnessWorkspace,
   type HarnessServiceStatus,
   type HarnessWorkspacePaths,
-  readWorkspaceSummary
+  readWorkspaceSummary,
 } from "./cli/workspace.js";
-import {
-  getGlobalRoot,
-  listRegisteredWorkspaces
-} from "./cli/workspace-registry.js";
+import { getGlobalRoot, listRegisteredWorkspaces } from "./cli/workspace-registry.js";
 import { addProjectDir, readConfig, removeProjectDir } from "./cli/config.js";
 import { LocalArtifactStore } from "./execution/artifact-store.js";
 import { getHarnessStore } from "./storage/factory.js";
@@ -44,15 +38,9 @@ import { OrchestratorV2 } from "./orchestrator/orchestrator-v2.js";
 import { ScriptedInvoker } from "./simulation/scripted-invoker.js";
 import { ChannelStore } from "./channels/channel-store.js";
 import { resolveBoardTickets } from "./channels/board-resolver.js";
-import {
-  createPrWatcherFactory,
-  getActiveWatcher
-} from "./cli/pr-watcher-factory.js";
+import { createPrWatcherFactory, getActiveWatcher } from "./cli/pr-watcher-factory.js";
 import type { HarnessPR } from "./integrations/scm.js";
-import {
-  fetchLinearProject,
-  mirrorLinearProject
-} from "./integrations/linear-mirror.js";
+import { fetchLinearProject, mirrorLinearProject } from "./integrations/linear-mirror.js";
 import { handleCrosslinkCommand } from "./crosslink/cli.js";
 import { startDashboard } from "./tui/dashboard.js";
 import { SessionStore } from "./cli/session-store.js";
@@ -80,11 +68,7 @@ export async function main(): Promise<void> {
     return;
   }
 
-  if (
-    rawCommand === "--version" ||
-    rawCommand === "-v" ||
-    rawCommand === "version"
-  ) {
+  if (rawCommand === "--version" || rawCommand === "-v" || rawCommand === "version") {
     const version = await readPackageVersion();
     console.log(`rly v${version}`);
     return;
@@ -120,7 +104,7 @@ export async function main(): Promise<void> {
       cwd,
       args,
       workspace,
-      artifactStore
+      artifactStore,
     });
     return;
   }
@@ -130,7 +114,7 @@ export async function main(): Promise<void> {
       cwd,
       args,
       workspace,
-      artifactStore
+      artifactStore,
     });
     return;
   }
@@ -235,7 +219,12 @@ export async function main(): Promise<void> {
     return;
   }
 
-  if (command === "claude" || command === "codex" || command.startsWith("claude-") || command.startsWith("codex-")) {
+  if (
+    command === "claude" ||
+    command === "codex" ||
+    command.startsWith("claude-") ||
+    command.startsWith("codex-")
+  ) {
     // First-run nudge: print a one-liner pointing at `rly welcome` if the
     // user hasn't done the tour. Non-blocking.
     if (!hasOnboarded()) {
@@ -266,7 +255,7 @@ export async function main(): Promise<void> {
           cliEntrypoint,
           userArgs,
           workspace,
-          autoApprove
+          autoApprove,
         })
       : userArgs;
     const exitCode = await launchInteractiveCommand({
@@ -279,8 +268,8 @@ export async function main(): Promise<void> {
         RELAY_ARTIFACTS_DIR: workspace.paths.artifactsDir,
         RELAY_RUNS_INDEX: workspace.paths.runsIndexPath,
         // Propagate to children (dispatched agents) so they inherit.
-        ...(autoApprove ? { RELAY_AUTO_APPROVE: "1" } : {})
-      }
+        ...(autoApprove ? { RELAY_AUTO_APPROVE: "1" } : {}),
+      },
     });
 
     process.exitCode = exitCode;
@@ -288,11 +277,14 @@ export async function main(): Promise<void> {
   }
 
   const sequential = args.includes("--sequential");
-  const featureRequest = args.filter((a) => !a.startsWith("--")).join(" ").trim();
+  const featureRequest = args
+    .filter((a) => !a.startsWith("--"))
+    .join(" ")
+    .trim();
 
   if (!featureRequest) {
     console.error("Usage: rly run <feature request>");
-    console.error("  Example: rly run \"Add user authentication with OAuth2\"");
+    console.error('  Example: rly run "Add user authentication with OAuth2"');
     process.exitCode = 1;
     return;
   }
@@ -319,17 +311,14 @@ export async function main(): Promise<void> {
           streamRenderers.set(spec.id, renderer);
           return (line: string) => renderer.onLine(line);
         }
-      : undefined
+      : undefined,
   });
 
   for (const agent of agents) {
     registry.register(agent);
   }
 
-  const verificationRunner = new VerificationRunner(
-    new NodeCommandInvoker(),
-    artifactStore
-  );
+  const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
   let run: Awaited<ReturnType<Orchestrator["run"]>>;
 
   const runId = `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -361,7 +350,7 @@ export async function main(): Promise<void> {
       orchestratorV2.attachPoller(
         createPrWatcherFactory({
           channelStore,
-          repoRoot: cwd
+          repoRoot: cwd,
         })
       );
       run = await orchestratorV2.run(featureRequest, runId);
@@ -384,8 +373,8 @@ export async function main(): Promise<void> {
         updatedAt: now,
         completedAt: now,
         phaseLedgerPath: null,
-        artifactsRoot: `${workspace.paths.artifactsDir}/${runId}`
-      }
+        artifactsRoot: `${workspace.paths.artifactsDir}/${runId}`,
+      },
     });
 
     process.exitCode = 1;
@@ -412,9 +401,7 @@ export async function main(): Promise<void> {
 
   for (const item of run.evidence) {
     const name = await getAgentName(item.agentId);
-    console.log(
-      `- [${name}] ${item.phaseId} attempt=${item.attempt} ${item.summary}`
-    );
+    console.log(`- [${name}] ${item.phaseId} attempt=${item.attempt} ${item.summary}`);
   }
 
   console.log("");
@@ -523,7 +510,9 @@ async function printChannels(args: string[] = []): Promise<void> {
     const activeMembers = ch.members.filter((m) => m.status === "active").length;
     console.log(`  ${ch.name} (${ch.channelId})`);
     console.log(`    ${ch.description}`);
-    console.log(`    Status: ${ch.status} | Members: ${activeMembers}/${ch.members.length} | Refs: ${ch.pinnedRefs.length}`);
+    console.log(
+      `    Status: ${ch.status} | Members: ${activeMembers}/${ch.members.length} | Refs: ${ch.pinnedRefs.length}`
+    );
     console.log("");
   }
 }
@@ -554,9 +543,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     let primaryWorkspaceId: string | undefined;
     if (primaryArg) {
       if (!repoAssignments || repoAssignments.length === 0) {
-        console.error(
-          `--primary ${primaryArg} requires --repos with at least one entry.`
-        );
+        console.error(`--primary ${primaryArg} requires --repos with at least one entry.`);
         process.exitCode = 1;
         return;
       }
@@ -582,7 +569,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
       name,
       description,
       repoAssignments,
-      primaryWorkspaceId
+      primaryWorkspaceId,
     });
 
     if (args.includes("--json")) {
@@ -627,10 +614,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     const reposArg = parseNamedArg(args, "--repos");
     const primaryArg = parseNamedArg(args, "--primary");
     const patch: Partial<
-      Pick<
-        import("./domain/channel.js").Channel,
-        "repoAssignments" | "primaryWorkspaceId"
-      >
+      Pick<import("./domain/channel.js").Channel, "repoAssignments" | "primaryWorkspaceId">
     > = {};
 
     if (reposArg) {
@@ -650,8 +634,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
         process.exitCode = 1;
         return;
       }
-      const effectiveAssignments =
-        patch.repoAssignments ?? existing.repoAssignments ?? [];
+      const effectiveAssignments = patch.repoAssignments ?? existing.repoAssignments ?? [];
       const match = effectiveAssignments.find((r) => r.alias === primaryArg);
       if (!match) {
         const known = effectiveAssignments.map((r) => r.alias).join(", ") || "(none)";
@@ -716,12 +699,17 @@ async function handleChannelCommand(args: string[]): Promise<void> {
 
   if (sub === "post") {
     const channelId = args[1];
-    const content = args.slice(2).filter((a) => !a.startsWith("--")).join(" ");
+    const content = args
+      .slice(2)
+      .filter((a) => !a.startsWith("--"))
+      .join(" ");
     const fromName = parseNamedArg(args, "--from") ?? "CLI";
     const entryType = parseNamedArg(args, "--type") ?? "message";
 
     if (!channelId || !content) {
-      console.error("Usage: rly channel post <channelId> <content> [--from <name>] [--type <type>]");
+      console.error(
+        "Usage: rly channel post <channelId> <content> [--from <name>] [--type <type>]"
+      );
       process.exitCode = 1;
       return;
     }
@@ -731,7 +719,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
       fromAgentId: null,
       fromDisplayName: fromName,
       content,
-      metadata: {}
+      metadata: {},
     });
 
     jsonOut(entry);
@@ -786,25 +774,18 @@ function getLinearApiKey(): string | null {
   return process.env.LINEAR_API_KEY ?? null;
 }
 
-async function handleChannelLinkLinear(
-  store: ChannelStore,
-  args: string[]
-): Promise<void> {
+async function handleChannelLinkLinear(store: ChannelStore, args: string[]): Promise<void> {
   const channelId = args[1];
   const projectId = args[2];
   if (!channelId || !projectId) {
-    console.error(
-      "Usage: rly channel link-linear <channelId> <linearProjectId>"
-    );
+    console.error("Usage: rly channel link-linear <channelId> <linearProjectId>");
     process.exitCode = 1;
     return;
   }
 
   const apiKey = getLinearApiKey();
   if (!apiKey) {
-    console.error(
-      "LINEAR_API_KEY is not set. Add it to ~/.relay/config.env and re-source."
-    );
+    console.error("LINEAR_API_KEY is not set. Add it to ~/.relay/config.env and re-source.");
     process.exitCode = 1;
     return;
   }
@@ -836,7 +817,7 @@ async function handleChannelLinkLinear(
 
   const result = await mirrorLinearProject(channelId, project.id, {
     store,
-    apiKey
+    apiKey,
   });
 
   await store.postEntry(channelId, {
@@ -847,8 +828,8 @@ async function handleChannelLinkLinear(
     metadata: {
       linearProjectId: project.id,
       linearProjectName: project.name,
-      fetched: result.fetched
-    }
+      fetched: result.fetched,
+    },
   });
 
   if (args.includes("--json")) {
@@ -857,19 +838,14 @@ async function handleChannelLinkLinear(
       linearProjectId: project.id,
       linearProjectName: project.name,
       fetched: result.fetched,
-      mirrored: result.mirrored.length
+      mirrored: result.mirrored.length,
     });
   } else {
-    console.log(
-      `Linked "${project.name}" (${project.id}) — mirrored ${result.fetched} issues.`
-    );
+    console.log(`Linked "${project.name}" (${project.id}) — mirrored ${result.fetched} issues.`);
   }
 }
 
-async function handleChannelLinearSync(
-  store: ChannelStore,
-  args: string[]
-): Promise<void> {
+async function handleChannelLinearSync(store: ChannelStore, args: string[]): Promise<void> {
   const channelId = args[1];
   if (!channelId) {
     console.error("Usage: rly channel linear-sync <channelId>");
@@ -900,7 +876,7 @@ async function handleChannelLinearSync(
 
   const result = await mirrorLinearProject(channelId, channel.linearProjectId, {
     store,
-    apiKey
+    apiKey,
   });
 
   if (args.includes("--json")) {
@@ -908,7 +884,7 @@ async function handleChannelLinearSync(
       channelId,
       linearProjectId: channel.linearProjectId,
       fetched: result.fetched,
-      mirrored: result.mirrored.length
+      mirrored: result.mirrored.length,
     });
   } else {
     console.log(
@@ -955,7 +931,9 @@ async function handlePrWatchCommand(args: string[]): Promise<void> {
 
   const pr = await resolvePrFromInput(input, watcher.repo, watcher.scm, branchHint);
   if (!pr) {
-    console.error(`Could not resolve PR from "${input}". Provide a full GitHub URL or a PR number.`);
+    console.error(
+      `Could not resolve PR from "${input}". Provide a full GitHub URL or a PR number.`
+    );
     process.exitCode = 1;
     return;
   }
@@ -976,10 +954,12 @@ async function handlePrWatchCommand(args: string[]): Promise<void> {
     ticketId,
     channelId: resolvedChannelId,
     pr,
-    repo: watcher.repo
+    repo: watcher.repo,
   });
 
-  console.log(`Tracking ${watcher.repo.owner}/${watcher.repo.name}#${pr.number} (ticket: ${ticketId})`);
+  console.log(
+    `Tracking ${watcher.repo.owner}/${watcher.repo.name}#${pr.number} (ticket: ${ticketId})`
+  );
 }
 
 /**
@@ -1019,7 +999,7 @@ async function handlePrStatusCommand(args: string[] = []): Promise<void> {
         branch: t.pr.branch,
         ci: t.last?.ci ?? null,
         review: t.last?.review ?? null,
-        prState: t.last?.prState ?? null
+        prState: t.last?.prState ?? null,
       }));
   } else {
     const channelStore = new ChannelStore(undefined, getHarnessStore());
@@ -1037,7 +1017,7 @@ async function handlePrStatusCommand(args: string[] = []): Promise<void> {
           branch: p.branch,
           ci: p.ci,
           review: p.review,
-          prState: p.prState
+          prState: p.prState,
         });
       }
     }
@@ -1058,7 +1038,9 @@ async function handlePrStatusCommand(args: string[] = []): Promise<void> {
   }
 
   console.log(`Tracked PRs (${rows.length}):`);
-  console.log("  TICKET             PR                                   STATE     CI        REVIEW");
+  console.log(
+    "  TICKET             PR                                   STATE     CI        REVIEW"
+  );
 
   for (const t of rows) {
     const label = `${t.owner}/${t.name}#${t.number}`;
@@ -1112,7 +1094,7 @@ async function handlePlanDecisionCommand(
       runId,
       decision,
       feedback,
-      artifactStore
+      artifactStore,
     });
     jsonOut({ ok: true, runId, decision, feedback, workspaceId, path });
   } catch (err) {
@@ -1129,10 +1111,7 @@ async function handlePlanDecisionCommand(
  * plan-approval banner / CTA. A run is "pending" when its `state` is
  * `AWAITING_APPROVAL` and no approval record has been written yet.
  */
-async function handlePendingPlansCommand(
-  args: string[],
-  _cwd: string
-): Promise<void> {
+async function handlePendingPlansCommand(args: string[], _cwd: string): Promise<void> {
   const workspaces = await listRegisteredWorkspaces();
   const pending: Array<{
     runId: string;
@@ -1156,7 +1135,7 @@ async function handlePendingPlansCommand(
         featureRequest: r.featureRequest,
         channelId: r.channelId,
         state: r.state,
-        updatedAt: r.updatedAt
+        updatedAt: r.updatedAt,
       });
     }
   }
@@ -1174,10 +1153,12 @@ async function handlePendingPlansCommand(
   console.log(`Runs awaiting approval (${pending.length}):`);
   for (const p of pending) {
     const channel = p.channelId ? ` channel=${p.channelId}` : "";
-    console.log(`  ${p.runId}  workspace=${p.workspaceId}${channel}  "${p.featureRequest.slice(0, 60)}"`);
+    console.log(
+      `  ${p.runId}  workspace=${p.workspaceId}${channel}  "${p.featureRequest.slice(0, 60)}"`
+    );
   }
   console.log("\nApprove with: rly approve <runId>");
-  console.log("Reject with:  rly reject <runId> [--feedback \"…\"]");
+  console.log('Reject with:  rly reject <runId> [--feedback "…"]');
 }
 
 async function resolveWorkspaceIdForRun(runId: string): Promise<string | null> {
@@ -1206,7 +1187,9 @@ async function resolveWorkspaceIdForRun(runId: string): Promise<string | null> {
 async function resolvePrFromInput(
   input: string,
   repo: { owner: string; name: string },
-  scm: { detectPR: (branch: string, repo: { owner: string; name: string }) => Promise<HarnessPR | null> },
+  scm: {
+    detectPR: (branch: string, repo: { owner: string; name: string }) => Promise<HarnessPR | null>;
+  },
   branchHint?: string
 ): Promise<HarnessPR | null> {
   const trimmed = input.trim();
@@ -1230,7 +1213,7 @@ async function resolvePrFromInput(
     return {
       number,
       url: `https://github.com/${urlMatch[1]}/${urlMatch[2]}/pull/${number}`,
-      branch: branchHint ?? ""
+      branch: branchHint ?? "",
     };
   }
 
@@ -1240,7 +1223,7 @@ async function resolvePrFromInput(
     return {
       number,
       url: `https://github.com/${repo.owner}/${repo.name}/pull/${number}`,
-      branch: branchHint ?? ""
+      branch: branchHint ?? "",
     };
   }
 
@@ -1261,12 +1244,26 @@ async function resolveDefaultChannelId(): Promise<string | null> {
 async function printRunningTasks(args: string[] = []): Promise<void> {
   const workspaces = await listRegisteredWorkspaces();
   const activeStates = new Set([
-    "CLASSIFYING", "DRAFT_PLAN", "PLAN_REVIEW", "AWAITING_APPROVAL",
-    "DESIGN_DOC", "PHASE_READY", "PHASE_EXECUTE", "TEST_FIX_LOOP",
-    "REVIEW_FIX_LOOP", "TICKETS_EXECUTING", "TICKETS_COMPLETE"
+    "CLASSIFYING",
+    "DRAFT_PLAN",
+    "PLAN_REVIEW",
+    "AWAITING_APPROVAL",
+    "DESIGN_DOC",
+    "PHASE_READY",
+    "PHASE_EXECUTE",
+    "TEST_FIX_LOOP",
+    "REVIEW_FIX_LOOP",
+    "TICKETS_EXECUTING",
+    "TICKETS_COMPLETE",
   ]);
 
-  const activeRuns: Array<{ runId: string; state: string; featureRequest: string; workspace: string; channelId: string | null }> = [];
+  const activeRuns: Array<{
+    runId: string;
+    state: string;
+    featureRequest: string;
+    workspace: string;
+    channelId: string | null;
+  }> = [];
 
   for (const ws of workspaces) {
     const wsArtifactStore = new LocalArtifactStore(
@@ -1282,7 +1279,7 @@ async function printRunningTasks(args: string[] = []): Promise<void> {
           state: run.state,
           featureRequest: run.featureRequest,
           workspace: ws.repoPath,
-          channelId: run.channelId ?? null
+          channelId: run.channelId ?? null,
         });
       }
     }
@@ -1332,10 +1329,7 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
     linearUrl?: string;
   }
   const board: Record<string, BoardRow[]> = {};
-  const resolved = await resolveBoardTickets(store, channelId, async (
-    workspaceId,
-    runId
-  ) => {
+  const resolved = await resolveBoardTickets(store, channelId, async (workspaceId, runId) => {
     const wsStore = new LocalArtifactStore(
       `${getGlobalRoot()}/workspaces/${workspaceId}/artifacts`,
       getHarnessStore()
@@ -1350,7 +1344,7 @@ async function printTaskBoard(channelId: string, args: string[] = []): Promise<v
       title: entry.title,
       source: entry.source,
       linearIdentifier: entry.linearIdentifier,
-      linearUrl: entry.linearUrl
+      linearUrl: entry.linearUrl,
     });
   }
 
@@ -1578,7 +1572,9 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     const sid = parseNamedArg(args, "--sid");
 
     if (!channelId || !sessionId || !alias || !sid) {
-      console.error("Usage: rly session update-claude-sid --channel <id> --session <id> --alias <name> --sid <claude_sid>");
+      console.error(
+        "Usage: rly session update-claude-sid --channel <id> --session <id> --alias <name> --sid <claude_sid>"
+      );
       process.exitCode = 1;
       return;
     }
@@ -1597,7 +1593,9 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     const content = extractPositionals(args).slice(1).join(" ");
 
     if (!channelId || !sessionId || !content) {
-      console.error("Usage: rly session append --channel <id> --session <id> --role <role> [--alias <name>] [--metadata <json>] <content>");
+      console.error(
+        "Usage: rly session append --channel <id> --session <id> --role <role> [--alias <name>] [--metadata <json>] <content>"
+      );
       process.exitCode = 1;
       return;
     }
@@ -1615,7 +1613,9 @@ async function handleSessionCommand(args: string[]): Promise<void> {
           throw new Error("--metadata must be a JSON object of string values");
         }
       } catch (err) {
-        console.error(`Invalid --metadata JSON: ${err instanceof Error ? err.message : String(err)}`);
+        console.error(
+          `Invalid --metadata JSON: ${err instanceof Error ? err.message : String(err)}`
+        );
         process.exitCode = 1;
         return;
       }
@@ -1626,7 +1626,7 @@ async function handleSessionCommand(args: string[]): Promise<void> {
       content,
       timestamp: new Date().toISOString(),
       agentAlias: alias,
-      ...(metadata ? { metadata } : {})
+      ...(metadata ? { metadata } : {}),
     });
 
     jsonOut({ ok: true });
@@ -1650,7 +1650,7 @@ async function handleSessionCommand(args: string[]): Promise<void> {
       role,
       content,
       timestamp: new Date().toISOString(),
-      agentAlias: alias
+      agentAlias: alias,
     });
 
     jsonOut({ ok: true });
@@ -1689,15 +1689,16 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     // orphaned); deleteSession still scrubs the on-disk JSONL + index.
     const channelStoreForDelete = new ChannelStore(undefined, getHarnessStore());
     const channelForDelete = await channelStoreForDelete.getChannel(channelId);
-    const repoPaths =
-      channelForDelete?.repoAssignments?.map((r) => r.repoPath) ?? [];
+    const repoPaths = channelForDelete?.repoAssignments?.map((r) => r.repoPath) ?? [];
 
     await store.deleteSession(channelId, sessionId, { repoPaths });
     jsonOut({ ok: true, deleted: sessionId });
     return;
   }
 
-  console.error("Usage: rly session <create|list|get|delete|update-claude-sid|append|update-last|messages>");
+  console.error(
+    "Usage: rly session <create|list|get|delete|update-claude-sid|append|update-last|messages>"
+  );
   process.exitCode = 1;
 }
 
@@ -1714,7 +1715,9 @@ async function handleChatCommand(
     const alias = parseNamedArg(args, "--alias");
 
     if (!channelId) {
-      console.error("Usage: rly chat system-prompt --channel <id> [--repo <path>] [--alias <name>]");
+      console.error(
+        "Usage: rly chat system-prompt --channel <id> [--repo <path>] [--alias <name>]"
+      );
       process.exitCode = 1;
       return;
     }
@@ -1765,7 +1768,9 @@ async function handleChatCommand(
     const key = parseNamedArg(args, "--key");
     const messageTimestamp = parseNamedArg(args, "--message-timestamp");
     if (!channelId || !sessionId || !key || !messageTimestamp) {
-      console.error("Usage: rly chat rewind-apply --channel <id> --session <id> --key <ref-key> --message-timestamp <iso8601>");
+      console.error(
+        "Usage: rly chat rewind-apply --channel <id> --session <id> --key <ref-key> --message-timestamp <iso8601>"
+      );
       process.exitCode = 1;
       return;
     }
@@ -1779,7 +1784,9 @@ async function handleChatCommand(
     return;
   }
 
-  console.error("Usage: rly chat <system-prompt|resolve-refs|mcp-config|rewind|rewind-snapshot|rewind-apply>");
+  console.error(
+    "Usage: rly chat <system-prompt|resolve-refs|mcp-config|rewind|rewind-snapshot|rewind-apply>"
+  );
   process.exitCode = 1;
 }
 
@@ -1853,9 +1860,7 @@ async function handleChatRewindCommand(args: string[]): Promise<void> {
       console.log("Rewindable user messages (most recent last):");
       for (let i = 0; i < recent.length; i += 1) {
         const c = recent[i];
-        const preview = c.message.content
-          .replace(/\s+/g, " ")
-          .slice(0, 60);
+        const preview = c.message.content.replace(/\s+/g, " ").slice(0, 60);
         console.log(`  [${i + 1}] ${c.message.timestamp}  ${preview}`);
       }
       const raw = (await rl.question("Pick a number (or Enter to cancel): ")).trim();
@@ -1875,9 +1880,7 @@ async function handleChatRewindCommand(args: string[]): Promise<void> {
       rl.close();
     }
   } else {
-    console.error(
-      "Specify --to <messageTimestamp> or --interactive. Recent candidates:"
-    );
+    console.error("Specify --to <messageTimestamp> or --interactive. Recent candidates:");
     for (const c of candidates.slice(-10)) {
       const preview = c.message.content.replace(/\s+/g, " ").slice(0, 60);
       console.error(`  ${c.message.timestamp}  ${preview}`);
@@ -1898,20 +1901,15 @@ async function handleChatRewindCommand(args: string[]): Promise<void> {
   // the message, but fresh snapshots ensure refs exist even if the original
   // ones were GC'd). The GUI path skips re-snapshotting; we follow suit
   // and only apply.
-  const result = await rewindApply(
-    channelId,
-    sessionId,
-    key,
-    chosen.message.timestamp
-  );
+  const result = await rewindApply(channelId, sessionId, key, chosen.message.timestamp);
   jsonOut({
     ok: true,
     target: {
       timestamp: chosen.message.timestamp,
       rewindKey: key,
-      preview: chosen.message.content.slice(0, 120)
+      preview: chosen.message.content.slice(0, 120),
     },
-    ...result
+    ...result,
   });
 }
 
@@ -1946,10 +1944,7 @@ async function printRunsIndex(
   }
 }
 
-async function printStatus(
-  artifactStore: LocalArtifactStore,
-  cwd: string
-): Promise<void> {
+async function printStatus(artifactStore: LocalArtifactStore, cwd: string): Promise<void> {
   const summary = await readWorkspaceSummary(artifactStore, cwd);
 
   console.log(`Workspace: ${cwd}`);
@@ -2003,12 +1998,10 @@ async function inspectMcp(input: {
     const claudeConfigPath = await ensureClaudeMcpConfig({
       cwd: input.cwd,
       cliEntrypoint,
-      paths: input.workspace.paths
+      paths: input.workspace.paths,
     });
     console.log(`Claude MCP config: ${claudeConfigPath}`);
-    console.log(
-      `Codex MCP server: relay -> ${cliEntrypoint} mcp-server --workspace ${input.cwd}`
-    );
+    console.log(`Codex MCP server: relay -> ${cliEntrypoint} mcp-server --workspace ${input.cwd}`);
     console.log("");
   }
 
@@ -2024,15 +2017,15 @@ async function inspectMcp(input: {
             workspace: input.workspace,
             // `mcp list` is a probe, no approvals needed and no spawning of
             // long-running agents. Skip auto-approve propagation here.
-            autoApprove: false
+            autoApprove: false,
           })
         : ["mcp", "list"],
       cwd: input.cwd,
       env: {
         RELAY_HOME: input.workspace.paths.rootDir,
         RELAY_ARTIFACTS_DIR: input.workspace.paths.artifactsDir,
-        RELAY_RUNS_INDEX: input.workspace.paths.runsIndexPath
-      }
+        RELAY_RUNS_INDEX: input.workspace.paths.runsIndexPath,
+      },
     });
 
     console.log(`${capitalize(candidate)} MCP servers:`);
@@ -2099,9 +2092,7 @@ async function printUpStatus(input: {
 
 async function readPackageVersion(): Promise<string> {
   const packageJsonPath = new URL("../package.json", import.meta.url);
-  const packageJson = JSON.parse(
-    await readFile(packageJsonPath, "utf8")
-  ) as { version?: string };
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: string };
 
   return packageJson.version ?? "0.0.0";
 }
@@ -2134,7 +2125,7 @@ async function printTopLevelHelp(): Promise<void> {
     "  version | --version      Print version",
     "",
     "Run `rly <command> --help` for command-specific help.",
-    "Docs: https://github.com/jcast90/relay#readme"
+    "Docs: https://github.com/jcast90/relay#readme",
   ];
   console.log(lines.join("\n"));
 }
@@ -2145,16 +2136,28 @@ function resolveCliEntrypoint(): string {
 
 async function handleServeCommand(cwd: string, args: string[]): Promise<void> {
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: rly serve [--port <n>] [--host <host>] [--token <token>] [--workspace <id>]");
+    console.log(
+      "Usage: rly serve [--port <n>] [--host <host>] [--token <token>] [--workspace <id>]"
+    );
     console.log("");
     console.log("Starts an HTTP/SSE MCP server exposing Relay's tool surface.");
     console.log("");
     console.log("Options:");
-    console.log("  --port <n>                         TCP port to bind (env: RELAY_PORT, default: 7420)");
-    console.log("  --host <host>                      Host/interface (default: 127.0.0.1 / loopback only)");
-    console.log("  --token <token>                    Require Authorization: Bearer <token> (env: RELAY_TOKEN)");
-    console.log("  --workspace <id>                   Workspace id (required unless the current repo is registered via `rly up`)");
-    console.log("  --allow-unauthenticated-remote     Opt-in: allow non-loopback --host without --token (DANGEROUS)");
+    console.log(
+      "  --port <n>                         TCP port to bind (env: RELAY_PORT, default: 7420)"
+    );
+    console.log(
+      "  --host <host>                      Host/interface (default: 127.0.0.1 / loopback only)"
+    );
+    console.log(
+      "  --token <token>                    Require Authorization: Bearer <token> (env: RELAY_TOKEN)"
+    );
+    console.log(
+      "  --workspace <id>                   Workspace id (required unless the current repo is registered via `rly up`)"
+    );
+    console.log(
+      "  --allow-unauthenticated-remote     Opt-in: allow non-loopback --host without --token (DANGEROUS)"
+    );
     console.log("");
     console.log("For multi-host deployments pass BOTH --host 0.0.0.0 AND --token explicitly.");
     return;
@@ -2298,9 +2301,9 @@ async function buildWrappedAgentLaunchArgs(input: {
       mcpConfigPath: await ensureClaudeMcpConfig({
         cwd: input.cwd,
         cliEntrypoint: input.cliEntrypoint,
-        paths: input.workspace.paths
+        paths: input.workspace.paths,
       }),
-      autoApprove: input.autoApprove
+      autoApprove: input.autoApprove,
     });
   }
 
@@ -2308,7 +2311,7 @@ async function buildWrappedAgentLaunchArgs(input: {
     userArgs: input.userArgs,
     cwd: input.cwd,
     cliEntrypoint: input.cliEntrypoint,
-    autoApprove: input.autoApprove
+    autoApprove: input.autoApprove,
   });
 }
 

--- a/src/integrations/linear-mirror.ts
+++ b/src/integrations/linear-mirror.ts
@@ -59,15 +59,13 @@ async function linearGraphql<T>(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: deps.apiKey
+      Authorization: deps.apiKey,
     },
-    body: JSON.stringify({ query, variables })
+    body: JSON.stringify({ query, variables }),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(
-      `Linear API HTTP ${res.status}: ${body.slice(0, 200)}`
-    );
+    throw new Error(`Linear API HTTP ${res.status}: ${body.slice(0, 200)}`);
   }
   const payload = (await res.json()) as {
     data?: T;
@@ -157,10 +155,7 @@ export function mirrorTicketId(issueId: string): string {
   return `${MIRROR_TICKET_PREFIX}${issueId}`;
 }
 
-export function toMirrorTicket(
-  issue: LinearIssueNode,
-  now: string
-): TicketLedgerEntry {
+export function toMirrorTicket(issue: LinearIssueNode, now: string): TicketLedgerEntry {
   return {
     ticketId: mirrorTicketId(issue.id),
     title: `${issue.identifier} ${issue.title}`,
@@ -182,7 +177,7 @@ export function toMirrorTicket(
     linearIssueId: issue.id,
     linearIdentifier: issue.identifier,
     linearState: issue.state.name,
-    linearUrl: issue.url
+    linearUrl: issue.url,
   };
 }
 
@@ -202,6 +197,6 @@ export async function mirrorLinearProject(
   const merged = await deps.store.upsertChannelTickets(channelId, mirrors);
   return {
     fetched: issues.length,
-    mirrored: merged.filter((t) => t.source === "linear")
+    mirrored: merged.filter((t) => t.source === "linear"),
   };
 }

--- a/src/integrations/plugin-env-mutex.ts
+++ b/src/integrations/plugin-env-mutex.ts
@@ -29,15 +29,13 @@ let held = false;
 
 export async function withEnvOverride<T>(
   overrides: Record<string, string | undefined>,
-  fn: () => T | Promise<T>,
+  fn: () => T | Promise<T>
 ): Promise<T> {
   // Fail fast on recursion. We throw *before* touching the chain so the outer
   // call's mutex state stays intact — once the outer `fn` returns normally,
   // subsequent unrelated callers queued behind it still run as usual.
   if (held) {
-    throw new Error(
-      "withEnvOverride: recursive call detected — plugin factories must not reenter",
-    );
+    throw new Error("withEnvOverride: recursive call detected — plugin factories must not reenter");
   }
 
   const prior = chain;

--- a/src/integrations/pr-poller.ts
+++ b/src/integrations/pr-poller.ts
@@ -12,13 +12,7 @@
  *   - prState -> "merged" | "closed": post entry + untrack.
  *   - Any other delta: informational entry only.
  */
-import type {
-  CiSummary,
-  EnrichedPR,
-  HarnessPR,
-  HarnessScm,
-  ReviewDecision,
-} from "./scm.js";
+import type { CiSummary, EnrichedPR, HarnessPR, HarnessScm, ReviewDecision } from "./scm.js";
 import type { ChannelStore } from "../channels/channel-store.js";
 
 export interface TrackedPr {
@@ -185,7 +179,7 @@ export class PrPoller {
   private async handleTransitions(
     entry: TrackedPr,
     previous: EnrichedPR,
-    current: EnrichedPR,
+    current: EnrichedPR
   ): Promise<void> {
     if (current.ci !== previous.ci) {
       await this.onCiChange(entry, previous.ci, current.ci);
@@ -227,7 +221,7 @@ export class PrPoller {
   private async onReviewChange(
     entry: TrackedPr,
     from: ReviewDecision,
-    to: ReviewDecision,
+    to: ReviewDecision
   ): Promise<void> {
     await this.post(entry.channelId, `Review ${from} -> ${to} on ${this.keyFor(entry)}`, {
       ticketId: entry.ticketId,
@@ -254,10 +248,7 @@ export class PrPoller {
     });
   }
 
-  private async onPrStateChange(
-    entry: TrackedPr,
-    to: "open" | "merged" | "closed",
-  ): Promise<void> {
+  private async onPrStateChange(entry: TrackedPr, to: "open" | "merged" | "closed"): Promise<void> {
     await this.post(entry.channelId, `PR ${this.keyFor(entry)} is now ${to}`, {
       ticketId: entry.ticketId,
       prUrl: entry.pr.url,
@@ -269,7 +260,7 @@ export class PrPoller {
   private async post(
     channelId: string,
     content: string,
-    metadata: Record<string, string>,
+    metadata: Record<string, string>
   ): Promise<void> {
     try {
       await this.channelStore.postEntry(channelId, {

--- a/src/integrations/scheduler-follow-up-dispatcher.ts
+++ b/src/integrations/scheduler-follow-up-dispatcher.ts
@@ -14,10 +14,7 @@
 import type { HarnessRun } from "../domain/run.js";
 import type { TicketDefinition } from "../domain/ticket.js";
 import type { TicketScheduler } from "../orchestrator/ticket-scheduler.js";
-import type {
-  FollowUpDispatcher,
-  FollowUpRequest
-} from "./pr-poller.js";
+import type { FollowUpDispatcher, FollowUpRequest } from "./pr-poller.js";
 
 export interface SchedulerFollowUpDispatcherOptions {
   scheduler: Pick<TicketScheduler, "enqueue">;
@@ -26,7 +23,7 @@ export interface SchedulerFollowUpDispatcherOptions {
 
 const DEFAULT_RETRY_POLICY = {
   maxAgentAttempts: 2,
-  maxTestFixLoops: 2
+  maxTestFixLoops: 2,
 } as const;
 
 export class SchedulerFollowUpDispatcher implements FollowUpDispatcher {
@@ -53,7 +50,7 @@ export class SchedulerFollowUpDispatcher implements FollowUpDispatcher {
       acceptanceCriteria: [
         request.kind === "fix-ci"
           ? "CI checks on the PR are passing after the follow-up commits."
-          : "All reviewer comments on the PR are addressed and resolved."
+          : "All reviewer comments on the PR are addressed and resolved.",
       ],
       allowedCommands: [],
       verificationCommands: [],
@@ -62,7 +59,7 @@ export class SchedulerFollowUpDispatcher implements FollowUpDispatcher {
       // block on the parent ticket, which by this point has already produced
       // a PR and moved on.
       dependsOn: [],
-      retryPolicy: DEFAULT_RETRY_POLICY
+      retryPolicy: DEFAULT_RETRY_POLICY,
     };
   }
 }

--- a/src/integrations/scm.ts
+++ b/src/integrations/scm.ts
@@ -5,12 +5,7 @@
  * rest of the codebase never imports AO types directly. Do not leak
  * `@aoagents/ao-core` types out of this module.
  */
-import type {
-  PRInfo,
-  ProjectConfig,
-  SCM,
-  Session,
-} from "@aoagents/ao-core";
+import type { PRInfo, ProjectConfig, SCM, Session } from "@aoagents/ao-core";
 import { create as createGithubScm } from "@aoagents/ao-plugin-scm-github";
 
 import { withEnvOverride } from "./plugin-env-mutex.js";
@@ -33,11 +28,7 @@ export interface HarnessProject {
 }
 
 export type CiSummary = "pending" | "passing" | "failing" | "none";
-export type ReviewDecision =
-  | "approved"
-  | "changes_requested"
-  | "pending"
-  | "none";
+export type ReviewDecision = "approved" | "changes_requested" | "pending" | "none";
 
 export interface PendingComment {
   id: string;
@@ -54,10 +45,7 @@ export interface EnrichedPR {
 }
 
 export interface HarnessScm {
-  detectPR(
-    branch: string,
-    repo: { owner: string; name: string },
-  ): Promise<HarnessPR | null>;
+  detectPR(branch: string, repo: { owner: string; name: string }): Promise<HarnessPR | null>;
   getCiSummary(pr: HarnessPR): Promise<CiSummary>;
   getReviewDecision(pr: HarnessPR): Promise<ReviewDecision>;
   getPendingComments(pr: HarnessPR): Promise<PendingComment[]>;
@@ -77,18 +65,9 @@ export interface HarnessScm {
  *    builds with different tokens can't observe each other's values.
  */
 export function createScm(kind: "github"): SCM;
-export function createScm(
-  kind: "github",
-  opts: { token?: undefined },
-): SCM;
-export function createScm(
-  kind: "github",
-  opts: { token: string },
-): Promise<SCM>;
-export function createScm(
-  kind: "github",
-  opts: { token?: string } = {},
-): SCM | Promise<SCM> {
+export function createScm(kind: "github", opts: { token?: undefined }): SCM;
+export function createScm(kind: "github", opts: { token: string }): Promise<SCM>;
+export function createScm(kind: "github", opts: { token?: string } = {}): SCM | Promise<SCM> {
   if (kind !== "github") {
     throw new Error(`createScm: unsupported kind "${kind as string}"`);
   }
@@ -98,9 +77,7 @@ export function createScm(
   // The github plugin shells out to `gh`, which reads GITHUB_TOKEN from env.
   // Serialize overlays so two concurrent calls with different tokens can't
   // race through the env.
-  return withEnvOverride({ GITHUB_TOKEN: opts.token }, () =>
-    createGithubScm(),
-  );
+  return withEnvOverride({ GITHUB_TOKEN: opts.token }, () => createGithubScm());
 }
 
 /** Produce the narrow facade from a raw AO `SCM`. */

--- a/src/integrations/tracker.ts
+++ b/src/integrations/tracker.ts
@@ -46,17 +46,11 @@ const ENV_VAR: Record<TrackerKind, string> = {
  *    is fundamentally async.
  */
 export function createTracker(kind: TrackerKind): Tracker;
+export function createTracker(kind: TrackerKind, opts: { token?: undefined }): Tracker;
+export function createTracker(kind: TrackerKind, opts: { token: string }): Promise<Tracker>;
 export function createTracker(
   kind: TrackerKind,
-  opts: { token?: undefined },
-): Tracker;
-export function createTracker(
-  kind: TrackerKind,
-  opts: { token: string },
-): Promise<Tracker>;
-export function createTracker(
-  kind: TrackerKind,
-  opts: { token?: string } = {},
+  opts: { token?: string } = {}
 ): Tracker | Promise<Tracker> {
   const build = (): Tracker =>
     kind === "github" ? githubTracker.create() : linearTracker.create();
@@ -75,11 +69,10 @@ export function createTracker(
 export async function resolveIssue(
   tracker: Tracker,
   identifier: string,
-  project: ProjectConfig,
+  project: ProjectConfig
 ): Promise<HarnessIssue> {
   const issue = await tracker.getIssue(identifier, project);
-  const branchName =
-    issue.branchName ?? tracker.branchName(identifier, project);
+  const branchName = issue.branchName ?? tracker.branchName(identifier, project);
   return {
     id: issue.id,
     title: issue.title,
@@ -91,7 +84,8 @@ export async function resolveIssue(
 }
 
 // GitHub issue URL: https://github.com/<owner>/<repo>/issues/<number>
-const GITHUB_ISSUE_URL = /^https?:\/\/(?:www\.)?github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:[/?#].*)?$/i;
+const GITHUB_ISSUE_URL =
+  /^https?:\/\/(?:www\.)?github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:[/?#].*)?$/i;
 // Linear issue URL: https://linear.app/<workspace>/issue/ABC-123(/...)
 const LINEAR_URL = /^https?:\/\/(?:www\.)?linear\.app\/[^/]+\/issue\/[A-Z][A-Z0-9]*-\d+/i;
 // Bare Linear identifier: ABC-123

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -2,10 +2,7 @@ import { getAgentName } from "../domain/agent-names.js";
 import { ChannelStore } from "../channels/channel-store.js";
 import { resolveBoardTickets } from "../channels/board-resolver.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
-import {
-  getGlobalRoot,
-  listRegisteredWorkspaces
-} from "../cli/workspace-registry.js";
+import { getGlobalRoot, listRegisteredWorkspaces } from "../cli/workspace-registry.js";
 import { getHarnessStore } from "../storage/factory.js";
 
 export interface ChannelToolState {
@@ -14,9 +11,17 @@ export interface ChannelToolState {
 }
 
 const ACTIVE_RUN_STATES = new Set([
-  "CLASSIFYING", "DRAFT_PLAN", "PLAN_REVIEW", "AWAITING_APPROVAL",
-  "DESIGN_DOC", "PHASE_READY", "PHASE_EXECUTE", "TEST_FIX_LOOP",
-  "REVIEW_FIX_LOOP", "TICKETS_EXECUTING", "TICKETS_COMPLETE"
+  "CLASSIFYING",
+  "DRAFT_PLAN",
+  "PLAN_REVIEW",
+  "AWAITING_APPROVAL",
+  "DESIGN_DOC",
+  "PHASE_READY",
+  "PHASE_EXECUTE",
+  "TEST_FIX_LOOP",
+  "REVIEW_FIX_LOOP",
+  "TICKETS_EXECUTING",
+  "TICKETS_COMPLETE",
 ]);
 
 export function isChannelTool(name: string): boolean {
@@ -35,22 +40,23 @@ export function getChannelToolDefinitions(): object[] {
         properties: {
           name: { type: "string", description: "Channel name, e.g. #feature-auth" },
           description: { type: "string" },
-          workspaceIds: { type: "array", items: { type: "string" } }
-        }
-      }
+          workspaceIds: { type: "array", items: { type: "string" } },
+        },
+      },
     },
     {
       name: "channel_get",
-      description: "Get channel details including members, pinned refs, recent feed, and active runs.",
+      description:
+        "Get channel details including members, pinned refs, recent feed, and active runs.",
       inputSchema: {
         type: "object",
         additionalProperties: false,
         required: ["channelId"],
         properties: {
           channelId: { type: "string" },
-          feedLimit: { type: "integer", minimum: 1, maximum: 100 }
-        }
-      }
+          feedLimit: { type: "integer", minimum: 1, maximum: 100 },
+        },
+      },
     },
     {
       name: "channel_post",
@@ -62,9 +68,9 @@ export function getChannelToolDefinitions(): object[] {
         properties: {
           channelId: { type: "string" },
           content: { type: "string" },
-          agentId: { type: "string" }
-        }
-      }
+          agentId: { type: "string" },
+        },
+      },
     },
     {
       name: "channel_record_decision",
@@ -80,9 +86,9 @@ export function getChannelToolDefinitions(): object[] {
           rationale: { type: "string" },
           alternatives: { type: "array", items: { type: "string" } },
           runId: { type: "string" },
-          ticketId: { type: "string" }
-        }
-      }
+          ticketId: { type: "string" },
+        },
+      },
     },
     {
       name: "channel_task_board",
@@ -91,8 +97,8 @@ export function getChannelToolDefinitions(): object[] {
         type: "object",
         additionalProperties: false,
         required: ["channelId"],
-        properties: { channelId: { type: "string" } }
-      }
+        properties: { channelId: { type: "string" } },
+      },
     },
     {
       name: "harness_running_tasks",
@@ -100,9 +106,9 @@ export function getChannelToolDefinitions(): object[] {
       inputSchema: {
         type: "object",
         additionalProperties: false,
-        properties: {}
-      }
-    }
+        properties: {},
+      },
+    },
   ];
 }
 
@@ -120,7 +126,7 @@ export async function callChannelTool(
         description: String(args.description ?? ""),
         workspaceIds: Array.isArray(args.workspaceIds)
           ? (args.workspaceIds as string[])
-          : undefined
+          : undefined,
       });
 
     case "channel_get": {
@@ -131,7 +137,7 @@ export async function callChannelTool(
       const [feed, runLinks, decisions] = await Promise.all([
         store.readFeed(channelId, Number(args.feedLimit ?? 20)),
         store.readRunLinks(channelId),
-        store.listDecisions(channelId)
+        store.listDecisions(channelId),
       ]);
 
       const activeMembers = channel.members.filter((m) => m.status === "active");
@@ -141,7 +147,7 @@ export async function callChannelTool(
         activeMembers,
         recentFeed: feed,
         runLinks,
-        recentDecisions: decisions.slice(0, 5)
+        recentDecisions: decisions.slice(0, 5),
       };
     }
 
@@ -153,7 +159,7 @@ export async function callChannelTool(
         fromAgentId: agentId,
         fromDisplayName: displayName,
         content: String(args.content ?? ""),
-        metadata: {}
+        metadata: {},
       });
     }
 
@@ -167,21 +173,21 @@ export async function callChannelTool(
         title: String(args.title ?? ""),
         description: String(args.description ?? ""),
         rationale: String(args.rationale ?? ""),
-        alternatives: Array.isArray(args.alternatives) ? args.alternatives as string[] : [],
+        alternatives: Array.isArray(args.alternatives) ? (args.alternatives as string[]) : [],
         decidedBy: agentId,
         decidedByName: displayName,
-        linkedArtifacts: []
+        linkedArtifacts: [],
       });
     }
 
     case "channel_task_board": {
       const channelId = String(args.channelId ?? "");
-      const board: Record<string, Array<{ ticketId: string; title: string; runId: string | null }>> = {};
+      const board: Record<
+        string,
+        Array<{ ticketId: string; title: string; runId: string | null }>
+      > = {};
 
-      const tickets = await resolveBoardTickets(store, channelId, async (
-        workspaceId,
-        runId
-      ) => {
+      const tickets = await resolveBoardTickets(store, channelId, async (workspaceId, runId) => {
         const artifactStore = buildArtifactStoreForWorkspace(workspaceId);
         return artifactStore.readTicketLedger(runId);
       });
@@ -191,7 +197,7 @@ export async function callChannelTool(
         board[entry.status].push({
           ticketId: entry.ticketId,
           title: entry.title,
-          runId
+          runId,
         });
       }
 
@@ -221,7 +227,7 @@ export async function callChannelTool(
               runId: run.runId,
               state: run.state,
               featureRequest: run.featureRequest,
-              channelId: run.channelId ?? null
+              channelId: run.channelId ?? null,
             });
           }
         }
@@ -237,5 +243,8 @@ export async function callChannelTool(
 
 function buildArtifactStoreForWorkspace(workspaceId: string): LocalArtifactStore {
   const globalRoot = getGlobalRoot();
-  return new LocalArtifactStore(`${globalRoot}/workspaces/${workspaceId}/artifacts`, getHarnessStore());
+  return new LocalArtifactStore(
+    `${globalRoot}/workspaces/${workspaceId}/artifacts`,
+    getHarnessStore()
+  );
 }

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -93,7 +93,7 @@ export async function startHttpMcpServer(
           res.end(
             JSON.stringify({
               error: "payload_too_large",
-              error_detail: `body exceeded ${error.limit} byte limit (received ${error.byteCount} bytes)`
+              error_detail: `body exceeded ${error.limit} byte limit (received ${error.byteCount} bytes)`,
             })
           );
         } else {
@@ -160,7 +160,8 @@ export async function startHttpMcpServer(
     await new Promise<void>((resolve) => {
       server.close(() => resolve());
       // Force-close any idle keep-alive sockets so close() resolves promptly.
-      const maybeCloseAll = (server as Server & { closeAllConnections?: () => void }).closeAllConnections;
+      const maybeCloseAll = (server as Server & { closeAllConnections?: () => void })
+        .closeAllConnections;
       if (typeof maybeCloseAll === "function") {
         maybeCloseAll.call(server);
       }
@@ -171,7 +172,7 @@ export async function startHttpMcpServer(
     stop,
     url: `http://${host}:${boundPort}/sse`,
     port: boundPort,
-    host
+    host,
   };
 }
 
@@ -230,7 +231,7 @@ async function handleSse(
     response: res,
     handler,
     cleanup: sessionCleanup,
-    inflight: new Set()
+    inflight: new Set(),
   };
   sessions.set(sessionId, session);
 
@@ -299,8 +300,8 @@ async function handleMessagePost(
           id: message.id ?? null,
           error: {
             code: -32603,
-            message: error instanceof Error ? error.message : "Internal error"
-          }
+            message: error instanceof Error ? error.message : "Internal error",
+          },
         },
         sessionId
       );

--- a/src/mcp/serve-validation.ts
+++ b/src/mcp/serve-validation.ts
@@ -63,7 +63,7 @@ export function validateServeOptions(opts: ServeOptions): ServeValidation {
       kind: "error",
       message:
         `[rly serve] Refusing to start: --host ${opts.host} is non-loopback and no --token was provided.\n` +
-        "           Either pass --token <token> (recommended) or --allow-unauthenticated-remote to override."
+        "           Either pass --token <token> (recommended) or --allow-unauthenticated-remote to override.",
     };
   }
 
@@ -73,9 +73,7 @@ export function validateServeOptions(opts: ServeOptions): ServeValidation {
     warnings.push(
       "[rly serve] WARNING: no auth token — anyone who can reach this host:port can use the MCP server."
     );
-    warnings.push(
-      "           Set RELAY_TOKEN or pass --token <token> to require a Bearer token."
-    );
+    warnings.push("           Set RELAY_TOKEN or pass --token <token> to require a Bearer token.");
   }
 
   if (!loopback && !opts.token && opts.allowUnauthenticatedRemote) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,13 +13,13 @@ import {
   callChannelTool,
   getChannelToolDefinitions,
   isChannelTool,
-  type ChannelToolState
+  type ChannelToolState,
 } from "./channel-tools.js";
 import {
   callCrosslinkTool,
   getCrosslinkToolDefinitions,
   isCrosslinkTool,
-  type CrosslinkToolState
+  type CrosslinkToolState,
 } from "../crosslink/tools.js";
 
 export interface JsonRpcMessage {
@@ -57,24 +57,23 @@ export async function buildMcpMessageHandler(
   const crosslinkStore = new CrosslinkStore(undefined, getHarnessStore());
   const crosslinkState: CrosslinkToolState = {
     sessionId: null,
-    store: crosslinkStore
+    store: crosslinkStore,
   };
   const channelStore = new ChannelStore(undefined, getHarnessStore());
   const channelState: ChannelToolState = {
     sessionId: null,
-    channelStore
+    channelStore,
   };
 
   // Auto-register this session
-  const agentProvider = (process.env.RELAY_PROVIDER ?? "unknown") as
-    "claude" | "codex" | "unknown";
+  const agentProvider = (process.env.RELAY_PROVIDER ?? "unknown") as "claude" | "codex" | "unknown";
   const session = await crosslinkStore.registerSession({
     pid: process.pid,
     repoPath: workspaceRoot,
     description: `Agent session in ${workspaceRoot}`,
     capabilities: ["general"],
     agentProvider,
-    status: "active"
+    status: "active",
   });
   crosslinkState.sessionId = session.sessionId;
   channelState.sessionId = session.sessionId;
@@ -99,7 +98,7 @@ export async function buildMcpMessageHandler(
 
   return {
     handler,
-    context: { workspaceRoot, artifactStore, crosslinkState, channelState, cleanup }
+    context: { workspaceRoot, artifactStore, crosslinkState, channelState, cleanup },
   };
 }
 
@@ -107,8 +106,14 @@ export async function startMcpServer(workspaceRoot: string): Promise<void> {
   const { handler, context } = await buildMcpMessageHandler(workspaceRoot);
 
   process.on("exit", context.cleanup);
-  process.on("SIGTERM", () => { context.cleanup(); process.exit(0); });
-  process.on("SIGINT", () => { context.cleanup(); process.exit(0); });
+  process.on("SIGTERM", () => {
+    context.cleanup();
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    context.cleanup();
+    process.exit(0);
+  });
 
   const transport = new StdioJsonRpcTransport(handler);
   transport.start();
@@ -133,13 +138,13 @@ async function handleMessage(
         result: {
           protocolVersion: "2024-11-05",
           capabilities: {
-            tools: {}
+            tools: {},
           },
           serverInfo: {
             name: "relay",
-            version: "0.1.0"
-          }
-        }
+            version: "0.1.0",
+          },
+        },
       };
     case "notifications/initialized":
       return null;
@@ -157,8 +162,8 @@ async function handleMessage(
               inputSchema: {
                 type: "object",
                 additionalProperties: false,
-                properties: {}
-              }
+                properties: {},
+              },
             },
             {
               name: "harness_list_runs",
@@ -167,22 +172,23 @@ async function handleMessage(
                 type: "object",
                 additionalProperties: false,
                 properties: {
-                  limit: { type: "integer", minimum: 1, maximum: 50 }
-                }
-              }
+                  limit: { type: "integer", minimum: 1, maximum: 50 },
+                },
+              },
             },
             {
               name: "harness_get_run_detail",
-              description: "Get full run snapshot including classification, tickets, evidence, artifacts, and optionally the event log.",
+              description:
+                "Get full run snapshot including classification, tickets, evidence, artifacts, and optionally the event log.",
               inputSchema: {
                 type: "object",
                 additionalProperties: false,
                 required: ["runId"],
                 properties: {
                   runId: { type: "string" },
-                  includeEvents: { type: "boolean" }
-                }
-              }
+                  includeEvents: { type: "boolean" },
+                },
+              },
             },
             {
               name: "harness_get_artifact",
@@ -192,9 +198,9 @@ async function handleMessage(
                 additionalProperties: false,
                 required: ["path"],
                 properties: {
-                  path: { type: "string" }
-                }
-              }
+                  path: { type: "string" },
+                },
+              },
             },
             {
               name: "harness_approve_plan",
@@ -204,9 +210,9 @@ async function handleMessage(
                 additionalProperties: false,
                 required: ["runId"],
                 properties: {
-                  runId: { type: "string" }
-                }
-              }
+                  runId: { type: "string" },
+                },
+              },
             },
             {
               name: "harness_reject_plan",
@@ -217,9 +223,9 @@ async function handleMessage(
                 required: ["runId"],
                 properties: {
                   runId: { type: "string" },
-                  feedback: { type: "string" }
-                }
-              }
+                  feedback: { type: "string" },
+                },
+              },
             },
             {
               name: "project_create",
@@ -233,14 +239,14 @@ async function handleMessage(
                 properties: {
                   name: {
                     type: "string",
-                    description: "Project name, e.g. 'Auth Refactor' or 'New Dashboard'"
+                    description: "Project name, e.g. 'Auth Refactor' or 'New Dashboard'",
                   },
                   description: {
                     type: "string",
-                    description: "What the project is about"
-                  }
-                }
-              }
+                    description: "What the project is about",
+                  },
+                },
+              },
             },
             {
               name: "harness_dispatch",
@@ -255,17 +261,19 @@ async function handleMessage(
                 properties: {
                   featureRequest: {
                     type: "string",
-                    description: "The feature to build — should be well-defined from your chat discussion"
+                    description:
+                      "The feature to build — should be well-defined from your chat discussion",
                   },
                   channelId: {
                     type: "string",
-                    description: "Channel/project to link this run to. If omitted, a new channel is created."
-                  }
-                }
-              }
-            }
-          ]
-        }
+                    description:
+                      "Channel/project to link this run to. If omitted, a new channel is created.",
+                  },
+                },
+              },
+            },
+          ],
+        },
       };
     case "tools/call":
       try {
@@ -284,11 +292,11 @@ async function handleMessage(
             content: [
               {
                 type: "text",
-                text: JSON.stringify(toolResult, null, 2)
-              }
+                text: JSON.stringify(toolResult, null, 2),
+              },
             ],
-            isError: false
-          }
+            isError: false,
+          },
         };
       } catch (error) {
         return {
@@ -298,11 +306,11 @@ async function handleMessage(
             content: [
               {
                 type: "text",
-                text: error instanceof Error ? error.message : "Unknown MCP tool failure."
-              }
+                text: error instanceof Error ? error.message : "Unknown MCP tool failure.",
+              },
             ],
-            isError: true
-          }
+            isError: true,
+          },
         };
       }
     default:
@@ -311,8 +319,8 @@ async function handleMessage(
         id: message.id ?? null,
         error: {
           code: -32601,
-          message: `Method not found: ${message.method}`
-        }
+          message: `Method not found: ${message.method}`,
+        },
       };
   }
 }
@@ -342,17 +350,13 @@ async function callTool(
         throw new Error(`Run snapshot not found: ${runId}`);
       }
 
-      const events = includeEvents
-        ? await artifactStore.readEventLog(runId)
-        : [];
+      const events = includeEvents ? await artifactStore.readEventLog(runId) : [];
 
       return { ...snapshot, events };
     }
     case "harness_get_artifact": {
       const inputPath = String(args.path ?? "");
-      const path = isAbsolute(inputPath)
-        ? inputPath
-        : resolve(workspacePaths.rootDir, inputPath);
+      const path = isAbsolute(inputPath) ? inputPath : resolve(workspacePaths.rootDir, inputPath);
 
       if (!path.startsWith(workspacePaths.rootDir)) {
         throw new Error("Artifact path must be inside the workspace harness directory.");
@@ -365,7 +369,7 @@ async function callTool(
       const path = await submitApproval({
         runId,
         decision: "approved",
-        artifactStore
+        artifactStore,
       });
       return { runId, decision: "approved", path };
     }
@@ -376,7 +380,7 @@ async function callTool(
         runId,
         decision: "rejected",
         feedback,
-        artifactStore
+        artifactStore,
       });
       return { runId, decision: "rejected", feedback, path };
     }
@@ -388,21 +392,21 @@ async function callTool(
       const channel = await channelStore.createChannel({
         name,
         description,
-        workspaceIds: [workspaceId]
+        workspaceIds: [workspaceId],
       });
       await channelStore.postEntry(channel.channelId, {
         type: "status_update",
         fromAgentId: null,
         fromDisplayName: "Orchestrator",
         content: `Project "${name}" created.`,
-        metadata: { workspaceId }
+        metadata: { workspaceId },
       });
       return {
         projectId: channel.channelId,
         channelId: channel.channelId,
         name: channel.name,
         description: channel.description,
-        workspaceId
+        workspaceId,
       };
     }
     case "harness_dispatch": {
@@ -412,7 +416,7 @@ async function callTool(
       const result = await dispatch({
         featureRequest,
         repoPath: workspaceRoot,
-        channelId
+        channelId,
       });
       return result;
     }

--- a/src/orchestrator/approval-gate.ts
+++ b/src/orchestrator/approval-gate.ts
@@ -17,7 +17,7 @@ export async function checkApproval(input: {
 
   return {
     decision: record.decision,
-    feedback: record.feedback
+    feedback: record.feedback,
   };
 }
 
@@ -30,6 +30,6 @@ export async function submitApproval(input: {
   return input.artifactStore.saveApprovalRecord({
     runId: input.runId,
     decision: input.decision,
-    feedback: input.feedback
+    feedback: input.feedback,
   });
 }

--- a/src/orchestrator/classifier.ts
+++ b/src/orchestrator/classifier.ts
@@ -1,7 +1,7 @@
 import {
   parseClassificationResult,
   type ClassificationResult,
-  type ComplexityTier
+  type ComplexityTier,
 } from "../domain/classification.js";
 import type { AgentResult, WorkRequest } from "../domain/agent.js";
 import type { HarnessRun } from "../domain/run.js";
@@ -10,7 +10,7 @@ import {
   detectTrackerKind,
   resolveIssue,
   type HarnessIssue,
-  type TrackerKind
+  type TrackerKind,
 } from "../integrations/tracker.js";
 import { basename } from "node:path";
 
@@ -23,7 +23,7 @@ const TRIVIAL_PATTERNS = [
   /\bconfig\s+change\b/i,
   /\badd\s+comment\b/i,
   /\bformat(ting)?\b/i,
-  /\blint\s+fix\b/i
+  /\blint\s+fix\b/i,
 ];
 
 const BUGFIX_PATTERNS = [
@@ -34,7 +34,7 @@ const BUGFIX_PATTERNS = [
   /\berror\b/i,
   /\bnot\s+working\b/i,
   /\bregression\b/i,
-  /\bdebug\b/i
+  /\bdebug\b/i,
 ];
 
 export function classifyByHeuristic(featureRequest: string): ComplexityTier | null {
@@ -61,7 +61,7 @@ export function buildHeuristicClassification(
     suggestedSpecialties: ["general"],
     estimatedTicketCount: tier === "trivial" ? 1 : 2,
     needsDesignDoc: false,
-    needsUserApproval: false
+    needsUserApproval: false,
   };
 }
 
@@ -116,7 +116,7 @@ function buildProjectConfig(
     repo: repo || leaf,
     path: repoRoot,
     defaultBranch: "main",
-    sessionPrefix: leaf
+    sessionPrefix: leaf,
   };
 }
 
@@ -154,10 +154,7 @@ async function tryResolveTrackerIssue(
  * heuristics and the LLM prompt see the title + body + labels, not just a
  * bare URL.
  */
-function enrichFeatureRequest(
-  featureRequest: string,
-  issue: HarnessIssue
-): string {
+function enrichFeatureRequest(featureRequest: string, issue: HarnessIssue): string {
   const labels = issue.labels.length ? `\nLabels: ${issue.labels.join(", ")}` : "";
   const body = issue.body ? `\n\n${issue.body}` : "";
   return `${issue.title}${labels}${body}\n\nSource: ${issue.url}`;
@@ -184,7 +181,7 @@ export async function classifyRequest(input: {
 
   const context: string[] = [
     `Repository root: ${input.repoRoot}`,
-    `Feature request: ${effectiveRequest}`
+    `Feature request: ${effectiveRequest}`,
   ];
   if (issue) {
     context.push(`Tracker: ${issue.url}`);
@@ -202,7 +199,7 @@ export async function classifyRequest(input: {
     acceptanceCriteria: [
       "Classify the request into exactly one complexity tier.",
       "Provide a rationale for the classification.",
-      "Estimate the number of parallelizable tickets."
+      "Estimate the number of parallelizable tickets.",
     ],
     allowedCommands: [],
     verificationCommands: [],
@@ -211,7 +208,7 @@ export async function classifyRequest(input: {
     artifactContext: [],
     attempt: 1,
     maxAttempts: 2,
-    priorEvidence: []
+    priorEvidence: [],
   });
 
   try {
@@ -225,7 +222,7 @@ export async function classifyRequest(input: {
       suggestedSpecialties: ["general"],
       estimatedTicketCount: 3,
       needsDesignDoc: false,
-      needsUserApproval: false
+      needsUserApproval: false,
     };
     return suggestedBranch ? { ...fallback, suggestedBranch } : fallback;
   }

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -4,10 +4,7 @@ import { NodeCommandInvoker } from "../agents/command-invoker.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
 import { VerificationRunner } from "../execution/verification-runner.js";
 import { ChannelStore } from "../channels/channel-store.js";
-import {
-  buildWorkspaceId,
-  getWorkspaceDir
-} from "../cli/workspace-registry.js";
+import { buildWorkspaceId, getWorkspaceDir } from "../cli/workspace-registry.js";
 import { OrchestratorV2, buildRunId } from "./orchestrator-v2.js";
 import { createPrWatcherFactory } from "../cli/pr-watcher-factory.js";
 import { getHarnessStore } from "../storage/factory.js";
@@ -46,7 +43,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const registry = new AgentRegistry();
   const agents = createLiveAgents({
     cwd: repoPath,
-    defaultProvider
+    defaultProvider,
   });
   for (const agent of agents) {
     registry.register(agent);
@@ -58,15 +55,12 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     const channel = await channelStore.createChannel({
       name: featureRequest.slice(0, 60),
       description: featureRequest,
-      workspaceIds: [workspaceId]
+      workspaceIds: [workspaceId],
     });
     channelId = channel.channelId;
   }
 
-  const verificationRunner = new VerificationRunner(
-    new NodeCommandInvoker(),
-    artifactStore
-  );
+  const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
 
   const orchestrator = new OrchestratorV2(
     registry,
@@ -82,7 +76,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     createPrWatcherFactory({
       channelStore,
       repoRoot: repoPath,
-      defaultChannelId: channelId
+      defaultChannelId: channelId,
     })
   );
 
@@ -97,13 +91,12 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   // surface the failure to the channel feed so users don't see "dispatched"
   // and then nothing. We only swallow the *return value* (the background task
   // must not throw), never the error itself.
-  orchestrator.run(featureRequest, runId)
-    .catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      const stack = error instanceof Error && error.stack
-        ? error.stack.split("\n").slice(0, 20).join("\n")
-        : "";
-      channelStore.postEntry(channelId!, {
+  orchestrator.run(featureRequest, runId).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const stack =
+      error instanceof Error && error.stack ? error.stack.split("\n").slice(0, 20).join("\n") : "";
+    channelStore
+      .postEntry(channelId!, {
         type: "status_update",
         fromAgentId: null,
         fromDisplayName: "Orchestrator",
@@ -114,9 +107,10 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
           workspaceId,
           error: "true",
           errorMessage: message,
-          ...(stack ? { errorStack: stack } : {})
-        }
-      }).catch((postErr: unknown) => {
+          ...(stack ? { errorStack: stack } : {}),
+        },
+      })
+      .catch((postErr: unknown) => {
         // If posting the failure entry itself fails there is nowhere left to
         // surface it — log to stderr so operators still see the loss.
         const postMessage = postErr instanceof Error ? postErr.message : String(postErr);
@@ -124,12 +118,12 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
           `[orchestrator] failed to post run-failure entry (runId=${runId} channelId=${channelId}): ${postMessage}`
         );
       });
-    });
+  });
 
   return {
     runId,
     channelId,
     workspaceId,
-    status: "dispatched"
+    status: "dispatched",
   };
 }

--- a/src/orchestrator/failure-routing.ts
+++ b/src/orchestrator/failure-routing.ts
@@ -22,7 +22,8 @@ export function fallbackFailureClassification(input: {
   artifactContext: string[];
   rejectedCommands: string[];
 }): FailureClassification {
-  const combined = `${input.artifactContext.join("\n")}\n${input.rejectedCommands.join("\n")}`.toLowerCase();
+  const combined =
+    `${input.artifactContext.join("\n")}\n${input.rejectedCommands.join("\n")}`.toLowerCase();
 
   if (
     input.rejectedCommands.length > 0 ||
@@ -33,7 +34,7 @@ export function fallbackFailureClassification(input: {
     return {
       category: "bad_command_plan",
       rationale: "The failure points to a command-plan or execution-environment issue.",
-      nextAction: "Adjust the verification command plan before changing product code."
+      nextAction: "Adjust the verification command plan before changing product code.",
     };
   }
 
@@ -45,20 +46,18 @@ export function fallbackFailureClassification(input: {
     return {
       category: "fix_test",
       rationale: "The failing artifact looks isolated to tests or verification setup.",
-      nextAction: "Repair tests, fixtures, mocks, or verification setup."
+      nextAction: "Repair tests, fixtures, mocks, or verification setup.",
     };
   }
 
   return {
     category: "fix_code",
     rationale: "The failing artifact most likely points to implementation logic.",
-    nextAction: "Repair the product or business logic implicated by the failure."
+    nextAction: "Repair the product or business logic implicated by the failure.",
   };
 }
 
-export function buildRetryContext(
-  classification: FailureClassification | null
-): string[] {
+export function buildRetryContext(classification: FailureClassification | null): string[] {
   if (!classification) {
     return [];
   }
@@ -66,12 +65,10 @@ export function buildRetryContext(
   return [
     `Failure category: ${classification.category}`,
     `Failure rationale: ${classification.rationale}`,
-    `Suggested next action: ${classification.nextAction}`
+    `Suggested next action: ${classification.nextAction}`,
   ];
 }
 
-export function isVerificationPlanIssue(
-  category: FailureCategory | null
-): boolean {
+export function isVerificationPlanIssue(category: FailureCategory | null): boolean {
   return category === "bad_command_plan";
 }

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -3,7 +3,7 @@ import {
   tierNeedsApproval,
   tierNeedsDesignDoc,
   tierSkipsPlanning,
-  type ClassificationResult
+  type ClassificationResult,
 } from "../domain/classification.js";
 import { createSeedPlan } from "../domain/phase-plan.js";
 import type {
@@ -11,7 +11,7 @@ import type {
   EvidenceRecord,
   HarnessRun,
   RunEvent,
-  RunEventType
+  RunEventType,
 } from "../domain/run.js";
 import { initializeTicketLedger } from "../domain/ticket.js";
 import { assertTransition } from "../domain/state-machine.js";
@@ -126,7 +126,7 @@ export class OrchestratorV2 {
       phaseLedgerPath: null,
       ticketLedger: [],
       ticketLedgerPath: null,
-      runIndexPath: null
+      runIndexPath: null,
     };
 
     this.recordEvent(run, "TaskSubmitted", "phase_00", { featureRequest });
@@ -137,7 +137,7 @@ export class OrchestratorV2 {
         const channel = await this.channelStore.createChannel({
           name: featureRequest.slice(0, 60),
           description: featureRequest,
-          workspaceIds: [this.workspaceId]
+          workspaceIds: [this.workspaceId],
         });
         run.channelId = channel.channelId;
         await this.channelStore.linkRun(channel.channelId, run.id, this.workspaceId);
@@ -146,16 +146,14 @@ export class OrchestratorV2 {
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `Run started: ${featureRequest}`,
-          metadata: { runId: run.id, state: run.state }
+          metadata: { runId: run.id, state: run.state },
         });
       } catch (err) {
         // Channel creation is non-critical — continue without it, but don't
         // swallow silently. A logged warning lets operators see why a run
         // has no channel without having to trace through the code.
         const message = err instanceof Error ? err.message : String(err);
-        console.warn(
-          `[orchestrator] channel creation failed (runId=${run.id}): ${message}`
-        );
+        console.warn(`[orchestrator] channel creation failed (runId=${run.id}): ${message}`);
       }
     }
 
@@ -164,19 +162,19 @@ export class OrchestratorV2 {
       run,
       featureRequest,
       repoRoot: this.repoRoot,
-      dispatch: (r, req) => this.dispatch(r, req)
+      dispatch: (r, req) => this.dispatch(r, req),
     });
 
     run.classification = classification;
     await this.artifactStore.saveClassification({
       runId: run.id,
-      classification
+      classification,
     });
 
     await this.transition(run, "ClassificationComplete", "phase_00");
     this.recordEvent(run, "ClassificationComplete", "phase_00", {
       tier: classification.tier,
-      rationale: classification.rationale
+      rationale: classification.rationale,
     });
 
     // Step 2: Route by tier
@@ -193,19 +191,19 @@ export class OrchestratorV2 {
       objective: featureRequest,
       acceptanceCriteria: [
         "Create bounded phases with acceptance criteria.",
-        "Include retry policy and verification commands."
+        "Include retry policy and verification commands.",
       ],
       allowedCommands: [],
       verificationCommands: [],
       docsToUpdate: ["README.md"],
       context: [
         `Repository root: ${this.repoRoot}`,
-        `Classification: ${classification.tier} (${classification.rationale})`
+        `Classification: ${classification.tier} (${classification.rationale})`,
       ],
       artifactContext: [],
       attempt: 1,
       maxAttempts: 2,
-      priorEvidence: []
+      priorEvidence: [],
     });
 
     run.plan = planResult.phasePlan ?? createSeedPlan(featureRequest, this.repoRoot);
@@ -221,7 +219,7 @@ export class OrchestratorV2 {
         objective: `Create an architectural design document for: ${featureRequest}`,
         acceptanceCriteria: [
           "Document should cover architecture, trade-offs, and implementation approach.",
-          "Include component boundaries and data flow."
+          "Include component boundaries and data flow.",
         ],
         allowedCommands: [],
         verificationCommands: [],
@@ -229,17 +227,17 @@ export class OrchestratorV2 {
         context: [
           `Repository root: ${this.repoRoot}`,
           `Plan: ${run.plan.task.title}`,
-          ...run.plan.phases.map((p) => `Phase: ${p.title} (${p.specialty})`)
+          ...run.plan.phases.map((p) => `Phase: ${p.title} (${p.specialty})`),
         ],
         artifactContext: [],
         attempt: 1,
         maxAttempts: 2,
-        priorEvidence: []
+        priorEvidence: [],
       });
 
       await this.artifactStore.saveDesignDoc({
         runId: run.id,
-        content: designResult.summary
+        content: designResult.summary,
       });
     }
 
@@ -249,7 +247,7 @@ export class OrchestratorV2 {
       plan: run.plan,
       classification,
       repoRoot: this.repoRoot,
-      dispatch: (r, req) => this.dispatch(r, req)
+      dispatch: (r, req) => this.dispatch(r, req),
     });
 
     run.ticketPlan = ticketPlan;
@@ -257,7 +255,7 @@ export class OrchestratorV2 {
 
     await this.artifactStore.saveTicketLedger({
       runId: run.id,
-      ticketLedger: run.ticketLedger
+      ticketLedger: run.ticketLedger,
     });
 
     // Channel board is the live, unified ticket view across chat + orchestrator.
@@ -273,7 +271,7 @@ export class OrchestratorV2 {
       // Non-blocking: check if approval already exists, otherwise return waiting
       const approvalResult = await checkApproval({
         runId: run.id,
-        artifactStore: this.artifactStore
+        artifactStore: this.artifactStore,
       });
 
       if (!approvalResult) {
@@ -299,7 +297,7 @@ export class OrchestratorV2 {
     }
 
     this.recordEvent(run, "TicketsCreated", "phase_00", {
-      ticketCount: String(ticketPlan.tickets.length)
+      ticketCount: String(ticketPlan.tickets.length),
     });
 
     const scheduler = this.buildScheduler(run);
@@ -315,7 +313,7 @@ export class OrchestratorV2 {
 
     if (allTicketsSucceeded) {
       this.recordEvent(run, "AllTicketsComplete", "phase_00", {
-        ticketCount: String(run.ticketLedger.length)
+        ticketCount: String(run.ticketLedger.length),
       });
     }
 
@@ -331,7 +329,7 @@ export class OrchestratorV2 {
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `Run completed: ${run.state}`,
-          metadata: { runId: run.id, state: run.state }
+          metadata: { runId: run.id, state: run.state },
         })
       );
     }
@@ -351,7 +349,7 @@ export class OrchestratorV2 {
         const channel = await this.channelStore.createChannel({
           name: featureRequest.slice(0, 60),
           description: featureRequest,
-          workspaceIds: [this.workspaceId]
+          workspaceIds: [this.workspaceId],
         });
         run.channelId = channel.channelId;
         await this.channelStore.linkRun(channel.channelId, run.id, this.workspaceId);
@@ -360,13 +358,11 @@ export class OrchestratorV2 {
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `Run started (trivial): ${featureRequest}`,
-          metadata: { runId: run.id, state: run.state }
+          metadata: { runId: run.id, state: run.state },
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.warn(
-          `[orchestrator] trivial channel setup failed (runId=${run.id}): ${message}`
-        );
+        console.warn(`[orchestrator] trivial channel setup failed (runId=${run.id}): ${message}`);
       }
     }
 
@@ -386,7 +382,7 @@ export class OrchestratorV2 {
 
     this.recordEvent(run, "TicketsCreated", "phase_00", {
       ticketCount: String(ticketPlan.tickets.length),
-      fastTrack: "trivial"
+      fastTrack: "trivial",
     });
 
     const scheduler = this.buildScheduler(run);
@@ -410,7 +406,7 @@ export class OrchestratorV2 {
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `Run completed: ${run.state}`,
-          metadata: { runId: run.id, state: run.state }
+          metadata: { runId: run.id, state: run.state },
         })
       );
     }
@@ -440,15 +436,12 @@ export class OrchestratorV2 {
       (r, type, phaseId, details) => this.recordEvent(r, type, phaseId, details),
       {
         channelStore: this.channelStore,
-        ...(this.executor ? { executor: this.executor } : {})
+        ...(this.executor ? { executor: this.executor } : {}),
       }
     );
   }
 
-  private startPoller(
-    run: HarnessRun,
-    scheduler: TicketScheduler
-  ): PollerHandle | null {
+  private startPoller(run: HarnessRun, scheduler: TicketScheduler): PollerHandle | null {
     if (!this.pollerFactory) return null;
     try {
       const poller = this.pollerFactory({ run, scheduler });
@@ -456,17 +449,12 @@ export class OrchestratorV2 {
       return poller;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[orchestrator] poller start failed (runId=${run.id}): ${message}`
-      );
+      console.warn(`[orchestrator] poller start failed (runId=${run.id}): ${message}`);
       return null;
     }
   }
 
-  private async dispatch(
-    run: HarnessRun,
-    input: Omit<WorkRequest, "runId">
-  ): Promise<AgentResult> {
+  private async dispatch(run: HarnessRun, input: Omit<WorkRequest, "runId">): Promise<AgentResult> {
     let lastError: Error | null = null;
 
     for (let attempt = 1; attempt <= input.maxAttempts; attempt += 1) {
@@ -477,7 +465,7 @@ export class OrchestratorV2 {
         agentId: agent.id,
         provider: agent.provider,
         workKind: input.kind,
-        attempt: String(attempt)
+        attempt: String(attempt),
       });
 
       if (run.channelId && this.channelStore) {
@@ -488,7 +476,7 @@ export class OrchestratorV2 {
             fromAgentId: agent.id,
             fromDisplayName: agent.name,
             content: `Dispatched for ${input.kind}: ${input.title}`,
-            metadata: { attempt: String(attempt) }
+            metadata: { attempt: String(attempt) },
           })
         );
       }
@@ -505,20 +493,20 @@ export class OrchestratorV2 {
           summary: result.summary,
           evidence: result.evidence,
           proposedCommands: result.proposedCommands,
-          blockers: result.blockers
+          blockers: result.blockers,
         });
 
         this.recordEvent(run, "AgentCompleted", input.phaseId, {
           agentId: agent.id,
           summary: result.summary,
-          attempt: String(attempt)
+          attempt: String(attempt),
         });
 
         if (result.blockers.length > 0 && attempt < input.maxAttempts) {
           this.recordEvent(run, "AgentRetried", input.phaseId, {
             agentId: agent.id,
             attempt: String(attempt),
-            reason: result.blockers.join("; ")
+            reason: result.blockers.join("; "),
           });
           continue;
         }
@@ -528,13 +516,13 @@ export class OrchestratorV2 {
         lastError = error instanceof Error ? error : new Error(String(error));
         this.recordEvent(run, "AgentFailed", input.phaseId, {
           attempt: String(attempt),
-          message: lastError.message
+          message: lastError.message,
         });
 
         if (attempt < input.maxAttempts) {
           this.recordEvent(run, "AgentRetried", input.phaseId, {
             attempt: String(attempt),
-            reason: lastError.message
+            reason: lastError.message,
           });
           continue;
         }
@@ -562,7 +550,7 @@ export class OrchestratorV2 {
           fromAgentId: null,
           fromDisplayName: "Orchestrator",
           content: `${eventType} → ${run.state}`,
-          metadata: { runId: run.id, state: run.state, event: eventType }
+          metadata: { runId: run.id, state: run.state, event: eventType },
         })
       );
     }
@@ -578,7 +566,7 @@ export class OrchestratorV2 {
       type,
       phaseId,
       details,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
     };
 
     run.events.push(event);
@@ -611,8 +599,8 @@ export class OrchestratorV2 {
         phaseLedgerPath: run.phaseLedgerPath,
         artifactsRoot: this.artifactsDir
           ? `${this.artifactsDir}/${run.id}`
-          : `${this.repoRoot}/.relay/artifacts/${run.id}`
-      }
+          : `${this.repoRoot}/.relay/artifacts/${run.id}`,
+      },
     });
     await this.artifactStore.saveRunSnapshot(run);
   }
@@ -649,10 +637,7 @@ export class OrchestratorV2 {
    * semantic while preventing teardown races in tests and real callers who
    * tear down the artifacts dir immediately after `run()` returns.
    */
-  private trackChannelPost(
-    run: HarnessRun,
-    promise: Promise<unknown>
-  ): Promise<void> {
+  private trackChannelPost(run: HarnessRun, promise: Promise<unknown>): Promise<void> {
     const tracked: Promise<void> = promise.then(
       () => undefined,
       (err: unknown) => this.warnChannelPostFailed(run, err)

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -6,20 +6,20 @@ import type {
   HarnessRun,
   PhaseLedgerEntry,
   RunEvent,
-  RunEventType
+  RunEventType,
 } from "../domain/run.js";
 import { assertTransition } from "../domain/state-machine.js";
 import { AgentRegistry } from "../agents/registry.js";
 import type { ArtifactStore } from "../execution/artifact-store.js";
 import {
   selectVerificationCommands,
-  VerificationRunner
+  VerificationRunner,
 } from "../execution/verification-runner.js";
 import {
   buildRetryContext,
   buildRetryObjective,
   fallbackFailureClassification,
-  isVerificationPlanIssue
+  isVerificationPlanIssue,
 } from "./failure-routing.js";
 
 export class Orchestrator {
@@ -51,11 +51,11 @@ export class Orchestrator {
       phaseLedgerPath: null,
       ticketLedger: [],
       ticketLedgerPath: null,
-      runIndexPath: null
+      runIndexPath: null,
     };
 
     this.recordEvent(run, "TaskSubmitted", "phase_00", {
-      featureRequest
+      featureRequest,
     });
 
     const planResult = await this.dispatch(run, {
@@ -66,7 +66,7 @@ export class Orchestrator {
       objective: featureRequest,
       acceptanceCriteria: [
         "Create bounded phases with acceptance criteria.",
-        "Include retry policy and verification commands."
+        "Include retry policy and verification commands.",
       ],
       allowedCommands: [],
       verificationCommands: [],
@@ -75,7 +75,7 @@ export class Orchestrator {
       artifactContext: [],
       attempt: 1,
       maxAttempts: 2,
-      priorEvidence: []
+      priorEvidence: [],
     });
     run.plan = planResult.phasePlan ?? createSeedPlan(featureRequest, this.repoRoot);
     this.initializePhaseLedger(run);
@@ -88,7 +88,7 @@ export class Orchestrator {
       await this.updatePhaseLedger(run, phase.id, {
         lifecycle: "implementing",
         verification: "pending",
-        chosenNextAction: "Implement the current phase objective."
+        chosenNextAction: "Implement the current phase objective.",
       });
 
       const checksPassed = await this.executePhaseUntilVerified(run, phase, featureRequest);
@@ -113,16 +113,16 @@ export class Orchestrator {
         context: phase.acceptanceCriteria,
         artifactContext: await this.collectArtifactContext(run, phase.id, {
           includeSuccessful: true,
-          limit: 3
+          limit: 3,
         }),
         attempt: 1,
         maxAttempts: phase.retryPolicy.maxAgentAttempts,
-        priorEvidence: this.collectPhaseEvidence(run, phase.id)
+        priorEvidence: this.collectPhaseEvidence(run, phase.id),
       });
       await this.transition(run, "ReviewResolved", phase.id);
       await this.updatePhaseLedger(run, phase.id, {
         lifecycle: "completed",
-        chosenNextAction: "Phase complete. Advance to the next phase."
+        chosenNextAction: "Phase complete. Advance to the next phase.",
       });
     }
     await this.transition(run, "NoPhasesRemain", run.plan.phases.at(-1)?.id ?? "phase_00");
@@ -133,17 +133,14 @@ export class Orchestrator {
     return run;
   }
 
-  private async dispatch(
-    run: HarnessRun,
-    input: Omit<WorkRequest, "runId">
-  ) {
+  private async dispatch(run: HarnessRun, input: Omit<WorkRequest, "runId">) {
     let lastError: Error | null = null;
 
     for (let attempt = 1; attempt <= input.maxAttempts; attempt += 1) {
       const request: WorkRequest = {
         runId: run.id,
         ...input,
-        attempt
+        attempt,
       };
       const agent = this.registry.resolve(request);
 
@@ -151,7 +148,7 @@ export class Orchestrator {
         agentId: agent.id,
         provider: agent.provider,
         workKind: input.kind,
-        attempt: String(attempt)
+        attempt: String(attempt),
       });
 
       try {
@@ -166,20 +163,20 @@ export class Orchestrator {
           summary: result.summary,
           evidence: result.evidence,
           proposedCommands: result.proposedCommands,
-          blockers: result.blockers
+          blockers: result.blockers,
         });
 
         this.recordEvent(run, "AgentCompleted", input.phaseId, {
           agentId: agent.id,
           summary: result.summary,
-          attempt: String(attempt)
+          attempt: String(attempt),
         });
 
         if (result.blockers.length > 0 && attempt < input.maxAttempts) {
           this.recordEvent(run, "AgentRetried", input.phaseId, {
             agentId: agent.id,
             attempt: String(attempt),
-            reason: result.blockers.join("; ")
+            reason: result.blockers.join("; "),
           });
           continue;
         }
@@ -189,13 +186,13 @@ export class Orchestrator {
         lastError = error instanceof Error ? error : new Error(String(error));
         this.recordEvent(run, "AgentFailed", input.phaseId, {
           attempt: String(attempt),
-          message: lastError.message
+          message: lastError.message,
         });
 
         if (attempt < input.maxAttempts) {
           this.recordEvent(run, "AgentRetried", input.phaseId, {
             attempt: String(attempt),
-            reason: lastError.message
+            reason: lastError.message,
           });
           continue;
         }
@@ -212,11 +209,7 @@ export class Orchestrator {
   ): Promise<boolean> {
     let classification: FailureClassification | null = null;
 
-    for (
-      let loop = 1;
-      loop <= phase.retryPolicy.maxTestFixLoops;
-      loop += 1
-    ) {
+    for (let loop = 1; loop <= phase.retryPolicy.maxTestFixLoops; loop += 1) {
       await this.dispatch(run, {
         phaseId: phase.id,
         kind: "implement_phase",
@@ -230,15 +223,15 @@ export class Orchestrator {
         context: [
           `Feature request: ${featureRequest}`,
           `Verification loop: ${loop} of ${phase.retryPolicy.maxTestFixLoops}`,
-          ...buildRetryContext(classification)
+          ...buildRetryContext(classification),
         ],
         artifactContext: await this.collectArtifactContext(run, phase.id, {
           includeSuccessful: false,
-          limit: 2
+          limit: 2,
         }),
         attempt: 1,
         maxAttempts: phase.retryPolicy.maxAgentAttempts,
-        priorEvidence: this.collectPhaseEvidence(run, phase.id)
+        priorEvidence: this.collectPhaseEvidence(run, phase.id),
       });
       await this.transition(run, "PatchGenerated", phase.id);
       await this.updatePhaseLedger(run, phase.id, {
@@ -246,7 +239,7 @@ export class Orchestrator {
         verification: "running",
         chosenNextAction: classification
           ? classification.nextAction
-          : "Run the verification commands for the current phase."
+          : "Run the verification commands for the current phase.",
       });
 
       const testerResult = await this.dispatch(run, {
@@ -264,11 +257,11 @@ export class Orchestrator {
         context: [...phase.acceptanceCriteria, ...buildRetryContext(classification)],
         artifactContext: await this.collectArtifactContext(run, phase.id, {
           includeSuccessful: false,
-          limit: 2
+          limit: 2,
         }),
         attempt: 1,
         maxAttempts: phase.retryPolicy.maxAgentAttempts,
-        priorEvidence: this.collectPhaseEvidence(run, phase.id)
+        priorEvidence: this.collectPhaseEvidence(run, phase.id),
       });
 
       const verificationResult = await this.executeVerificationCommands(
@@ -283,23 +276,19 @@ export class Orchestrator {
         await this.updatePhaseLedger(run, phase.id, {
           lifecycle: "reviewing",
           verification: "passed",
-          chosenNextAction: "Verification passed. Proceed to review."
+          chosenNextAction: "Verification passed. Proceed to review.",
         });
         return true;
       }
 
-      classification = await this.classifyFailure(
-        run,
-        phase,
-        verificationResult.rejected
-      );
+      classification = await this.classifyFailure(run, phase, verificationResult.rejected);
 
       if (loop < phase.retryPolicy.maxTestFixLoops) {
         await this.transition(run, "ChecksFailedRecoverable", phase.id);
         await this.updatePhaseLedger(run, phase.id, {
           lifecycle: "implementing",
           verification: "failed_recoverable",
-          chosenNextAction: classification.nextAction
+          chosenNextAction: classification.nextAction,
         });
         continue;
       }
@@ -308,7 +297,7 @@ export class Orchestrator {
       await this.updatePhaseLedger(run, phase.id, {
         lifecycle: "failed",
         verification: "failed_terminal",
-        chosenNextAction: classification.nextAction
+        chosenNextAction: classification.nextAction,
       });
       return false;
     }
@@ -323,7 +312,7 @@ export class Orchestrator {
   ): Promise<FailureClassification> {
     const artifactContext = await this.collectArtifactContext(run, phase.id, {
       includeSuccessful: false,
-      limit: 3
+      limit: 3,
     });
     const classificationResult = await this.dispatch(run, {
       phaseId: phase.id,
@@ -334,49 +323,48 @@ export class Orchestrator {
         "Classify the failing artifacts before retrying. Choose one category: fix_code, fix_test, or bad_command_plan.",
       acceptanceCriteria: [
         "Use artifact contents to choose the most likely failure category.",
-        "Explain the rationale and the next best retry action."
+        "Explain the rationale and the next best retry action.",
       ],
       allowedCommands: phase.allowedCommands,
       verificationCommands: phase.verificationCommands,
       docsToUpdate: [],
-      context: rejectedCommands.length > 0
-        ? [`Rejected commands: ${rejectedCommands.join(", ")}`]
-        : [],
+      context:
+        rejectedCommands.length > 0 ? [`Rejected commands: ${rejectedCommands.join(", ")}`] : [],
       artifactContext,
       attempt: 1,
       maxAttempts: phase.retryPolicy.maxAgentAttempts,
-      priorEvidence: this.collectPhaseEvidence(run, phase.id)
+      priorEvidence: this.collectPhaseEvidence(run, phase.id),
     });
 
     const classification =
       classificationResult.failureClassification ??
       fallbackFailureClassification({
         artifactContext,
-        rejectedCommands
+        rejectedCommands,
       });
 
     this.recordEvent(run, "FailureClassified", phase.id, {
       category: classification.category,
       rationale: classification.rationale,
-      nextAction: classification.nextAction
+      nextAction: classification.nextAction,
     });
     const artifact = await this.artifactStore.saveFailureClassification({
       runId: run.id,
       phaseId: phase.id,
-      classification
+      classification,
     });
     this.recordArtifact(run, artifact);
     this.recordEvent(run, "ArtifactCaptured", phase.id, {
       artifactId: artifact.artifactId,
-      path: artifact.path
+      path: artifact.path,
     });
     await this.updatePhaseLedger(run, phase.id, {
       lastClassification: {
         category: classification.category,
         rationale: classification.rationale,
-        nextAction: classification.nextAction
+        nextAction: classification.nextAction,
       },
-      chosenNextAction: classification.nextAction
+      chosenNextAction: classification.nextAction,
     });
 
     return classification;
@@ -388,15 +376,12 @@ export class Orchestrator {
     proposedCommands: string[],
     allowlistedCommands: string[]
   ) {
-    const selection = selectVerificationCommands(
-      proposedCommands,
-      allowlistedCommands
-    );
+    const selection = selectVerificationCommands(proposedCommands, allowlistedCommands);
 
     for (const rejected of selection.rejected) {
       this.recordEvent(run, "CommandRejected", phaseId, {
         command: rejected,
-        reason: "not_allowlisted"
+        reason: "not_allowlisted",
       });
     }
 
@@ -404,25 +389,25 @@ export class Orchestrator {
 
     for (const command of selection.commandsToRun) {
       this.recordEvent(run, "CommandStarted", phaseId, {
-        command
+        command,
       });
       const entry = await this.verificationRunner.executeCommand({
         runId: run.id,
         phaseId,
         repoRoot: this.repoRoot,
-        command
+        command,
       });
 
       this.recordArtifact(run, entry.artifact);
       this.recordEvent(run, "ArtifactCaptured", phaseId, {
         artifactId: entry.artifact.artifactId,
-        path: entry.artifact.path
+        path: entry.artifact.path,
       });
       this.recordEvent(run, "CommandCompleted", phaseId, {
         command,
         exitCode: String(entry.result.exitCode),
         stdoutBytes: String(entry.result.stdout.length),
-        stderrBytes: String(entry.result.stderr.length)
+        stderrBytes: String(entry.result.stderr.length),
       });
       this.recordEvidence(run, {
         phaseId,
@@ -434,13 +419,10 @@ export class Orchestrator {
         evidence: [
           `artifact=${entry.artifact.path}`,
           `stdout_bytes=${entry.result.stdout.length}`,
-          `stderr_bytes=${entry.result.stderr.length}`
+          `stderr_bytes=${entry.result.stderr.length}`,
         ],
         proposedCommands: [command],
-        blockers:
-          entry.result.exitCode === 0
-            ? []
-            : [`Verification command failed: ${command}`]
+        blockers: entry.result.exitCode === 0 ? [] : [`Verification command failed: ${command}`],
       });
 
       success = success && entry.result.exitCode === 0;
@@ -449,7 +431,7 @@ export class Orchestrator {
     return {
       success,
       executedCount: selection.commandsToRun.length,
-      rejected: selection.rejected
+      rejected: selection.rejected,
     };
   }
 
@@ -461,7 +443,7 @@ export class Orchestrator {
     run.state = assertTransition(run.state, eventType);
     run.updatedAt = new Date().toISOString();
     this.recordEvent(run, eventType, phaseId, {
-      state: run.state
+      state: run.state,
     });
     await this.persistRunIndex(run);
   }
@@ -476,7 +458,7 @@ export class Orchestrator {
       type,
       phaseId,
       details,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
     };
 
     run.events.push(event);
@@ -509,7 +491,7 @@ export class Orchestrator {
       verification: "pending",
       lastClassification: null,
       chosenNextAction: "Await phase start.",
-      updatedAt: new Date().toISOString()
+      updatedAt: new Date().toISOString(),
     }));
   }
 
@@ -525,7 +507,7 @@ export class Orchestrator {
     }
 
     Object.assign(entry, patch, {
-      updatedAt: new Date().toISOString()
+      updatedAt: new Date().toISOString(),
     });
 
     await this.persistPhaseLedger(run);
@@ -534,7 +516,7 @@ export class Orchestrator {
   private async persistPhaseLedger(run: HarnessRun): Promise<void> {
     run.phaseLedgerPath = await this.artifactStore.savePhaseLedger({
       runId: run.id,
-      phaseLedger: run.phaseLedger
+      phaseLedger: run.phaseLedger,
     });
     run.updatedAt = new Date().toISOString();
     await this.persistRunIndex(run);
@@ -552,9 +534,9 @@ export class Orchestrator {
         channelId: run.channelId,
         phaseLedgerPath: run.phaseLedgerPath,
         artifactsRoot: this.artifactsDir
-        ? `${this.artifactsDir}/${run.id}`
-        : `${this.repoRoot}/.relay/artifacts/${run.id}`
-      }
+          ? `${this.artifactsDir}/${run.id}`
+          : `${this.repoRoot}/.relay/artifacts/${run.id}`,
+      },
     });
     await this.artifactStore.saveRunSnapshot(run);
   }
@@ -610,7 +592,7 @@ function formatArtifactContext(input: {
     "STDOUT:",
     stdout,
     "STDERR:",
-    stderr
+    stderr,
   ].join("\n");
 }
 

--- a/src/orchestrator/ticket-decomposer.ts
+++ b/src/orchestrator/ticket-decomposer.ts
@@ -6,7 +6,7 @@ import {
   linearizeTickets,
   parseTicketPlan,
   validateTicketDag,
-  type TicketPlan
+  type TicketPlan,
 } from "../domain/ticket.js";
 
 export async function decomposePlanToTickets(input: {
@@ -26,7 +26,7 @@ export async function decomposePlanToTickets(input: {
       "Each ticket must have clear acceptance criteria and verification commands.",
       "Tickets that can run in parallel should NOT depend on each other.",
       "Tickets that need sequential execution must declare dependsOn edges.",
-      "The dependency graph must be a DAG (no cycles)."
+      "The dependency graph must be a DAG (no cycles).",
     ],
     allowedCommands: [],
     verificationCommands: [],
@@ -36,14 +36,15 @@ export async function decomposePlanToTickets(input: {
       `Classification tier: ${input.classification.tier}`,
       `Estimated ticket count: ${input.classification.estimatedTicketCount}`,
       `Plan phases: ${input.plan.phases.map((p) => `${p.id}: ${p.title}`).join(", ")}`,
-      ...input.plan.phases.map((p) =>
-        `Phase ${p.id} (${p.specialty}): ${p.goal} [commands: ${p.verificationCommands.join(", ")}]`
-      )
+      ...input.plan.phases.map(
+        (p) =>
+          `Phase ${p.id} (${p.specialty}): ${p.goal} [commands: ${p.verificationCommands.join(", ")}]`
+      ),
     ],
     artifactContext: [],
     attempt: 1,
     maxAttempts: 2,
-    priorEvidence: []
+    priorEvidence: [],
   });
 
   if (result.ticketPlan) {
@@ -62,7 +63,7 @@ function validateAndFixTicketPlan(plan: TicketPlan): TicketPlan {
 
   return {
     ...plan,
-    tickets: linearizeTickets(plan.tickets)
+    tickets: linearizeTickets(plan.tickets),
   };
 }
 
@@ -80,7 +81,7 @@ export function buildTicketPlanFromPhases(
     verificationCommands: phase.verificationCommands,
     docsToUpdate: phase.docsToUpdate,
     dependsOn: index > 0 ? [`ticket_${String(index).padStart(2, "0")}`] : [],
-    retryPolicy: phase.retryPolicy
+    retryPolicy: phase.retryPolicy,
   }));
 
   return parseTicketPlan({
@@ -89,6 +90,6 @@ export function buildTicketPlanFromPhases(
     classification,
     tickets,
     finalVerification: plan.finalVerification,
-    docsToUpdate: plan.docsToUpdate
+    docsToUpdate: plan.docsToUpdate,
   });
 }

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -3,14 +3,8 @@ import { getAgentName } from "../domain/agent-names.js";
 import { roleForWork } from "../domain/agent.js";
 import type { AgentRegistry } from "../agents/registry.js";
 import type { HarnessRun, RunEventType } from "../domain/run.js";
-import type {
-  TicketDefinition,
-  TicketLedgerEntry
-} from "../domain/ticket.js";
-import {
-  getReadyTickets,
-  initializeTicketLedger
-} from "../domain/ticket.js";
+import type { TicketDefinition, TicketLedgerEntry } from "../domain/ticket.js";
+import { getReadyTickets, initializeTicketLedger } from "../domain/ticket.js";
 import type { ArtifactStore } from "../execution/artifact-store.js";
 import type { ChannelStore } from "../channels/channel-store.js";
 import type { AgentExecutor } from "../execution/executor.js";
@@ -20,7 +14,7 @@ import {
   buildRetryContext,
   buildRetryObjective,
   fallbackFailureClassification,
-  isVerificationPlanIssue
+  isVerificationPlanIssue,
 } from "./failure-routing.js";
 
 export type SchedulerDispatch = (
@@ -52,7 +46,7 @@ export interface TicketSchedulerOptions {
 }
 
 const DEFAULT_OPTIONS: Required<Pick<TicketSchedulerOptions, "maxConcurrency">> = {
-  maxConcurrency: 3
+  maxConcurrency: 3,
 };
 
 // Sentinel marker returned by the wake-up channel — distinct from any real
@@ -139,9 +133,7 @@ export class TicketScheduler {
       );
     }
     if (!dispatch && !executor) {
-      throw new Error(
-        "TicketScheduler requires either a dispatch callback or options.executor."
-      );
+      throw new Error("TicketScheduler requires either a dispatch callback or options.executor.");
     }
 
     this.dispatch = dispatch ?? this.buildExecutorDispatch(executor!);
@@ -187,7 +179,7 @@ export class TicketScheduler {
       try {
         handle = await executor.start(ticket, {
           runId: run.id,
-          repoRoot: this.repoRoot
+          repoRoot: this.repoRoot,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -199,7 +191,7 @@ export class TicketScheduler {
           this.recordEvent(run, "TicketFailed", "__executor_start__", {
             runId: run.id,
             ticketId: ticket.id,
-            error: message
+            error: message,
           });
         } catch {
           // recordEvent itself must never break the scheduler loop.
@@ -208,7 +200,7 @@ export class TicketScheduler {
           summary: `executor.start failed: ${message}`,
           evidence: [`executor.start threw: ${message}`],
           proposedCommands: [],
-          blockers: [message]
+          blockers: [message],
         };
       }
 
@@ -225,7 +217,7 @@ export class TicketScheduler {
           this.recordEvent(run, "TicketFailed", "__executor_wait__", {
             runId: run.id,
             ticketId: ticket.id,
-            error: message
+            error: message,
           });
         } catch {
           /* recordEvent itself must never break the loop */
@@ -234,7 +226,7 @@ export class TicketScheduler {
           summary: `executor.wait failed: ${message}`,
           evidence: [`executor.wait threw: ${message}`],
           proposedCommands: [],
-          blockers: [message]
+          blockers: [message],
         };
       }
 
@@ -242,23 +234,20 @@ export class TicketScheduler {
       if (result.stdout) evidence.push(`stdout: ${result.stdout.slice(0, 2000)}`);
       if (result.stderr) evidence.push(`stderr: ${result.stderr.slice(0, 2000)}`);
 
-      const blockers = result.exitCode === 0
-        ? []
-        : [`Executor exited with code ${result.exitCode}`];
+      const blockers =
+        result.exitCode === 0 ? [] : [`Executor exited with code ${result.exitCode}`];
 
       // Prefer the ticket's verificationCommands as the tester proposal —
       // same default used when a tester agent echoes its allowlist. For
       // non-tester work kinds this just gets ignored by verification.
       const proposedCommands =
-        request.kind === "run_checks"
-          ? [...request.verificationCommands]
-          : [];
+        request.kind === "run_checks" ? [...request.verificationCommands] : [];
 
       return {
         summary: result.summary ?? `exit ${result.exitCode}`,
         evidence,
         proposedCommands,
-        blockers
+        blockers,
       };
     };
   }
@@ -344,7 +333,7 @@ export class TicketScheduler {
       console.warn(`[scheduler] tail drain failed: ${message}`);
       try {
         this.recordEvent(run, "TicketFailed", "__scheduler_tail__", {
-          error: message
+          error: message,
         });
       } catch {
         /* recordEvent itself must never break the chain */
@@ -387,9 +376,7 @@ export class TicketScheduler {
 
       this.updateBlockedTickets(run);
 
-      const ready = getReadyTickets(run.ticketLedger).filter(
-        (t) => !executing.has(t.ticketId)
-      );
+      const ready = getReadyTickets(run.ticketLedger).filter((t) => !executing.has(t.ticketId));
       const slotsAvailable = this.options.maxConcurrency - executing.size;
 
       for (const ticket of ready.slice(0, slotsAvailable)) {
@@ -407,14 +394,14 @@ export class TicketScheduler {
           status: "executing",
           assignedAgentId: agentId,
           assignedAgentName: agentDisplayName,
-          startedAt: new Date().toISOString()
+          startedAt: new Date().toISOString(),
         });
 
         this.recordEvent(run, "TicketStarted", ticket.ticketId, {
           ticketId: ticket.ticketId,
           title: ticket.title,
           assignedAgent: agentDisplayName,
-          agentId
+          agentId,
         });
 
         const promise = this.executeTicket(run, ticketDef).then(
@@ -434,10 +421,7 @@ export class TicketScheduler {
       }
 
       const wakePromise = this.makeWakePromise();
-      const completed = await Promise.race<RaceResult>([
-        ...executing.values(),
-        wakePromise
-      ]);
+      const completed = await Promise.race<RaceResult>([...executing.values(), wakePromise]);
 
       if ("wake" in completed && completed.wake) {
         // Wake signal fired — re-scan the ledger for newly appended work.
@@ -450,19 +434,19 @@ export class TicketScheduler {
         this.updateTicketStatus(run, completed.ticketId, {
           status: "completed",
           verification: "passed",
-          completedAt: new Date().toISOString()
+          completedAt: new Date().toISOString(),
         });
         this.recordEvent(run, "TicketCompleted", completed.ticketId, {
-          ticketId: completed.ticketId
+          ticketId: completed.ticketId,
         });
       } else {
         this.updateTicketStatus(run, completed.ticketId, {
           status: "failed",
           verification: "failed_terminal",
-          completedAt: new Date().toISOString()
+          completedAt: new Date().toISOString(),
         });
         this.recordEvent(run, "TicketFailed", completed.ticketId, {
-          ticketId: completed.ticketId
+          ticketId: completed.ticketId,
         });
       }
 
@@ -505,10 +489,7 @@ export class TicketScheduler {
     }
   }
 
-  private async executeTicket(
-    run: HarnessRun,
-    ticket: TicketDefinition
-  ): Promise<boolean> {
+  private async executeTicket(run: HarnessRun, ticket: TicketDefinition): Promise<boolean> {
     let classification: FailureClassification | null = null;
 
     for (let loop = 1; loop <= ticket.retryPolicy.maxTestFixLoops; loop += 1) {
@@ -526,17 +507,17 @@ export class TicketScheduler {
           `Feature request: ${run.featureRequest}`,
           `Ticket: ${ticket.id} - ${ticket.title}`,
           `Verification loop: ${loop} of ${ticket.retryPolicy.maxTestFixLoops}`,
-          ...buildRetryContext(classification)
+          ...buildRetryContext(classification),
         ],
         artifactContext: [],
         attempt: 1,
         maxAttempts: ticket.retryPolicy.maxAgentAttempts,
-        priorEvidence: []
+        priorEvidence: [],
       });
 
       this.updateTicketStatus(run, ticket.id, {
         status: "verifying",
-        verification: "running"
+        verification: "running",
       });
 
       const testerResult = await this.dispatch(run, {
@@ -555,7 +536,7 @@ export class TicketScheduler {
         artifactContext: [],
         attempt: 1,
         maxAttempts: ticket.retryPolicy.maxAgentAttempts,
-        priorEvidence: []
+        priorEvidence: [],
       });
 
       const verificationResult = await this.executeVerificationCommands(
@@ -578,14 +559,14 @@ export class TicketScheduler {
           lastClassification: {
             category: classification.category,
             rationale: classification.rationale,
-            nextAction: classification.nextAction
+            nextAction: classification.nextAction,
           },
-          attempt: loop + 1
+          attempt: loop + 1,
         });
         this.recordEvent(run, "TicketRetried", ticket.id, {
           ticketId: ticket.id,
           loop: String(loop),
-          category: classification.category
+          category: classification.category,
         });
         continue;
       }
@@ -604,29 +585,27 @@ export class TicketScheduler {
       kind: "classify_failure",
       specialty: ticket.specialty,
       title: `${ticket.title} failure classification`,
-      objective:
-        "Classify the failing artifacts. Choose: fix_code, fix_test, or bad_command_plan.",
+      objective: "Classify the failing artifacts. Choose: fix_code, fix_test, or bad_command_plan.",
       acceptanceCriteria: [
         "Use artifact contents to choose the most likely failure category.",
-        "Explain the rationale and the next best retry action."
+        "Explain the rationale and the next best retry action.",
       ],
       allowedCommands: ticket.allowedCommands,
       verificationCommands: ticket.verificationCommands,
       docsToUpdate: [],
-      context: rejectedCommands.length > 0
-        ? [`Rejected commands: ${rejectedCommands.join(", ")}`]
-        : [],
+      context:
+        rejectedCommands.length > 0 ? [`Rejected commands: ${rejectedCommands.join(", ")}`] : [],
       artifactContext: [],
       attempt: 1,
       maxAttempts: ticket.retryPolicy.maxAgentAttempts,
-      priorEvidence: []
+      priorEvidence: [],
     });
 
     return (
       result.failureClassification ??
       fallbackFailureClassification({
         artifactContext: [],
-        rejectedCommands
+        rejectedCommands,
       })
     );
   }
@@ -642,10 +621,7 @@ export class TicketScheduler {
     overridden: boolean;
     substitutedCommands: string[];
   }> {
-    const selection = selectVerificationCommands(
-      proposedCommands,
-      allowlistedCommands
-    );
+    const selection = selectVerificationCommands(proposedCommands, allowlistedCommands);
 
     let success = true;
 
@@ -654,7 +630,7 @@ export class TicketScheduler {
         runId: run.id,
         phaseId: ticketId,
         repoRoot: this.repoRoot,
-        command
+        command,
       });
 
       success = success && entry.result.exitCode === 0;
@@ -685,8 +661,8 @@ export class TicketScheduler {
               ticketId,
               verification: success ? "passed-with-override" : "failed-with-override",
               rejectedCommands: selection.rejected,
-              substitutedCommands
-            }
+              substitutedCommands,
+            },
           })
           .catch((err: unknown) => {
             const message = err instanceof Error ? err.message : String(err);
@@ -701,15 +677,13 @@ export class TicketScheduler {
       success,
       rejected: selection.rejected,
       overridden: selection.overridden,
-      substitutedCommands
+      substitutedCommands,
     };
   }
 
   private updateBlockedTickets(run: HarnessRun): void {
     const completedIds = new Set(
-      run.ticketLedger
-        .filter((t) => t.status === "completed")
-        .map((t) => t.ticketId)
+      run.ticketLedger.filter((t) => t.status === "completed").map((t) => t.ticketId)
     );
 
     for (const entry of run.ticketLedger) {
@@ -757,7 +731,7 @@ export class TicketScheduler {
         artifactContext: [],
         attempt: 1,
         maxAttempts: 1,
-        priorEvidence: []
+        priorEvidence: [],
       });
       return agent.id;
     } catch {
@@ -765,17 +739,14 @@ export class TicketScheduler {
     }
   }
 
-  private findTicketDefinition(
-    run: HarnessRun,
-    ticketId: string
-  ): TicketDefinition | null {
+  private findTicketDefinition(run: HarnessRun, ticketId: string): TicketDefinition | null {
     return run.ticketPlan?.tickets.find((t) => t.id === ticketId) ?? null;
   }
 
   private async persistTicketLedger(run: HarnessRun): Promise<void> {
     run.ticketLedgerPath = await this.artifactStore.saveTicketLedger({
       runId: run.id,
-      ticketLedger: run.ticketLedger
+      ticketLedger: run.ticketLedger,
     });
 
     // Mirror status changes onto the channel's unified ticket board so chat
@@ -798,7 +769,7 @@ export class TicketScheduler {
           this.recordEvent(run, "TicketFailed", "__channel_mirror__", {
             runId: run.id,
             channelId: run.channelId,
-            error: message
+            error: message,
           });
         } catch {
           // recordEvent itself must never break the scheduler loop.

--- a/src/simulation/scripted-invoker.ts
+++ b/src/simulation/scripted-invoker.ts
@@ -1,7 +1,11 @@
 import { writeFile } from "node:fs/promises";
 
 import { createSeedPlan } from "../domain/phase-plan.js";
-import type { CommandInvocation, CommandInvoker, CommandResult } from "../agents/command-invoker.js";
+import type {
+  CommandInvocation,
+  CommandInvoker,
+  CommandResult,
+} from "../agents/command-invoker.js";
 
 export class ScriptedInvoker implements CommandInvoker {
   constructor(private readonly cwd: string) {}
@@ -12,9 +16,7 @@ export class ScriptedInvoker implements CommandInvoker {
 
     if (invocation.command === "codex") {
       const outputFlagIndex = invocation.args.findIndex((arg) => arg === "-o");
-      const outputPath = outputFlagIndex >= 0
-        ? invocation.args[outputFlagIndex + 1]
-        : undefined;
+      const outputPath = outputFlagIndex >= 0 ? invocation.args[outputFlagIndex + 1] : undefined;
 
       if (!outputPath) {
         throw new Error("Scripted codex invocation missing output file path.");
@@ -25,14 +27,14 @@ export class ScriptedInvoker implements CommandInvoker {
       return {
         stdout: "",
         stderr: "",
-        exitCode: 0
+        exitCode: 0,
       };
     }
 
     return {
       stdout: JSON.stringify(response),
       stderr: "",
-      exitCode: 0
+      exitCode: 0,
     };
   }
 }
@@ -44,9 +46,7 @@ function buildResponse(prompt: string, cwd: string) {
   if (workKind === "classify_request") {
     return {
       summary: `Classified "${title}" as a feature_small request.`,
-      evidence: [
-        "Request appears to be a moderate-scope feature addition."
-      ],
+      evidence: ["Request appears to be a moderate-scope feature addition."],
       proposedCommands: [],
       blockers: [],
       classification: {
@@ -55,19 +55,17 @@ function buildResponse(prompt: string, cwd: string) {
         suggestedSpecialties: ["general"],
         estimatedTicketCount: 3,
         needsDesignDoc: false,
-        needsUserApproval: false
-      }
+        needsUserApproval: false,
+      },
     };
   }
 
   if (workKind === "generate_design_doc") {
     return {
       summary: `Generated design document for "${title}".`,
-      evidence: [
-        "Design document covers architecture, trade-offs, and implementation approach."
-      ],
+      evidence: ["Design document covers architecture, trade-offs, and implementation approach."],
       proposedCommands: [],
-      blockers: []
+      blockers: [],
     };
   }
 
@@ -76,7 +74,7 @@ function buildResponse(prompt: string, cwd: string) {
       summary: `Decomposed "${title}" into parallelizable tickets.`,
       evidence: [
         "Tickets were derived from the phase plan.",
-        "Dependencies between tickets were identified."
+        "Dependencies between tickets were identified.",
       ],
       proposedCommands: [],
       blockers: [],
@@ -85,7 +83,7 @@ function buildResponse(prompt: string, cwd: string) {
         task: {
           title,
           featureRequest: title,
-          repoRoot: cwd
+          repoRoot: cwd,
         },
         classification: {
           tier: "feature_small",
@@ -93,7 +91,7 @@ function buildResponse(prompt: string, cwd: string) {
           suggestedSpecialties: ["general"],
           estimatedTicketCount: 2,
           needsDesignDoc: false,
-          needsUserApproval: false
+          needsUserApproval: false,
         },
         tickets: [
           {
@@ -106,7 +104,7 @@ function buildResponse(prompt: string, cwd: string) {
             verificationCommands: ["pnpm typecheck"],
             docsToUpdate: [],
             dependsOn: [],
-            retryPolicy: { maxAgentAttempts: 2, maxTestFixLoops: 2 }
+            retryPolicy: { maxAgentAttempts: 2, maxTestFixLoops: 2 },
           },
           {
             id: "ticket_02",
@@ -118,12 +116,12 @@ function buildResponse(prompt: string, cwd: string) {
             verificationCommands: ["pnpm typecheck", "pnpm test"],
             docsToUpdate: ["README.md"],
             dependsOn: ["ticket_01"],
-            retryPolicy: { maxAgentAttempts: 2, maxTestFixLoops: 2 }
-          }
+            retryPolicy: { maxAgentAttempts: 2, maxTestFixLoops: 2 },
+          },
         ],
         finalVerification: { commands: ["pnpm typecheck", "pnpm test"] },
-        docsToUpdate: ["README.md"]
-      }
+        docsToUpdate: ["README.md"],
+      },
     };
   }
 
@@ -132,11 +130,11 @@ function buildResponse(prompt: string, cwd: string) {
       summary: `Created a structured phase plan for "${title}".`,
       evidence: [
         "Planner produced a bounded multi-phase plan.",
-        "Retry budgets and verification commands were included."
+        "Retry budgets and verification commands were included.",
       ],
       proposedCommands: [],
       blockers: [],
-      phasePlan: createSeedPlan(title, cwd)
+      phasePlan: createSeedPlan(title, cwd),
     };
   }
 
@@ -145,10 +143,10 @@ function buildResponse(prompt: string, cwd: string) {
       summary: `Prepared implementation guidance for "${title}".`,
       evidence: [
         "Implementation agent identified the phase objective.",
-        "Acceptance criteria were preserved in the response."
+        "Acceptance criteria were preserved in the response.",
       ],
       proposedCommands: ["pnpm typecheck"],
-      blockers: []
+      blockers: [],
     };
   }
 
@@ -180,37 +178,31 @@ function buildResponse(prompt: string, cwd: string) {
 
     return {
       summary: `Classified the failure for "${title}" as ${category}.`,
-      evidence: [
-        "Failure category was derived from captured artifact contents."
-      ],
+      evidence: ["Failure category was derived from captured artifact contents."],
       proposedCommands: [],
       blockers: [],
       failureClassification: {
         category,
         rationale,
-        nextAction
-      }
+        nextAction,
+      },
     };
   }
 
   if (workKind === "run_checks") {
     return {
       summary: `Prepared a verification pass for "${title}".`,
-      evidence: [
-        "Verification commands were surfaced back to the harness."
-      ],
+      evidence: ["Verification commands were surfaced back to the harness."],
       proposedCommands: ["pnpm typecheck", "pnpm test"],
-      blockers: []
+      blockers: [],
     };
   }
 
   return {
     summary: `Reviewed "${title}" for correctness and scope alignment.`,
-    evidence: [
-      "Review covered scope drift and missing acceptance criteria."
-    ],
+    evidence: ["Review covered scope drift and missing acceptance criteria."],
     proposedCommands: [],
-    blockers: []
+    blockers: [],
   };
 }
 

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -79,9 +79,7 @@ function resolveKind(explicit: StoreKind | undefined): StoreKind {
  *
  * Precedence: `opts.kind` > `HARNESS_STORE` env > default `"file"`.
  */
-export function buildHarnessStore(
-  opts: StoreFactoryOptions = {}
-): HarnessStore {
+export function buildHarnessStore(opts: StoreFactoryOptions = {}): HarnessStore {
   const kind = resolveKind(opts.kind);
 
   if (kind === "file") {

--- a/src/storage/file-store.ts
+++ b/src/storage/file-store.ts
@@ -6,17 +6,12 @@ import {
   rename,
   rm,
   stat,
-  writeFile
+  writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "./store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "./store.js";
 
 /**
  * Filesystem-backed implementation of `HarnessStore`. Layout under `rootDir`:
@@ -88,9 +83,7 @@ export class FileHarnessStore implements HarnessStore {
         return null;
       }
       throw new Error(
-        `Failed to read doc at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Failed to read doc at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
 
@@ -101,9 +94,7 @@ export class FileHarnessStore implements HarnessStore {
       // Callers rely on corrupt→throw to avoid overwriting real data via a
       // subsequent putDoc.
       throw new Error(
-        `Corrupt doc at ${path}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
+        `Corrupt doc at ${path}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }
@@ -153,11 +144,7 @@ export class FileHarnessStore implements HarnessStore {
     await appendFile(path, JSON.stringify(entry) + "\n");
   }
 
-  async readLog<T>(
-    ns: string,
-    id: string,
-    opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(ns: string, id: string, opts?: ReadLogOptions): Promise<T[]> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
     const path = this.logPath(ns, id);
@@ -180,9 +167,7 @@ export class FileHarnessStore implements HarnessStore {
         // Match `getDoc`'s corruption posture: surface with file + line so
         // operators can repair instead of silently dropping the bad record.
         throw new Error(
-          `Corrupt log at ${path} line ${i}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `Corrupt log at ${path} line ${i}: ${err instanceof Error ? err.message : String(err)}`,
           { cause: err }
         );
       }
@@ -191,9 +176,7 @@ export class FileHarnessStore implements HarnessStore {
     let filtered = entries;
     if (opts?.after !== undefined) {
       const cursor = opts.after;
-      const idx = filtered.findIndex(
-        (e) => cursorKey(e) !== undefined && cursorKey(e) === cursor
-      );
+      const idx = filtered.findIndex((e) => cursorKey(e) !== undefined && cursorKey(e) === cursor);
       // Cursor not found → return []. Returning the full log would cause
       // duplicate delivery on resume; the contract is documented on
       // `ReadLogOptions.after`.
@@ -220,9 +203,7 @@ export class FileHarnessStore implements HarnessStore {
 
     const hasMeta = meta !== undefined && Object.keys(meta).length > 0;
     const blobTmp = `${path}.tmp.${process.pid}.${tmpCounter++}`;
-    const metaTmp = hasMeta
-      ? `${metaPath}.tmp.${process.pid}.${tmpCounter++}`
-      : null;
+    const metaTmp = hasMeta ? `${metaPath}.tmp.${process.pid}.${tmpCounter++}` : null;
 
     // Stage both tmp files BEFORE either rename so we never end up with a
     // durable blob that's missing its sidecar metadata.
@@ -262,7 +243,7 @@ export class FileHarnessStore implements HarnessStore {
       ns,
       id,
       size: bytes.byteLength,
-      contentType: hasMeta ? meta?.["contentType"] : undefined
+      contentType: hasMeta ? meta?.["contentType"] : undefined,
     };
   }
 
@@ -274,11 +255,7 @@ export class FileHarnessStore implements HarnessStore {
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
 
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
     return withKeyLock(ns, id, async () => {
@@ -312,11 +289,7 @@ export class FileHarnessStore implements HarnessStore {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
     const pollIntervalMs = 250;
-    const candidates = [
-      this.docPath(ns, id),
-      this.logPath(ns, id),
-      this.blobPath(ns, id)
-    ];
+    const candidates = [this.docPath(ns, id), this.logPath(ns, id), this.blobPath(ns, id)];
 
     let lastMtimes = await readMtimes(candidates);
     let closed = false;
@@ -375,11 +348,7 @@ export class FileHarnessStore implements HarnessStore {
  * tail and installs its own. Self-cleans when no successor is queued.
  * In-process only.
  */
-async function withKeyLock<T>(
-  ns: string,
-  id: string,
-  fn: () => Promise<T>
-): Promise<T> {
+async function withKeyLock<T>(ns: string, id: string, fn: () => Promise<T>): Promise<T> {
   const key = `${ns}\u0000${id}`;
   const prev = keyLocks.get(key) ?? Promise.resolve();
   let resolveCurrent!: () => void;

--- a/src/storage/migrations/runner.ts
+++ b/src/storage/migrations/runner.ts
@@ -32,17 +32,13 @@ CREATE TABLE IF NOT EXISTS harness_schema_migrations (
 )
 `;
 
-export async function migrate(
-  opts: MigrateOptions = {}
-): Promise<AppliedMigration[]> {
+export async function migrate(opts: MigrateOptions = {}): Promise<AppliedMigration[]> {
   const { pool, ownsPool } = resolvePool(opts);
   const dir = opts.migrationsDir ?? defaultMigrationsDir();
 
   try {
     await pool.query(SCHEMA_TABLE_DDL);
-    const files = (await readdir(dir))
-      .filter((f) => /^\d+_.*\.sql$/.test(f))
-      .sort();
+    const files = (await readdir(dir)).filter((f) => /^\d+_.*\.sql$/.test(f)).sort();
 
     const applied: AppliedMigration[] = [];
     for (const file of files) {
@@ -61,10 +57,9 @@ export async function migrate(
         }
         const sql = await readFile(join(dir, file), "utf8");
         await client.query(sql);
-        await client.query(
-          "INSERT INTO harness_schema_migrations (version) VALUES ($1)",
-          [version]
-        );
+        await client.query("INSERT INTO harness_schema_migrations (version) VALUES ($1)", [
+          version,
+        ]);
         await client.query("COMMIT");
         applied.push({ version, alreadyApplied: false });
       } catch (err) {
@@ -89,8 +84,7 @@ function resolvePool(opts: MigrateOptions): {
   ownsPool: boolean;
 } {
   if (opts.pool) return { pool: opts.pool, ownsPool: false };
-  const connectionString =
-    opts.connectionString ?? process.env["HARNESS_POSTGRES_URL"];
+  const connectionString = opts.connectionString ?? process.env["HARNESS_POSTGRES_URL"];
   if (!connectionString) {
     throw new Error(
       "migrate(): pass { pool } or { connectionString }, or set HARNESS_POSTGRES_URL"
@@ -118,9 +112,7 @@ if (isMain && process.argv[2] === "migrate") {
       }
     })
     .catch((err) => {
-      process.stderr.write(
-        `migrate failed: ${err instanceof Error ? err.message : String(err)}\n`
-      );
+      process.stderr.write(`migrate failed: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);
     });
 }

--- a/src/storage/namespaces.ts
+++ b/src/storage/namespaces.ts
@@ -17,7 +17,7 @@ export const STORE_NS = {
   session: "session",
   decision: "decision",
   crosslinkSession: "crosslink-session",
-  crosslinkMailbox: "crosslink-mailbox"
+  crosslinkMailbox: "crosslink-mailbox",
 } as const;
 
 export type StoreNamespace = (typeof STORE_NS)[keyof typeof STORE_NS];

--- a/src/storage/postgres-store.ts
+++ b/src/storage/postgres-store.ts
@@ -1,12 +1,7 @@
 import pg from "pg";
 
 import { assertSafeSegment } from "./file-store.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "./store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "./store.js";
 
 /**
  * Postgres channel names truncate at 63 bytes. The prefix `harness_change_`
@@ -71,9 +66,7 @@ export class PostgresHarnessStore implements HarnessStore {
       this.ownsPool = true;
       this.connectionString = opts.connectionString;
     } else {
-      throw new Error(
-        "PostgresHarnessStore requires `pool` or `connectionString`"
-      );
+      throw new Error("PostgresHarnessStore requires `pool` or `connectionString`");
     }
   }
 
@@ -133,8 +126,7 @@ export class PostgresHarnessStore implements HarnessStore {
     // literally, mirroring FileHarnessStore.listDocs which uses
     // `String.startsWith`. Without this, a prefix of `a_b` would match
     // `axb`, `aab`, etc., diverging from the contract.
-    const escapedPrefix =
-      prefix !== undefined ? prefix.replace(/[\\%_]/g, "\\$&") : null;
+    const escapedPrefix = prefix !== undefined ? prefix.replace(/[\\%_]/g, "\\$&") : null;
     const result = await this.pool.query<{ doc: T }>(
       `SELECT doc FROM harness_docs
        WHERE ns = $1
@@ -148,26 +140,20 @@ export class PostgresHarnessStore implements HarnessStore {
   async deleteDoc(ns: string, id: string): Promise<void> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
-    await this.pool.query(
-      "DELETE FROM harness_docs WHERE ns = $1 AND id = $2",
-      [ns, id]
-    );
+    await this.pool.query("DELETE FROM harness_docs WHERE ns = $1 AND id = $2", [ns, id]);
   }
 
   async appendLog(ns: string, id: string, entry: unknown): Promise<void> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
-    await this.pool.query(
-      "INSERT INTO harness_logs (ns, id, entry) VALUES ($1, $2, $3::jsonb)",
-      [ns, id, JSON.stringify(entry)]
-    );
+    await this.pool.query("INSERT INTO harness_logs (ns, id, entry) VALUES ($1, $2, $3::jsonb)", [
+      ns,
+      id,
+      JSON.stringify(entry),
+    ]);
   }
 
-  async readLog<T>(
-    ns: string,
-    id: string,
-    opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(ns: string, id: string, opts?: ReadLogOptions): Promise<T[]> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
 
@@ -241,7 +227,7 @@ export class PostgresHarnessStore implements HarnessStore {
       ns,
       id,
       size: bytes.byteLength,
-      contentType: hasMeta ? contentType : undefined
+      contentType: hasMeta ? contentType : undefined,
     };
   }
 
@@ -253,9 +239,7 @@ export class PostgresHarnessStore implements HarnessStore {
       [ref.ns, ref.id]
     );
     if (result.rowCount === 0) {
-      const err: NodeJS.ErrnoException = new Error(
-        `Blob not found: ${ref.ns}/${ref.id}`
-      );
+      const err: NodeJS.ErrnoException = new Error(`Blob not found: ${ref.ns}/${ref.id}`);
       err.code = "ENOENT";
       throw err;
     }
@@ -277,11 +261,7 @@ export class PostgresHarnessStore implements HarnessStore {
    * is rolled back and no row is modified. `fn` itself should be pure and
    * fast — the row lock is held for its entire runtime.
    */
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     assertSafeSegment(ns, "ns");
     assertSafeSegment(id, "id");
     const client = await this.pool.connect();
@@ -296,18 +276,16 @@ export class PostgresHarnessStore implements HarnessStore {
       // byte (`E'\0'`) is rejected by Postgres's UTF8 input at parse time
       // so we deliberately avoid it even though it would be a more obvious
       // delimiter.
-      await client.query(
-        "SELECT pg_advisory_xact_lock(hashtextextended($1 || '/' || $2, 0))",
-        [ns, id]
-      );
+      await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1 || '/' || $2, 0))", [
+        ns,
+        id,
+      ]);
       const existing = await client.query<{ doc: T }>(
         "SELECT doc FROM harness_docs WHERE ns = $1 AND id = $2 FOR UPDATE",
         [ns, id]
       );
       const prev: T | null =
-        existing.rowCount && existing.rowCount > 0
-          ? existing.rows[0]!.doc
-          : null;
+        existing.rowCount && existing.rowCount > 0 ? existing.rows[0]!.doc : null;
       const next = fn(prev);
       await client.query(
         `INSERT INTO harness_docs (ns, id, doc, updated_at)
@@ -360,12 +338,10 @@ export class PostgresHarnessStore implements HarnessStore {
         if (sub.closed) return { value: undefined, done: true };
         const queued = sub.queue.shift();
         if (queued) return { value: queued, done: false };
-        const event = await new Promise<ChangeEvent | null>(
-          (resolve, reject) => {
-            sub.resolveWaiter = resolve;
-            sub.rejectWaiter = reject;
-          }
-        );
+        const event = await new Promise<ChangeEvent | null>((resolve, reject) => {
+          sub.resolveWaiter = resolve;
+          sub.rejectWaiter = reject;
+        });
         if (event === null) return { value: undefined, done: true };
         return { value: event, done: false };
       },
@@ -378,18 +354,15 @@ export class PostgresHarnessStore implements HarnessStore {
         const sub = await subPromise;
         await store.unsubscribe(ns, sub);
         throw err;
-      }
+      },
     };
 
     return {
-      [Symbol.asyncIterator]: () => iterator
+      [Symbol.asyncIterator]: () => iterator,
     };
   }
 
-  private async subscribe(
-    ns: string,
-    id: string
-  ): Promise<WatchSubscription> {
+  private async subscribe(ns: string, id: string): Promise<WatchSubscription> {
     const sub: WatchSubscription = {
       ns,
       expectedId: id,
@@ -397,13 +370,13 @@ export class PostgresHarnessStore implements HarnessStore {
       resolveWaiter: null,
       rejectWaiter: null,
       closed: false,
-      error: null
+      error: null,
     };
 
     let entry = this.listenClients.get(ns);
     if (!entry) {
       const client = new pg.Client({
-        connectionString: this.connectionStringForClient()
+        connectionString: this.connectionStringForClient(),
       });
       // A Pool client can't hold a long-lived LISTEN because the pool will
       // rotate it back into the free list. Dedicated Client instead.
@@ -473,10 +446,7 @@ export class PostgresHarnessStore implements HarnessStore {
     return sub;
   }
 
-  private async unsubscribe(
-    ns: string,
-    sub: WatchSubscription
-  ): Promise<void> {
+  private async unsubscribe(ns: string, sub: WatchSubscription): Promise<void> {
     sub.closed = true;
     // Wake any pending waiter so the generator's finally can run; otherwise
     // iterator.return() awaits a promise that will never resolve.

--- a/src/storage/store.ts
+++ b/src/storage/store.ts
@@ -141,4 +141,3 @@ export interface HarnessStore {
    */
   watch(ns: string, id: string): AsyncIterable<ChangeEvent>;
 }
-

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -4,10 +4,7 @@ import { listAgentNames } from "../domain/agent-names.js";
 import type { Channel, ChannelEntry } from "../domain/channel.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
-import {
-  getGlobalRoot,
-  listRegisteredWorkspaces
-} from "../cli/workspace-registry.js";
+import { getGlobalRoot, listRegisteredWorkspaces } from "../cli/workspace-registry.js";
 import {
   bold,
   boxBottom,
@@ -26,13 +23,21 @@ import {
   showCursor,
   statusColor,
   truncate,
-  yellow
+  yellow,
 } from "./render.js";
 
 const ACTIVE_RUN_STATES = new Set([
-  "CLASSIFYING", "DRAFT_PLAN", "PLAN_REVIEW", "AWAITING_APPROVAL",
-  "DESIGN_DOC", "PHASE_READY", "PHASE_EXECUTE", "TEST_FIX_LOOP",
-  "REVIEW_FIX_LOOP", "TICKETS_EXECUTING", "TICKETS_COMPLETE"
+  "CLASSIFYING",
+  "DRAFT_PLAN",
+  "PLAN_REVIEW",
+  "AWAITING_APPROVAL",
+  "DESIGN_DOC",
+  "PHASE_READY",
+  "PHASE_EXECUTE",
+  "TEST_FIX_LOOP",
+  "REVIEW_FIX_LOOP",
+  "TICKETS_EXECUTING",
+  "TICKETS_COMPLETE",
 ]);
 
 interface DashboardState {
@@ -53,7 +58,7 @@ export async function startDashboard(): Promise<void> {
     feed: [],
     tickets: [],
     activeRuns: [],
-    agents: []
+    agents: [],
   };
 
   hideCursor();
@@ -104,7 +109,7 @@ async function refresh(state: DashboardState, channelStore: ChannelStore): Promi
     id: a.agentId,
     name: a.displayName,
     role: a.role,
-    provider: a.provider
+    provider: a.provider,
   }));
 
   const selectedChannel = state.channels[state.selectedChannelIndex];
@@ -140,7 +145,7 @@ async function refresh(state: DashboardState, channelStore: ChannelStore): Promi
           runId: run.runId,
           state: run.state,
           featureRequest: run.featureRequest,
-          workspace: ws.repoPath.split("/").pop() ?? ws.workspaceId
+          workspace: ws.repoPath.split("/").pop() ?? ws.workspaceId,
         });
       }
     }
@@ -161,8 +166,7 @@ function draw(state: DashboardState): void {
   // Header
   moveTo(row, 1);
   process.stdout.write(
-    bold(cyan(" AGENT HARNESS ")) +
-    dim(`  q=quit  j/k=navigate  refreshing every 3s`)
+    bold(cyan(" AGENT HARNESS ")) + dim(`  q=quit  j/k=navigate  refreshing every 3s`)
   );
   row += 2;
 
@@ -258,17 +262,25 @@ function draw(state: DashboardState): void {
 
     // Group tickets by status
     const groups = groupTicketsByStatus(state.tickets);
-    const statusOrder = ["executing", "verifying", "ready", "blocked", "pending", "retry", "completed", "failed"];
+    const statusOrder = [
+      "executing",
+      "verifying",
+      "ready",
+      "blocked",
+      "pending",
+      "retry",
+      "completed",
+      "failed",
+    ];
 
     for (const status of statusOrder) {
       const tickets = groups[status];
       if (!tickets || tickets.length === 0) continue;
 
       moveTo(boardRow, leftWidth + centerWidth + 3);
-      process.stdout.write(boxRow(
-        `${statusColor(status.toUpperCase())} ${dim(`(${tickets.length})`)}`,
-        rightWidth
-      ));
+      process.stdout.write(
+        boxRow(`${statusColor(status.toUpperCase())} ${dim(`(${tickets.length})`)}`, rightWidth)
+      );
       boardRow++;
 
       for (const ticket of tickets.slice(0, 3)) {
@@ -299,10 +311,7 @@ function draw(state: DashboardState): void {
       for (const run of state.activeRuns.slice(0, 4)) {
         const label = truncate(run.featureRequest, rightWidth - 18);
         moveTo(boardRow, leftWidth + centerWidth + 3);
-        process.stdout.write(boxRow(
-          `  ${statusColor(run.state)} ${dim(label)}`,
-          rightWidth
-        ));
+        process.stdout.write(boxRow(`  ${statusColor(run.state)} ${dim(label)}`, rightWidth));
         boardRow++;
       }
     }
@@ -317,28 +326,38 @@ function draw(state: DashboardState): void {
   const ticketCount = state.tickets.length;
   const runCount = state.activeRuns.length;
   process.stdout.write(
-    dim(` ${channelCount} channel(s)  ${ticketCount} ticket(s)  ${runCount} active run(s)  ${state.agents.length} agent(s)`)
+    dim(
+      ` ${channelCount} channel(s)  ${ticketCount} ticket(s)  ${runCount} active run(s)  ${state.agents.length} agent(s)`
+    )
   );
 }
 
 function feedIcon(type: string): string {
   switch (type) {
-    case "message": return cyan("💬");
-    case "decision": return yellow("⚖️");
-    case "status_update": return magenta("📊");
-    case "artifact": return green("📎");
-    case "agent_joined": return green("→");
-    case "agent_left": return red("←");
-    case "run_started": return cyan("▶");
-    case "run_completed": return green("✓");
-    case "ref_added": return dim("🔗");
-    default: return dim("·");
+    case "message":
+      return cyan("💬");
+    case "decision":
+      return yellow("⚖️");
+    case "status_update":
+      return magenta("📊");
+    case "artifact":
+      return green("📎");
+    case "agent_joined":
+      return green("→");
+    case "agent_left":
+      return red("←");
+    case "run_started":
+      return cyan("▶");
+    case "run_completed":
+      return green("✓");
+    case "ref_added":
+      return dim("🔗");
+    default:
+      return dim("·");
   }
 }
 
-function groupTicketsByStatus(
-  tickets: TicketLedgerEntry[]
-): Record<string, TicketLedgerEntry[]> {
+function groupTicketsByStatus(tickets: TicketLedgerEntry[]): Record<string, TicketLedgerEntry[]> {
   const groups: Record<string, TicketLedgerEntry[]> = {};
 
   for (const ticket of tickets) {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -31,7 +31,7 @@ export function moveTo(row: number, col: number): void {
 export function getTerminalSize(): { rows: number; cols: number } {
   return {
     rows: process.stdout.rows ?? 24,
-    cols: process.stdout.columns ?? 80
+    cols: process.stdout.columns ?? 80,
   };
 }
 

--- a/test/agent-names.test.ts
+++ b/test/agent-names.test.ts
@@ -9,15 +9,10 @@ import {
   getAgentName,
   listAgentNames,
   setAgentName,
-  type AgentNameEntry
+  type AgentNameEntry,
 } from "../src/domain/agent-names.js";
 import { STORE_NS } from "../src/storage/namespaces.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "../src/storage/store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "../src/storage/store.js";
 
 /**
  * Minimal in-memory HarnessStore. Same shape as the one used in the T-101
@@ -54,11 +49,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.appendLog is not implemented");
   }
 
-  async readLog<T>(
-    _ns: string,
-    _id: string,
-    _opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(_ns: string, _id: string, _opts?: ReadLogOptions): Promise<T[]> {
     throw new Error("FakeHarnessStore.readLog is not implemented");
   }
 
@@ -70,11 +61,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.getBlob is not implemented");
   }
 
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     this.mutateCalls.push({ ns, id });
     const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
     const next = fn(prev);
@@ -101,7 +88,7 @@ describe("agent names", () => {
 
   it("sets and retrieves agent display names", async () => {
     await setAgentName("test-agent-1", "Test Agent One", "claude", "planner", {
-      relayDir
+      relayDir,
     });
 
     const name = await getAgentName("test-agent-1", { relayDir });
@@ -116,7 +103,7 @@ describe("agent names", () => {
 
     // Overwrite
     await setAgentName("test-agent-1", "Updated Name", "claude", "reviewer", {
-      relayDir
+      relayDir,
     });
     const updated = await getAgentName("test-agent-1", { relayDir });
     expect(updated).toBe("Updated Name");
@@ -127,24 +114,15 @@ describe("agent names", () => {
     // After a set, the on-disk file must contain the full registry as a flat
     // JSON array — never an object wrapper, never under a sub-path.
     await setAgentName("planner-1", "Planner One", "claude", "planner", {
-      relayDir
+      relayDir,
     });
-    await setAgentName(
-      "implementer-1",
-      "Implementer One",
-      "codex",
-      "implementer",
-      { relayDir }
-    );
+    await setAgentName("implementer-1", "Implementer One", "codex", "implementer", { relayDir });
 
     const onDisk = JSON.parse(
       await readFile(join(relayDir, "agent-names.json"), "utf8")
     ) as AgentNameEntry[];
     expect(Array.isArray(onDisk)).toBe(true);
-    expect(onDisk.map((e) => e.agentId).sort()).toEqual([
-      "implementer-1",
-      "planner-1"
-    ]);
+    expect(onDisk.map((e) => e.agentId).sort()).toEqual(["implementer-1", "planner-1"]);
   });
 
   it("mirrors the registry through the injected HarnessStore", async () => {
@@ -152,15 +130,12 @@ describe("agent names", () => {
 
     await setAgentName("planner-1", "Planner One", "claude", "planner", {
       relayDir,
-      store: fake
+      store: fake,
     });
-    await setAgentName(
-      "implementer-1",
-      "Implementer One",
-      "codex",
-      "implementer",
-      { relayDir, store: fake }
-    );
+    await setAgentName("implementer-1", "Implementer One", "codex", "implementer", {
+      relayDir,
+      store: fake,
+    });
 
     // Coordination record is stored under STORE_NS.agentName via mutate so
     // Postgres-backed stores can layer advisory-lock coordination later.
@@ -169,15 +144,9 @@ describe("agent names", () => {
     );
     expect(calls).toHaveLength(2);
 
-    const mirrored = await fake.getDoc<AgentNameEntry[]>(
-      STORE_NS.agentName,
-      "registry"
-    );
+    const mirrored = await fake.getDoc<AgentNameEntry[]>(STORE_NS.agentName, "registry");
     expect(mirrored).not.toBeNull();
-    expect(mirrored!.map((e) => e.agentId).sort()).toEqual([
-      "implementer-1",
-      "planner-1"
-    ]);
+    expect(mirrored!.map((e) => e.agentId).sort()).toEqual(["implementer-1", "planner-1"]);
   });
 
   it("does not fail setAgentName when the HarnessStore mirror throws", async () => {
@@ -212,13 +181,13 @@ describe("agent names", () => {
       },
       watch: async function* () {
         throw new Error("not implemented");
-      }
+      },
     };
 
     await expect(
       setAgentName("resilient-agent", "Resilient", "claude", "planner", {
         relayDir,
-        store: flaky
+        store: flaky,
       })
     ).resolves.toMatchObject({ agentId: "resilient-agent" });
 
@@ -236,9 +205,7 @@ describe("agent names reads legacy pre-migration fixture", () => {
     // relayDir. `listAgentNames` reads `<relayDir>/agent-names.json`, so the
     // fixture has to live under that exact name at the dir root.
     workDir = await mkdtemp(join(tmpdir(), "agent-names-legacy-"));
-    const src = fileURLToPath(
-      new URL("./fixtures/legacy-agent-names.json", import.meta.url)
-    );
+    const src = fileURLToPath(new URL("./fixtures/legacy-agent-names.json", import.meta.url));
     await cp(src, join(workDir, "agent-names.json"));
   });
 
@@ -248,10 +215,7 @@ describe("agent names reads legacy pre-migration fixture", () => {
 
   it("reads pre-migration agent-names.json via the new API", async () => {
     const entries = await listAgentNames({ relayDir: workDir });
-    expect(entries.map((e) => e.agentId).sort()).toEqual([
-      "implementer-codex",
-      "planner-claude"
-    ]);
+    expect(entries.map((e) => e.agentId).sort()).toEqual(["implementer-codex", "planner-claude"]);
 
     const name = await getAgentName("planner-claude", { relayDir: workDir });
     expect(name).toBe("Claude (Planner)");

--- a/test/agent-wrapper.test.ts
+++ b/test/agent-wrapper.test.ts
@@ -9,7 +9,7 @@ import {
   buildCodexLaunchArgs,
   ensureClaudeMcpConfig,
   hasHarnessMcpOptOut,
-  stripHarnessMcpOptOut
+  stripHarnessMcpOptOut,
 } from "../src/cli/agent-wrapper.js";
 import { getHarnessWorkspacePaths } from "../src/cli/workspace.js";
 
@@ -22,7 +22,7 @@ describe("agent wrapper", () => {
       const configPath = await ensureClaudeMcpConfig({
         cwd,
         cliEntrypoint: "/tmp/relay/dist/cli.js",
-        paths
+        paths,
       });
       const config = JSON.parse(await readFile(configPath, "utf8")) as {
         mcpServers: {
@@ -40,18 +40,14 @@ describe("agent wrapper", () => {
         "/tmp/relay/dist/cli.js",
         "mcp-server",
         "--workspace",
-        cwd
+        cwd,
       ]);
-      expect(config.mcpServers.relay.env.RELAY_HOME).toBe(
-        paths.rootDir
-      );
-      expect(config.mcpServers.relay.env.RELAY_RUNS_INDEX).toBe(
-        paths.runsIndexPath
-      );
+      expect(config.mcpServers.relay.env.RELAY_HOME).toBe(paths.rootDir);
+      expect(config.mcpServers.relay.env.RELAY_RUNS_INDEX).toBe(paths.runsIndexPath);
     } finally {
       await rm(cwd, {
         recursive: true,
-        force: true
+        force: true,
       });
     }
   });
@@ -59,12 +55,12 @@ describe("agent wrapper", () => {
   it("builds launch arguments that auto-attach MCP to Claude and Codex", () => {
     const claudeArgs = buildClaudeLaunchArgs({
       userArgs: ["--help"],
-      mcpConfigPath: "/tmp/claude.mcp.json"
+      mcpConfigPath: "/tmp/claude.mcp.json",
     });
     const codexArgs = buildCodexLaunchArgs({
       userArgs: ["--help"],
       cwd: "/tmp/workspace",
-      cliEntrypoint: "/tmp/relay/dist/cli.js"
+      cliEntrypoint: "/tmp/relay/dist/cli.js",
     });
 
     expect(claudeArgs).toContain("--mcp-config");
@@ -74,9 +70,7 @@ describe("agent wrapper", () => {
     expect(claudeArgs.at(-1)).toBe("--help");
 
     expect(codexArgs).toContain("-c");
-    expect(codexArgs).toContain(
-      `mcp_servers.relay.command=${JSON.stringify(process.execPath)}`
-    );
+    expect(codexArgs).toContain(`mcp_servers.relay.command=${JSON.stringify(process.execPath)}`);
     expect(codexArgs).toContain(
       'mcp_servers.relay.args=["/tmp/relay/dist/cli.js","mcp-server","--workspace","/tmp/workspace"]'
     );
@@ -86,8 +80,6 @@ describe("agent wrapper", () => {
   it("supports opting out of harness MCP attachment", () => {
     expect(hasHarnessMcpOptOut(["--no-harness-mcp", "--help"])).toBe(true);
     expect(hasHarnessMcpOptOut(["--help"])).toBe(false);
-    expect(stripHarnessMcpOptOut(["--no-harness-mcp", "--help"])).toEqual([
-      "--help"
-    ]);
+    expect(stripHarnessMcpOptOut(["--no-harness-mcp", "--help"])).toEqual(["--help"]);
   });
 });

--- a/test/artifact-store-harness-store.test.ts
+++ b/test/artifact-store-harness-store.test.ts
@@ -1,12 +1,4 @@
-import {
-  cp,
-  mkdir,
-  mkdtemp,
-  readFile,
-  rm,
-  stat,
-  writeFile
-} from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,12 +9,7 @@ import { createPrLifecycle } from "../src/domain/pr-lifecycle.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import { STORE_NS } from "../src/storage/namespaces.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "../src/storage/store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "../src/storage/store.js";
 import type { HarnessRun, RunEvent } from "../src/domain/run.js";
 
 /**
@@ -62,11 +49,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.appendLog is not implemented");
   }
 
-  async readLog<T>(
-    _ns: string,
-    _id: string,
-    _opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(_ns: string, _id: string, _opts?: ReadLogOptions): Promise<T[]> {
     throw new Error("FakeHarnessStore.readLog is not implemented");
   }
 
@@ -82,7 +65,7 @@ class FakeHarnessStore implements HarnessStore {
       ns,
       id,
       size: bytes.byteLength,
-      contentType: meta?.["contentType"]
+      contentType: meta?.["contentType"],
     };
   }
 
@@ -92,11 +75,7 @@ class FakeHarnessStore implements HarnessStore {
     return bytes;
   }
 
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     this.mutateCalls.push({ ns, id });
     const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
     const next = fn(prev);
@@ -131,7 +110,7 @@ function buildTestRun(overrides?: Partial<HarnessRun>): HarnessRun {
     ticketLedger: [],
     ticketLedgerPath: null,
     runIndexPath: null,
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -156,7 +135,7 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
       phaseId: "phase_01",
       command: "pnpm test",
       result: { exitCode: 0, stdout: "ok", stderr: "" },
-      cwd: "/tmp"
+      cwd: "/tmp",
     });
 
     expect(record.type).toBe("command_result");
@@ -178,8 +157,8 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
       classification: {
         category: "fix_test",
         rationale: "verification setup",
-        nextAction: "repair tests"
-      }
+        nextAction: "repair tests",
+      },
     });
 
     expect(record.type).toBe("failure_classification");
@@ -201,8 +180,8 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
         suggestedSpecialties: [],
         estimatedTicketCount: 1,
         needsDesignDoc: false,
-        needsUserApproval: false
-      }
+        needsUserApproval: false,
+      },
     });
 
     expect(uri.startsWith("blob://")).toBe(true);
@@ -217,7 +196,7 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
   it("routes design docs through putBlob", async () => {
     const uri = await store.saveDesignDoc({
       runId: "run-hs-1",
-      content: "# Design\n\nSome markdown."
+      content: "# Design\n\nSome markdown.",
     });
 
     expect(uri.startsWith("blob://")).toBe(true);
@@ -225,7 +204,7 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
     const bytes = await fake.getBlob({
       ns: STORE_NS.runArtifacts,
       id: "run-hs-1__design-doc",
-      size: 0
+      size: 0,
     });
     expect(new TextDecoder().decode(bytes)).toContain("# Design");
   });
@@ -234,7 +213,7 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
     await store.saveApprovalRecord({
       runId: "run-hs-1",
       decision: "approved",
-      feedback: "LGTM"
+      feedback: "LGTM",
     });
     const record = await store.readApprovalRecord("run-hs-1");
     expect(record).not.toBeNull();
@@ -247,7 +226,7 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
 
     expect(fake.mutateCalls).toContainEqual({
       ns: STORE_NS.runArtifacts,
-      id: "run-hs-1__run-snapshot"
+      id: "run-hs-1__run-snapshot",
     });
 
     // And the on-disk Rust-visible snapshot is still present at the
@@ -261,7 +240,7 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
       type: "TaskSubmitted",
       phaseId: "phase_00",
       details: {},
-      createdAt: "2026-04-20T00:00:00.000Z"
+      createdAt: "2026-04-20T00:00:00.000Z",
     };
 
     await store.appendEvent("run-hs-1", event);
@@ -277,8 +256,8 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
         completedAt: "2026-04-20T00:00:00.000Z",
         channelId: null,
         phaseLedgerPath: "/tmp/phase-ledger.json",
-        artifactsRoot: "/tmp"
-      }
+        artifactsRoot: "/tmp",
+      },
     });
 
     const ids = new Set(fake.mutateCalls.map((c) => c.id));
@@ -295,12 +274,8 @@ describe("LocalArtifactStore with HarnessStore injection", () => {
 
     // The data itself is on disk at the Rust-compat paths.
     await expect(stat(join(artifactsDir, "run-hs-1", "run.json"))).resolves.toBeTruthy();
-    await expect(
-      stat(join(artifactsDir, "run-hs-1", "ticket-ledger.json"))
-    ).resolves.toBeTruthy();
-    await expect(
-      stat(join(artifactsDir, "run-hs-1", "phase-ledger.json"))
-    ).resolves.toBeTruthy();
+    await expect(stat(join(artifactsDir, "run-hs-1", "ticket-ledger.json"))).resolves.toBeTruthy();
+    await expect(stat(join(artifactsDir, "run-hs-1", "phase-ledger.json"))).resolves.toBeTruthy();
 
     // The HarnessStore's runArtifacts ns must NOT have picked up a doc mirror
     // for the Rust-visible payloads — only the coordination record.
@@ -321,9 +296,7 @@ describe("LocalArtifactStore reads legacy Rust-layout fixtures", () => {
 
   beforeEach(async () => {
     workDir = await mkdtemp(join(tmpdir(), "as-legacy-"));
-    const src = fileURLToPath(
-      new URL("./fixtures/legacy-artifacts", import.meta.url)
-    );
+    const src = fileURLToPath(new URL("./fixtures/legacy-artifacts", import.meta.url));
     await cp(src, workDir, { recursive: true });
   });
 
@@ -334,10 +307,7 @@ describe("LocalArtifactStore reads legacy Rust-layout fixtures", () => {
   it("reads pre-migration run.json, events.jsonl, and ledgers", async () => {
     const storeRoot = await mkdtemp(join(tmpdir(), "as-legacy-hs-"));
     try {
-      const store = new LocalArtifactStore(
-        workDir,
-        new FileHarnessStore(storeRoot)
-      );
+      const store = new LocalArtifactStore(workDir, new FileHarnessStore(storeRoot));
 
       const snapshot = await store.readRunSnapshot("run-legacy-1");
       expect(snapshot).not.toBeNull();
@@ -352,9 +322,7 @@ describe("LocalArtifactStore reads legacy Rust-layout fixtures", () => {
 
       const tickets = await store.readTicketLedger("run-legacy-1");
       expect(tickets).not.toBeNull();
-      expect(tickets!.map((t) => t.ticketId)).toEqual([
-        "ticket-legacy-1"
-      ]);
+      expect(tickets!.map((t) => t.ticketId)).toEqual(["ticket-legacy-1"]);
 
       const runs = await store.readRunsIndex();
       expect(runs).toHaveLength(1);
@@ -371,20 +339,12 @@ describe("LocalArtifactStore reads legacy Rust-layout fixtures", () => {
   it("reads a pre-migration command-result artifact via its absolute path", async () => {
     const storeRoot = await mkdtemp(join(tmpdir(), "as-legacy-cmd-hs-"));
     try {
-      const store = new LocalArtifactStore(
-        workDir,
-        new FileHarnessStore(storeRoot)
-      );
+      const store = new LocalArtifactStore(workDir, new FileHarnessStore(storeRoot));
 
       // Pre-T-103 artifacts were loose JSON files under
       // `<runId>/<phaseId>/<artifactId>.json` — the fallback path in
       // `readCommandResult` must still resolve them.
-      const path = join(
-        workDir,
-        "run-legacy-1",
-        "phase_01",
-        "artifact-legacy-1.json"
-      );
+      const path = join(workDir, "run-legacy-1", "phase_01", "artifact-legacy-1.json");
       const content = await store.readCommandResult(path);
       expect(content.command).toBe("pnpm test");
       expect(content.exitCode).toBe(0);
@@ -416,27 +376,27 @@ describe("LocalArtifactStore error handling (malformed URIs & missing legacy pat
   });
 
   it("throws on a blob:// URI missing a slash", async () => {
-    await expect(
-      store.readCommandResult("blob://run-artifacts")
-    ).rejects.toThrow(/Invalid blob URI.*blob:\/\/run-artifacts/);
+    await expect(store.readCommandResult("blob://run-artifacts")).rejects.toThrow(
+      /Invalid blob URI.*blob:\/\/run-artifacts/
+    );
   });
 
   it("throws on a blob:// URI with an empty namespace", async () => {
-    await expect(
-      store.readCommandResult("blob:///abc")
-    ).rejects.toThrow(/Invalid blob URI.*empty namespace/);
+    await expect(store.readCommandResult("blob:///abc")).rejects.toThrow(
+      /Invalid blob URI.*empty namespace/
+    );
   });
 
   it("throws on a blob:// URI with an empty id", async () => {
-    await expect(
-      store.readCommandResult("blob://run-artifacts/")
-    ).rejects.toThrow(/Invalid blob URI.*empty id/);
+    await expect(store.readCommandResult("blob://run-artifacts/")).rejects.toThrow(
+      /Invalid blob URI.*empty id/
+    );
   });
 
   it("throws on a malformed blob:// URI passed to readFailureClassification", async () => {
-    await expect(
-      store.readFailureClassification("blob://bogus")
-    ).rejects.toThrow(/Invalid blob URI.*blob:\/\/bogus/);
+    await expect(store.readFailureClassification("blob://bogus")).rejects.toThrow(
+      /Invalid blob URI.*blob:\/\/bogus/
+    );
   });
 
   it("wraps ENOENT on a legacy absolute path with contextual error", async () => {
@@ -462,7 +422,7 @@ describe("LocalArtifactStore error handling (malformed URIs & missing legacy pat
         exitCode: 0,
         stdout: "",
         stderr: "",
-        capturedAt: "2026-04-20T00:00:00.000Z"
+        capturedAt: "2026-04-20T00:00:00.000Z",
       })
     );
 
@@ -491,10 +451,7 @@ describe("LocalArtifactStore error handling (malformed URIs & missing legacy pat
 
   it("throws (not silent empty) on corrupt events.jsonl", async () => {
     await mkdir(join(artifactsDir, "run-bad-events"), { recursive: true });
-    await writeFile(
-      join(artifactsDir, "run-bad-events", "events.jsonl"),
-      "{not json}\n"
-    );
+    await writeFile(join(artifactsDir, "run-bad-events", "events.jsonl"), "{not json}\n");
     await expect(store.readEventLog("run-bad-events")).rejects.toThrow(
       /Failed to parse event log at .*events\.jsonl/
     );
@@ -502,10 +459,7 @@ describe("LocalArtifactStore error handling (malformed URIs & missing legacy pat
 
   it("throws (not silent null) on corrupt pr-lifecycle.json", async () => {
     await mkdir(join(artifactsDir, "run-bad-pr"), { recursive: true });
-    await writeFile(
-      join(artifactsDir, "run-bad-pr", "pr-lifecycle.json"),
-      "nope"
-    );
+    await writeFile(join(artifactsDir, "run-bad-pr", "pr-lifecycle.json"), "nope");
     await expect(store.readPrLifecycle("run-bad-pr")).rejects.toThrow(
       /Failed to parse PR lifecycle at .*pr-lifecycle\.json/
     );
@@ -513,10 +467,7 @@ describe("LocalArtifactStore error handling (malformed URIs & missing legacy pat
 
   it("throws (not silent null) on corrupt ticket-ledger.json", async () => {
     await mkdir(join(artifactsDir, "run-bad-tickets"), { recursive: true });
-    await writeFile(
-      join(artifactsDir, "run-bad-tickets", "ticket-ledger.json"),
-      "still not json"
-    );
+    await writeFile(join(artifactsDir, "run-bad-tickets", "ticket-ledger.json"), "still not json");
     await expect(store.readTicketLedger("run-bad-tickets")).rejects.toThrow(
       /Failed to parse ticket ledger at .*ticket-ledger\.json/
     );
@@ -554,7 +505,7 @@ describe("LocalArtifactStore blob round-trip (saveCommandResult -> readCommandRe
       phaseId: "phase_07",
       command: "pnpm run build",
       result: { exitCode: 1, stdout: "line one\nline two", stderr: "boom" },
-      cwd: "/work"
+      cwd: "/work",
     });
 
     // The returned path is a blob URI with the expected ns prefix.
@@ -585,13 +536,13 @@ describe("LocalArtifactStore PR lifecycle coordination record", () => {
     try {
       const lifecycle = createPrLifecycle({
         runId: "run-pr-coord-1",
-        branch: "feature/x"
+        branch: "feature/x",
       });
       await store.savePrLifecycle(lifecycle);
 
       expect(fake.mutateCalls).toContainEqual({
         ns: STORE_NS.runArtifacts,
-        id: "run-pr-coord-1__pr-lifecycle"
+        id: "run-pr-coord-1__pr-lifecycle",
       });
       const coord = await fake.getDoc<{ kind: string }>(
         STORE_NS.runArtifacts,

--- a/test/artifact-store.test.ts
+++ b/test/artifact-store.test.ts
@@ -20,8 +20,8 @@ describe("artifact store", () => {
         classification: {
           category: "fix_test",
           rationale: "The failure is isolated to verification setup.",
-          nextAction: "Repair the tests before changing product logic."
-        }
+          nextAction: "Repair the tests before changing product logic.",
+        },
       });
       const content = await store.readFailureClassification(artifact.path);
 
@@ -36,11 +36,11 @@ describe("artifact store", () => {
     } finally {
       await rm(artifactRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
       await rm(storeRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
     }
   });

--- a/test/channel-store-harness-store.test.ts
+++ b/test/channel-store-harness-store.test.ts
@@ -1,10 +1,4 @@
-import {
-  cp,
-  mkdtemp,
-  readFile,
-  rm,
-  stat
-} from "node:fs/promises";
+import { cp, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,12 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ChannelStore } from "../src/channels/channel-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import { STORE_NS } from "../src/storage/namespaces.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "../src/storage/store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "../src/storage/store.js";
 
 /**
  * Minimal in-memory HarnessStore. Good enough to verify ChannelStore calls
@@ -59,11 +48,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.appendLog is not implemented");
   }
 
-  async readLog<T>(
-    _ns: string,
-    _id: string,
-    _opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(_ns: string, _id: string, _opts?: ReadLogOptions): Promise<T[]> {
     throw new Error("FakeHarnessStore.readLog is not implemented");
   }
 
@@ -75,11 +60,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.getBlob is not implemented");
   }
 
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     this.mutateCalls.push({ ns, id });
     const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
     const next = fn(prev);
@@ -111,7 +92,7 @@ describe("ChannelStore with HarnessStore injection", () => {
   it("routes ticket-board coordination through HarnessStore.mutate", async () => {
     const channel = await store.createChannel({
       name: "#coord",
-      description: "coord-test"
+      description: "coord-test",
     });
 
     await store.upsertChannelTickets(channel.channelId, [
@@ -131,14 +112,14 @@ describe("ChannelStore with HarnessStore injection", () => {
         startedAt: null,
         completedAt: null,
         updatedAt: "2025-01-01T00:00:00.000Z",
-        runId: null
-      }
+        runId: null,
+      },
     ]);
 
     // The upsert must have written a coordination record through the store.
     expect(fake.mutateCalls).toContainEqual({
       ns: STORE_NS.channelTickets,
-      id: channel.channelId
+      id: channel.channelId,
     });
 
     const rec = await fake.getDoc<{ updatedAt: string; count: number }>(
@@ -153,7 +134,7 @@ describe("ChannelStore with HarnessStore injection", () => {
   it("keeps the Rust-compat tickets.json layout on disk", async () => {
     const channel = await store.createChannel({
       name: "#layout",
-      description: "layout-test"
+      description: "layout-test",
     });
 
     await store.upsertChannelTickets(channel.channelId, [
@@ -173,8 +154,8 @@ describe("ChannelStore with HarnessStore injection", () => {
         startedAt: null,
         completedAt: null,
         updatedAt: "2025-01-01T00:00:00.000Z",
-        runId: null
-      }
+        runId: null,
+      },
     ]);
 
     // Tickets still live at `channels/<id>/tickets.json` — not under the
@@ -190,7 +171,7 @@ describe("ChannelStore with HarnessStore injection", () => {
   it("channel doc stays at channelsDir/<id>.json (Rust-compat)", async () => {
     const channel = await store.createChannel({
       name: "#rust-doc",
-      description: "rust-doc-test"
+      description: "rust-doc-test",
     });
 
     const docPath = join(channelsDir, `${channel.channelId}.json`);
@@ -209,7 +190,7 @@ describe("ChannelStore with HarnessStore injection", () => {
     const defaulted = new ChannelStore(channelsDir);
     const channel = await defaulted.createChannel({
       name: "#default",
-      description: "default-ctor"
+      description: "default-ctor",
     });
     expect(channel.channelId).toMatch(/^channel-/);
   });
@@ -217,7 +198,7 @@ describe("ChannelStore with HarnessStore injection", () => {
   it("mirrors recorded decisions through HarnessStore.putDoc", async () => {
     const channel = await store.createChannel({
       name: "#decisions",
-      description: "decision-mirror-test"
+      description: "decision-mirror-test",
     });
 
     const decision = await store.recordDecision(channel.channelId, {
@@ -229,7 +210,7 @@ describe("ChannelStore with HarnessStore injection", () => {
       alternatives: ["redux", "context-only"],
       decidedBy: "planner-claude",
       decidedByName: "Claude (Planner)",
-      linkedArtifacts: []
+      linkedArtifacts: [],
     });
 
     // Primary source of truth still lives at channels/<id>/decisions/<did>.json
@@ -251,7 +232,7 @@ describe("ChannelStore with HarnessStore injection", () => {
     const storeId = `${channel.channelId}:${decision.decisionId}`;
     expect(fake.putCalls).toContainEqual({
       ns: STORE_NS.decision,
-      id: storeId
+      id: storeId,
     });
     const mirrored = await fake.getDoc<{ decisionId: string; title: string }>(
       STORE_NS.decision,
@@ -288,19 +269,16 @@ describe("ChannelStore with HarnessStore injection", () => {
       getBlob: async () => {
         throw new Error("not implemented");
       },
-      mutate: async <T>(
-        _ns: string,
-        _id: string,
-        fn: (prev: T | null) => T
-      ): Promise<T> => fn(null),
+      mutate: async <T>(_ns: string, _id: string, fn: (prev: T | null) => T): Promise<T> =>
+        fn(null),
       watch: async function* () {
         throw new Error("not implemented");
-      }
+      },
     };
     const flakyStore = new ChannelStore(channelsDir, flaky);
     const channel = await flakyStore.createChannel({
       name: "#flaky",
-      description: "flaky-mirror"
+      description: "flaky-mirror",
     });
 
     const decision = await flakyStore.recordDecision(channel.channelId, {
@@ -312,7 +290,7 @@ describe("ChannelStore with HarnessStore injection", () => {
       alternatives: [],
       decidedBy: "planner-claude",
       decidedByName: "Claude (Planner)",
-      linkedArtifacts: []
+      linkedArtifacts: [],
     });
 
     // Disk copy still landed.
@@ -328,7 +306,7 @@ describe("ChannelStore with HarnessStore injection", () => {
   it("serializes concurrent upsertChannelTickets on the same channel", async () => {
     const channel = await store.createChannel({
       name: "#race",
-      description: "race-test"
+      description: "race-test",
     });
 
     const makeTicket = (ticketId: string) => ({
@@ -347,7 +325,7 @@ describe("ChannelStore with HarnessStore injection", () => {
       startedAt: null,
       completedAt: null,
       updatedAt: "2025-01-01T00:00:00.000Z",
-      runId: null
+      runId: null,
     });
 
     // Fire 4 concurrent upserts with distinct ticketIds. The in-process
@@ -356,7 +334,7 @@ describe("ChannelStore with HarnessStore injection", () => {
       store.upsertChannelTickets(channel.channelId, [makeTicket("t-1")]),
       store.upsertChannelTickets(channel.channelId, [makeTicket("t-2")]),
       store.upsertChannelTickets(channel.channelId, [makeTicket("t-3")]),
-      store.upsertChannelTickets(channel.channelId, [makeTicket("t-4")])
+      store.upsertChannelTickets(channel.channelId, [makeTicket("t-4")]),
     ]);
 
     const final = await store.readChannelTickets(channel.channelId);
@@ -373,9 +351,7 @@ describe("ChannelStore reads legacy Rust-layout fixtures", () => {
     // hermetic and can create additional subdirectories without touching the
     // source tree.
     workDir = await mkdtemp(join(tmpdir(), "ch-legacy-"));
-    const src = fileURLToPath(
-      new URL("./fixtures/legacy-channel", import.meta.url)
-    );
+    const src = fileURLToPath(new URL("./fixtures/legacy-channel", import.meta.url));
     await cp(src, workDir, { recursive: true });
   });
 
@@ -388,10 +364,7 @@ describe("ChannelStore reads legacy Rust-layout fixtures", () => {
     // fixture test shouldn't depend on the user's home directory.
     const storeRoot = await mkdtemp(join(tmpdir(), "ch-legacy-store-"));
     try {
-      const store = new ChannelStore(
-        workDir,
-        new FileHarnessStore(storeRoot)
-      );
+      const store = new ChannelStore(workDir, new FileHarnessStore(storeRoot));
 
       const channel = await store.getChannel("channel-abc");
       expect(channel).not.toBeNull();
@@ -406,10 +379,7 @@ describe("ChannelStore reads legacy Rust-layout fixtures", () => {
       expect(feed[1].metadata).toEqual({ runId: "run-legacy-1" });
 
       const tickets = await store.readChannelTickets("channel-abc");
-      expect(tickets.map((t) => t.ticketId)).toEqual([
-        "ticket-legacy-1",
-        "ticket-legacy-2"
-      ]);
+      expect(tickets.map((t) => t.ticketId)).toEqual(["ticket-legacy-1", "ticket-legacy-2"]);
       expect(tickets[0].status).toBe("executing");
 
       const runs = await store.readRunLinks("channel-abc");
@@ -440,9 +410,7 @@ describe("ChannelStore reads legacy decisions fixture", () => {
 
   beforeEach(async () => {
     workDir = await mkdtemp(join(tmpdir(), "ch-dec-legacy-"));
-    const src = fileURLToPath(
-      new URL("./fixtures/legacy-channel-decisions", import.meta.url)
-    );
+    const src = fileURLToPath(new URL("./fixtures/legacy-channel-decisions", import.meta.url));
     await cp(src, workDir, { recursive: true });
   });
 
@@ -454,34 +422,25 @@ describe("ChannelStore reads legacy decisions fixture", () => {
     const storeRoot = await mkdtemp(join(tmpdir(), "ch-dec-legacy-store-"));
     try {
       const channelsDir = join(workDir, "channels");
-      const store = new ChannelStore(
-        channelsDir,
-        new FileHarnessStore(storeRoot)
-      );
+      const store = new ChannelStore(channelsDir, new FileHarnessStore(storeRoot));
 
       const decisions = await store.listDecisions("channel-decisions-legacy");
       // Sorted descending by createdAt in `listDecisions`, so the newer beta
       // comes first.
       expect(decisions.map((d) => d.decisionId)).toEqual([
         "decision-legacy-beta",
-        "decision-legacy-alpha"
+        "decision-legacy-alpha",
       ]);
       expect(decisions[0].title).toBe("JWT for v1 session tokens");
       expect(decisions[0].linkedArtifacts).toHaveLength(1);
       expect(decisions[1].alternatives).toContain("Redis SETNX");
 
-      const alpha = await store.getDecision(
-        "channel-decisions-legacy",
-        "decision-legacy-alpha"
-      );
+      const alpha = await store.getDecision("channel-decisions-legacy", "decision-legacy-alpha");
       expect(alpha).not.toBeNull();
       expect(alpha!.decidedBy).toBe("planner-claude");
       expect(alpha!.runId).toBe("run-legacy-alpha");
 
-      const beta = await store.getDecision(
-        "channel-decisions-legacy",
-        "decision-legacy-beta"
-      );
+      const beta = await store.getDecision("channel-decisions-legacy", "decision-legacy-beta");
       expect(beta).not.toBeNull();
       expect(beta!.ticketId).toBe("ticket-legacy-auth");
       expect(beta!.runId).toBeNull();

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -14,7 +14,7 @@ describe("channel store", () => {
     try {
       const channel = await store.createChannel({
         name: "#feature-auth",
-        description: "Authentication feature work"
+        description: "Authentication feature work",
       });
 
       expect(channel.name).toBe("#feature-auth");
@@ -36,9 +36,11 @@ describe("channel store", () => {
     try {
       const ch1 = await store.createChannel({ name: "#active", description: "Active" });
       await store.createChannel({ name: "#archived", description: "Archived" });
-      await store.archiveChannel((await store.listChannels())[0].channelId === ch1.channelId
-        ? (await store.listChannels())[1].channelId
-        : (await store.listChannels())[0].channelId);
+      await store.archiveChannel(
+        (await store.listChannels())[0].channelId === ch1.channelId
+          ? (await store.listChannels())[1].channelId
+          : (await store.listChannels())[0].channelId
+      );
 
       // At least one active channel
       const active = await store.listChannels("active");
@@ -60,7 +62,7 @@ describe("channel store", () => {
         displayName: "Claude (Planner)",
         role: "planner",
         provider: "claude",
-        sessionId: null
+        sessionId: null,
       });
 
       const updated = await store.getChannel(channel.channelId);
@@ -88,7 +90,7 @@ describe("channel store", () => {
         fromAgentId: "agent-1",
         fromDisplayName: "Agent One",
         content: "Hello channel!",
-        metadata: {}
+        metadata: {},
       });
 
       await store.postEntry(channel.channelId, {
@@ -96,7 +98,7 @@ describe("channel store", () => {
         fromAgentId: null,
         fromDisplayName: null,
         content: "Run started",
-        metadata: { runId: "run-1" }
+        metadata: { runId: "run-1" },
       });
 
       const feed = await store.readFeed(channel.channelId);
@@ -124,7 +126,7 @@ describe("channel store", () => {
       await store.addRef(channel.channelId, {
         type: "repo",
         targetId: "/path/to/repo",
-        label: "Backend repo"
+        label: "Backend repo",
       });
 
       const updated = await store.getChannel(channel.channelId);
@@ -163,7 +165,10 @@ describe("channel store", () => {
     const store = new ChannelStore(dir);
 
     try {
-      const channel = await store.createChannel({ name: "#decisions", description: "Decisions test" });
+      const channel = await store.createChannel({
+        name: "#decisions",
+        description: "Decisions test",
+      });
 
       const decision = await store.recordDecision(channel.channelId, {
         runId: "run-1",
@@ -174,7 +179,7 @@ describe("channel store", () => {
         alternatives: ["MySQL", "SQLite"],
         decidedBy: "planner-claude",
         decidedByName: "Claude (Planner)",
-        linkedArtifacts: []
+        linkedArtifacts: [],
       });
 
       expect(decision.title).toBe("Use PostgreSQL over MySQL");
@@ -202,7 +207,7 @@ describe("channel store", () => {
     const assignments = [
       { alias: "ui", workspaceId: "ws-ui", repoPath: "/tmp/ui" },
       { alias: "be", workspaceId: "ws-be", repoPath: "/tmp/be" },
-      { alias: "brain", workspaceId: "ws-brain", repoPath: "/tmp/brain" }
+      { alias: "brain", workspaceId: "ws-brain", repoPath: "/tmp/brain" },
     ];
 
     it("persists primaryWorkspaceId passed to createChannel", async () => {
@@ -213,7 +218,7 @@ describe("channel store", () => {
           name: "#multi-repo",
           description: "Multi-repo channel",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-be"
+          primaryWorkspaceId: "ws-be",
         });
 
         expect(channel.primaryWorkspaceId).toBe("ws-be");
@@ -232,7 +237,7 @@ describe("channel store", () => {
           name: "#bad-primary",
           description: "Dangling primary",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-does-not-exist"
+          primaryWorkspaceId: "ws-does-not-exist",
         });
 
         expect(channel.primaryWorkspaceId).toBeUndefined();
@@ -249,7 +254,7 @@ describe("channel store", () => {
           name: "#primary-set",
           description: "Primary set",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-brain"
+          primaryWorkspaceId: "ws-brain",
         });
 
         const primary = store.getPrimaryAssignment(channel);
@@ -268,7 +273,7 @@ describe("channel store", () => {
         const channel = await store.createChannel({
           name: "#primary-unset",
           description: "Primary unset",
-          repoAssignments: assignments
+          repoAssignments: assignments,
         });
 
         expect(channel.primaryWorkspaceId).toBeUndefined();
@@ -290,7 +295,7 @@ describe("channel store", () => {
         const channel = await store.createChannel({
           name: "#stale-primary",
           description: "Stale primary",
-          repoAssignments: assignments
+          repoAssignments: assignments,
         });
         const stale = { ...channel, primaryWorkspaceId: "ws-gone" };
 
@@ -308,7 +313,7 @@ describe("channel store", () => {
       try {
         const channel = await store.createChannel({
           name: "#no-repos",
-          description: "No repos"
+          description: "No repos",
         });
         expect(store.getPrimaryAssignment(channel)).toBeNull();
       } finally {
@@ -324,11 +329,11 @@ describe("channel store", () => {
           name: "#shrink",
           description: "Shrink repos",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-brain"
+          primaryWorkspaceId: "ws-brain",
         });
 
         const updated = await store.updateChannel(channel.channelId, {
-          repoAssignments: [assignments[0], assignments[1]] // drops brain
+          repoAssignments: [assignments[0], assignments[1]], // drops brain
         });
 
         expect(updated).not.toBeNull();
@@ -347,11 +352,11 @@ describe("channel store", () => {
           name: "#preserve",
           description: "Preserve primary",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-be"
+          primaryWorkspaceId: "ws-be",
         });
 
         const updated = await store.updateChannel(channel.channelId, {
-          repoAssignments: [assignments[0], assignments[1]] // keeps be
+          repoAssignments: [assignments[0], assignments[1]], // keeps be
         });
 
         expect(updated!.primaryWorkspaceId).toBe("ws-be");
@@ -368,11 +373,11 @@ describe("channel store", () => {
           name: "#repoint",
           description: "Repoint primary",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-ui"
+          primaryWorkspaceId: "ws-ui",
         });
 
         const updated = await store.updateChannel(channel.channelId, {
-          primaryWorkspaceId: "ws-brain"
+          primaryWorkspaceId: "ws-brain",
         });
 
         expect(updated!.primaryWorkspaceId).toBe("ws-brain");
@@ -389,11 +394,11 @@ describe("channel store", () => {
           name: "#clear",
           description: "Clear primary",
           repoAssignments: assignments,
-          primaryWorkspaceId: "ws-ui"
+          primaryWorkspaceId: "ws-ui",
         });
 
         const updated = await store.updateChannel(channel.channelId, {
-          repoAssignments: []
+          repoAssignments: [],
         });
 
         expect(updated!.primaryWorkspaceId).toBeUndefined();
@@ -410,12 +415,12 @@ describe("channel store", () => {
       try {
         const channel = await store.createChannel({
           name: "linked",
-          description: "test"
+          description: "test",
         });
         expect(channel.linearProjectId).toBeUndefined();
 
         const linked = await store.updateChannel(channel.channelId, {
-          linearProjectId: "proj-uuid-abc"
+          linearProjectId: "proj-uuid-abc",
         });
         expect(linked!.linearProjectId).toBe("proj-uuid-abc");
 
@@ -423,7 +428,7 @@ describe("channel store", () => {
         expect(reloaded!.linearProjectId).toBe("proj-uuid-abc");
 
         const cleared = await store.updateChannel(channel.channelId, {
-          linearProjectId: undefined
+          linearProjectId: undefined,
         });
         expect(cleared!.linearProjectId).toBeUndefined();
       } finally {
@@ -446,7 +451,7 @@ describe("channel store", () => {
       { label: "empty", value: "" },
       { label: "dot", value: "." },
       { label: "dot-dot", value: ".." },
-      { label: "backslash", value: "foo\\bar" }
+      { label: "backslash", value: "foo\\bar" },
     ];
 
     for (const { label, value } of badChannelIds) {
@@ -464,9 +469,7 @@ describe("channel store", () => {
           };
 
           await expectThrow(() => store.getChannel(value));
-          await expectThrow(() =>
-            store.updateChannel(value, { name: "x" })
-          );
+          await expectThrow(() => store.updateChannel(value, { name: "x" }));
           await expectThrow(() => store.archiveChannel(value));
           await expectThrow(() =>
             store.joinChannel(value, {
@@ -474,7 +477,7 @@ describe("channel store", () => {
               displayName: "A",
               role: "planner",
               provider: "claude",
-              sessionId: null
+              sessionId: null,
             })
           );
           await expectThrow(() => store.leaveChannel(value, "a"));
@@ -484,14 +487,12 @@ describe("channel store", () => {
               fromAgentId: null,
               fromDisplayName: null,
               content: "hi",
-              metadata: {}
+              metadata: {},
             })
           );
           await expectThrow(() => store.post(value, "hi"));
           await expectThrow(() => store.readFeed(value));
-          await expectThrow(() =>
-            store.addRef(value, { type: "repo", targetId: "x", label: "x" })
-          );
+          await expectThrow(() => store.addRef(value, { type: "repo", targetId: "x", label: "x" }));
           await expectThrow(() => store.removeRef(value, "x"));
           await expectThrow(() => store.linkRun(value, "run-1", "ws-1"));
           await expectThrow(() => store.readRunLinks(value));
@@ -510,7 +511,7 @@ describe("channel store", () => {
               alternatives: [],
               decidedBy: "a",
               decidedByName: "A",
-              linkedArtifacts: []
+              linkedArtifacts: [],
             })
           );
           await expectThrow(() => store.getDecision(value, "d"));
@@ -532,14 +533,14 @@ describe("channel store", () => {
       try {
         const channel = await store.createChannel({
           name: "#r",
-          description: "r"
+          description: "r",
         });
-        await expect(
-          store.linkRun(channel.channelId, "../bad-run", "ws-1")
-        ).rejects.toThrow(/Unsafe path segment/);
-        await expect(
-          store.linkRun(channel.channelId, "run-1", "../bad-ws")
-        ).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.linkRun(channel.channelId, "../bad-run", "ws-1")).rejects.toThrow(
+          /Unsafe path segment/
+        );
+        await expect(store.linkRun(channel.channelId, "run-1", "../bad-ws")).rejects.toThrow(
+          /Unsafe path segment/
+        );
       } finally {
         await rm(dir, { recursive: true, force: true });
       }
@@ -551,11 +552,11 @@ describe("channel store", () => {
       try {
         const channel = await store.createChannel({
           name: "#d",
-          description: "d"
+          description: "d",
         });
-        await expect(
-          store.getDecision(channel.channelId, "../escape")
-        ).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.getDecision(channel.channelId, "../escape")).rejects.toThrow(
+          /Unsafe path segment/
+        );
       } finally {
         await rm(dir, { recursive: true, force: true });
       }

--- a/test/channel-task-board-fallback.test.ts
+++ b/test/channel-task-board-fallback.test.ts
@@ -9,10 +9,7 @@ import { callChannelTool, type ChannelToolState } from "../src/mcp/channel-tools
 import { initializeTicketLedger } from "../src/domain/ticket.js";
 import type { TicketDefinition, TicketLedgerEntry } from "../src/domain/ticket.js";
 
-function makeTicket(
-  id: string,
-  overrides: Partial<TicketDefinition> = {}
-): TicketDefinition {
+function makeTicket(id: string, overrides: Partial<TicketDefinition> = {}): TicketDefinition {
   return {
     id,
     title: `Ticket ${id}`,
@@ -24,16 +21,13 @@ function makeTicket(
     docsToUpdate: [],
     dependsOn: [],
     retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
-    ...overrides
+    ...overrides,
   };
 }
 
 interface BoardResult {
   channelId: string;
-  board: Record<
-    string,
-    Array<{ ticketId: string; title: string; runId: string | null }>
-  >;
+  board: Record<string, Array<{ ticketId: string; title: string; runId: string | null }>>;
 }
 
 describe("channel_task_board MCP tool — unified + fallback", () => {
@@ -42,7 +36,7 @@ describe("channel_task_board MCP tool — unified + fallback", () => {
     const channelStore = new ChannelStore(dir);
     const channel = await channelStore.createChannel({
       name: "#empty",
-      description: ""
+      description: "",
     });
 
     try {
@@ -65,14 +59,14 @@ describe("channel_task_board MCP tool — unified + fallback", () => {
     const channelStore = new ChannelStore(dir);
     const channel = await channelStore.createChannel({
       name: "#populated",
-      description: ""
+      description: "",
     });
 
     try {
       // Populate the channel file with a mix of chat (runId=null) + orchestrator (runId set).
       const ledger: TicketLedgerEntry[] = [
         ...initializeTicketLedger([makeTicket("T-chat")], null),
-        ...initializeTicketLedger([makeTicket("T-run")], "run-alpha")
+        ...initializeTicketLedger([makeTicket("T-run")], "run-alpha"),
       ];
       await channelStore.writeChannelTickets(channel.channelId, ledger);
 
@@ -80,11 +74,7 @@ describe("channel_task_board MCP tool — unified + fallback", () => {
       // if the fallback ever activates, we'd see a crash or missing ticket.
       // The unified-read path must ignore the run link entirely when the
       // channel file is non-empty.
-      await channelStore.linkRun(
-        channel.channelId,
-        "ghost-run",
-        "ghost-workspace"
-      );
+      await channelStore.linkRun(channel.channelId, "ghost-run", "ghost-workspace");
 
       const state: ChannelToolState = { sessionId: null, channelStore };
       const result = (await callChannelTool(
@@ -111,7 +101,7 @@ describe("channel_task_board MCP tool — unified + fallback", () => {
     const channelStore = new ChannelStore(dir);
     const channel = await channelStore.createChannel({
       name: "#corrupt",
-      description: ""
+      description: "",
     });
 
     try {
@@ -124,11 +114,7 @@ describe("channel_task_board MCP tool — unified + fallback", () => {
 
       const state: ChannelToolState = { sessionId: null, channelStore };
       await expect(
-        callChannelTool(
-          "channel_task_board",
-          { channelId: channel.channelId },
-          state
-        )
+        callChannelTool("channel_task_board", { channelId: channel.channelId }, state)
       ).rejects.toThrow(/Corrupt channel ticket board/);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/test/channel-ticket-board.test.ts
+++ b/test/channel-ticket-board.test.ts
@@ -8,10 +8,7 @@ import { ChannelStore } from "../src/channels/channel-store.js";
 import { initializeTicketLedger } from "../src/domain/ticket.js";
 import type { TicketDefinition, TicketLedgerEntry } from "../src/domain/ticket.js";
 
-function makeTicket(
-  id: string,
-  overrides: Partial<TicketDefinition> = {}
-): TicketDefinition {
+function makeTicket(id: string, overrides: Partial<TicketDefinition> = {}): TicketDefinition {
   return {
     id,
     title: `Ticket ${id}`,
@@ -23,7 +20,7 @@ function makeTicket(
     docsToUpdate: [],
     dependsOn: [],
     retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -83,7 +80,7 @@ describe("channel ticket board (unified)", () => {
         ...initial[0],
         status: "completed",
         completedAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+        updatedAt: new Date().toISOString(),
       };
 
       const merged = await store.upsertChannelTickets(channel.channelId, [completedT1]);

--- a/test/channels/channel-store-post.test.ts
+++ b/test/channels/channel-store-post.test.ts
@@ -41,7 +41,7 @@ describe("ChannelStore.post", () => {
         type: "event",
         fromAgentId: "agent-7",
         fromDisplayName: "PR Bot",
-        metadata: { eventId: "evt-1", priority: "info" }
+        metadata: { eventId: "evt-1", priority: "info" },
       });
 
       const feed = await store.readFeed(channel.channelId);
@@ -69,8 +69,8 @@ describe("ChannelStore.post", () => {
           count: 42,
           flag: true,
           payload: { nested: { value: [1, 2, 3] } },
-          tags: ["a", "b"]
-        }
+          tags: ["a", "b"],
+        },
       });
 
       const feed = await store.readFeed(channel.channelId);
@@ -99,14 +99,11 @@ describe("ChannelStore.post", () => {
         metadata: {
           plain: "hello",
           count: 42,
-          payload: { x: 1 }
-        }
+          payload: { x: 1 },
+        },
       });
 
-      const rawLine = (await readFile(
-        join(dir, channel.channelId, "feed.jsonl"),
-        "utf8"
-      )).trim();
+      const rawLine = (await readFile(join(dir, channel.channelId, "feed.jsonl"), "utf8")).trim();
       const onDisk = JSON.parse(rawLine) as {
         metadata: Record<string, string>;
       };
@@ -142,8 +139,8 @@ describe("ChannelStore.post", () => {
           deep: doubleTagged,
           // A plain string that never touches the tag must not be double-
           // encoded (it should stay verbatim on disk).
-          plain: "just a string"
-        }
+          plain: "just a string",
+        },
       });
 
       const feed = await store.readFeed(channel.channelId);
@@ -153,10 +150,7 @@ describe("ChannelStore.post", () => {
 
       // On-disk shape is still strings only; the plain string stays
       // verbatim while the tag-colliding strings are tagged JSON.
-      const rawLine = (await readFile(
-        join(dir, channel.channelId, "feed.jsonl"),
-        "utf8"
-      )).trim();
+      const rawLine = (await readFile(join(dir, channel.channelId, "feed.jsonl"), "utf8")).trim();
       const onDisk = JSON.parse(rawLine) as {
         metadata: Record<string, string>;
       };
@@ -182,8 +176,8 @@ describe("ChannelStore.post", () => {
         metadata: {
           keep: "yes",
           droppedNull: null,
-          droppedUndef: undefined
-        }
+          droppedUndef: undefined,
+        },
       });
 
       const feed = await store.readFeed(channel.channelId);

--- a/test/chat-rewind.test.ts
+++ b/test/chat-rewind.test.ts
@@ -4,18 +4,10 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import {
-  rewindApply,
-  rewindSnapshot,
-  type RewindDeps
-} from "../src/cli/chat-rewind.js";
+import { rewindApply, rewindSnapshot, type RewindDeps } from "../src/cli/chat-rewind.js";
 import { SessionStore } from "../src/cli/session-store.js";
 import type { Channel } from "../src/domain/channel.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore
-} from "../src/storage/store.js";
+import type { BlobRef, ChangeEvent, HarnessStore } from "../src/storage/store.js";
 
 // Minimal HarnessStore stub: the rewind flow only ever touches SessionStore,
 // which in turn writes/deletes an advisory coordination record. Anything
@@ -41,11 +33,7 @@ class NullHarnessStore implements HarnessStore {
   async getBlob(): Promise<Uint8Array> {
     throw new Error("NullHarnessStore.getBlob not used by rewind tests");
   }
-  async mutate<T>(
-    _ns: string,
-    _id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(_ns: string, _id: string, fn: (prev: T | null) => T): Promise<T> {
     return fn(null);
   }
   // eslint-disable-next-line require-yield
@@ -103,10 +91,10 @@ function makeChannel(repoPaths: string[]): Channel {
     repoAssignments: repoPaths.map((p, i) => ({
       alias: `repo${i + 1}`,
       workspaceId: `ws-${i + 1}`,
-      repoPath: p
+      repoPath: p,
     })),
     createdAt: "2025-01-01T00:00:00.000Z",
-    updatedAt: "2025-01-01T00:00:00.000Z"
+    updatedAt: "2025-01-01T00:00:00.000Z",
   };
 }
 
@@ -116,17 +104,17 @@ describe("rewindSnapshot", () => {
     const git = makeGit({
       stdoutByKey: {
         "/repos/a": { "rev-parse HEAD": "a1b2c3d\n" },
-        "/repos/b": { "rev-parse HEAD": "e4f5g6h\n" }
-      }
+        "/repos/b": { "rev-parse HEAD": "e4f5g6h\n" },
+      },
     });
     const deps: RewindDeps = {
       channelStore: fakeChannelStore(channel),
       sessionStore: {
         truncateBeforeTimestamp: async () => 0,
-        clearClaudeSessionIds: async () => null
+        clearClaudeSessionIds: async () => null,
       },
       gitExec: git.exec,
-      now: () => 1700000000000
+      now: () => 1700000000000,
     };
 
     const result = await rewindSnapshot("ch-1", "sess-1", deps);
@@ -137,26 +125,20 @@ describe("rewindSnapshot", () => {
         alias: "repo1",
         repoPath: "/repos/a",
         sha: "a1b2c3d",
-        ref: "refs/harness-rewind/sess-1/1700000000000"
+        ref: "refs/harness-rewind/sess-1/1700000000000",
       },
       {
         alias: "repo2",
         repoPath: "/repos/b",
         sha: "e4f5g6h",
-        ref: "refs/harness-rewind/sess-1/1700000000000"
-      }
+        ref: "refs/harness-rewind/sess-1/1700000000000",
+      },
     ]);
 
     // Every repo got exactly one rev-parse HEAD + one update-ref.
     const perRepo = (cwd: string) => git.calls.filter((c) => c.cwd === cwd);
-    expect(perRepo("/repos/a").map((c) => c.args[0])).toEqual([
-      "rev-parse",
-      "update-ref"
-    ]);
-    expect(perRepo("/repos/b").map((c) => c.args[0])).toEqual([
-      "rev-parse",
-      "update-ref"
-    ]);
+    expect(perRepo("/repos/a").map((c) => c.args[0])).toEqual(["rev-parse", "update-ref"]);
+    expect(perRepo("/repos/b").map((c) => c.args[0])).toEqual(["rev-parse", "update-ref"]);
   });
 
   it("throws a clear error when the channel is missing", async () => {
@@ -164,31 +146,27 @@ describe("rewindSnapshot", () => {
       channelStore: fakeChannelStore(null),
       sessionStore: {
         truncateBeforeTimestamp: async () => 0,
-        clearClaudeSessionIds: async () => null
+        clearClaudeSessionIds: async () => null,
       },
-      gitExec: makeGit().exec
+      gitExec: makeGit().exec,
     };
-    await expect(rewindSnapshot("missing", "sess-x", deps)).rejects.toThrow(
-      /Channel not found/
-    );
+    await expect(rewindSnapshot("missing", "sess-x", deps)).rejects.toThrow(/Channel not found/);
   });
 
   it("throws when `git rev-parse HEAD` produces empty output", async () => {
     const channel = makeChannel(["/repos/a"]);
     const git = makeGit({
-      stdoutByKey: { "/repos/a": { "rev-parse HEAD": "" } }
+      stdoutByKey: { "/repos/a": { "rev-parse HEAD": "" } },
     });
     const deps: RewindDeps = {
       channelStore: fakeChannelStore(channel),
       sessionStore: {
         truncateBeforeTimestamp: async () => 0,
-        clearClaudeSessionIds: async () => null
+        clearClaudeSessionIds: async () => null,
       },
-      gitExec: git.exec
+      gitExec: git.exec,
     };
-    await expect(rewindSnapshot("ch-1", "sess-1", deps)).rejects.toThrow(
-      /empty output/
-    );
+    await expect(rewindSnapshot("ch-1", "sess-1", deps)).rejects.toThrow(/empty output/);
   });
 });
 
@@ -202,20 +180,19 @@ describe("rewindApply", () => {
       stdoutByKey: {
         "/repos/a": {
           [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
-          "status --porcelain": ""
+          "status --porcelain": "",
         },
         "/repos/b": {
           [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
-          "status --porcelain": ""
-        }
-      }
+          "status --porcelain": "",
+        },
+      },
     });
   }
 
   it("pre-flight-verifies every ref + clean worktree before mutating", async () => {
     const git = happyPathGit();
-    const truncated: Array<{ channelId: string; sessionId: string; ts: string }> =
-      [];
+    const truncated: Array<{ channelId: string; sessionId: string; ts: string }> = [];
     const cleared: Array<{ channelId: string; sessionId: string }> = [];
     const deps: RewindDeps = {
       channelStore: fakeChannelStore(channel),
@@ -227,23 +204,17 @@ describe("rewindApply", () => {
         clearClaudeSessionIds: async (channelId, sessionId) => {
           cleared.push({ channelId, sessionId });
           return null;
-        }
+        },
       },
-      gitExec: git.exec
+      gitExec: git.exec,
     };
 
-    const result = await rewindApply(
-      "ch-1",
-      "sess-1",
-      refKey,
-      "2025-01-01T00:00:05.000Z",
-      deps
-    );
+    const result = await rewindApply("ch-1", "sess-1", refKey, "2025-01-01T00:00:05.000Z", deps);
 
     // Each reset advertises its SHA.
     expect(result.reset).toEqual([
       { alias: "repo1", repoPath: "/repos/a", sha: "aaa" },
-      { alias: "repo2", repoPath: "/repos/b", sha: "bbb" }
+      { alias: "repo2", repoPath: "/repos/b", sha: "bbb" },
     ]);
     expect(result.removedMessages).toBe(3);
 
@@ -254,11 +225,7 @@ describe("rewindApply", () => {
     const firstReset = kinds.findIndex((k) => k.startsWith("reset --hard"));
     const lastPreflight = Math.max(
       ...kinds
-        .map((k, i) =>
-          k.startsWith("rev-parse --verify") || k === "status --porcelain"
-            ? i
-            : -1
-        )
+        .map((k, i) => (k.startsWith("rev-parse --verify") || k === "status --porcelain" ? i : -1))
         .filter((i) => i >= 0)
     );
     expect(lastPreflight).toBeLessThan(firstReset);
@@ -272,13 +239,13 @@ describe("rewindApply", () => {
       stdoutByKey: {
         "/repos/a": {
           [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
-          "status --porcelain": ""
+          "status --porcelain": "",
         },
         "/repos/b": {
           [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
-          "status --porcelain": " M src/hand-edited.ts\n?? untracked.txt\n"
-        }
-      }
+          "status --porcelain": " M src/hand-edited.ts\n?? untracked.txt\n",
+        },
+      },
     });
     let truncated = false;
     let cleared = false;
@@ -292,9 +259,9 @@ describe("rewindApply", () => {
         clearClaudeSessionIds: async () => {
           cleared = true;
           return null;
-        }
+        },
       },
-      gitExec: git.exec
+      gitExec: git.exec,
     };
 
     await expect(
@@ -302,9 +269,7 @@ describe("rewindApply", () => {
     ).rejects.toThrow(/uncommitted or untracked/);
 
     // Pre-flight must fail BEFORE any reset --hard or session mutation.
-    expect(
-      git.calls.some((c) => c.args[0] === "reset" && c.args[1] === "--hard")
-    ).toBe(false);
+    expect(git.calls.some((c) => c.args[0] === "reset" && c.args[1] === "--hard")).toBe(false);
     expect(truncated).toBe(false);
     expect(cleared).toBe(false);
   });
@@ -314,14 +279,14 @@ describe("rewindApply", () => {
       stdoutByKey: {
         "/repos/a": {
           [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
-          "status --porcelain": ""
-        }
+          "status --porcelain": "",
+        },
       },
       throwByKey: {
         "/repos/b": {
-          [`rev-parse --verify ${refName}^{commit}`]: "fatal: Needed a single revision"
-        }
-      }
+          [`rev-parse --verify ${refName}^{commit}`]: "fatal: Needed a single revision",
+        },
+      },
     });
     let truncated = false;
     const deps: RewindDeps = {
@@ -331,18 +296,16 @@ describe("rewindApply", () => {
           truncated = true;
           return 0;
         },
-        clearClaudeSessionIds: async () => null
+        clearClaudeSessionIds: async () => null,
       },
-      gitExec: git.exec
+      gitExec: git.exec,
     };
 
     await expect(
       rewindApply("ch-1", "sess-1", refKey, "2025-01-01T00:00:00.000Z", deps)
     ).rejects.toThrow(/missing or unresolvable/);
 
-    expect(
-      git.calls.some((c) => c.args[0] === "reset" && c.args[1] === "--hard")
-    ).toBe(false);
+    expect(git.calls.some((c) => c.args[0] === "reset" && c.args[1] === "--hard")).toBe(false);
     expect(truncated).toBe(false);
   });
 
@@ -354,16 +317,16 @@ describe("rewindApply", () => {
       stdoutByKey: {
         "/repos/a": {
           [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
-          "status --porcelain": ""
+          "status --porcelain": "",
         },
         "/repos/b": {
           [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
-          "status --porcelain": ""
-        }
+          "status --porcelain": "",
+        },
       },
       throwByKey: {
-        "/repos/b": { "reset --hard bbb": "fatal: Unable to write new index file" }
-      }
+        "/repos/b": { "reset --hard bbb": "fatal: Unable to write new index file" },
+      },
     });
     let truncated = false;
     const deps: RewindDeps = {
@@ -373,9 +336,9 @@ describe("rewindApply", () => {
           truncated = true;
           return 0;
         },
-        clearClaudeSessionIds: async () => null
+        clearClaudeSessionIds: async () => null,
       },
-      gitExec: git.exec
+      gitExec: git.exec,
     };
 
     await expect(
@@ -406,7 +369,7 @@ describe("SessionStore.truncateBeforeTimestamp + clearClaudeSessionIds", () => {
       role: "user",
       content,
       timestamp: ts,
-      agentAlias: null
+      agentAlias: null,
     });
     await store.appendMessage("ch", session.sessionId, makeMsg("2025-01-01T00:00:00.000Z", "m1"));
     await store.appendMessage("ch", session.sessionId, makeMsg("2025-01-01T00:00:05.000Z", "m2"));
@@ -499,21 +462,19 @@ describe("SessionStore.deleteSession prunes rewind refs", () => {
       role: "user",
       content: "hi",
       timestamp: "2025-01-01T00:00:00.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
 
     await store.deleteSession("ch", session.sessionId, {
-      repoPaths: ["/repos/a", "/repos/b"]
+      repoPaths: ["/repos/a", "/repos/b"],
     });
 
-    const deletes = gitCalls.filter(
-      (c) => c.args[0] === "update-ref" && c.args[1] === "-d"
-    );
+    const deletes = gitCalls.filter((c) => c.args[0] === "update-ref" && c.args[1] === "-d");
     const deleted = deletes.map((c) => `${c.cwd}::${c.args[2]}`).sort();
     expect(deleted).toEqual([
       `/repos/a::refs/harness-rewind/${session.sessionId}/k1`,
       `/repos/a::refs/harness-rewind/${session.sessionId}/k2`,
-      `/repos/b::refs/harness-rewind/${session.sessionId}/k3`
+      `/repos/b::refs/harness-rewind/${session.sessionId}/k3`,
     ]);
   });
 
@@ -525,7 +486,7 @@ describe("SessionStore.deleteSession prunes rewind refs", () => {
       if (args[0] === "for-each-ref") {
         return {
           stdout: `refs/harness-rewind/s/ref1\nrefs/harness-rewind/s/ref2\n`,
-          stderr: ""
+          stderr: "",
         };
       }
       if (
@@ -566,9 +527,7 @@ describe("SessionStore.deleteSession prunes rewind refs", () => {
 
     // Disk cleanup still happened.
     const sessionsAfter = await store.listSessions("ch");
-    expect(sessionsAfter.map((s) => s.sessionId)).not.toContain(
-      session.sessionId
-    );
+    expect(sessionsAfter.map((s) => s.sessionId)).not.toContain(session.sessionId);
   });
 
   it("is a no-op (no git calls) when repoPaths is not supplied", async () => {
@@ -609,20 +568,20 @@ describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () 
       role: "user",
       content: "before",
       timestamp: "2025-01-01T00:00:00.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
     await sessionStore.appendMessage("ch-e2e", session.sessionId, {
       role: "user",
       content: "cutoff",
       timestamp: "2025-01-01T00:00:05.000Z",
       agentAlias: null,
-      metadata: { rewindKey: "k1" }
+      metadata: { rewindKey: "k1" },
     });
     await sessionStore.appendMessage("ch-e2e", session.sessionId, {
       role: "assistant",
       content: "after",
       timestamp: "2025-01-01T00:00:10.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
 
     const channel = makeChannel(["/fake/repo"]);
@@ -631,14 +590,14 @@ describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () 
       stdoutByKey: {
         "/fake/repo": {
           [`rev-parse --verify ${refName}^{commit}`]: "deadbeef\n",
-          "status --porcelain": ""
-        }
-      }
+          "status --porcelain": "",
+        },
+      },
     });
     const deps: RewindDeps = {
       channelStore: fakeChannelStore(channel),
       sessionStore,
-      gitExec: git.exec
+      gitExec: git.exec,
     };
 
     const result = await rewindApply(
@@ -650,10 +609,7 @@ describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () 
     );
 
     expect(result.removedMessages).toBe(2);
-    const remaining = await sessionStore.loadMessages(
-      "ch-e2e",
-      session.sessionId
-    );
+    const remaining = await sessionStore.loadMessages("ch-e2e", session.sessionId);
     expect(remaining.map((m) => m.content)).toEqual(["before"]);
 
     // JSONL file on disk matches what we expect — sanity check.
@@ -672,14 +628,14 @@ describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () 
       role: "user",
       content: "m1",
       timestamp: "2025-01-01T00:00:00.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
     await sessionStore.appendMessage("ch-fail", session.sessionId, {
       role: "user",
       content: "m2",
       timestamp: "2025-01-01T00:00:05.000Z",
       agentAlias: null,
-      metadata: { rewindKey: "boom" }
+      metadata: { rewindKey: "boom" },
     });
 
     const chatPath = join(dir, "ch-fail", "sessions", `${session.sessionId}.jsonl`);
@@ -691,23 +647,23 @@ describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () 
       stdoutByKey: {
         "/repos/a": {
           [`rev-parse --verify ${refName}^{commit}`]: "aaa\n",
-          "status --porcelain": ""
+          "status --porcelain": "",
         },
         "/repos/b": {
           [`rev-parse --verify ${refName}^{commit}`]: "bbb\n",
-          "status --porcelain": ""
-        }
+          "status --porcelain": "",
+        },
       },
       throwByKey: {
-        "/repos/b": { "reset --hard bbb": "fatal: broken" }
-      }
+        "/repos/b": { "reset --hard bbb": "fatal: broken" },
+      },
     });
 
     await expect(
       rewindApply("ch-fail", session.sessionId, "boom", "2025-01-01T00:00:05.000Z", {
         channelStore: fakeChannelStore(channel),
         sessionStore,
-        gitExec: git.exec
+        gitExec: git.exec,
       })
     ).rejects.toThrow(/broken/);
 
@@ -719,4 +675,3 @@ describe("rewindSnapshot + rewindApply end-to-end with a real SessionStore", () 
     expect(stillThere!.messageCount).toBe(2);
   });
 });
-

--- a/test/classification.test.ts
+++ b/test/classification.test.ts
@@ -4,11 +4,11 @@ import {
   parseClassificationResult,
   tierNeedsApproval,
   tierNeedsDesignDoc,
-  tierSkipsPlanning
+  tierSkipsPlanning,
 } from "../src/domain/classification.js";
 import {
   classifyByHeuristic,
-  buildHeuristicClassification
+  buildHeuristicClassification,
 } from "../src/orchestrator/classifier.js";
 
 describe("classification domain", () => {
@@ -19,7 +19,7 @@ describe("classification domain", () => {
       suggestedSpecialties: ["ui", "api_crud"],
       estimatedTicketCount: 5,
       needsDesignDoc: false,
-      needsUserApproval: true
+      needsUserApproval: true,
     });
 
     expect(result.tier).toBe("feature_large");
@@ -35,7 +35,7 @@ describe("classification domain", () => {
         suggestedSpecialties: [],
         estimatedTicketCount: 1,
         needsDesignDoc: false,
-        needsUserApproval: false
+        needsUserApproval: false,
       })
     ).toThrow();
   });

--- a/test/cli/pr-watcher-factory.test.ts
+++ b/test/cli/pr-watcher-factory.test.ts
@@ -10,7 +10,7 @@ import {
   createPrWatcherFactory,
   getActiveWatcher,
   parseGithubRemote,
-  type ExecGit
+  type ExecGit,
 } from "../../src/cli/pr-watcher-factory.js";
 import type { HarnessRun } from "../../src/domain/run.js";
 import type { TicketScheduler } from "../../src/orchestrator/ticket-scheduler.js";
@@ -41,7 +41,7 @@ function minimalRun(overrides: Partial<HarnessRun> = {}): HarnessRun {
     ticketLedger: [],
     ticketLedgerPath: null,
     runIndexPath: null,
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -52,7 +52,7 @@ function stubScheduler(): Pick<TicketScheduler, "enqueue"> {
   return {
     enqueue: vi.fn(async () => {
       /* no-op */
-    })
+    }),
   } as unknown as Pick<TicketScheduler, "enqueue">;
 }
 
@@ -60,22 +60,22 @@ describe("parseGithubRemote", () => {
   it("parses HTTPS remotes with and without .git", () => {
     expect(parseGithubRemote("https://github.com/owner/repo.git")).toEqual({
       owner: "owner",
-      name: "repo"
+      name: "repo",
     });
     expect(parseGithubRemote("https://github.com/owner/repo")).toEqual({
       owner: "owner",
-      name: "repo"
+      name: "repo",
     });
   });
 
   it("parses SSH remotes", () => {
     expect(parseGithubRemote("git@github.com:owner/repo.git")).toEqual({
       owner: "owner",
-      name: "repo"
+      name: "repo",
     });
     expect(parseGithubRemote("git@github.com:owner/repo")).toEqual({
       owner: "owner",
-      name: "repo"
+      name: "repo",
     });
   });
 
@@ -115,12 +115,12 @@ describe("createPrWatcherFactory", () => {
     const factory = createPrWatcherFactory({
       channelStore,
       repoRoot: "/irrelevant",
-      execGit
+      execGit,
     });
 
     const handle = factory({
       run: minimalRun(),
-      scheduler: stubScheduler() as TicketScheduler
+      scheduler: stubScheduler() as TicketScheduler,
     });
 
     expect(handle).not.toBeNull();
@@ -146,19 +146,19 @@ describe("createPrWatcherFactory", () => {
     // the stdout info message above.
     const channel = await channelStore.createChannel({
       name: "#test",
-      description: "missing-token test"
+      description: "missing-token test",
     });
 
     const factory = createPrWatcherFactory({
       channelStore,
       repoRoot: "/irrelevant",
       defaultChannelId: channel.channelId,
-      execGit
+      execGit,
     });
 
     factory({
       run: minimalRun(),
-      scheduler: stubScheduler() as TicketScheduler
+      scheduler: stubScheduler() as TicketScheduler,
     });
 
     // Let the fire-and-forget postEntry settle. postEntry awaits mkdir,
@@ -168,9 +168,7 @@ describe("createPrWatcherFactory", () => {
 
     const entries = await channelStore.readFeed(channel.channelId);
     const warning = entries.find(
-      (e) =>
-        e.type === "status_update" &&
-        e.metadata.warning === "missing_github_token"
+      (e) => e.type === "status_update" && e.metadata.warning === "missing_github_token"
     );
     expect(warning).toBeDefined();
     expect(warning!.fromDisplayName).toBe("PR Watcher");
@@ -186,21 +184,21 @@ describe("createPrWatcherFactory", () => {
 
     const channel = await channelStore.createChannel({
       name: "#test-dedupe",
-      description: "dedupe test"
+      description: "dedupe test",
     });
 
     const factory = createPrWatcherFactory({
       channelStore,
       repoRoot: "/irrelevant",
       defaultChannelId: channel.channelId,
-      execGit
+      execGit,
     });
 
     // Invoke the factory three times — simulating three back-to-back runs.
     for (let i = 0; i < 3; i += 1) {
       factory({
         run: minimalRun(),
-        scheduler: stubScheduler() as TicketScheduler
+        scheduler: stubScheduler() as TicketScheduler,
       });
     }
 
@@ -208,9 +206,7 @@ describe("createPrWatcherFactory", () => {
 
     const entries = await channelStore.readFeed(channel.channelId);
     const warnings = entries.filter(
-      (e) =>
-        e.type === "status_update" &&
-        e.metadata.warning === "missing_github_token"
+      (e) => e.type === "status_update" && e.metadata.warning === "missing_github_token"
     );
     expect(warnings).toHaveLength(1);
 
@@ -227,12 +223,12 @@ describe("createPrWatcherFactory", () => {
     const factory = createPrWatcherFactory({
       channelStore,
       repoRoot: "/not/a/repo",
-      execGit
+      execGit,
     });
 
     const handle = factory({
       run: minimalRun(),
-      scheduler: stubScheduler() as TicketScheduler
+      scheduler: stubScheduler() as TicketScheduler,
     });
 
     expect(handle).not.toBeNull();
@@ -255,7 +251,7 @@ describe("createPrWatcherFactory", () => {
     process.env.GITHUB_TOKEN = "fake-token";
     const execGit: ExecGit = vi.fn(async () => ({
       stdout: "git@github.com:acme/widgets.git\n",
-      stderr: ""
+      stderr: "",
     }));
 
     // Use a large intervalMs so the branch-detection setInterval never fires
@@ -264,12 +260,12 @@ describe("createPrWatcherFactory", () => {
       channelStore,
       repoRoot: "/repo",
       intervalMs: 60_000,
-      execGit
+      execGit,
     });
 
     const handle = factory({
       run: minimalRun(),
-      scheduler: stubScheduler() as TicketScheduler
+      scheduler: stubScheduler() as TicketScheduler,
     });
 
     handle!.start();

--- a/test/cli/serve-command.test.ts
+++ b/test/cli/serve-command.test.ts
@@ -38,7 +38,7 @@ function runCli(
     const child = spawn(tsxBin, [cliEntry, ...args], {
       cwd: opts.cwd ?? repoRoot,
       env: { ...process.env, ...(opts.env ?? {}) },
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
     let stdout = "";
@@ -76,15 +76,7 @@ describe("rly serve — flag validation", () => {
 
   it("refuses to start when binding non-loopback without --token or --allow-unauthenticated-remote", async () => {
     const result = await runCli(
-      [
-        "serve",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "0",
-        "--workspace",
-        "test-workspace"
-      ],
+      ["serve", "--host", "0.0.0.0", "--port", "0", "--workspace", "test-workspace"],
       { cwd: tmpRepo, env: { RELAY_TOKEN: "" } }
     );
 
@@ -117,17 +109,11 @@ describe("rly serve — startup errors map to friendly messages", () => {
 
   it("EADDRINUSE — prints a clear 'port is already in use' message and exits 1", async () => {
     const result = await runCli(
-      [
-        "serve",
-        "--port",
-        String(blockedPort),
-        "--workspace",
-        "test-workspace"
-      ],
+      ["serve", "--port", String(blockedPort), "--workspace", "test-workspace"],
       {
         // Point at a scratch cwd so workspace-registry fallback isn't the
         // error we trip on.
-        cwd: tmpdir()
+        cwd: tmpdir(),
       }
     );
 

--- a/test/cli/welcome-scaffold.test.ts
+++ b/test/cli/welcome-scaffold.test.ts
@@ -28,7 +28,7 @@ describe("scaffoldConfigEnv", () => {
   });
 
   it("copies template -> config.env when target is missing", async () => {
-    const templateBody = "# test template\n# export GITHUB_TOKEN=\"\"\n";
+    const templateBody = '# test template\n# export GITHUB_TOKEN=""\n';
     await writeFile(join(dir, "config.env.template"), templateBody);
 
     const result = await scaffoldConfigEnv(dir);

--- a/test/cli/welcome-write-key.test.ts
+++ b/test/cli/welcome-write-key.test.ts
@@ -28,7 +28,7 @@ describe("writeConfigEnvKey", () => {
     const body = [
       "# header comment",
       '# export GITHUB_TOKEN=""',
-      '# export LINEAR_API_KEY=""'
+      '# export LINEAR_API_KEY=""',
     ].join("\n");
     await writeFile(join(dir, "config.env"), body);
 
@@ -93,14 +93,14 @@ describe("writeConfigEnvKey", () => {
 
   it("rejects bogus env var names so the inlined regex can't be gamed", async () => {
     await writeFile(join(dir, "config.env"), "# stub\n");
-    await expect(
-      writeConfigEnvKey(dir, "GITHUB_TOKEN.*", "x")
-    ).rejects.toThrow(/invalid env var name/);
+    await expect(writeConfigEnvKey(dir, "GITHUB_TOKEN.*", "x")).rejects.toThrow(
+      /invalid env var name/
+    );
   });
 
   it("re-applies 0600 permissions after writing", async () => {
     await writeFile(join(dir, "config.env"), '# export GITHUB_TOKEN=""\n', {
-      mode: 0o644
+      mode: 0o644,
     });
 
     await writeConfigEnvKey(dir, "GITHUB_TOKEN", "v");

--- a/test/command-invoker.test.ts
+++ b/test/command-invoker.test.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_ENV_WHITELIST,
   NodeCommandInvoker,
   isSecretEnvName,
-  sanitizeEnv
+  sanitizeEnv,
 } from "../src/agents/command-invoker.js";
 
 /**
@@ -81,7 +81,7 @@ describe("sanitizeEnv", () => {
     LINEAR_API_KEY: "lin-secret",
     DATABASE_PASSWORD: "pw",
     // Unrelated var that isn't whitelisted: should be stripped too.
-    RANDOM_VAR: "nope"
+    RANDOM_VAR: "nope",
   };
 
   it("forwards the default whitelist and strips everything else", () => {
@@ -114,7 +114,7 @@ describe("sanitizeEnv", () => {
 
   it("lets passEnv opt specific secrets back in", () => {
     const out = sanitizeEnv(secretHeavyEnv, {
-      passEnv: ["ANTHROPIC_API_KEY", "GITHUB_TOKEN"]
+      passEnv: ["ANTHROPIC_API_KEY", "GITHUB_TOKEN"],
     });
 
     expect(out.ANTHROPIC_API_KEY).toBe("sk-ant-secret");
@@ -125,10 +125,7 @@ describe("sanitizeEnv", () => {
   });
 
   it("silently skips passEnv names not present in parent env", () => {
-    const out = sanitizeEnv(
-      { PATH: "/usr/bin" },
-      { passEnv: ["NOT_SET", "ALSO_NOT_SET"] }
-    );
+    const out = sanitizeEnv({ PATH: "/usr/bin" }, { passEnv: ["NOT_SET", "ALSO_NOT_SET"] });
 
     expect(out.PATH).toBe("/usr/bin");
     expect(out.NOT_SET).toBeUndefined();
@@ -136,7 +133,7 @@ describe("sanitizeEnv", () => {
 
   it("env overrides layer on top unfiltered", () => {
     const out = sanitizeEnv(secretHeavyEnv, {
-      env: { API_KEY_FOR_TESTS: "explicit" }
+      env: { API_KEY_FOR_TESTS: "explicit" },
     });
 
     expect(out.API_KEY_FOR_TESTS).toBe("explicit");
@@ -146,7 +143,7 @@ describe("sanitizeEnv", () => {
 
   it("env value of undefined unsets the key", () => {
     const out = sanitizeEnv(secretHeavyEnv, {
-      env: { PATH: undefined }
+      env: { PATH: undefined },
     });
 
     expect(out.PATH).toBeUndefined();
@@ -181,7 +178,7 @@ describe("NodeCommandInvoker — env sanitization in a real subprocess", () => {
       INJECTED_GITHUB_TOKEN: process.env.INJECTED_GITHUB_TOKEN,
       INJECTED_API_KEY: process.env.INJECTED_API_KEY,
       INJECTED_SAFE_VAR: process.env.INJECTED_SAFE_VAR,
-      HARNESS_INJECTED: process.env.HARNESS_INJECTED
+      HARNESS_INJECTED: process.env.HARNESS_INJECTED,
     };
     process.env.INJECTED_GITHUB_TOKEN = "ghp_should_not_leak";
     process.env.INJECTED_API_KEY = "sk-should-not-leak";
@@ -191,14 +188,11 @@ describe("NodeCommandInvoker — env sanitization in a real subprocess", () => {
     try {
       const result = await invoker.exec({
         command: process.execPath,
-        args: [
-          "-e",
-          "console.log(JSON.stringify(process.env))"
-        ],
+        args: ["-e", "console.log(JSON.stringify(process.env))"],
         cwd: process.cwd(),
         timeoutMs: 10_000,
         passEnv: opts.passEnv,
-        env: opts.env
+        env: opts.env,
       });
       expect(result.exitCode).toBe(0);
       return JSON.parse(result.stdout.trim()) as Record<string, string>;
@@ -230,7 +224,7 @@ describe("NodeCommandInvoker — env sanitization in a real subprocess", () => {
 
   it("passEnv opts a named secret back in", async () => {
     const childEnv = await runEnvDump({
-      passEnv: ["INJECTED_GITHUB_TOKEN"]
+      passEnv: ["INJECTED_GITHUB_TOKEN"],
     });
 
     expect(childEnv.INJECTED_GITHUB_TOKEN).toBe("ghp_should_not_leak");
@@ -240,7 +234,7 @@ describe("NodeCommandInvoker — env sanitization in a real subprocess", () => {
 
   it("env overrides deliver explicit key/value pairs to the child", async () => {
     const childEnv = await runEnvDump({
-      env: { RELAY_EXPLICIT_OVERRIDE: "deliberate" }
+      env: { RELAY_EXPLICIT_OVERRIDE: "deliberate" },
     });
 
     expect(childEnv.RELAY_EXPLICIT_OVERRIDE).toBe("deliberate");

--- a/test/crosslink-hook.test.ts
+++ b/test/crosslink-hook.test.ts
@@ -85,7 +85,7 @@ describe("generateHookScripts", () => {
         agentProvider: "claude",
         status: "active",
         registeredAt: new Date().toISOString(),
-        lastHeartbeat: new Date().toISOString()
+        lastHeartbeat: new Date().toISOString(),
       })
     );
 
@@ -102,7 +102,7 @@ describe("generateHookScripts", () => {
         status: "pending",
         createdAt: new Date().toISOString(),
         deliveredAt: null,
-        repliedAt: null
+        repliedAt: null,
       })
     );
 
@@ -110,7 +110,7 @@ describe("generateHookScripts", () => {
     // session deterministically regardless of PID-ancestry heuristics.
     const out = execFileSync(process.execPath, [nodeScriptPath], {
       env: { ...process.env, RELAY_SESSION: sessionId },
-      encoding: "utf8"
+      encoding: "utf8",
     });
 
     expect(out).toContain("CROSSLINK INBOUND");

--- a/test/crosslink-store.test.ts
+++ b/test/crosslink-store.test.ts
@@ -5,10 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  CrosslinkStore,
-  __resetLegacyLayoutWarnings
-} from "../src/crosslink/store.js";
+import { CrosslinkStore, __resetLegacyLayoutWarnings } from "../src/crosslink/store.js";
 
 describe("crosslink store", () => {
   it("registers and discovers a session", async () => {
@@ -22,7 +19,7 @@ describe("crosslink store", () => {
         description: "Test session",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       expect(session.sessionId).toMatch(/^session-/);
@@ -48,7 +45,7 @@ describe("crosslink store", () => {
         description: "Test session",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       await store.deregisterSession(session.sessionId);
@@ -72,7 +69,7 @@ describe("crosslink store", () => {
         description: "Dead session",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       // Manually set heartbeat to the past to trigger stale detection
@@ -84,11 +81,7 @@ describe("crosslink store", () => {
       // directly to simulate a stale heartbeat since the public API
       // refreshes it on every write.
       const { writeFile } = await import("node:fs/promises");
-      const sessionFile = join(
-        root,
-        "crosslink-session",
-        `${session.sessionId}.json`
-      );
+      const sessionFile = join(root, "crosslink-session", `${session.sessionId}.json`);
       const raw = JSON.parse(
         await (await import("node:fs/promises")).readFile(sessionFile, "utf8")
       );
@@ -113,7 +106,7 @@ describe("crosslink store", () => {
         description: "Session A",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const sessionB = await store.registerSession({
@@ -122,7 +115,7 @@ describe("crosslink store", () => {
         description: "Session B",
         capabilities: ["code_implementation"],
         agentProvider: "codex",
-        status: "active"
+        status: "active",
       });
 
       // A sends to B
@@ -130,7 +123,7 @@ describe("crosslink store", () => {
         fromSessionId: sessionA.sessionId,
         toSessionId: sessionB.sessionId,
         content: "What is the API schema for /users?",
-        type: "question"
+        type: "question",
       });
 
       expect(message.messageId).toMatch(/^msg-/);
@@ -162,14 +155,14 @@ describe("crosslink store", () => {
         description: "Test",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const message = await store.sendMessage({
         fromSessionId: "other-session",
         toSessionId: session.sessionId,
         content: "Hello",
-        type: "question"
+        type: "question",
       });
 
       await store.updateMessageStatus(session.sessionId, message.messageId, "replied");
@@ -193,12 +186,12 @@ describe("crosslink store", () => {
         description: "Initial",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const updated = await store.updateSession(session.sessionId, {
         description: "Working on auth feature",
-        capabilities: ["code_implementation", "architecture"]
+        capabilities: ["code_implementation", "architecture"],
       });
 
       expect(updated).not.toBeNull();
@@ -223,14 +216,14 @@ describe("crosslink store", () => {
         description: "Test",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const message = await store.sendMessage({
         fromSessionId: "other",
         toSessionId: session.sessionId,
         content: "Old message",
-        type: "question"
+        type: "question",
       });
 
       // Manually backdate the message. Same layout rationale as above —
@@ -267,9 +260,7 @@ describe("crosslink store reads legacy canonical-layout fixture", () => {
     // pre-populated data and surface it through the new API without any
     // bootstrap writes.
     workDir = await mkdtemp(join(tmpdir(), "xlink-legacy-"));
-    const src = fileURLToPath(
-      new URL("./fixtures/legacy-crosslink", import.meta.url)
-    );
+    const src = fileURLToPath(new URL("./fixtures/legacy-crosslink", import.meta.url));
     await cp(src, workDir, { recursive: true });
   });
 

--- a/test/crosslink-tools.test.ts
+++ b/test/crosslink-tools.test.ts
@@ -8,7 +8,7 @@ import { CrosslinkStore } from "../src/crosslink/store.js";
 import {
   callCrosslinkTool,
   isCrosslinkTool,
-  type CrosslinkToolState
+  type CrosslinkToolState,
 } from "../src/crosslink/tools.js";
 
 describe("crosslink tools", () => {
@@ -29,15 +29,15 @@ describe("crosslink tools", () => {
         description: "Test session",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const state: CrosslinkToolState = {
         sessionId: session.sessionId,
-        store
+        store,
       };
 
-      const result = await callCrosslinkTool("crosslink_discover", {}, state) as {
+      const result = (await callCrosslinkTool("crosslink_discover", {}, state)) as {
         currentSessionId: string;
         sessions: Array<{ sessionId: string; isSelf: boolean }>;
       };
@@ -61,7 +61,7 @@ describe("crosslink tools", () => {
         description: "Session A",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const sessionB = await store.registerSession({
@@ -70,22 +70,26 @@ describe("crosslink tools", () => {
         description: "Session B",
         capabilities: ["code_implementation"],
         agentProvider: "codex",
-        status: "active"
+        status: "active",
       });
 
       const stateA: CrosslinkToolState = { sessionId: sessionA.sessionId, store };
       const stateB: CrosslinkToolState = { sessionId: sessionB.sessionId, store };
 
       // A sends to B
-      const sendResult = await callCrosslinkTool("crosslink_send", {
-        toSessionId: sessionB.sessionId,
-        content: "What endpoints exist?"
-      }, stateA) as { messageId: string };
+      const sendResult = (await callCrosslinkTool(
+        "crosslink_send",
+        {
+          toSessionId: sessionB.sessionId,
+          content: "What endpoints exist?",
+        },
+        stateA
+      )) as { messageId: string };
 
       expect(sendResult.messageId).toMatch(/^msg-/);
 
       // B polls
-      const pollResult = await callCrosslinkTool("crosslink_poll", {}, stateB) as {
+      const pollResult = (await callCrosslinkTool("crosslink_poll", {}, stateB)) as {
         count: number;
         messages: Array<{ messageId: string; content: string; fromSessionId: string }>;
       };
@@ -95,15 +99,19 @@ describe("crosslink tools", () => {
       expect(pollResult.messages[0].fromSessionId).toBe(sessionA.sessionId);
 
       // B replies
-      const replyResult = await callCrosslinkTool("crosslink_reply", {
-        messageId: pollResult.messages[0].messageId,
-        content: "GET /users, POST /users"
-      }, stateB) as { replyMessageId: string; toSessionId: string };
+      const replyResult = (await callCrosslinkTool(
+        "crosslink_reply",
+        {
+          messageId: pollResult.messages[0].messageId,
+          content: "GET /users, POST /users",
+        },
+        stateB
+      )) as { replyMessageId: string; toSessionId: string };
 
       expect(replyResult.toSessionId).toBe(sessionA.sessionId);
 
       // A polls and gets the reply
-      const replyPoll = await callCrosslinkTool("crosslink_poll", {}, stateA) as {
+      const replyPoll = (await callCrosslinkTool("crosslink_poll", {}, stateA)) as {
         count: number;
         messages: Array<{ content: string; inReplyTo: string | null }>;
       };
@@ -127,15 +135,19 @@ describe("crosslink tools", () => {
         description: "Initial",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const state: CrosslinkToolState = { sessionId: session.sessionId, store };
 
-      const result = await callCrosslinkTool("crosslink_register", {
-        description: "Working on auth module",
-        capabilities: ["code_implementation", "architecture"]
-      }, state) as { description: string; capabilities: string[] };
+      const result = (await callCrosslinkTool(
+        "crosslink_register",
+        {
+          description: "Working on auth module",
+          capabilities: ["code_implementation", "architecture"],
+        },
+        state
+      )) as { description: string; capabilities: string[] };
 
       expect(result.description).toBe("Working on auth module");
       expect(result.capabilities).toEqual(["code_implementation", "architecture"]);
@@ -155,12 +167,12 @@ describe("crosslink tools", () => {
         description: "Test",
         capabilities: ["general"],
         agentProvider: "claude",
-        status: "active"
+        status: "active",
       });
 
       const state: CrosslinkToolState = { sessionId: session.sessionId, store };
 
-      const result = await callCrosslinkTool("crosslink_deregister", {}, state) as {
+      const result = (await callCrosslinkTool("crosslink_deregister", {}, state)) as {
         deregistered: string;
       };
 

--- a/test/execution/git-worktree-sandbox.test.ts
+++ b/test/execution/git-worktree-sandbox.test.ts
@@ -11,7 +11,7 @@ import { resolveLocalPath } from "../../src/execution/sandbox.js";
 import {
   GitWorktreeSandboxProvider,
   type RunGit,
-  type RunGitResult
+  type RunGitResult,
 } from "../../src/execution/sandboxes/git-worktree.js";
 
 const runRealGit = promisify(execFileCb);
@@ -28,29 +28,21 @@ function makeRecordingRunGit(
   responder: (call: RecordedCall) => RunGitResult | Promise<RunGitResult> = () => ({
     stdout: "",
     stderr: "",
-    code: 0
+    code: 0,
   })
 ): { runGit: RunGit; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
   const runGit: RunGit = async (args, cwd) => {
     calls.push({ args, cwd });
     const result = await responder({ args, cwd });
-    if (
-      result.code === 0 &&
-      args[0] === "worktree" &&
-      args[1] === "add"
-    ) {
+    if (result.code === 0 && args[0] === "worktree" && args[1] === "add") {
       // `-b <branch> <path> <base>` — the path is the 4th positional arg.
       const path = args[4];
       if (path) {
         await mkdir(path, { recursive: true });
       }
     }
-    if (
-      result.code === 0 &&
-      args[0] === "worktree" &&
-      args[1] === "remove"
-    ) {
+    if (result.code === 0 && args[0] === "worktree" && args[1] === "remove") {
       const path = args[args.length - 1];
       if (path) {
         await rm(path, { recursive: true, force: true });
@@ -80,21 +72,14 @@ describe("GitWorktreeSandboxProvider.create", () => {
 
     const ref = await provider.create(repo, "main", {
       runId: "run-abc",
-      ticketId: "T-042"
+      ticketId: "T-042",
     });
 
     expect(calls).toHaveLength(1);
     const expectedPath = join(baseDir, "run-run-abc", "T-042");
     expect(calls[0]).toEqual({
-      args: [
-        "worktree",
-        "add",
-        "-b",
-        "sandbox/run-abc/T-042",
-        expectedPath,
-        "main"
-      ],
-      cwd: repo.root
+      args: ["worktree", "add", "-b", "sandbox/run-abc/T-042", expectedPath, "main"],
+      cwd: repo.root,
     });
 
     expect(ref.id).toBe("runtime-run-abc-T-042");
@@ -115,20 +100,17 @@ describe("GitWorktreeSandboxProvider.create", () => {
 
     const ref = await provider.create(repo, "develop", {
       runId: "run-xyz",
-      ticketId: "T-007"
+      ticketId: "T-007",
     });
 
-    const statePath = join(
-      resolveLocalPath(ref) ?? "/missing",
-      ".relay-state.json"
-    );
+    const statePath = join(resolveLocalPath(ref) ?? "/missing", ".relay-state.json");
     const raw = JSON.parse(await readFile(statePath, "utf8"));
 
     expect(raw).toMatchObject({
       runId: "run-xyz",
       ticketId: "T-007",
       base: "develop",
-      branch: "sandbox/run-xyz/T-007"
+      branch: "sandbox/run-xyz/T-007",
     });
     expect(typeof raw.createdAt).toBe("string");
     expect(Number.isNaN(Date.parse(raw.createdAt))).toBe(false);
@@ -143,12 +125,12 @@ describe("GitWorktreeSandboxProvider.create", () => {
 
     const ref = await provider.create(repo, "main", {
       runId: "r1",
-      ticketId: "T-1"
+      ticketId: "T-1",
     });
 
     expect(ref.workdir).toEqual({
       kind: "local",
-      path: join(baseDir, "run-r1", "T-1")
+      path: join(baseDir, "run-r1", "T-1"),
     });
     expect(ref.meta?.branch).toBe("sandbox/r1/T-1");
 
@@ -160,13 +142,13 @@ describe("GitWorktreeSandboxProvider.create", () => {
     const { runGit } = makeRecordingRunGit(() => ({
       stdout: "",
       stderr: "fatal: invalid reference: nope",
-      code: 128
+      code: 128,
     }));
     const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
 
-    await expect(
-      provider.create(repo, "nope", { runId: "r", ticketId: "T" })
-    ).rejects.toThrow(/invalid reference/);
+    await expect(provider.create(repo, "nope", { runId: "r", ticketId: "T" })).rejects.toThrow(
+      /invalid reference/
+    );
 
     await rm(baseDir, { recursive: true, force: true });
   });
@@ -176,7 +158,7 @@ describe("GitWorktreeSandboxProvider.create", () => {
     const { runGit } = makeRecordingRunGit(() => ({
       stdout: "progress: cloning",
       stderr: "fatal: boom",
-      code: 128
+      code: 128,
     }));
     const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
 
@@ -184,9 +166,9 @@ describe("GitWorktreeSandboxProvider.create", () => {
     // snippet, not just the stderr — without those, an operator staring at
     // the thrown error has no way to tell a non-zero git exit from a random
     // JS runtime failure.
-    await expect(
-      provider.create(repo, "main", { runId: "r", ticketId: "T" })
-    ).rejects.toThrow(/exit 128.*boom.*stdout: progress: cloning/);
+    await expect(provider.create(repo, "main", { runId: "r", ticketId: "T" })).rejects.toThrow(
+      /exit 128.*boom.*stdout: progress: cloning/
+    );
 
     await rm(baseDir, { recursive: true, force: true });
   });
@@ -198,7 +180,7 @@ describe("GitWorktreeSandboxProvider.create", () => {
 
     const [a, b] = await Promise.all([
       provider.create(repo, "main", { runId: "run-a", ticketId: "T-1" }),
-      provider.create(repo, "main", { runId: "run-b", ticketId: "T-2" })
+      provider.create(repo, "main", { runId: "run-b", ticketId: "T-2" }),
     ]);
 
     expect(a.id).not.toBe(b.id);
@@ -219,9 +201,9 @@ describe("GitWorktreeSandboxProvider.create", () => {
 
     await provider.create(repo, "main", { runId: "r", ticketId: "T-dup" });
 
-    await expect(
-      provider.create(repo, "main", { runId: "r", ticketId: "T-dup" })
-    ).rejects.toThrow(/already exists.*T-203 recovery should handle resume/);
+    await expect(provider.create(repo, "main", { runId: "r", ticketId: "T-dup" })).rejects.toThrow(
+      /already exists.*T-203 recovery should handle resume/
+    );
 
     await rm(baseDir, { recursive: true, force: true });
   });
@@ -243,14 +225,12 @@ describe("GitWorktreeSandboxProvider.create", () => {
     };
     const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
 
-    await expect(
-      provider.create(repo, "main", { runId: "r", ticketId: "T" })
-    ).rejects.toThrow(/Failed to write \.relay-state\.json/);
+    await expect(provider.create(repo, "main", { runId: "r", ticketId: "T" })).rejects.toThrow(
+      /Failed to write \.relay-state\.json/
+    );
 
     // Rollback = a second invocation with `--force` on the target path.
-    const rollback = calls.find(
-      (c) => c.args[1] === "remove" && c.args.includes("--force")
-    );
+    const rollback = calls.find((c) => c.args[1] === "remove" && c.args.includes("--force"));
     expect(rollback).toBeDefined();
 
     await rm(baseDir, { recursive: true, force: true });
@@ -263,7 +243,7 @@ describe("GitWorktreeSandboxProvider.create", () => {
       { label: "backslash", value: "\\x" },
       { label: "empty string", value: "" },
       { label: "leading space", value: " space" },
-      { label: "null byte", value: "null\0byte" }
+      { label: "null byte", value: "null\0byte" },
     ];
 
     for (const { label, value } of unsafeValues) {
@@ -300,14 +280,12 @@ describe("GitWorktreeSandboxProvider.create", () => {
           id: `runtime-${value}-T-1`,
           workdir: {
             kind: "local" as const,
-            path: join(baseDir, `run-${value}`, "T-1")
+            path: join(baseDir, `run-${value}`, "T-1"),
           },
-          meta: { runId: value, ticketId: "T-1" }
+          meta: { runId: value, ticketId: "T-1" },
         };
 
-        await expect(provider.destroy(forgedRef)).rejects.toThrow(
-          /Unsafe path segment/
-        );
+        await expect(provider.destroy(forgedRef)).rejects.toThrow(/Unsafe path segment/);
 
         await rm(baseDir, { recursive: true, force: true });
       });
@@ -321,14 +299,12 @@ describe("GitWorktreeSandboxProvider.create", () => {
           id: `runtime-r-${value}`,
           workdir: {
             kind: "local" as const,
-            path: join(baseDir, "run-r", value)
+            path: join(baseDir, "run-r", value),
           },
-          meta: { runId: "r", ticketId: value }
+          meta: { runId: "r", ticketId: value },
         };
 
-        await expect(provider.destroy(forgedRef)).rejects.toThrow(
-          /Unsafe path segment/
-        );
+        await expect(provider.destroy(forgedRef)).rejects.toThrow(/Unsafe path segment/);
 
         await rm(baseDir, { recursive: true, force: true });
       });
@@ -344,7 +320,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
 
     const ref = await provider.create(repo, "main", {
       runId: "r",
-      ticketId: "T"
+      ticketId: "T",
     });
 
     const outcome = await provider.destroy(ref);
@@ -352,11 +328,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
 
     const removeCall = calls.find((c) => c.args[1] === "remove");
     expect(removeCall).toBeDefined();
-    expect(removeCall!.args).toEqual([
-      "worktree",
-      "remove",
-      resolveLocalPath(ref)
-    ]);
+    expect(removeCall!.args).toEqual(["worktree", "remove", resolveLocalPath(ref)]);
     expect(removeCall!.args).not.toContain("--force");
     expect(removeCall!.cwd).toBe(repo.root);
 
@@ -370,7 +342,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
 
     const ref = await provider.create(repo, "main", {
       runId: "r",
-      ticketId: "T"
+      ticketId: "T",
     });
 
     const outcome = await provider.destroy(ref, { force: true });
@@ -378,12 +350,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
 
     const removeCall = calls.find((c) => c.args[1] === "remove");
     expect(removeCall).toBeDefined();
-    expect(removeCall!.args).toEqual([
-      "worktree",
-      "remove",
-      "--force",
-      resolveLocalPath(ref)
-    ]);
+    expect(removeCall!.args).toEqual(["worktree", "remove", "--force", resolveLocalPath(ref)]);
 
     await rm(baseDir, { recursive: true, force: true });
   });
@@ -393,7 +360,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     const { runGit, calls } = makeRecordingRunGit();
     const provider = new GitWorktreeSandboxProvider({
       baseDir,
-      runGit
+      runGit,
     });
 
     // Build a ref for a path that was never created on disk.
@@ -401,13 +368,13 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       id: "runtime-ghost-T-0",
       workdir: {
         kind: "local" as const,
-        path: join(baseDir, "run-ghost", "T-0")
+        path: join(baseDir, "run-ghost", "T-0"),
       },
-      meta: { branch: "sandbox/ghost/T-0", runId: "ghost", ticketId: "T-0" }
+      meta: { branch: "sandbox/ghost/T-0", runId: "ghost", ticketId: "T-0" },
     };
 
     await expect(provider.destroy(phantom)).resolves.toEqual({
-      kind: "missing"
+      kind: "missing",
     });
     // No git invocation should happen when the path is missing.
     expect(calls).toHaveLength(0);
@@ -429,7 +396,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     const orphanRef = {
       id: "runtime-orphan-T-0",
       workdir: { kind: "local" as const, path: existingPath },
-      meta: { branch: "sandbox/orphan/T-0", runId: "orphan", ticketId: "T-0" }
+      meta: { branch: "sandbox/orphan/T-0", runId: "orphan", ticketId: "T-0" },
     };
 
     await expect(provider.destroy(orphanRef)).rejects.toThrow(
@@ -456,9 +423,8 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       if (failNextRemove && args[1] === "remove") {
         return {
           stdout: "",
-          stderr:
-            "fatal: '...' contains modified or untracked files, use --force to delete it",
-          code: 128
+          stderr: "fatal: '...' contains modified or untracked files, use --force to delete it",
+          code: 128,
         };
       }
       return { stdout: "", stderr: "", code: 0 };
@@ -467,7 +433,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
     const ref = await provider.create(repo, "main", {
       runId: "r",
-      ticketId: "T-dirty"
+      ticketId: "T-dirty",
     });
 
     const path = resolveLocalPath(ref)!;
@@ -504,7 +470,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
         return {
           stdout: "last-line: help",
           stderr: "fatal: catastrophic failure",
-          code: 128
+          code: 128,
         };
       }
       return { stdout: "", stderr: "", code: 0 };
@@ -513,7 +479,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
     const provider = new GitWorktreeSandboxProvider({ baseDir, runGit });
     const ref = await provider.create(repo, "main", {
       runId: "r",
-      ticketId: "T-err"
+      ticketId: "T-err",
     });
 
     phase = "remove";
@@ -527,8 +493,7 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
 
 // Integration test gated behind RELAY_TEST_REAL_GIT=1. Uses a real git repo in
 // a temp dir so CI stays fast and hermetic by default.
-const realGitSuite =
-  process.env.RELAY_TEST_REAL_GIT === "1" ? describe : describe.skip;
+const realGitSuite = process.env.RELAY_TEST_REAL_GIT === "1" ? describe : describe.skip;
 
 realGitSuite("GitWorktreeSandboxProvider — real git integration", () => {
   it("creates and destroys a real worktree", async () => {
@@ -543,11 +508,10 @@ realGitSuite("GitWorktreeSandboxProvider — real git integration", () => {
     );
 
     const provider = new GitWorktreeSandboxProvider({ baseDir });
-    const ref = await provider.create(
-      { root: repoRoot },
-      "main",
-      { runId: "real", ticketId: "T-real" }
-    );
+    const ref = await provider.create({ root: repoRoot }, "main", {
+      runId: "real",
+      ticketId: "T-real",
+    });
 
     const path = resolveLocalPath(ref)!;
     expect(await exists(path)).toBe(true);

--- a/test/execution/local-child-process-executor.test.ts
+++ b/test/execution/local-child-process-executor.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   NodeCommandInvoker,
   type CommandInvoker,
-  type SpawnedProcess
+  type SpawnedProcess,
 } from "../../src/agents/command-invoker.js";
 import type { TicketDefinition } from "../../src/domain/ticket.js";
 import type { ExecutionEvent } from "../../src/execution/executor.js";
@@ -17,7 +17,7 @@ import type {
   DestroyResult,
   RepoRef,
   SandboxProvider,
-  SandboxRef
+  SandboxRef,
 } from "../../src/execution/sandbox.js";
 
 function makeTicket(partial: Partial<TicketDefinition> = {}): TicketDefinition {
@@ -31,13 +31,11 @@ function makeTicket(partial: Partial<TicketDefinition> = {}): TicketDefinition {
     verificationCommands: partial.verificationCommands ?? [],
     docsToUpdate: partial.docsToUpdate ?? [],
     dependsOn: partial.dependsOn ?? [],
-    retryPolicy: partial.retryPolicy ?? { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+    retryPolicy: partial.retryPolicy ?? { maxAgentAttempts: 1, maxTestFixLoops: 1 },
   };
 }
 
-async function collectStream(
-  stream: AsyncIterable<ExecutionEvent>
-): Promise<ExecutionEvent[]> {
+async function collectStream(stream: AsyncIterable<ExecutionEvent>): Promise<ExecutionEvent[]> {
   const events: ExecutionEvent[] = [];
   for await (const event of stream) {
     events.push(event);
@@ -52,9 +50,8 @@ async function collectStream(
 class FakeSpawned {
   private stdoutListener: ((chunk: string) => void) | null = null;
   private stderrListener: ((chunk: string) => void) | null = null;
-  private exitListener:
-    | ((code: number | null, signal: NodeJS.Signals | null) => void)
-    | null = null;
+  private exitListener: ((code: number | null, signal: NodeJS.Signals | null) => void) | null =
+    null;
   private errorListener: ((err: Error) => void) | null = null;
   public killed: NodeJS.Signals[] = [];
   private alive = true;
@@ -94,7 +91,7 @@ class FakeSpawned {
         const s = (signal ?? "SIGTERM") as NodeJS.Signals;
         this.killed.push(s);
         return this.alive;
-      }
+      },
     };
   }
 }
@@ -107,11 +104,7 @@ class FakeInvoker implements CommandInvoker {
     throw new Error("FakeInvoker.exec not supported");
   }
 
-  spawn(invocation: {
-    command: string;
-    args: string[];
-    cwd: string;
-  }): SpawnedProcess {
+  spawn(invocation: { command: string; args: string[]; cwd: string }): SpawnedProcess {
     this.lastInvocation = { ...invocation };
     const fake = new FakeSpawned();
     this.spawned.push(fake);
@@ -134,7 +127,7 @@ class CountingSandboxProvider implements SandboxProvider {
     this.lastRef = {
       id: `counting-${this.creates}`,
       workdir: { kind: "local", path: this.workdirPath },
-      meta: { base }
+      meta: { base },
     };
     return this.lastRef;
   }
@@ -153,7 +146,7 @@ describe("LocalChildProcessExecutor - real child processes", () => {
     try {
       const executor = new LocalChildProcessExecutor({
         invoker: new NodeCommandInvoker(),
-        resolveCommand: () => ({ command: "echo", args: ["hello"] })
+        resolveCommand: () => ({ command: "echo", args: ["hello"] }),
       });
       const provider = new NoopSandboxProvider();
       const sandbox = await provider.create({ root: tmp }, "main");
@@ -161,7 +154,7 @@ describe("LocalChildProcessExecutor - real child processes", () => {
       const handle = await executor.start(makeTicket(), {
         runId: "run-echo",
         repoRoot: tmp,
-        sandbox
+        sandbox,
       });
 
       const result = await handle.wait();
@@ -177,7 +170,7 @@ describe("LocalChildProcessExecutor - real child processes", () => {
     const tmp = await mkdtemp(join(tmpdir(), "local-exec-default-"));
     try {
       const executor = new LocalChildProcessExecutor({
-        invoker: new NodeCommandInvoker()
+        invoker: new NodeCommandInvoker(),
       });
       const provider = new NoopSandboxProvider();
       const sandbox = await provider.create({ root: tmp }, "main");
@@ -186,7 +179,7 @@ describe("LocalChildProcessExecutor - real child processes", () => {
       const handle = await executor.start(ticket, {
         runId: "run-default",
         repoRoot: tmp,
-        sandbox
+        sandbox,
       });
 
       const result = await handle.wait();
@@ -203,7 +196,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const invoker = new FakeInvoker();
     const executor = new LocalChildProcessExecutor({
       invoker,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     const provider = new NoopSandboxProvider();
@@ -211,7 +204,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const handle = await executor.start(makeTicket(), {
       runId: "run-stream",
       repoRoot: "/tmp/repo",
-      sandbox
+      sandbox,
     });
 
     // Drive the fake through its lifecycle on the next tick so stream() has
@@ -236,7 +229,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const invoker = new FakeInvoker();
     const executor = new LocalChildProcessExecutor({
       invoker,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     const provider = new NoopSandboxProvider();
@@ -244,7 +237,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const handle = await executor.start(makeTicket(), {
       runId: "run-stream-2",
       repoRoot: "/tmp/repo",
-      sandbox
+      sandbox,
     });
 
     invoker.spawned[0].emitExit(0, null);
@@ -258,7 +251,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const invoker = new FakeInvoker();
     const executor = new LocalChildProcessExecutor({
       invoker,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     const provider = new NoopSandboxProvider();
@@ -266,7 +259,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const handle = await executor.start(makeTicket(), {
       runId: "run-kill",
       repoRoot: "/tmp/repo",
-      sandbox
+      sandbox,
     });
 
     expect(handle.status).toBe("running");
@@ -287,7 +280,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const invoker = new FakeInvoker();
     const executor = new LocalChildProcessExecutor({
       invoker,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     const provider = new NoopSandboxProvider();
@@ -295,7 +288,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const handle = await executor.start(makeTicket(), {
       runId: "run-kill-after",
       repoRoot: "/tmp/repo",
-      sandbox
+      sandbox,
     });
 
     invoker.spawned[0].emitExit(0, null);
@@ -314,7 +307,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const executor = new LocalChildProcessExecutor({
       invoker,
       resolveCommand: () => ({ command: "sleep", args: ["999"] }),
-      killGraceMs: 20
+      killGraceMs: 20,
     });
 
     const provider = new NoopSandboxProvider();
@@ -323,7 +316,7 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
       runId: "run-timeout",
       repoRoot: "/tmp/repo",
       sandbox,
-      timeoutMs: 30
+      timeoutMs: 30,
     });
 
     // Don't emit exit for SIGTERM - simulate an uncooperative child that only
@@ -345,19 +338,19 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
     const invoker = new FakeInvoker();
     const executor = new LocalChildProcessExecutor({
       invoker,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     const remoteSandbox: SandboxRef = {
       id: "remote-1",
-      workdir: { kind: "remote", uri: "pod://ns/name:/work" }
+      workdir: { kind: "remote", uri: "pod://ns/name:/work" },
     };
 
     await expect(
       executor.start(makeTicket(), {
         runId: "run-remote",
         repoRoot: "/tmp/repo",
-        sandbox: remoteSandbox
+        sandbox: remoteSandbox,
       })
     ).rejects.toThrow(/kind === "local"/);
   });
@@ -373,14 +366,14 @@ describe("LocalChildProcessExecutor - lifecycle and streaming", () => {
       executor.start(makeTicket({ allowedCommands: [] }), {
         runId: "run-nocmd",
         repoRoot: "/tmp/repo",
-        sandbox
+        sandbox,
       })
     ).rejects.toThrow(/No command resolved/);
   });
 
   it("rejects an invoker that does not implement spawn at construction time", () => {
     const bareInvoker: CommandInvoker = {
-      exec: async () => ({ stdout: "", stderr: "", exitCode: 0 })
+      exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
     };
     expect(() => new LocalChildProcessExecutor({ invoker: bareInvoker })).toThrow(
       /requires a CommandInvoker that implements spawn/
@@ -397,12 +390,12 @@ describe("LocalChildProcessExecutor - sandbox lifecycle via injected provider", 
       const executor = new LocalChildProcessExecutor({
         invoker,
         sandboxProvider: provider,
-        resolveCommand: () => ({ command: "noop", args: [] })
+        resolveCommand: () => ({ command: "noop", args: [] }),
       });
 
       const handle = await executor.start(makeTicket(), {
         runId: "run-sb-success",
-        repoRoot: tmp
+        repoRoot: tmp,
       });
 
       expect(provider.creates).toBe(1);
@@ -428,12 +421,12 @@ describe("LocalChildProcessExecutor - sandbox lifecycle via injected provider", 
       const executor = new LocalChildProcessExecutor({
         invoker,
         sandboxProvider: provider,
-        resolveCommand: () => ({ command: "noop", args: [] })
+        resolveCommand: () => ({ command: "noop", args: [] }),
       });
 
       const handle = await executor.start(makeTicket(), {
         runId: "run-sb-fail",
-        repoRoot: tmp
+        repoRoot: tmp,
       });
 
       invoker.spawned[0].emitStderr("oops");
@@ -454,13 +447,13 @@ describe("LocalChildProcessExecutor - sandbox lifecycle via injected provider", 
     const executor = new LocalChildProcessExecutor({
       invoker: new FakeInvoker(),
       sandboxProvider: provider,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     await expect(
       executor.start(makeTicket(), {
         runId: "run-sb-create-fail",
-        repoRoot: "/tmp/repo"
+        repoRoot: "/tmp/repo",
       })
     ).rejects.toThrow(/create failed/);
   });
@@ -471,24 +464,24 @@ describe("LocalChildProcessExecutor - sandbox lifecycle via injected provider", 
       async create(): Promise<SandboxRef> {
         return {
           id: "remote-from-provider",
-          workdir: { kind: "remote", uri: "pod://x" }
+          workdir: { kind: "remote", uri: "pod://x" },
         };
       },
       async destroy(): Promise<DestroyResult> {
         destroyed = true;
         return { kind: "missing" };
-      }
+      },
     };
     const executor = new LocalChildProcessExecutor({
       invoker: new FakeInvoker(),
       sandboxProvider: provider,
-      resolveCommand: () => ({ command: "noop", args: [] })
+      resolveCommand: () => ({ command: "noop", args: [] }),
     });
 
     await expect(
       executor.start(makeTicket(), {
         runId: "run-remote-prov",
-        repoRoot: "/tmp/repo"
+        repoRoot: "/tmp/repo",
       })
     ).rejects.toThrow(/kind === "local"/);
     expect(destroyed).toBe(true);
@@ -509,23 +502,23 @@ describe("LocalChildProcessExecutor - sandbox lifecycle via injected provider", 
         async create(): Promise<SandboxRef> {
           return {
             id: "sb-destroy-will-fail",
-            workdir: { kind: "remote", uri: "pod://y" }
+            workdir: { kind: "remote", uri: "pod://y" },
           };
         },
         async destroy(): Promise<DestroyResult> {
           throw new Error("destroy boom");
-        }
+        },
       };
       const executor = new LocalChildProcessExecutor({
         invoker: new FakeInvoker(),
         sandboxProvider: provider,
-        resolveCommand: () => ({ command: "noop", args: [] })
+        resolveCommand: () => ({ command: "noop", args: [] }),
       });
 
       await expect(
         executor.start(makeTicket({ id: "T-destroy-fail" }), {
           runId: "run-destroy-fail",
-          repoRoot: "/tmp/repo"
+          repoRoot: "/tmp/repo",
         })
       ).rejects.toThrow(/kind === "local"/);
 
@@ -549,7 +542,7 @@ describe("LocalChildProcessExecutor - stuck-child and failure-mode escape hatche
     const executor = new LocalChildProcessExecutor({
       invoker,
       resolveCommand: () => ({ command: "noop", args: [] }),
-      postKillWatchdogMs: 30
+      postKillWatchdogMs: 30,
     });
 
     const provider = new NoopSandboxProvider();
@@ -557,7 +550,7 @@ describe("LocalChildProcessExecutor - stuck-child and failure-mode escape hatche
     const handle = await executor.start(makeTicket(), {
       runId: "run-stuck",
       repoRoot: "/tmp/repo",
-      sandbox
+      sandbox,
     });
 
     const waitP = handle.wait();
@@ -575,12 +568,12 @@ describe("LocalChildProcessExecutor - stuck-child and failure-mode escape hatche
   it("maps ENOENT to exit 127 (command not found) and EACCES to exit 126 (permission denied)", async () => {
     for (const [code, expectedExit] of [
       ["ENOENT", 127],
-      ["EACCES", 126]
+      ["EACCES", 126],
     ] as const) {
       const invoker = new FakeInvoker();
       const executor = new LocalChildProcessExecutor({
         invoker,
-        resolveCommand: () => ({ command: "noop", args: [] })
+        resolveCommand: () => ({ command: "noop", args: [] }),
       });
 
       const provider = new NoopSandboxProvider();
@@ -588,7 +581,7 @@ describe("LocalChildProcessExecutor - stuck-child and failure-mode escape hatche
       const handle = await executor.start(makeTicket(), {
         runId: `run-err-${code}`,
         repoRoot: "/tmp/repo",
-        sandbox
+        sandbox,
       });
 
       const err: NodeJS.ErrnoException = new Error(`spawn ${code}`);
@@ -610,7 +603,7 @@ describe("LocalChildProcessExecutor - stuck-child and failure-mode escape hatche
       invoker,
       resolveCommand: () => ({ command: "noop", args: [] }),
       heartbeatIntervalMs: 5,
-      maxHeartbeatCount: 3
+      maxHeartbeatCount: 3,
     });
 
     const provider = new NoopSandboxProvider();
@@ -618,7 +611,7 @@ describe("LocalChildProcessExecutor - stuck-child and failure-mode escape hatche
     const handle = await executor.start(makeTicket(), {
       runId: "run-hb-cap",
       repoRoot: "/tmp/repo",
-      sandbox
+      sandbox,
     });
 
     // Collect events in the background. We'll emit exit after the cap trips

--- a/test/execution/noop-executor.test.ts
+++ b/test/execution/noop-executor.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { TicketDefinition } from "../../src/domain/ticket.js";
 import type { ExecutionEvent } from "../../src/execution/executor.js";
-import {
-  NoopExecutor,
-  NoopSandboxProvider
-} from "../../src/execution/noop-executor.js";
+import { NoopExecutor, NoopSandboxProvider } from "../../src/execution/noop-executor.js";
 import type { RepoRef } from "../../src/execution/sandbox.js";
 import { resolveLocalPath } from "../../src/execution/sandbox.js";
 
@@ -19,14 +16,12 @@ const ticket: TicketDefinition = {
   verificationCommands: [],
   docsToUpdate: [],
   dependsOn: [],
-  retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+  retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
 };
 
 const repo: RepoRef = { root: "/tmp/fake-repo" };
 
-async function collectStream(
-  stream: AsyncIterable<ExecutionEvent>
-): Promise<ExecutionEvent[]> {
+async function collectStream(stream: AsyncIterable<ExecutionEvent>): Promise<ExecutionEvent[]> {
   const events: ExecutionEvent[] = [];
 
   for await (const event of stream) {
@@ -78,7 +73,7 @@ describe("NoopSandboxProvider", () => {
   it("resolveLocalPath returns null for a remote workdir ref", () => {
     const ref = {
       id: "remote-1",
-      workdir: { kind: "remote" as const, uri: "pod://ns/name:/work" }
+      workdir: { kind: "remote" as const, uri: "pod://ns/name:/work" },
     };
 
     expect(resolveLocalPath(ref)).toBeNull();
@@ -93,7 +88,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     const first = await handle.wait();
@@ -103,7 +98,7 @@ describe("NoopExecutor", () => {
       exitCode: 0,
       summary: "noop",
       stdout: "",
-      stderr: ""
+      stderr: "",
     });
     expect(second).toBe(first);
   });
@@ -115,7 +110,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     const events = await collectStream(handle.stream());
@@ -131,7 +126,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     await handle.kill("SIGKILL");
@@ -161,7 +156,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     const result = await handle.wait();
@@ -181,7 +176,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     expect(handle.status).toBe("running");
@@ -196,7 +191,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     expect(handle.status).toBe("running");
@@ -213,7 +208,7 @@ describe("NoopExecutor", () => {
     const handle = await executor.start(ticket, {
       runId: "run-1",
       repoRoot: repo.root,
-      sandbox
+      sandbox,
     });
 
     // Drive the handle to completion first so both stream() calls operate on

--- a/test/failure-routing.test.ts
+++ b/test/failure-routing.test.ts
@@ -4,7 +4,7 @@ import {
   buildRetryContext,
   buildRetryObjective,
   fallbackFailureClassification,
-  isVerificationPlanIssue
+  isVerificationPlanIssue,
 } from "../src/orchestrator/failure-routing.js";
 
 describe("failure routing", () => {
@@ -13,7 +13,7 @@ describe("failure routing", () => {
       buildRetryObjective("Repair the phase.", {
         category: "fix_code",
         rationale: "Code path failed.",
-        nextAction: "Fix product logic."
+        nextAction: "Fix product logic.",
       })
     ).toContain("product or business logic");
 
@@ -21,7 +21,7 @@ describe("failure routing", () => {
       buildRetryObjective("Repair the phase.", {
         category: "fix_test",
         rationale: "Tests failed.",
-        nextAction: "Fix tests."
+        nextAction: "Fix tests.",
       })
     ).toContain("tests, fixtures, mocks");
   });
@@ -30,17 +30,19 @@ describe("failure routing", () => {
     expect(
       fallbackFailureClassification({
         artifactContext: ["STDERR:\ncommand not found: pnpmx"],
-        rejectedCommands: []
+        rejectedCommands: [],
       }).category
     ).toBe("bad_command_plan");
   });
 
   it("marks bad command plan as a verification-plan issue", () => {
     expect(isVerificationPlanIssue("bad_command_plan")).toBe(true);
-    expect(buildRetryContext({
-      category: "bad_command_plan",
-      rationale: "Allowlist mismatch.",
-      nextAction: "Repair command plan."
-    })[0]).toContain("bad_command_plan");
+    expect(
+      buildRetryContext({
+        category: "bad_command_plan",
+        rationale: "Allowlist mismatch.",
+        nextAction: "Repair command plan.",
+      })[0]
+    ).toContain("bad_command_plan");
   });
 });

--- a/test/integrations/ao-notifier.test.ts
+++ b/test/integrations/ao-notifier.test.ts
@@ -17,7 +17,7 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
     timestamp: new Date("2026-04-20T12:00:00.000Z"),
     message: "PR updated",
     data: {},
-    ...overrides
+    ...overrides,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
@@ -30,7 +30,7 @@ describe("HarnessChannelNotifier", () => {
       const channel = await store.createChannel({ name: "#main", description: "" });
       const notifier = new HarnessChannelNotifier({
         channelStore: store,
-        defaultChannelId: channel.channelId
+        defaultChannelId: channel.channelId,
       });
 
       const data = { prNumber: 42, reviewer: "alice", labels: ["urgent", "bug"] };
@@ -67,12 +67,12 @@ describe("HarnessChannelNotifier", () => {
       const channel = await store.createChannel({ name: "#main", description: "" });
       const notifier = new HarnessChannelNotifier({
         channelStore: store,
-        defaultChannelId: channel.channelId
+        defaultChannelId: channel.channelId,
       });
 
       await notifier.notifyWithActions(buildEvent(), [
         { label: "View PR", url: "https://example.com/pr/1" },
-        { label: "Ack", callbackEndpoint: "https://example.com/ack" }
+        { label: "Ack", callbackEndpoint: "https://example.com/ack" },
       ]);
 
       const feed = await store.readFeed(channel.channelId);
@@ -94,7 +94,7 @@ describe("HarnessChannelNotifier", () => {
       const otherChannel = await store.createChannel({ name: "#other", description: "" });
       const notifier = new HarnessChannelNotifier({
         channelStore: store,
-        defaultChannelId: defaultChannel.channelId
+        defaultChannelId: defaultChannel.channelId,
       });
 
       const entryId = await notifier.post("hi", { channel: otherChannel.channelId });
@@ -119,7 +119,7 @@ describe("HarnessChannelNotifier", () => {
       const channel = await store.createChannel({ name: "#default", description: "" });
       const notifier = new HarnessChannelNotifier({
         channelStore: store,
-        defaultChannelId: channel.channelId
+        defaultChannelId: channel.channelId,
       });
 
       await notifier.post("ping", { sessionId: "s-1", projectId: "p-1", prUrl: "u" });

--- a/test/integrations/classifier-url-ingestion.test.ts
+++ b/test/integrations/classifier-url-ingestion.test.ts
@@ -10,16 +10,17 @@ const mocks = vi.hoisted(() => ({
     const s = input.trim();
     if (!s) return null;
     if (/^https?:\/\/(?:www\.)?github\.com\/[^/]+\/[^/]+\/issues\/\d+/i.test(s)) return "github";
-    if (/^https?:\/\/(?:www\.)?linear\.app\/[^/]+\/issue\/[A-Z][A-Z0-9]*-\d+/i.test(s)) return "linear";
+    if (/^https?:\/\/(?:www\.)?linear\.app\/[^/]+\/issue\/[A-Z][A-Z0-9]*-\d+/i.test(s))
+      return "linear";
     if (/^[A-Z][A-Z0-9]*-\d+$/.test(s)) return "linear";
     return null;
-  }
+  },
 }));
 
 vi.mock("../../src/integrations/tracker.js", () => ({
   createTracker: mocks.createTracker,
   resolveIssue: mocks.resolveIssue,
-  detectTrackerKind: (input: string) => mocks.detectTrackerKindReal(input)
+  detectTrackerKind: (input: string) => mocks.detectTrackerKindReal(input),
 }));
 
 import { classifyRequest } from "../../src/orchestrator/classifier.js";
@@ -46,7 +47,7 @@ function buildRun(featureRequest: string): HarnessRun {
     phaseLedgerPath: null,
     ticketLedger: [],
     ticketLedgerPath: null,
-    runIndexPath: null
+    runIndexPath: null,
   };
 }
 
@@ -67,7 +68,7 @@ describe("classifyRequest — tracker URL ingestion", () => {
       body: "We need RBAC with org scoping and row-level policies.",
       url,
       labels: ["feature", "backend"],
-      branchName: "42-add-user-management"
+      branchName: "42-add-user-management",
     });
 
     // Dispatch receives the enriched feature request; capture and respond.
@@ -86,9 +87,9 @@ describe("classifyRequest — tracker URL ingestion", () => {
             suggestedSpecialties: ["api_crud", "ui"],
             estimatedTicketCount: 5,
             needsDesignDoc: false,
-            needsUserApproval: true
-          }
-        })
+            needsUserApproval: true,
+          },
+        }),
       };
       return result;
     });
@@ -97,7 +98,7 @@ describe("classifyRequest — tracker URL ingestion", () => {
       run: buildRun(url),
       featureRequest: url,
       repoRoot: "/tmp/fake-repo",
-      dispatch
+      dispatch,
     });
 
     // Tracker seam was exercised with parsed identifier "42".
@@ -128,7 +129,7 @@ describe("classifyRequest — tracker URL ingestion", () => {
       body: "Small docs fix.",
       url,
       labels: [],
-      branchName: "7-fix-typo"
+      branchName: "7-fix-typo",
     });
 
     // Heuristic should short-circuit — dispatch must NOT be called.
@@ -136,14 +137,14 @@ describe("classifyRequest — tracker URL ingestion", () => {
       summary: "",
       evidence: [],
       proposedCommands: [],
-      blockers: []
+      blockers: [],
     }));
 
     const result = await classifyRequest({
       run: buildRun(url),
       featureRequest: url,
       repoRoot: "/tmp/fake-repo",
-      dispatch
+      dispatch,
     });
 
     expect(dispatch).not.toHaveBeenCalled();
@@ -169,16 +170,16 @@ describe("classifyRequest — tracker URL ingestion", () => {
           suggestedSpecialties: ["general"],
           estimatedTicketCount: 2,
           needsDesignDoc: false,
-          needsUserApproval: false
-        }
-      })
+          needsUserApproval: false,
+        },
+      }),
     }));
 
     const classification = await classifyRequest({
       run: buildRun(url),
       featureRequest: url,
       repoRoot: "/tmp/fake-repo",
-      dispatch
+      dispatch,
     });
 
     // Classification still returned, and the original URL text was fed straight to dispatch.

--- a/test/integrations/linear-mirror.test.ts
+++ b/test/integrations/linear-mirror.test.ts
@@ -11,7 +11,7 @@ import {
   mirrorLinearProject,
   mirrorTicketId,
   toMirrorTicket,
-  type LinearIssueNode
+  type LinearIssueNode,
 } from "../../src/integrations/linear-mirror.js";
 import { FileHarnessStore } from "../../src/storage/file-store.js";
 
@@ -30,7 +30,7 @@ function stubFetch(responses: Array<unknown>): typeof fetch {
     i += 1;
     return new Response(JSON.stringify(body), {
       status: 200,
-      headers: { "content-type": "application/json" }
+      headers: { "content-type": "application/json" },
     });
   }) as unknown as typeof fetch;
 }
@@ -43,7 +43,7 @@ function issue(
     url: `https://linear.app/acme/issue/${overrides.identifier}`,
     state: { type: "unstarted", name: "Todo" },
     updatedAt: "2026-04-21T00:00:00.000Z",
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -75,7 +75,7 @@ describe("linear-mirror", () => {
         id: "issue-uuid-1",
         identifier: "ENG-42",
         title: "Rate-limit search",
-        state: { type: "started", name: "In Progress" }
+        state: { type: "started", name: "In Progress" },
       }),
       "2026-04-21T10:00:00.000Z"
     );
@@ -101,7 +101,7 @@ describe("linear-mirror", () => {
         id: "b",
         identifier: "ENG-2",
         state: { type: "completed", name: "Done" },
-        updatedAt: "2026-04-20T00:00:00.000Z"
+        updatedAt: "2026-04-20T00:00:00.000Z",
       }),
       "2026-04-21T00:00:00.000Z"
     );
@@ -112,25 +112,23 @@ describe("linear-mirror", () => {
     const fetchImpl = stubFetch([{ data: { project: null } }]);
     const out = await fetchLinearProject("missing", {
       apiKey: "lin_api_x",
-      fetch: fetchImpl
+      fetch: fetchImpl,
     });
     expect(out).toBeNull();
   });
 
   it("surfaces Linear GraphQL errors so the CLI can stop before writing", async () => {
-    const fetchImpl = stubFetch([
-      { errors: [{ message: "Invalid project id" }] }
-    ]);
-    await expect(
-      fetchLinearProject("bad", { apiKey: "k", fetch: fetchImpl })
-    ).rejects.toThrow(/Invalid project id/);
+    const fetchImpl = stubFetch([{ errors: [{ message: "Invalid project id" }] }]);
+    await expect(fetchLinearProject("bad", { apiKey: "k", fetch: fetchImpl })).rejects.toThrow(
+      /Invalid project id/
+    );
   });
 
   it("mirrors issues onto the channel board and preserves existing Relay tickets", async () => {
     await withStore(async (store) => {
       const channel = await store.createChannel({
         name: "mirror-test",
-        description: "test"
+        description: "test",
       });
 
       // Seed a Relay-authored ticket so we can prove the mirror is additive.
@@ -151,8 +149,8 @@ describe("linear-mirror", () => {
           startedAt: null,
           completedAt: null,
           updatedAt: "2026-04-21T00:00:00.000Z",
-          runId: null
-        }
+          runId: null,
+        },
       ]);
 
       const fetchImpl = stubFetch([
@@ -164,19 +162,19 @@ describe("linear-mirror", () => {
                 issue({
                   id: "li-2",
                   identifier: "ENG-2",
-                  state: { type: "started", name: "In Progress" }
-                })
-              ]
-            }
-          }
-        }
+                  state: { type: "started", name: "In Progress" },
+                }),
+              ],
+            },
+          },
+        },
       ]);
 
-      const result = await mirrorLinearProject(
-        channel.channelId,
-        "proj-uuid",
-        { store, apiKey: "lin_api_x", fetch: fetchImpl }
-      );
+      const result = await mirrorLinearProject(channel.channelId, "proj-uuid", {
+        store,
+        apiKey: "lin_api_x",
+        fetch: fetchImpl,
+      });
 
       expect(result.fetched).toBe(2);
       expect(result.mirrored).toHaveLength(2);
@@ -200,7 +198,7 @@ describe("linear-mirror", () => {
     await withStore(async (store) => {
       const channel = await store.createChannel({
         name: "resync",
-        description: "test"
+        description: "test",
       });
 
       const firstFetch = stubFetch([
@@ -211,17 +209,17 @@ describe("linear-mirror", () => {
                 issue({
                   id: "li-1",
                   identifier: "ENG-7",
-                  state: { type: "unstarted", name: "Todo" }
-                })
-              ]
-            }
-          }
-        }
+                  state: { type: "unstarted", name: "Todo" },
+                }),
+              ],
+            },
+          },
+        },
       ]);
       await mirrorLinearProject(channel.channelId, "proj", {
         store,
         apiKey: "k",
-        fetch: firstFetch
+        fetch: firstFetch,
       });
 
       const secondFetch = stubFetch([
@@ -233,17 +231,17 @@ describe("linear-mirror", () => {
                   id: "li-1",
                   identifier: "ENG-7",
                   state: { type: "completed", name: "Done" },
-                  updatedAt: "2026-04-22T00:00:00.000Z"
-                })
-              ]
-            }
-          }
-        }
+                  updatedAt: "2026-04-22T00:00:00.000Z",
+                }),
+              ],
+            },
+          },
+        },
       ]);
       await mirrorLinearProject(channel.channelId, "proj", {
         store,
         apiKey: "k",
-        fetch: secondFetch
+        fetch: secondFetch,
       });
 
       const board = await store.readChannelTickets(channel.channelId);
@@ -259,20 +257,20 @@ describe("linear-mirror", () => {
       async () =>
         new Response("rate limited", {
           status: 429,
-          headers: { "content-type": "text/plain" }
+          headers: { "content-type": "text/plain" },
         })
     ) as unknown as typeof fetch;
 
     await withStore(async (store) => {
       const channel = await store.createChannel({
         name: "err",
-        description: "test"
+        description: "test",
       });
       await expect(
         mirrorLinearProject(channel.channelId, "proj", {
           store,
           apiKey: "k",
-          fetch: fetchImpl
+          fetch: fetchImpl,
         })
       ).rejects.toThrow(/HTTP 429/);
     });

--- a/test/integrations/plugin-env-mutex.test.ts
+++ b/test/integrations/plugin-env-mutex.test.ts
@@ -69,7 +69,11 @@ describe("withEnvOverride — serialization of concurrent overlays", () => {
     // Both callers look at process.env[KEY] before and after an await.
     // If the mutex is correct, each caller sees only its own value at both
     // observation points.
-    const observations: Array<{ who: "A" | "B"; before: string | undefined; after: string | undefined }> = [];
+    const observations: Array<{
+      who: "A" | "B";
+      before: string | undefined;
+      after: string | undefined;
+    }> = [];
 
     const callA = withEnvOverride({ [KEY]: "AAA" }, async () => {
       const before = process.env[KEY];
@@ -107,7 +111,7 @@ describe("withEnvOverride — serialization of concurrent overlays", () => {
           order.push(`start:${label}:${process.env[KEY]}`);
           await new Promise((r) => setTimeout(r, 5));
           order.push(`end:${label}:${process.env[KEY]}`);
-        }),
+        })
       );
     }
     await Promise.all(jobs);
@@ -137,7 +141,7 @@ describe("withEnvOverride — restore on throw", () => {
     await expect(
       withEnvOverride({ [KEY]: "OVERLAY" }, () => {
         throw new Error("boom");
-      }),
+      })
     ).rejects.toThrow("boom");
     expect(process.env[KEY]).toBe("PRIOR");
   });
@@ -148,7 +152,7 @@ describe("withEnvOverride — restore on throw", () => {
       withEnvOverride({ [KEY]: "OVERLAY" }, async () => {
         await new Promise((r) => setTimeout(r, 5));
         throw new Error("async boom");
-      }),
+      })
     ).rejects.toThrow("async boom");
     expect(process.env[KEY]).toBe("PRIOR");
   });
@@ -183,9 +187,7 @@ describe("withEnvOverride — recursion self-deadlock guard", () => {
       await withEnvOverride({ [KEY]: "INNER" }, () => process.env[KEY]);
     });
 
-    await expect(recursive).rejects.toThrow(
-      /recursive call detected/,
-    );
+    await expect(recursive).rejects.toThrow(/recursive call detected/);
     // Outer's finally must have run, restoring env.
     expect(process.env[KEY]).toBeUndefined();
   });

--- a/test/integrations/pr-poller.test.ts
+++ b/test/integrations/pr-poller.test.ts
@@ -9,7 +9,7 @@ import {
   PrPoller,
   type FollowUpDispatcher,
   type FollowUpRequest,
-  type TrackedPr
+  type TrackedPr,
 } from "../../src/integrations/pr-poller.js";
 import type { EnrichedPR, HarnessScm } from "../../src/integrations/scm.js";
 
@@ -20,9 +20,9 @@ function makeTracked(channelId: string): TrackedPr {
     pr: {
       number: 42,
       url: "https://github.com/acme/widgets/pull/42",
-      branch: "feat/42"
+      branch: "feat/42",
     },
-    repo: { owner: "acme", name: "widgets" }
+    repo: { owner: "acme", name: "widgets" },
   };
 }
 
@@ -30,7 +30,7 @@ function seed(state: Partial<EnrichedPR> = {}): EnrichedPR {
   return {
     ci: state.ci ?? "none",
     review: state.review ?? "pending",
-    prState: state.prState ?? "open"
+    prState: state.prState ?? "open",
   };
 }
 
@@ -49,7 +49,7 @@ function scriptedScm(series: Array<Map<string, EnrichedPR>>): HarnessScm {
       const next = series[Math.min(i, series.length - 1)];
       i += 1;
       return next;
-    })
+    }),
   } as unknown as HarnessScm;
 }
 
@@ -63,9 +63,7 @@ describe("PrPoller", () => {
         async () => "followup-id"
       );
       const scheduler: FollowUpDispatcher = { enqueueFollowUp };
-      const scm = scriptedScm([
-        new Map([["acme/widgets#42", seed({ ci: "passing" })]])
-      ]);
+      const scm = scriptedScm([new Map([["acme/widgets#42", seed({ ci: "passing" })]])]);
       const snapshots: Array<ReadonlyArray<unknown>> = [];
       const poller = new PrPoller({
         scm,
@@ -73,7 +71,7 @@ describe("PrPoller", () => {
         scheduler,
         onSnapshot: (rows) => {
           snapshots.push([...rows]);
-        }
+        },
       });
       poller.track(makeTracked(channel.channelId));
       expect(snapshots.length).toBeGreaterThanOrEqual(1);
@@ -106,7 +104,7 @@ describe("PrPoller", () => {
       const scheduler: FollowUpDispatcher = { enqueueFollowUp };
 
       const scm = scriptedScm([
-        new Map([["acme/widgets#42", seed({ ci: "none", review: "pending", prState: "open" })]])
+        new Map([["acme/widgets#42", seed({ ci: "none", review: "pending", prState: "open" })]]),
       ]);
       const poller = new PrPoller({ scm, channelStore: store, scheduler });
       poller.track(makeTracked(channel.channelId));
@@ -135,7 +133,7 @@ describe("PrPoller", () => {
 
       const scm = scriptedScm([
         new Map([["acme/widgets#42", seed({ ci: "none" })]]),
-        new Map([["acme/widgets#42", seed({ ci: "failing" })]])
+        new Map([["acme/widgets#42", seed({ ci: "failing" })]]),
       ]);
       const poller = new PrPoller({ scm, channelStore: store, scheduler });
       poller.track(makeTracked(channel.channelId));
@@ -179,7 +177,7 @@ describe("PrPoller", () => {
 
       const scm = scriptedScm([
         new Map([["acme/widgets#42", seed({ review: "pending" })]]),
-        new Map([["acme/widgets#42", seed({ review: "changes_requested" })]])
+        new Map([["acme/widgets#42", seed({ review: "changes_requested" })]]),
       ]);
       const poller = new PrPoller({ scm, channelStore: store, scheduler });
       poller.track(makeTracked(channel.channelId));
@@ -228,7 +226,7 @@ describe("PrPoller", () => {
         getCiSummary: vi.fn(),
         getReviewDecision: vi.fn(),
         getPendingComments: vi.fn(),
-        enrichBatch
+        enrichBatch,
       } as unknown as HarnessScm;
 
       const poller = new PrPoller({ scm, channelStore: store, scheduler });
@@ -268,7 +266,7 @@ describe("PrPoller", () => {
         getCiSummary: vi.fn(),
         getReviewDecision: vi.fn(),
         getPendingComments: vi.fn(),
-        enrichBatch
+        enrichBatch,
       } as unknown as HarnessScm;
 
       const intervalMs = 1_000;
@@ -310,7 +308,7 @@ describe("PrPoller", () => {
         new Map([["acme/widgets#42", seed({ prState: "open" })]]),
         new Map([["acme/widgets#42", seed({ prState: "merged" })]]),
         // third tick returns nothing new — if still tracked, poller would query
-        new Map([["acme/widgets#42", seed({ prState: "merged" })]])
+        new Map([["acme/widgets#42", seed({ prState: "merged" })]]),
       ]);
       const poller = new PrPoller({ scm, channelStore: store, scheduler });
       poller.track(makeTracked(channel.channelId));

--- a/test/integrations/scheduler-follow-up-dispatcher.test.ts
+++ b/test/integrations/scheduler-follow-up-dispatcher.test.ts
@@ -4,12 +4,9 @@ import type { HarnessRun } from "../../src/domain/run.js";
 import type { TicketDefinition } from "../../src/domain/ticket.js";
 import {
   SchedulerFollowUpDispatcher,
-  buildFollowUpTicketId
+  buildFollowUpTicketId,
 } from "../../src/integrations/scheduler-follow-up-dispatcher.js";
-import type {
-  FollowUpKind,
-  FollowUpRequest
-} from "../../src/integrations/pr-poller.js";
+import type { FollowUpKind, FollowUpRequest } from "../../src/integrations/pr-poller.js";
 
 function makeRun(): HarnessRun {
   const now = new Date().toISOString();
@@ -31,7 +28,7 @@ function makeRun(): HarnessRun {
     phaseLedgerPath: null,
     ticketLedger: [],
     ticketLedgerPath: null,
-    runIndexPath: null
+    runIndexPath: null,
   };
 }
 
@@ -44,30 +41,28 @@ function request(overrides: Partial<FollowUpRequest> = {}): FollowUpRequest {
     pr: overrides.pr ?? {
       number: 7,
       url: "https://github.com/acme/widgets/pull/7",
-      branch: "feat/7"
+      branch: "feat/7",
     },
     repo: overrides.repo ?? { owner: "acme", name: "widgets" },
     title: overrides.title ?? `${kind}: acme/widgets#7`,
-    prompt: overrides.prompt ?? "Investigate and fix the failing CI run."
+    prompt: overrides.prompt ?? "Investigate and fix the failing CI run.",
   };
 }
 
 describe("SchedulerFollowUpDispatcher", () => {
   it("synthesizes a ticket and forwards it to scheduler.enqueue", async () => {
     const run = makeRun();
-    const enqueue = vi.fn(
-      async (_r: HarnessRun, _t: TicketDefinition) => undefined
-    );
+    const enqueue = vi.fn(async (_r: HarnessRun, _t: TicketDefinition) => undefined);
     const dispatcher = new SchedulerFollowUpDispatcher({
       scheduler: { enqueue },
-      run
+      run,
     });
 
     const req = request({
       kind: "fix-ci",
       parentTicketId: "ticket_42",
       title: "fix-ci: acme/widgets#7",
-      prompt: "CI is failing; reproduce and push a fix to feat/7."
+      prompt: "CI is failing; reproduce and push a fix to feat/7.",
     });
 
     const ticketId = await dispatcher.enqueueFollowUp(req);
@@ -92,18 +87,16 @@ describe("SchedulerFollowUpDispatcher", () => {
 
   it("uses a distinct acceptance line for address-reviews follow-ups", async () => {
     const run = makeRun();
-    const enqueue = vi.fn(
-      async (_r: HarnessRun, _t: TicketDefinition) => undefined
-    );
+    const enqueue = vi.fn(async (_r: HarnessRun, _t: TicketDefinition) => undefined);
     const dispatcher = new SchedulerFollowUpDispatcher({
       scheduler: { enqueue },
-      run
+      run,
     });
 
     const req = request({
       kind: "address-reviews",
       parentTicketId: "ticket_99",
-      title: "address-reviews: acme/widgets#7"
+      title: "address-reviews: acme/widgets#7",
     });
 
     await dispatcher.enqueueFollowUp(req);
@@ -111,21 +104,13 @@ describe("SchedulerFollowUpDispatcher", () => {
     const [, ticket] = enqueue.mock.calls[0]!;
     expect(ticket.id).toBe(buildFollowUpTicketId(req));
     expect(ticket.id).toContain("address-reviews");
-    expect(ticket.acceptanceCriteria.join(" ").toLowerCase()).toContain(
-      "comments"
-    );
+    expect(ticket.acceptanceCriteria.join(" ").toLowerCase()).toContain("comments");
   });
 
   it("produces stable ids per (parentTicketId, kind) pair", () => {
-    const a = buildFollowUpTicketId(
-      request({ kind: "fix-ci", parentTicketId: "x" })
-    );
-    const b = buildFollowUpTicketId(
-      request({ kind: "fix-ci", parentTicketId: "x" })
-    );
-    const c = buildFollowUpTicketId(
-      request({ kind: "address-reviews", parentTicketId: "x" })
-    );
+    const a = buildFollowUpTicketId(request({ kind: "fix-ci", parentTicketId: "x" }));
+    const b = buildFollowUpTicketId(request({ kind: "fix-ci", parentTicketId: "x" }));
+    const c = buildFollowUpTicketId(request({ kind: "address-reviews", parentTicketId: "x" }));
     expect(a).toBe(b);
     expect(a).not.toBe(c);
   });

--- a/test/integrations/scm.test.ts
+++ b/test/integrations/scm.test.ts
@@ -6,7 +6,7 @@ function makePr(overrides: Partial<HarnessPR> = {}): HarnessPR {
   return {
     number: overrides.number ?? 7,
     url: overrides.url ?? "https://github.com/acme/widgets/pull/7",
-    branch: overrides.branch ?? "feat/seven"
+    branch: overrides.branch ?? "feat/seven",
   };
 }
 
@@ -14,7 +14,7 @@ const projectDescriptor = {
   owner: "acme",
   name: "widgets",
   path: "/tmp/repo",
-  defaultBranch: "main"
+  defaultBranch: "main",
 };
 
 describe("wrapScm — facade delegation", () => {
@@ -27,7 +27,7 @@ describe("wrapScm — facade delegation", () => {
       owner: "acme",
       repo: "widgets",
       baseBranch: "main",
-      isDraft: false
+      isDraft: false,
     }));
 
     const scm = { name: "gh", detectPR } as any;
@@ -38,12 +38,11 @@ describe("wrapScm — facade delegation", () => {
     expect(res).toEqual({
       number: 7,
       url: "https://github.com/acme/widgets/pull/7",
-      branch: "feat/seven"
+      branch: "feat/seven",
     });
-    const firstCall = detectPR.mock.calls[0] as unknown as [
-      { branch: string },
-      unknown
-    ] | undefined;
+    const firstCall = detectPR.mock.calls[0] as unknown as
+      | [{ branch: string }, unknown]
+      | undefined;
     expect(firstCall).toBeDefined();
     expect(firstCall![0].branch).toBe("feat/seven");
   });
@@ -62,9 +61,9 @@ describe("wrapScm — facade delegation", () => {
           line: 10,
           isResolved: false,
           createdAt: new Date(),
-          url: "https://github.com/acme/widgets/pull/7#c1"
-        }
-      ])
+          url: "https://github.com/acme/widgets/pull/7#c1",
+        },
+      ]),
     } as any;
 
     const wrapped = wrapScm(scm, projectDescriptor);
@@ -75,13 +74,13 @@ describe("wrapScm — facade delegation", () => {
 
     const comments = await wrapped.getPendingComments(pr);
     expect(comments).toEqual([
-      { id: "c1", author: "alice", body: "nit: rename", path: "src/a.ts", line: 10 }
+      { id: "c1", author: "alice", body: "nit: rename", path: "src/a.ts", line: 10 },
     ]);
 
     expect(scm.getCISummary).toHaveBeenCalledTimes(1);
-    const ciCall = scm.getCISummary.mock.calls[0] as unknown as [
-      { number: number; owner: string; repo: string }
-    ] | undefined;
+    const ciCall = scm.getCISummary.mock.calls[0] as unknown as
+      | [{ number: number; owner: string; repo: string }]
+      | undefined;
     expect(ciCall).toBeDefined();
     expect(ciCall![0].number).toBe(7);
     expect(ciCall![0].owner).toBe("acme");
@@ -91,23 +90,24 @@ describe("wrapScm — facade delegation", () => {
   it("enrichBatch prefers scm.enrichSessionsPRBatch when available", async () => {
     const scm = {
       name: "gh",
-      enrichSessionsPRBatch: vi.fn(async () =>
-        new Map([
-          [
-            "acme/widgets#7",
-            {
-              state: "open" as const,
-              ciStatus: "passing" as const,
-              reviewDecision: "approved" as const,
-              mergeable: true
-            }
-          ]
-        ])
+      enrichSessionsPRBatch: vi.fn(
+        async () =>
+          new Map([
+            [
+              "acme/widgets#7",
+              {
+                state: "open" as const,
+                ciStatus: "passing" as const,
+                reviewDecision: "approved" as const,
+                mergeable: true,
+              },
+            ],
+          ])
       ),
       // Fallback methods should NOT be called when the batch method exists.
       getPRState: vi.fn(),
       getCISummary: vi.fn(),
-      getReviewDecision: vi.fn()
+      getReviewDecision: vi.fn(),
     } as any;
 
     const wrapped = wrapScm(scm, projectDescriptor);
@@ -121,7 +121,7 @@ describe("wrapScm — facade delegation", () => {
     expect(result.get("acme/widgets#7")).toEqual({
       ci: "passing",
       review: "approved",
-      prState: "open"
+      prState: "open",
     });
   });
 });
@@ -136,7 +136,7 @@ describe("wrapScm — detectPR cross-repo routing", () => {
       owner: "a",
       name: "alpha",
       path: "/tmp/alpha",
-      defaultBranch: "main"
+      defaultBranch: "main",
     });
 
     // Call detectPR with a different repo (b/beta).
@@ -145,7 +145,7 @@ describe("wrapScm — detectPR cross-repo routing", () => {
     expect(detectPR).toHaveBeenCalledTimes(1);
     const call = detectPR.mock.calls[0] as unknown as [
       unknown,
-      { name: string; repo: string; path: string; defaultBranch: string; sessionPrefix: string }
+      { name: string; repo: string; path: string; defaultBranch: string; sessionPrefix: string },
     ];
     const projectArg = call[1];
 
@@ -165,15 +165,12 @@ describe("wrapScm — detectPR cross-repo routing", () => {
       owner: "a",
       name: "alpha",
       path: "/tmp/alpha",
-      defaultBranch: "main"
+      defaultBranch: "main",
     });
 
     await wrapped.detectPR("feat/x", { owner: "a", name: "alpha" });
 
-    const call = detectPR.mock.calls[0] as unknown as [
-      unknown,
-      { repo: string }
-    ];
+    const call = detectPR.mock.calls[0] as unknown as [unknown, { repo: string }];
     expect(call[1].repo).toBe("a/alpha");
   });
 });
@@ -185,13 +182,13 @@ describe("wrapScm — enrichBatch fallback", () => {
       // no enrichSessionsPRBatch defined
       getPRState: vi.fn(async () => "open" as const),
       getCISummary: vi.fn(async () => "failing" as const),
-      getReviewDecision: vi.fn(async () => "pending" as const)
+      getReviewDecision: vi.fn(async () => "pending" as const),
     } as any;
 
     const wrapped = wrapScm(scm, projectDescriptor);
     const prs = [
       makePr({ number: 1, url: "u1", branch: "b1" }),
-      makePr({ number: 2, url: "u2", branch: "b2" })
+      makePr({ number: 2, url: "u2", branch: "b2" }),
     ];
     const result = await wrapped.enrichBatch(prs);
 
@@ -199,12 +196,12 @@ describe("wrapScm — enrichBatch fallback", () => {
     expect(result.get("acme/widgets#1")).toEqual({
       prState: "open",
       ci: "failing",
-      review: "pending"
+      review: "pending",
     });
     expect(result.get("acme/widgets#2")).toEqual({
       prState: "open",
       ci: "failing",
-      review: "pending"
+      review: "pending",
     });
 
     // Per-PR calls: 2 PRs × 3 methods

--- a/test/integrations/tracker.test.ts
+++ b/test/integrations/tracker.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  createTracker,
-  detectTrackerKind,
-  resolveIssue
-} from "../../src/integrations/tracker.js";
+import { createTracker, detectTrackerKind, resolveIssue } from "../../src/integrations/tracker.js";
 
 // Mock the AO GitHub tracker so its `create()` throws when invoked. We use
 // plain `vi.mock` here — no seam in tracker.ts was needed, since tracker.ts
@@ -16,12 +12,12 @@ vi.mock("@aoagents/ao-plugin-tracker-github", () => ({
       name: "tracker-github",
       slot: "tracker" as const,
       description: "mocked",
-      version: "0.0.0-test"
+      version: "0.0.0-test",
     },
     create: () => {
       throw new Error("boom from mocked plugin create()");
-    }
-  }
+    },
+  },
 }));
 
 describe("detectTrackerKind", () => {
@@ -29,38 +25,38 @@ describe("detectTrackerKind", () => {
     {
       input: "https://github.com/acme/widgets/issues/42",
       expected: "github",
-      why: "GitHub issue URL"
+      why: "GitHub issue URL",
     },
     {
       input: "https://linear.app/acme/issue/ABC-123/some-title",
       expected: "linear",
-      why: "Linear issue URL"
+      why: "Linear issue URL",
     },
     {
       input: "ABC-123",
       expected: "linear",
-      why: "bare Linear identifier"
+      why: "bare Linear identifier",
     },
     {
       input: "build me a new auth system",
       expected: null,
-      why: "plain text"
+      why: "plain text",
     },
     {
       input: "",
       expected: null,
-      why: "empty string"
+      why: "empty string",
     },
     {
       input: "   ",
       expected: null,
-      why: "whitespace only"
+      why: "whitespace only",
     },
     {
       input: "https://github.com/acme/widgets/pull/42",
       expected: null,
-      why: "GitHub PR URL, not an issue"
-    }
+      why: "GitHub PR URL, not an issue",
+    },
   ];
 
   for (const { input, expected, why } of cases) {
@@ -79,7 +75,7 @@ describe("resolveIssue", () => {
       url: "https://github.com/acme/widgets/issues/42",
       state: "open",
       labels: ["bug", "p1"],
-      branchName: "issue/42-fix-the-thing"
+      branchName: "issue/42-fix-the-thing",
     };
 
     const tracker = {
@@ -88,7 +84,7 @@ describe("resolveIssue", () => {
       isCompleted: async () => false,
       issueUrl: () => fakeIssue.url,
       branchName: () => "fallback-should-not-be-used",
-      generatePrompt: async () => "prompt"
+      generatePrompt: async () => "prompt",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -97,7 +93,7 @@ describe("resolveIssue", () => {
       repo: "acme/widgets",
       path: "/tmp",
       defaultBranch: "main",
-      sessionPrefix: "widgets"
+      sessionPrefix: "widgets",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -109,7 +105,7 @@ describe("resolveIssue", () => {
       body: "Body text describes the bug.",
       url: "https://github.com/acme/widgets/issues/42",
       labels: ["bug", "p1"],
-      branchName: "issue/42-fix-the-thing"
+      branchName: "issue/42-fix-the-thing",
     });
   });
 
@@ -120,7 +116,7 @@ describe("resolveIssue", () => {
       description: "No branch on issue.",
       url: "https://linear.app/acme/issue/ABC-123",
       state: "open",
-      labels: []
+      labels: [],
       // no branchName
     };
 
@@ -134,7 +130,7 @@ describe("resolveIssue", () => {
         branchNameCalledWith = { identifier };
         return "abc-123-another";
       },
-      generatePrompt: async () => "prompt"
+      generatePrompt: async () => "prompt",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -143,7 +139,7 @@ describe("resolveIssue", () => {
       repo: "ws/proj",
       path: "/tmp",
       defaultBranch: "main",
-      sessionPrefix: "proj"
+      sessionPrefix: "proj",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -162,7 +158,7 @@ describe("resolveIssue", () => {
       description: "",
       url: "https://github.com/acme/widgets/issues/7",
       state: "open",
-      branchName: "issue/7"
+      branchName: "issue/7",
       // labels omitted
     };
 
@@ -172,7 +168,7 @@ describe("resolveIssue", () => {
       isCompleted: async () => false,
       issueUrl: () => fakeIssue.url,
       branchName: () => "ignored",
-      generatePrompt: async () => "p"
+      generatePrompt: async () => "p",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -181,7 +177,7 @@ describe("resolveIssue", () => {
       repo: "acme/widgets",
       path: "/tmp",
       defaultBranch: "main",
-      sessionPrefix: "widgets"
+      sessionPrefix: "widgets",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -201,9 +197,9 @@ describe("createTracker — env restoration when plugin create() throws", () => 
       expect(process.env.GITHUB_TOKEN).toBeUndefined();
       expect("GITHUB_TOKEN" in process.env).toBe(false);
 
-      await expect(
-        createTracker("github", { token: "throwaway" })
-      ).rejects.toThrow(/boom from mocked plugin create\(\)/);
+      await expect(createTracker("github", { token: "throwaway" })).rejects.toThrow(
+        /boom from mocked plugin create\(\)/
+      );
 
       // After the throw propagates, the env var must be gone again — matching
       // its prior undefined / absent state, not a lingering "throwaway".
@@ -220,9 +216,9 @@ describe("createTracker — env restoration when plugin create() throws", () => 
     process.env.GITHUB_TOKEN = "original-token";
 
     try {
-      await expect(
-        createTracker("github", { token: "throwaway" })
-      ).rejects.toThrow(/boom from mocked plugin create\(\)/);
+      await expect(createTracker("github", { token: "throwaway" })).rejects.toThrow(
+        /boom from mocked plugin create\(\)/
+      );
 
       expect(process.env.GITHUB_TOKEN).toBe("original-token");
     } finally {

--- a/test/mcp/http-transport.test.ts
+++ b/test/mcp/http-transport.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   BodyTooLargeError,
   compareTokens,
-  startHttpMcpServer
+  startHttpMcpServer,
 } from "../../src/mcp/http-transport.js";
 import type { JsonRpcMessage, McpMessageHandler } from "../../src/mcp/server.js";
 
@@ -21,14 +21,14 @@ function stubHandler(): { handler: McpMessageHandler; cleanup: () => void } {
         result: {
           protocolVersion: "2024-11-05",
           capabilities: { tools: {} },
-          serverInfo: { name: "relay-test", version: "0.0.0" }
-        }
+          serverInfo: { name: "relay-test", version: "0.0.0" },
+        },
       };
     }
     return {
       jsonrpc: "2.0",
       id: message.id ?? null,
-      error: { code: -32601, message: `Method not found: ${message.method}` }
+      error: { code: -32601, message: `Method not found: ${message.method}` },
     };
   };
   return { handler, cleanup: () => {} };
@@ -55,7 +55,7 @@ async function openSse(
     return {
       response,
       readFrame: async () => null,
-      close: () => controller.abort()
+      close: () => controller.abort(),
     };
   }
 
@@ -95,7 +95,7 @@ async function openSse(
       } finally {
         controller.abort();
       }
-    }
+    },
   };
 }
 
@@ -132,8 +132,8 @@ describe("startHttpMcpServer", () => {
         jsonrpc: "2.0",
         id: 1,
         method: "initialize",
-        params: {}
-      })
+        params: {},
+      }),
     });
     expect(postRes.status).toBe(202);
     // Drain the body so fetch/undici doesn't leak the socket into the next tick.
@@ -143,7 +143,9 @@ describe("startHttpMcpServer", () => {
     expect(messageFrame?.event).toBe("message");
     const payload = JSON.parse(messageFrame?.data ?? "{}") as JsonRpcMessage;
     expect(payload.id).toBe(1);
-    expect((payload.result as { serverInfo?: { name?: string } })?.serverInfo?.name).toBe("relay-test");
+    expect((payload.result as { serverInfo?: { name?: string } })?.serverInfo?.name).toBe(
+      "relay-test"
+    );
 
     sse.close();
   });
@@ -151,7 +153,7 @@ describe("startHttpMcpServer", () => {
   it("rejects /sse when the auth token is missing", async () => {
     handle = await startHttpMcpServer(async () => stubHandler(), {
       port: 0,
-      authToken: "secret"
+      authToken: "secret",
     });
 
     const response = await fetch(handle.url);
@@ -162,11 +164,11 @@ describe("startHttpMcpServer", () => {
   it("rejects /sse when the auth token is wrong", async () => {
     handle = await startHttpMcpServer(async () => stubHandler(), {
       port: 0,
-      authToken: "secret"
+      authToken: "secret",
     });
 
     const response = await fetch(handle.url, {
-      headers: { Authorization: "Bearer wrong" }
+      headers: { Authorization: "Bearer wrong" },
     });
     expect(response.status).toBe(401);
     await response.text();
@@ -175,7 +177,7 @@ describe("startHttpMcpServer", () => {
   it("accepts /sse with the correct bearer token", async () => {
     handle = await startHttpMcpServer(async () => stubHandler(), {
       port: 0,
-      authToken: "secret"
+      authToken: "secret",
     });
 
     const sse = await openSse(handle.url, "secret");
@@ -204,7 +206,7 @@ describe("startHttpMcpServer", () => {
     const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: "{not valid json,"
+      body: "{not valid json,",
     });
     expect(postRes.status).toBe(400);
     const body = (await postRes.json()) as { error?: string; error_detail?: string };
@@ -228,7 +230,7 @@ describe("startHttpMcpServer", () => {
     const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "foo", params: { blob: oversized } })
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "foo", params: { blob: oversized } }),
     });
     expect(postRes.status).toBe(413);
     const body = (await postRes.json()) as { error?: string; error_detail?: string };
@@ -250,7 +252,7 @@ describe("startHttpMcpServer", () => {
       return {
         jsonrpc: "2.0",
         id: message.id ?? null,
-        result: { ok: true }
+        result: { ok: true },
       };
     };
 
@@ -261,10 +263,7 @@ describe("startHttpMcpServer", () => {
     process.on("unhandledRejection", onRejection);
 
     try {
-      handle = await startHttpMcpServer(
-        async () => ({ handler, cleanup: () => {} }),
-        { port: 0 }
-      );
+      handle = await startHttpMcpServer(async () => ({ handler, cleanup: () => {} }), { port: 0 });
 
       const sse = await openSse(handle.url);
       const endpointFrame = await sse.readFrame();
@@ -273,7 +272,7 @@ describe("startHttpMcpServer", () => {
       const postRes = await fetch(`http://${handle.host}:${handle.port}${messagePath}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 42, method: "slow", params: {} })
+        body: JSON.stringify({ jsonrpc: "2.0", id: 42, method: "slow", params: {} }),
       });
       expect(postRes.status).toBe(202);
       await postRes.text();

--- a/test/mcp/serve-validation.test.ts
+++ b/test/mcp/serve-validation.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  isLoopbackHost,
-  validateServeOptions
-} from "../../src/mcp/serve-validation.js";
+import { isLoopbackHost, validateServeOptions } from "../../src/mcp/serve-validation.js";
 
 /**
  * OSS-03: `rly serve` must hard-stop when asked to bind non-loopback
@@ -40,7 +37,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "0.0.0.0",
       token: undefined,
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
 
     expect(result.kind).toBe("error");
@@ -54,7 +51,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "192.168.1.10",
       token: undefined,
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
 
     expect(result.kind).toBe("error");
@@ -67,7 +64,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "0.0.0.0",
       token: "s3cret",
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
 
     expect(result.kind).toBe("ok");
@@ -80,7 +77,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "0.0.0.0",
       token: undefined,
-      allowUnauthenticatedRemote: true
+      allowUnauthenticatedRemote: true,
     });
 
     expect(result.kind).toBe("ok");
@@ -98,7 +95,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "127.0.0.1",
       token: undefined,
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
 
     expect(result.kind).toBe("ok");
@@ -114,7 +111,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "127.0.0.1",
       token: "s3cret",
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
 
     expect(result.kind).toBe("ok");
@@ -127,7 +124,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "::1",
       token: undefined,
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
     expect(result.kind).toBe("ok");
   });
@@ -140,7 +137,7 @@ describe("validateServeOptions", () => {
     const result = validateServeOptions({
       host: "localhost",
       token: undefined,
-      allowUnauthenticatedRemote: false
+      allowUnauthenticatedRemote: false,
     });
 
     expect(result.kind).toBe("error");

--- a/test/orchestrator-v2.test.ts
+++ b/test/orchestrator-v2.test.ts
@@ -31,7 +31,7 @@ function buildOrchestrator(
   const registry = new AgentRegistry();
   const agents = createLiveAgents({
     cwd,
-    invoker: new ScriptedInvoker(cwd)
+    invoker: new ScriptedInvoker(cwd),
   });
 
   for (const agent of agents) {
@@ -42,10 +42,7 @@ function buildOrchestrator(
     artifactsDir,
     new FileHarnessStore(join(artifactsDir, "__hs__"))
   );
-  const verificationRunner = new VerificationRunner(
-    new NodeCommandInvoker(),
-    artifactStore
-  );
+  const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
 
   return new OrchestratorV2(
     registry,
@@ -144,9 +141,9 @@ describe("OrchestratorV2 integration", () => {
 
     try {
       const artifactStore = new LocalArtifactStore(
-    artifactsDir,
-    new FileHarnessStore(join(artifactsDir, "__hs__"))
-  );
+        artifactsDir,
+        new FileHarnessStore(join(artifactsDir, "__hs__"))
+      );
       const orchestrator = buildOrchestrator(tmpDir, artifactsDir);
       const run = await orchestrator.run("Fix typo in README");
 
@@ -177,7 +174,7 @@ describe("OrchestratorV2 integration", () => {
       const channelStore = new ChannelStore(channelsDir);
       const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
         channelStore,
-        workspaceId: "ws-test"
+        workspaceId: "ws-test",
       });
       const run = await orchestrator.run(
         "Implement a new authentication system with JWT tokens and session management"
@@ -206,7 +203,7 @@ describe("OrchestratorV2 integration", () => {
       const channelStore = new ChannelStore(channelsDir);
       const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
         channelStore,
-        workspaceId: "ws-test"
+        workspaceId: "ws-test",
       });
       const run = await orchestrator.run("Fix typo in README");
 
@@ -235,7 +232,7 @@ describe("OrchestratorV2 integration", () => {
 
       const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
         channelStore,
-        workspaceId: "ws-test"
+        workspaceId: "ws-test",
       });
       const run = await orchestrator.run(
         "Implement a new authentication system with JWT tokens and session management"

--- a/test/orchestrator/dispatch-error-surface.test.ts
+++ b/test/orchestrator/dispatch-error-surface.test.ts
@@ -13,13 +13,13 @@ runRejection.stack = [
   "    at frame 1",
   "    at frame 2",
   "    at frame 3",
-  "    at frame 4"
+  "    at frame 4",
 ].join("\n");
 
 vi.mock("../../src/orchestrator/orchestrator-v2.js", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../src/orchestrator/orchestrator-v2.js")
-  >("../../src/orchestrator/orchestrator-v2.js");
+  const actual = await vi.importActual<typeof import("../../src/orchestrator/orchestrator-v2.js")>(
+    "../../src/orchestrator/orchestrator-v2.js"
+  );
   class MockOrchestratorV2 {
     attachPoller(): void {
       /* no-op */
@@ -30,7 +30,7 @@ vi.mock("../../src/orchestrator/orchestrator-v2.js", async () => {
   }
   return {
     ...actual,
-    OrchestratorV2: MockOrchestratorV2
+    OrchestratorV2: MockOrchestratorV2,
   };
 });
 
@@ -39,7 +39,7 @@ vi.mock("../../src/agents/factory.js", () => ({
   createLiveAgents: () => [],
   registerAgentNames: async () => {
     /* no-op */
-  }
+  },
 }));
 
 // Pin the storage factory to a tmp-backed FileHarnessStore so dispatch's call
@@ -52,7 +52,7 @@ vi.mock("../../src/storage/factory.js", async () => {
   const store = new FileHarnessStore(root);
   return {
     getHarnessStore: () => store,
-    buildHarnessStore: () => store
+    buildHarnessStore: () => store,
   };
 });
 
@@ -88,7 +88,7 @@ describe("dispatch surfaces fire-and-forget orchestrator errors", () => {
 
     const result = await dispatch({
       featureRequest: "Test feature",
-      repoPath: "/irrelevant/repo"
+      repoPath: "/irrelevant/repo",
     });
 
     expect(result.status).toBe("dispatched");

--- a/test/orchestrator/ticket-scheduler-enqueue.test.ts
+++ b/test/orchestrator/ticket-scheduler-enqueue.test.ts
@@ -7,15 +7,12 @@ import { describe, expect, it } from "vitest";
 import { NodeCommandInvoker } from "../../src/agents/command-invoker.js";
 import { createLiveAgents } from "../../src/agents/factory.js";
 import { AgentRegistry } from "../../src/agents/registry.js";
-import type {
-  AgentResult,
-  WorkRequest
-} from "../../src/domain/agent.js";
+import type { AgentResult, WorkRequest } from "../../src/domain/agent.js";
 import type { HarnessRun, RunEventType } from "../../src/domain/run.js";
 import {
   initializeTicketLedger,
   parseTicketPlan,
-  type TicketDefinition
+  type TicketDefinition,
 } from "../../src/domain/ticket.js";
 import { ChannelStore } from "../../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
@@ -37,7 +34,7 @@ function ticket(id: string, title = `Ticket ${id}`): TicketDefinition {
     verificationCommands: [],
     docsToUpdate: [],
     dependsOn: [],
-    retryPolicy: { ...RETRY_POLICY }
+    retryPolicy: { ...RETRY_POLICY },
   };
 }
 
@@ -48,7 +45,7 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
     task: {
       title: "Test run",
       featureRequest: "Test feature",
-      repoRoot
+      repoRoot,
     },
     classification: {
       tier: "feature_small",
@@ -56,11 +53,11 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
       suggestedSpecialties: ["general"],
       estimatedTicketCount: tickets.length,
       needsDesignDoc: false,
-      needsUserApproval: false
+      needsUserApproval: false,
     },
     tickets,
     finalVerification: { commands: [] },
-    docsToUpdate: []
+    docsToUpdate: [],
   });
 
   return {
@@ -81,7 +78,7 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
     phaseLedgerPath: null,
     ticketLedger: initializeTicketLedger(tickets),
     ticketLedgerPath: null,
-    runIndexPath: null
+    runIndexPath: null,
   };
 }
 
@@ -92,10 +89,7 @@ interface RecordedEvent {
 }
 
 interface BuildSchedulerOptions {
-  dispatchOverride?: (
-    run: HarnessRun,
-    req: Omit<WorkRequest, "runId">
-  ) => Promise<AgentResult>;
+  dispatchOverride?: (run: HarnessRun, req: Omit<WorkRequest, "runId">) => Promise<AgentResult>;
   onRecordEvent?: (event: RecordedEvent) => void;
   channelStore?: ChannelStore;
 }
@@ -105,14 +99,11 @@ interface BuildSchedulerOptions {
  * commands are proposed, so the built-in verification pass sees an empty
  * command list and trivially succeeds.
  */
-async function buildScheduler(
-  repoRoot: string,
-  options: BuildSchedulerOptions = {}
-) {
+async function buildScheduler(repoRoot: string, options: BuildSchedulerOptions = {}) {
   const registry = new AgentRegistry();
   for (const agent of createLiveAgents({
     cwd: repoRoot,
-    invoker: new ScriptedInvoker(repoRoot)
+    invoker: new ScriptedInvoker(repoRoot),
   })) {
     registry.register(agent);
   }
@@ -121,10 +112,7 @@ async function buildScheduler(
     join(repoRoot, "artifacts"),
     new FileHarnessStore(join(repoRoot, "__hs__"))
   );
-  const verificationRunner = new VerificationRunner(
-    new NodeCommandInvoker(),
-    artifactStore
-  );
+  const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
 
   const dispatched: WorkRequest[] = [];
   const events: RecordedEvent[] = [];
@@ -138,15 +126,12 @@ async function buildScheduler(
       summary: `ok:${req.kind}`,
       evidence: [],
       proposedCommands: [],
-      blockers: []
+      blockers: [],
     };
   };
 
   const dispatch = options.dispatchOverride
-    ? async (
-        run: HarnessRun,
-        req: Omit<WorkRequest, "runId">
-      ): Promise<AgentResult> => {
+    ? async (run: HarnessRun, req: Omit<WorkRequest, "runId">): Promise<AgentResult> => {
         dispatched.push({ runId: "run-test", ...req });
         return options.dispatchOverride!(run, req);
       }
@@ -194,10 +179,7 @@ describe("TicketScheduler.enqueue", () => {
       expect(ids).toEqual(["t_initial", "t_followup"]);
 
       // And in the ticket plan so snapshots see it.
-      expect(run.ticketPlan!.tickets.map((t) => t.id)).toEqual([
-        "t_initial",
-        "t_followup"
-      ]);
+      expect(run.ticketPlan!.tickets.map((t) => t.id)).toEqual(["t_initial", "t_followup"]);
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }
@@ -268,7 +250,7 @@ describe("TicketScheduler.enqueue", () => {
           if (ev.type === "TicketStarted" && ev.phaseId === "t_poison") {
             throw new Error("boom: synthetic drain failure");
           }
-        }
+        },
       });
 
       // Pre-seed the run via executeAll so the scheduler is idle when the
@@ -296,17 +278,11 @@ describe("TicketScheduler.enqueue", () => {
       // sentinel phaseId, or a console.warn with the scheduler prefix. The
       // production code emits both, but we accept either so the test doesn't
       // pin a specific implementation detail beyond visibility.
-      const tailEvent = events.find(
-        (e) => e.phaseId === "__scheduler_tail__"
-      );
-      const tailWarn = warnCalls.find((w) =>
-        w.includes("[scheduler] tail drain failed")
-      );
+      const tailEvent = events.find((e) => e.phaseId === "__scheduler_tail__");
+      const tailWarn = warnCalls.find((w) => w.includes("[scheduler] tail drain failed"));
       expect(tailEvent || tailWarn).toBeTruthy();
       if (tailEvent) {
-        expect(tailEvent.details.error).toContain(
-          "boom: synthetic drain failure"
-        );
+        expect(tailEvent.details.error).toContain("boom: synthetic drain failure");
       }
       if (tailWarn) {
         expect(tailWarn).toContain("boom: synthetic drain failure");
@@ -369,7 +345,7 @@ describe("TicketScheduler channel board mirror", () => {
       const channelStore = new ChannelStore(join(tmp, "channels"));
       const channel = await channelStore.createChannel({
         name: "#mirror",
-        description: "mirror test"
+        description: "mirror test",
       });
 
       const run = buildRun(tmp, [ticket("t_a"), ticket("t_b")]);
@@ -401,7 +377,7 @@ describe("TicketScheduler channel board mirror", () => {
       const channelStore = new ChannelStore(join(tmp, "channels"));
       const channel = await channelStore.createChannel({
         name: "#mirror-fail",
-        description: "mirror failure test"
+        description: "mirror failure test",
       });
       channelStore.upsertChannelTickets = async () => {
         throw new Error("simulated mirror failure");
@@ -420,9 +396,7 @@ describe("TicketScheduler channel board mirror", () => {
       const mirrorWarn = warnCalls.find((w) =>
         w.includes("[scheduler] channel board mirror failed")
       );
-      const mirrorEvent = events.find(
-        (e) => e.phaseId === "__channel_mirror__"
-      );
+      const mirrorEvent = events.find((e) => e.phaseId === "__channel_mirror__");
       expect(mirrorWarn || mirrorEvent).toBeTruthy();
     } finally {
       console.warn = originalWarn;
@@ -436,7 +410,7 @@ describe("TicketScheduler channel board mirror", () => {
       const channelStore = new ChannelStore(join(tmp, "channels"));
       const channel = await channelStore.createChannel({
         name: "#concurrent",
-        description: "concurrency test"
+        description: "concurrency test",
       });
 
       // Two disjoint upserts fired at once. If upsert read-modified-wrote
@@ -447,7 +421,7 @@ describe("TicketScheduler channel board mirror", () => {
 
       await Promise.all([
         channelStore.upsertChannelTickets(channel.channelId, [a]),
-        channelStore.upsertChannelTickets(channel.channelId, [b])
+        channelStore.upsertChannelTickets(channel.channelId, [b]),
       ]);
 
       const board = await channelStore.readChannelTickets(channel.channelId);

--- a/test/orchestrator/ticket-scheduler-executor.test.ts
+++ b/test/orchestrator/ticket-scheduler-executor.test.ts
@@ -7,15 +7,12 @@ import { describe, expect, it } from "vitest";
 import { NodeCommandInvoker } from "../../src/agents/command-invoker.js";
 import { createLiveAgents } from "../../src/agents/factory.js";
 import { AgentRegistry } from "../../src/agents/registry.js";
-import type {
-  AgentResult,
-  WorkRequest
-} from "../../src/domain/agent.js";
+import type { AgentResult, WorkRequest } from "../../src/domain/agent.js";
 import type { HarnessRun, RunEventType } from "../../src/domain/run.js";
 import {
   initializeTicketLedger,
   parseTicketPlan,
-  type TicketDefinition
+  type TicketDefinition,
 } from "../../src/domain/ticket.js";
 import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../../src/storage/file-store.js";
@@ -36,7 +33,7 @@ function ticket(id: string): TicketDefinition {
     verificationCommands: [],
     docsToUpdate: [],
     dependsOn: [],
-    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 }
+    retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
   };
 }
 
@@ -47,7 +44,7 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
     task: {
       title: "Test run",
       featureRequest: "Test feature",
-      repoRoot
+      repoRoot,
     },
     classification: {
       tier: "feature_small",
@@ -55,11 +52,11 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
       suggestedSpecialties: ["general"],
       estimatedTicketCount: tickets.length,
       needsDesignDoc: false,
-      needsUserApproval: false
+      needsUserApproval: false,
     },
     tickets,
     finalVerification: { commands: [] },
-    docsToUpdate: []
+    docsToUpdate: [],
   });
 
   return {
@@ -80,7 +77,7 @@ function buildRun(repoRoot: string, tickets: TicketDefinition[]): HarnessRun {
     phaseLedgerPath: null,
     ticketLedger: initializeTicketLedger(tickets),
     ticketLedgerPath: null,
-    runIndexPath: null
+    runIndexPath: null,
   };
 }
 
@@ -88,7 +85,7 @@ async function buildBasics(repoRoot: string) {
   const registry = new AgentRegistry();
   for (const agent of createLiveAgents({
     cwd: repoRoot,
-    invoker: new ScriptedInvoker(repoRoot)
+    invoker: new ScriptedInvoker(repoRoot),
   })) {
     registry.register(agent);
   }
@@ -97,10 +94,7 @@ async function buildBasics(repoRoot: string) {
     join(repoRoot, "artifacts"),
     new FileHarnessStore(join(repoRoot, "__hs__"))
   );
-  const verificationRunner = new VerificationRunner(
-    new NodeCommandInvoker(),
-    artifactStore
-  );
+  const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
   return { registry, artifactStore, verificationRunner };
 }
 
@@ -108,18 +102,9 @@ describe("TicketScheduler + executor wiring", () => {
   it("throws when neither dispatch nor executor is supplied", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "ts-exec-none-"));
     try {
-      const { registry, artifactStore, verificationRunner } =
-        await buildBasics(tmp);
+      const { registry, artifactStore, verificationRunner } = await buildBasics(tmp);
       expect(
-        () =>
-          new TicketScheduler(
-            tmp,
-            artifactStore,
-            verificationRunner,
-            registry,
-            null,
-            () => {}
-          )
+        () => new TicketScheduler(tmp, artifactStore, verificationRunner, registry, null, () => {})
       ).toThrow(/either a dispatch callback or options.executor/);
     } finally {
       await rm(tmp, { recursive: true, force: true });
@@ -129,13 +114,12 @@ describe("TicketScheduler + executor wiring", () => {
   it("throws when both dispatch and executor are supplied", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "ts-exec-both-"));
     try {
-      const { registry, artifactStore, verificationRunner } =
-        await buildBasics(tmp);
+      const { registry, artifactStore, verificationRunner } = await buildBasics(tmp);
       const dispatch = async (): Promise<AgentResult> => ({
         summary: "ok",
         evidence: [],
         proposedCommands: [],
-        blockers: []
+        blockers: [],
       });
       expect(
         () =>
@@ -157,8 +141,7 @@ describe("TicketScheduler + executor wiring", () => {
   it("runs an end-to-end ticket via options.executor (no dispatch callback)", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "ts-exec-run-"));
     try {
-      const { registry, artifactStore, verificationRunner } =
-        await buildBasics(tmp);
+      const { registry, artifactStore, verificationRunner } = await buildBasics(tmp);
 
       // Track that the executor actually gets invoked. The adapter maps
       // executor.start().wait() results back onto AgentResult so the
@@ -169,12 +152,9 @@ describe("TicketScheduler + executor wiring", () => {
       const executor: AgentExecutor = {
         async start(t, opts): Promise<ExecutionHandle> {
           startCalls += 1;
-          const sandbox = await sandboxProvider.create(
-            { root: tmp },
-            "main"
-          );
+          const sandbox = await sandboxProvider.create({ root: tmp }, "main");
           return underlying.start(t, { ...opts, sandbox });
-        }
+        },
       };
 
       const scheduler = new TicketScheduler(
@@ -206,8 +186,7 @@ describe("TicketScheduler + executor wiring", () => {
   it("converts an executor.start() throw into an AgentResult blocker so retry engages", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "ts-exec-throw-"));
     try {
-      const { registry, artifactStore, verificationRunner } =
-        await buildBasics(tmp);
+      const { registry, artifactStore, verificationRunner } = await buildBasics(tmp);
 
       // Fake executor that rejects on the first start() call and then
       // succeeds on subsequent calls by delegating to NoopExecutor. If the
@@ -218,7 +197,11 @@ describe("TicketScheduler + executor wiring", () => {
       let startCalls = 0;
       const sandboxProvider = new NoopSandboxProvider();
       const underlying = new NoopExecutor();
-      const events: Array<{ type: RunEventType; phaseId: string; details: Record<string, string> }> = [];
+      const events: Array<{
+        type: RunEventType;
+        phaseId: string;
+        details: Record<string, string>;
+      }> = [];
       const executor: AgentExecutor = {
         async start(t, opts): Promise<ExecutionHandle> {
           startCalls += 1;
@@ -227,7 +210,7 @@ describe("TicketScheduler + executor wiring", () => {
           }
           const sandbox = await sandboxProvider.create({ root: tmp }, "main");
           return underlying.start(t, { ...opts, sandbox });
-        }
+        },
       };
 
       const scheduler = new TicketScheduler(
@@ -253,9 +236,7 @@ describe("TicketScheduler + executor wiring", () => {
       // exception. The start counter must be at least 2, proving the retry
       // path actually re-engaged instead of the scheduler dying.
       expect(startCalls).toBeGreaterThanOrEqual(2);
-      const startFailure = events.find(
-        (e) => e.phaseId === "__executor_start__"
-      );
+      const startFailure = events.find((e) => e.phaseId === "__executor_start__");
       expect(startFailure).toBeDefined();
       expect(startFailure?.details.error).toContain("simulated spawn failure");
       expect(startFailure?.details.ticketId).toBe("t_throw");
@@ -267,8 +248,7 @@ describe("TicketScheduler + executor wiring", () => {
   it("preserves the legacy dispatch path when no executor is supplied", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "ts-exec-legacy-"));
     try {
-      const { registry, artifactStore, verificationRunner } =
-        await buildBasics(tmp);
+      const { registry, artifactStore, verificationRunner } = await buildBasics(tmp);
       const dispatched: Array<Omit<WorkRequest, "runId">> = [];
       const dispatch = async (
         _run: HarnessRun,
@@ -279,7 +259,7 @@ describe("TicketScheduler + executor wiring", () => {
           summary: `ok:${req.kind}`,
           evidence: [],
           proposedCommands: [],
-          blockers: []
+          blockers: [],
         };
       };
 

--- a/test/orchestrator/verification-override-feed.test.ts
+++ b/test/orchestrator/verification-override-feed.test.ts
@@ -7,15 +7,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NodeCommandInvoker } from "../../src/agents/command-invoker.js";
 import { createLiveAgents } from "../../src/agents/factory.js";
 import { AgentRegistry } from "../../src/agents/registry.js";
-import type {
-  AgentResult,
-  WorkRequest
-} from "../../src/domain/agent.js";
+import type { AgentResult, WorkRequest } from "../../src/domain/agent.js";
 import type { HarnessRun } from "../../src/domain/run.js";
 import {
   initializeTicketLedger,
   parseTicketPlan,
-  type TicketDefinition
+  type TicketDefinition,
 } from "../../src/domain/ticket.js";
 import { ChannelStore } from "../../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../../src/execution/artifact-store.js";
@@ -26,10 +23,7 @@ import { ScriptedInvoker } from "../../src/simulation/scripted-invoker.js";
 
 const RETRY_POLICY = { maxAgentAttempts: 1, maxTestFixLoops: 1 } as const;
 
-function buildTicket(
-  id: string,
-  verificationCommands: string[]
-): TicketDefinition {
+function buildTicket(id: string, verificationCommands: string[]): TicketDefinition {
   return {
     id,
     title: `Ticket ${id}`,
@@ -40,22 +34,18 @@ function buildTicket(
     verificationCommands,
     docsToUpdate: [],
     dependsOn: [],
-    retryPolicy: { ...RETRY_POLICY }
+    retryPolicy: { ...RETRY_POLICY },
   };
 }
 
-function buildRun(
-  repoRoot: string,
-  tickets: TicketDefinition[],
-  channelId: string
-): HarnessRun {
+function buildRun(repoRoot: string, tickets: TicketDefinition[], channelId: string): HarnessRun {
   const now = new Date().toISOString();
   const ticketPlan = parseTicketPlan({
     version: 1,
     task: {
       title: "Test run",
       featureRequest: "Test feature",
-      repoRoot
+      repoRoot,
     },
     classification: {
       tier: "feature_small",
@@ -63,11 +53,11 @@ function buildRun(
       suggestedSpecialties: ["general"],
       estimatedTicketCount: tickets.length,
       needsDesignDoc: false,
-      needsUserApproval: false
+      needsUserApproval: false,
     },
     tickets,
     finalVerification: { commands: [] },
-    docsToUpdate: []
+    docsToUpdate: [],
   });
 
   return {
@@ -88,7 +78,7 @@ function buildRun(
     phaseLedgerPath: null,
     ticketLedger: initializeTicketLedger(tickets),
     ticketLedgerPath: null,
-    runIndexPath: null
+    runIndexPath: null,
   };
 }
 
@@ -110,13 +100,13 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
     const channelStore = new ChannelStore(join(tmp, "channels"));
     const channel = await channelStore.createChannel({
       name: "#ver-override",
-      description: "override test"
+      description: "override test",
     });
 
     const registry = new AgentRegistry();
     for (const agent of createLiveAgents({
       cwd: tmp,
-      invoker: new ScriptedInvoker(tmp)
+      invoker: new ScriptedInvoker(tmp),
     })) {
       registry.register(agent);
     }
@@ -125,10 +115,7 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
       join(tmp, "artifacts"),
       new FileHarnessStore(join(tmp, "__hs__"))
     );
-    const verificationRunner = new VerificationRunner(
-      new NodeCommandInvoker(),
-      artifactStore
-    );
+    const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
 
     // The tester dispatch proposes a command that is not on the ticket's
     // allowlist. The scheduler must (a) fall back to the allowlist for
@@ -142,14 +129,14 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
           summary: "proposed bogus commands",
           evidence: [],
           proposedCommands: ["rm -rf /tmp/nope"],
-          blockers: []
+          blockers: [],
         };
       }
       return {
         summary: `ok:${req.kind}`,
         evidence: [],
         proposedCommands: [],
-        blockers: []
+        blockers: [],
       };
     };
 
@@ -165,11 +152,7 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
       { maxConcurrency: 1, channelStore }
     );
 
-    const run = buildRun(
-      tmp,
-      [buildTicket("t_override", ["echo allowlisted"])],
-      channel.channelId
-    );
+    const run = buildRun(tmp, [buildTicket("t_override", ["echo allowlisted"])], channel.channelId);
 
     await scheduler.executeAll(run);
 
@@ -178,9 +161,7 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
     // feed entry is visible here without a sleep workaround.
     const entries = await channelStore.readFeed(channel.channelId);
     const override = entries.find(
-      (e) =>
-        e.type === "status_update" &&
-        e.content.startsWith("Verification override")
+      (e) => e.type === "status_update" && e.content.startsWith("Verification override")
     );
     expect(override).toBeDefined();
     expect(override!.fromDisplayName).toBe("Verifier");

--- a/test/phase-ledger.test.ts
+++ b/test/phase-ledger.test.ts
@@ -26,12 +26,12 @@ describe("phase ledger persistence", () => {
             lastClassification: {
               category: "fix_test",
               rationale: "The failure is isolated to verification setup.",
-              nextAction: "Repair the tests before changing product logic."
+              nextAction: "Repair the tests before changing product logic.",
             },
             chosenNextAction: "Repair the tests before changing product logic.",
-            updatedAt: "2026-03-30T00:00:00.000Z"
-          }
-        ]
+            updatedAt: "2026-03-30T00:00:00.000Z",
+          },
+        ],
       });
 
       expect(path).toContain("phase-ledger.json");
@@ -51,11 +51,11 @@ describe("phase ledger persistence", () => {
     } finally {
       await rm(artifactRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
       await rm(storeRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
     }
   });

--- a/test/phase-plan.test.ts
+++ b/test/phase-plan.test.ts
@@ -18,13 +18,13 @@ describe("phase plan schema", () => {
         task: {
           title: "Bad",
           featureRequest: "Missing phases",
-          repoRoot: process.cwd()
+          repoRoot: process.cwd(),
         },
         phases: [],
         finalVerification: {
-          commands: []
+          commands: [],
         },
-        docsToUpdate: []
+        docsToUpdate: [],
       })
     ).toThrow();
   });

--- a/test/pr-lifecycle.test.ts
+++ b/test/pr-lifecycle.test.ts
@@ -4,11 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import {
-  createPrLifecycle,
-  advancePrStage,
-  canTransition
-} from "../src/domain/pr-lifecycle.js";
+import { createPrLifecycle, advancePrStage, canTransition } from "../src/domain/pr-lifecycle.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 
@@ -16,7 +12,7 @@ describe("PR lifecycle domain", () => {
   it("creates a lifecycle in branch_created stage", () => {
     const lifecycle = createPrLifecycle({
       runId: "run-1",
-      branch: "feature/widget"
+      branch: "feature/widget",
     });
 
     expect(lifecycle.runId).toBe("run-1");
@@ -31,7 +27,7 @@ describe("PR lifecycle domain", () => {
   it("advances through stages and records events", () => {
     let lifecycle = createPrLifecycle({
       runId: "run-1",
-      branch: "feature/widget"
+      branch: "feature/widget",
     });
 
     lifecycle = advancePrStage(lifecycle, "commits_pushed");
@@ -40,7 +36,7 @@ describe("PR lifecycle domain", () => {
 
     lifecycle = advancePrStage(lifecycle, "pr_opened", {
       prNumber: "42",
-      prUrl: "https://github.com/org/repo/pull/42"
+      prUrl: "https://github.com/org/repo/pull/42",
     });
     expect(lifecycle.currentStage).toBe("pr_opened");
     expect(lifecycle.prNumber).toBe(42);
@@ -68,7 +64,7 @@ describe("PR lifecycle persistence", () => {
       const lifecycle = createPrLifecycle({
         runId: "run-pr-1",
         branch: "feature/test",
-        baseBranch: "develop"
+        baseBranch: "develop",
       });
 
       const path = await store.savePrLifecycle(lifecycle);

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -11,7 +11,7 @@ describe("agent registry", () => {
 
     for (const agent of createLiveAgents({
       cwd,
-      invoker: new ScriptedInvoker(cwd)
+      invoker: new ScriptedInvoker(cwd),
     })) {
       registry.register(agent);
     }
@@ -31,7 +31,7 @@ describe("agent registry", () => {
       artifactContext: [],
       attempt: 1,
       maxAttempts: 2,
-      priorEvidence: []
+      priorEvidence: [],
     });
 
     const apiAgent = registry.resolve({
@@ -49,7 +49,7 @@ describe("agent registry", () => {
       artifactContext: [],
       attempt: 1,
       maxAttempts: 2,
-      priorEvidence: []
+      priorEvidence: [],
     });
 
     expect(uiAgent.id).toBe("pixel");

--- a/test/run-persistence.test.ts
+++ b/test/run-persistence.test.ts
@@ -8,13 +8,17 @@ import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import type { HarnessRun, RunEvent } from "../src/domain/run.js";
 
-async function makeStore(): Promise<{ root: string; store: LocalArtifactStore; storeRoot: string }> {
+async function makeStore(): Promise<{
+  root: string;
+  store: LocalArtifactStore;
+  storeRoot: string;
+}> {
   const root = await mkdtemp(join(tmpdir(), "run-persist-"));
   const storeRoot = await mkdtemp(join(tmpdir(), "run-persist-hs-"));
   return {
     root,
     storeRoot,
-    store: new LocalArtifactStore(root, new FileHarnessStore(storeRoot))
+    store: new LocalArtifactStore(root, new FileHarnessStore(storeRoot)),
   };
 }
 
@@ -37,8 +41,8 @@ function buildTestRun(overrides?: Partial<HarnessRun>): HarnessRun {
         type: "TaskSubmitted",
         phaseId: "phase_00",
         details: { featureRequest: "Add a widget" },
-        createdAt: now
-      }
+        createdAt: now,
+      },
     ],
     evidence: [],
     artifacts: [],
@@ -47,7 +51,7 @@ function buildTestRun(overrides?: Partial<HarnessRun>): HarnessRun {
     ticketLedger: [],
     ticketLedgerPath: null,
     runIndexPath: null,
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -94,14 +98,14 @@ describe("run persistence", () => {
         type: "TaskSubmitted",
         phaseId: "phase_00",
         details: { featureRequest: "Test" },
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
       };
 
       const event2: RunEvent = {
         type: "PlanGenerated",
         phaseId: "phase_00",
         details: { state: "PLAN_REVIEW" },
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
       };
 
       await store.appendEvent("run-events-1", event1);

--- a/test/runs-index.test.ts
+++ b/test/runs-index.test.ts
@@ -24,8 +24,8 @@ describe("runs index", () => {
           completedAt: "2026-03-30T00:01:00.000Z",
           channelId: null,
           phaseLedgerPath: "/tmp/run-1/phase-ledger.json",
-          artifactsRoot: "/tmp/run-1"
-        }
+          artifactsRoot: "/tmp/run-1",
+        },
       });
 
       await store.saveRunsIndex({
@@ -38,8 +38,8 @@ describe("runs index", () => {
           completedAt: "2026-03-30T00:03:00.000Z",
           channelId: null,
           phaseLedgerPath: "/tmp/run-2/phase-ledger.json",
-          artifactsRoot: "/tmp/run-2"
-        }
+          artifactsRoot: "/tmp/run-2",
+        },
       });
 
       const entries = await store.readRunsIndex();
@@ -52,11 +52,11 @@ describe("runs index", () => {
     } finally {
       await rm(artifactRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
       await rm(storeRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
     }
   });

--- a/test/session-store-harness-store.test.ts
+++ b/test/session-store-harness-store.test.ts
@@ -8,12 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionStore } from "../src/cli/session-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import { STORE_NS } from "../src/storage/namespaces.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "../src/storage/store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "../src/storage/store.js";
 
 class FakeHarnessStore implements HarnessStore {
   readonly docs: Map<string, unknown> = new Map();
@@ -46,11 +41,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.appendLog is not implemented");
   }
 
-  async readLog<T>(
-    _ns: string,
-    _id: string,
-    _opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(_ns: string, _id: string, _opts?: ReadLogOptions): Promise<T[]> {
     throw new Error("FakeHarnessStore.readLog is not implemented");
   }
 
@@ -62,11 +53,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.getBlob is not implemented");
   }
 
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     this.mutateCalls.push({ ns, id });
     const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
     const next = fn(prev);
@@ -101,7 +88,7 @@ describe("SessionStore with HarnessStore injection", () => {
     const expectedId = `channel-1:${session.sessionId}`;
     expect(fake.mutateCalls).toContainEqual({
       ns: STORE_NS.session,
-      id: expectedId
+      id: expectedId,
     });
 
     const rec = await fake.getDoc<{ updatedAt: string; messageCount: number }>(
@@ -121,7 +108,7 @@ describe("SessionStore with HarnessStore injection", () => {
       role: "user",
       content: "hi",
       timestamp: "2025-01-01T00:00:00.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
 
     const rec = await fake.getDoc<{ updatedAt: string; messageCount: number }>(
@@ -132,9 +119,7 @@ describe("SessionStore with HarnessStore injection", () => {
     expect(rec!.messageCount).toBe(1);
 
     // Sanity: at least two mutate calls (create + append → updateSession).
-    const calls = fake.mutateCalls.filter(
-      (c) => c.ns === STORE_NS.session && c.id === coordId
-    );
+    const calls = fake.mutateCalls.filter((c) => c.ns === STORE_NS.session && c.id === coordId);
     expect(calls.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -145,7 +130,7 @@ describe("SessionStore with HarnessStore injection", () => {
       role: "user",
       content: "rust?",
       timestamp: "2025-01-01T00:00:00.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
 
     // Sessions index where Rust's `sessions_index_path` expects it.
@@ -159,17 +144,9 @@ describe("SessionStore with HarnessStore injection", () => {
     expect(raw[0].messageCount).toBe(1);
 
     // Chat JSONL where Rust's `session_chat_path` expects it.
-    const chatPath = join(
-      channelsDir,
-      "channel-rust",
-      "sessions",
-      `${session.sessionId}.jsonl`
-    );
+    const chatPath = join(channelsDir, "channel-rust", "sessions", `${session.sessionId}.jsonl`);
     await expect(stat(chatPath)).resolves.toBeTruthy();
-    const lines = (await readFile(chatPath, "utf8"))
-      .trimEnd()
-      .split("\n")
-      .filter(Boolean);
+    const lines = (await readFile(chatPath, "utf8")).trimEnd().split("\n").filter(Boolean);
     expect(lines).toHaveLength(1);
   });
 
@@ -181,7 +158,7 @@ describe("SessionStore with HarnessStore injection", () => {
 
     expect(fake.deleteCalls).toContainEqual({
       ns: STORE_NS.session,
-      id: coordId
+      id: coordId,
     });
 
     const rec = await fake.getDoc(STORE_NS.session, coordId);
@@ -202,12 +179,8 @@ describe("SessionStore with HarnessStore injection", () => {
     const indexPath = join(channelDir, "sessions.json");
     await writeFile(indexPath, "this is not JSON", "utf8");
 
-    await expect(store.listSessions("corrupt-channel")).rejects.toThrow(
-      /Corrupt sessions index/
-    );
-    await expect(store.listSessions("corrupt-channel")).rejects.toThrow(
-      indexPath
-    );
+    await expect(store.listSessions("corrupt-channel")).rejects.toThrow(/Corrupt sessions index/);
+    await expect(store.listSessions("corrupt-channel")).rejects.toThrow(indexPath);
   });
 
   it("swallows coordination-record mutate failures + logs (disk write still commits)", async () => {
@@ -221,18 +194,11 @@ describe("SessionStore with HarnessStore injection", () => {
       .mockRejectedValueOnce(new Error("coordination store exploded"));
 
     try {
-      const session = await store.createSession(
-        "mutate-fails-channel",
-        "disk still commits"
-      );
+      const session = await store.createSession("mutate-fails-channel", "disk still commits");
       expect(session.sessionId).toBeTruthy();
 
       // Disk write committed — sessions.json has the entry.
-      const indexPath = join(
-        channelsDir,
-        "mutate-fails-channel",
-        "sessions.json"
-      );
+      const indexPath = join(channelsDir, "mutate-fails-channel", "sessions.json");
       const raw = JSON.parse(await readFile(indexPath, "utf8")) as Array<{
         sessionId: string;
       }>;
@@ -240,12 +206,8 @@ describe("SessionStore with HarnessStore injection", () => {
 
       // Operator-visible diagnostic was emitted.
       const warnings = warnSpy.mock.calls.map((c) => c.join(" "));
-      expect(
-        warnings.some((w) => w.includes("coordination-record mutate failed"))
-      ).toBe(true);
-      expect(
-        warnings.some((w) => w.includes("coordination store exploded"))
-      ).toBe(true);
+      expect(warnings.some((w) => w.includes("coordination-record mutate failed"))).toBe(true);
+      expect(warnings.some((w) => w.includes("coordination store exploded"))).toBe(true);
     } finally {
       warnSpy.mockRestore();
       mutateSpy.mockRestore();
@@ -258,22 +220,13 @@ describe("SessionStore with HarnessStore injection", () => {
       role: "user",
       content: "valid",
       timestamp: "2025-01-01T00:00:00.000Z",
-      agentAlias: null
+      agentAlias: null,
     });
 
     // Manually append a garbage line to simulate data corruption /
     // manual edit damage.
-    const chatPath = join(
-      channelsDir,
-      "jsonl-warn",
-      "sessions",
-      `${session.sessionId}.jsonl`
-    );
-    await writeFile(
-      chatPath,
-      (await readFile(chatPath, "utf8")) + "this is not JSON\n",
-      "utf8"
-    );
+    const chatPath = join(channelsDir, "jsonl-warn", "sessions", `${session.sessionId}.jsonl`);
+    await writeFile(chatPath, (await readFile(chatPath, "utf8")) + "this is not JSON\n", "utf8");
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -284,9 +237,7 @@ describe("SessionStore with HarnessStore injection", () => {
       expect(messages[0].content).toBe("valid");
 
       const warnings = warnSpy.mock.calls.map((c) => c.join(" "));
-      expect(
-        warnings.some((w) => w.includes("skipping malformed JSONL line"))
-      ).toBe(true);
+      expect(warnings.some((w) => w.includes("skipping malformed JSONL line"))).toBe(true);
       expect(warnings.some((w) => w.includes(chatPath))).toBe(true);
       // Line number should be present — 2 (second line is garbage).
       expect(warnings.some((w) => /:2:/.test(w))).toBe(true);
@@ -301,9 +252,7 @@ describe("SessionStore reads legacy Rust-layout fixtures", () => {
 
   beforeEach(async () => {
     workDir = await mkdtemp(join(tmpdir(), "sess-legacy-"));
-    const fixtureSrc = fileURLToPath(
-      new URL("./fixtures/legacy-session", import.meta.url)
-    );
+    const fixtureSrc = fileURLToPath(new URL("./fixtures/legacy-session", import.meta.url));
     await cp(fixtureSrc, workDir, { recursive: true });
   });
 
@@ -328,9 +277,7 @@ describe("SessionStore reads legacy Rust-layout fixtures", () => {
       expect(messages[1].role).toBe("assistant");
 
       // Legacy-read path must not have written coordination state.
-      await expect(
-        stat(join(storeRoot, "session"))
-      ).rejects.toThrow();
+      await expect(stat(join(storeRoot, "session"))).rejects.toThrow();
     } finally {
       await rm(storeRoot, { recursive: true, force: true });
     }

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -10,15 +10,11 @@ describe("state machine", () => {
   });
 
   it("can fail a phase when verification budget is exhausted", () => {
-    expect(getNextState("TEST_FIX_LOOP", "ChecksFailedNonRecoverable")).toBe(
-      "FAILED"
-    );
+    expect(getNextState("TEST_FIX_LOOP", "ChecksFailedNonRecoverable")).toBe("FAILED");
   });
 
   it("throws for invalid transitions", () => {
-    expect(() => assertTransition("DRAFT_PLAN", "ChecksPassed")).toThrow(
-      /Invalid transition/
-    );
+    expect(() => assertTransition("DRAFT_PLAN", "ChecksPassed")).toThrow(/Invalid transition/);
   });
 
   it("supports classification and ticket execution path", () => {

--- a/test/storage/factory.test.ts
+++ b/test/storage/factory.test.ts
@@ -5,10 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { FileHarnessStore } from "../../src/storage/file-store.js";
-import {
-  buildHarnessStore,
-  NotImplementedError
-} from "../../src/storage/factory.js";
+import { buildHarnessStore, NotImplementedError } from "../../src/storage/factory.js";
 import { getHarnessStore } from "../../src/index.js";
 
 describe("buildHarnessStore", () => {
@@ -54,9 +51,7 @@ describe("buildHarnessStore", () => {
   });
 
   it("throws NotImplementedError for explicit opts.kind=sqlite (same guard path)", () => {
-    expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(
-      NotImplementedError
-    );
+    expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(NotImplementedError);
     expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(/sqlite/i);
   });
 
@@ -66,13 +61,13 @@ describe("buildHarnessStore", () => {
     expect(() =>
       buildHarnessStore({
         kind: "postgres",
-        postgresUrl: "postgres://example/db"
+        postgresUrl: "postgres://example/db",
       })
     ).toThrow(NotImplementedError);
     expect(() =>
       buildHarnessStore({
         kind: "postgres",
-        postgresUrl: "postgres://example/db"
+        postgresUrl: "postgres://example/db",
       })
     ).toThrow(/T-402/);
   });

--- a/test/storage/file-store.test.ts
+++ b/test/storage/file-store.test.ts
@@ -53,17 +53,17 @@ describe("FileHarnessStore", () => {
       await store.putDoc<Widget>("widgets", "beta-2", {
         id: "beta-2",
         label: "b2",
-        count: 0
+        count: 0,
       });
       await store.putDoc<Widget>("widgets", "alpha-1", {
         id: "alpha-1",
         label: "a1",
-        count: 0
+        count: 0,
       });
       await store.putDoc<Widget>("widgets", "alpha-2", {
         id: "alpha-2",
         label: "a2",
-        count: 0
+        count: 0,
       });
 
       const all = await store.listDocs<Widget>("widgets");
@@ -77,7 +77,7 @@ describe("FileHarnessStore", () => {
       await store.putDoc<Widget>("widgets", "w1", {
         id: "w1",
         label: "a",
-        count: 1
+        count: 1,
       });
       expect(await store.getDoc<Widget>("widgets", "w1")).not.toBeNull();
 
@@ -95,10 +95,7 @@ describe("FileHarnessStore", () => {
       await store.appendLog("events", "run-1", { id: "b", v: 2 });
       await store.appendLog("events", "run-1", { id: "c", v: 3 });
 
-      const entries = await store.readLog<{ id: string; v: number }>(
-        "events",
-        "run-1"
-      );
+      const entries = await store.readLog<{ id: string; v: number }>("events", "run-1");
       expect(entries.map((e) => e.id)).toEqual(["a", "b", "c"]);
     });
 
@@ -106,11 +103,7 @@ describe("FileHarnessStore", () => {
       for (const n of [1, 2, 3, 4, 5]) {
         await store.appendLog("events", "run-2", { id: `e${n}`, v: n });
       }
-      const tail = await store.readLog<{ id: string; v: number }>(
-        "events",
-        "run-2",
-        { limit: 2 }
-      );
+      const tail = await store.readLog<{ id: string; v: number }>("events", "run-2", { limit: 2 });
       expect(tail.map((e) => e.id)).toEqual(["e4", "e5"]);
     });
 
@@ -118,11 +111,9 @@ describe("FileHarnessStore", () => {
       for (const n of [1, 2, 3, 4]) {
         await store.appendLog("events", "run-3", { id: `e${n}`, v: n });
       }
-      const after = await store.readLog<{ id: string; v: number }>(
-        "events",
-        "run-3",
-        { after: "e2" }
-      );
+      const after = await store.readLog<{ id: string; v: number }>("events", "run-3", {
+        after: "e2",
+      });
       expect(after.map((e) => e.id)).toEqual(["e3", "e4"]);
     });
 
@@ -138,14 +129,14 @@ describe("FileHarnessStore", () => {
       for (let i = 0; i < 256; i++) bytes[i] = i;
 
       const ref = await store.putBlob("artifacts", "bin-1", bytes, {
-        contentType: "application/octet-stream"
+        contentType: "application/octet-stream",
       });
 
       expect(ref).toMatchObject({
         ns: "artifacts",
         id: "bin-1",
         size: 256,
-        contentType: "application/octet-stream"
+        contentType: "application/octet-stream",
       });
 
       const loaded = await store.getBlob(ref);
@@ -162,7 +153,7 @@ describe("FileHarnessStore", () => {
       const manual: BlobRef = {
         ns: "artifacts",
         id: "txt-1",
-        size: payload.byteLength
+        size: payload.byteLength,
       };
       const loaded = await store.getBlob(manual);
       expect(new TextDecoder().decode(loaded)).toBe("hello world");
@@ -184,7 +175,7 @@ describe("FileHarnessStore", () => {
       await store.putDoc<Widget>("widgets", "ctr", {
         id: "ctr",
         label: "counter",
-        count: 0
+        count: 0,
       });
 
       const ops: Promise<Widget>[] = [];
@@ -193,7 +184,7 @@ describe("FileHarnessStore", () => {
           store.mutate<Widget>("widgets", "ctr", (prev) => ({
             id: "ctr",
             label: "counter",
-            count: (prev?.count ?? 0) + 1
+            count: (prev?.count ?? 0) + 1,
           }))
         );
       }
@@ -218,16 +209,12 @@ describe("FileHarnessStore", () => {
       await store.putDoc<Widget>("widgets", "watched", {
         id: "watched",
         label: "hi",
-        count: 1
+        count: 1,
       });
 
-      const result = await Promise.race<
-        IteratorResult<ChangeEvent> | "timeout"
-      >([
+      const result = await Promise.race<IteratorResult<ChangeEvent> | "timeout">([
         nextEvent,
-        new Promise<"timeout">((resolve) =>
-          setTimeout(() => resolve("timeout"), 2000)
-        )
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 2000)),
       ]);
 
       expect(result).not.toBe("timeout");
@@ -239,7 +226,7 @@ describe("FileHarnessStore", () => {
       expect(events[0]).toMatchObject({
         ns: "widgets",
         id: "watched",
-        kind: "put"
+        kind: "put",
       });
 
       // Return closes the async generator; the polling loop should exit.
@@ -261,12 +248,10 @@ describe("FileHarnessStore", () => {
       await store.putDoc<Widget>("watch-errs", "w1", {
         id: "w1",
         label: "seed",
-        count: 0
+        count: 0,
       });
 
-      const iterator = store
-        .watch("watch-errs", "w1")
-        [Symbol.asyncIterator]();
+      const iterator = store.watch("watch-errs", "w1")[Symbol.asyncIterator]();
       const nextEvent = iterator.next();
 
       // Deny read on the namespace dir so stat() throws EACCES on the next
@@ -279,9 +264,7 @@ describe("FileHarnessStore", () => {
         await expect(
           Promise.race<IteratorResult<ChangeEvent> | "timeout">([
             nextEvent,
-            new Promise<"timeout">((resolve) =>
-              setTimeout(() => resolve("timeout"), 2000)
-            )
+            new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 2000)),
           ])
         ).rejects.toThrow();
       } finally {
@@ -300,7 +283,7 @@ describe("FileHarnessStore", () => {
           store.putDoc<Widget>("widgets", "concurrent", {
             id: "concurrent",
             label: `write-${i}`,
-            count: i
+            count: i,
           })
         );
       }
@@ -325,31 +308,19 @@ describe("FileHarnessStore", () => {
     const unsafeId = "../x";
 
     it("getDoc rejects unsafe ns and id", async () => {
-      await expect(store.getDoc("valid", unsafeId)).rejects.toThrow(
-        /Unsafe path segment/
-      );
-      await expect(store.getDoc(unsafeNs, "valid")).rejects.toThrow(
-        /Unsafe path segment/
-      );
+      await expect(store.getDoc("valid", unsafeId)).rejects.toThrow(/Unsafe path segment/);
+      await expect(store.getDoc(unsafeNs, "valid")).rejects.toThrow(/Unsafe path segment/);
     });
 
     it("putDoc rejects unsafe ns and id", async () => {
       const widget: Widget = { id: "x", label: "a", count: 0 };
-      await expect(store.putDoc("valid", unsafeId, widget)).rejects.toThrow(
-        /Unsafe path segment/
-      );
-      await expect(store.putDoc(unsafeNs, "valid", widget)).rejects.toThrow(
-        /Unsafe path segment/
-      );
+      await expect(store.putDoc("valid", unsafeId, widget)).rejects.toThrow(/Unsafe path segment/);
+      await expect(store.putDoc(unsafeNs, "valid", widget)).rejects.toThrow(/Unsafe path segment/);
     });
 
     it("deleteDoc rejects unsafe ns and id", async () => {
-      await expect(store.deleteDoc("valid", unsafeId)).rejects.toThrow(
-        /Unsafe path segment/
-      );
-      await expect(store.deleteDoc(unsafeNs, "valid")).rejects.toThrow(
-        /Unsafe path segment/
-      );
+      await expect(store.deleteDoc("valid", unsafeId)).rejects.toThrow(/Unsafe path segment/);
+      await expect(store.deleteDoc(unsafeNs, "valid")).rejects.toThrow(/Unsafe path segment/);
     });
 
     it("appendLog rejects unsafe ns and id", async () => {
@@ -363,12 +334,8 @@ describe("FileHarnessStore", () => {
 
     it("putBlob rejects unsafe ns and id", async () => {
       const bytes = new Uint8Array([0, 1, 2]);
-      await expect(store.putBlob("valid", unsafeId, bytes)).rejects.toThrow(
-        /Unsafe path segment/
-      );
-      await expect(store.putBlob(unsafeNs, "valid", bytes)).rejects.toThrow(
-        /Unsafe path segment/
-      );
+      await expect(store.putBlob("valid", unsafeId, bytes)).rejects.toThrow(/Unsafe path segment/);
+      await expect(store.putBlob(unsafeNs, "valid", bytes)).rejects.toThrow(/Unsafe path segment/);
     });
   });
 
@@ -380,11 +347,9 @@ describe("FileHarnessStore", () => {
 
       // Contract: unknown cursor → []. Returning the full log would cause
       // duplicate delivery on resume.
-      const out = await store.readLog<{ id: string; v: number }>(
-        "events",
-        "run-x",
-        { after: "does-not-exist" }
-      );
+      const out = await store.readLog<{ id: string; v: number }>("events", "run-x", {
+        after: "does-not-exist",
+      });
       expect(out).toEqual([]);
     });
   });

--- a/test/storage/postgres-migrations.integration.test.ts
+++ b/test/storage/postgres-migrations.integration.test.ts
@@ -3,15 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import pg from "pg";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it
-} from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { migrate } from "../../src/storage/migrations/runner.js";
 
@@ -28,127 +20,113 @@ const skipReason =
 
 const maybeDescribe = TEST_URL ? describe : describe.skip;
 
-maybeDescribe(
-  `migrate() runner (integration, ${TEST_URL ?? skipReason})`,
-  () => {
-    let pool: pg.Pool;
-    let migrationsDir: string;
-    let schemaPrefix: string;
+maybeDescribe(`migrate() runner (integration, ${TEST_URL ?? skipReason})`, () => {
+  let pool: pg.Pool;
+  let migrationsDir: string;
+  let schemaPrefix: string;
 
-    beforeAll(async () => {
-      if (!TEST_URL) return;
-      pool = new pg.Pool({ connectionString: TEST_URL });
-    });
+  beforeAll(async () => {
+    if (!TEST_URL) return;
+    pool = new pg.Pool({ connectionString: TEST_URL });
+  });
 
-    afterAll(async () => {
-      if (!pool) return;
-      await pool.end();
-    });
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.end();
+  });
 
-    beforeEach(async () => {
-      if (!TEST_URL) return;
-      // Unique per-test prefix lets multiple migration tests coexist in the
-      // same DB without fighting each other for the same table names. The
-      // SQL written into tmp files below interpolates this prefix so we
-      // never touch the real `harness_*` tables.
-      schemaPrefix = `mig_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
-      migrationsDir = await mkdtemp(join(tmpdir(), "relay-mig-"));
-    });
+  beforeEach(async () => {
+    if (!TEST_URL) return;
+    // Unique per-test prefix lets multiple migration tests coexist in the
+    // same DB without fighting each other for the same table names. The
+    // SQL written into tmp files below interpolates this prefix so we
+    // never touch the real `harness_*` tables.
+    schemaPrefix = `mig_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+    migrationsDir = await mkdtemp(join(tmpdir(), "relay-mig-"));
+  });
 
-    afterEach(async () => {
-      if (!TEST_URL) return;
-      if (pool) {
-        // Clean up anything these tests created. CASCADE avoids FK noise.
-        await pool.query(
-          `DROP TABLE IF EXISTS ${schemaPrefix}_a, ${schemaPrefix}_b CASCADE`
-        );
-        // Guarded because `harness_schema_migrations` is only created the
-        // first time any migrate() call runs in the DB; the `skip reason`
-        // test doesn't invoke migrate() so the table may not exist yet.
-        await pool
-          .query(
-            `DELETE FROM harness_schema_migrations WHERE version LIKE $1`,
-            [`${schemaPrefix}%`]
-          )
-          .catch(() => undefined);
-      }
-      if (migrationsDir) {
-        await rm(migrationsDir, { recursive: true, force: true });
-      }
-    });
+  afterEach(async () => {
+    if (!TEST_URL) return;
+    if (pool) {
+      // Clean up anything these tests created. CASCADE avoids FK noise.
+      await pool.query(`DROP TABLE IF EXISTS ${schemaPrefix}_a, ${schemaPrefix}_b CASCADE`);
+      // Guarded because `harness_schema_migrations` is only created the
+      // first time any migrate() call runs in the DB; the `skip reason`
+      // test doesn't invoke migrate() so the table may not exist yet.
+      await pool
+        .query(`DELETE FROM harness_schema_migrations WHERE version LIKE $1`, [`${schemaPrefix}%`])
+        .catch(() => undefined);
+    }
+    if (migrationsDir) {
+      await rm(migrationsDir, { recursive: true, force: true });
+    }
+  });
 
-    it("skip reason", () => {
-      if (!TEST_URL) {
-        // eslint-disable-next-line no-console
-        console.log(skipReason);
-      }
-      expect(true).toBe(true);
-    });
+  it("skip reason", () => {
+    if (!TEST_URL) {
+      // eslint-disable-next-line no-console
+      console.log(skipReason);
+    }
+    expect(true).toBe(true);
+  });
 
-    it("applies a single migration, then the second call is a no-op", async () => {
-      if (!TEST_URL) return;
-      const v1 = `001_${schemaPrefix}`;
-      await writeFile(
-        join(migrationsDir, `${v1}.sql`),
-        `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
-      );
+  it("applies a single migration, then the second call is a no-op", async () => {
+    if (!TEST_URL) return;
+    const v1 = `001_${schemaPrefix}`;
+    await writeFile(
+      join(migrationsDir, `${v1}.sql`),
+      `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
+    );
 
-      const first = await migrate({ pool, migrationsDir });
-      expect(first).toEqual([{ version: v1, alreadyApplied: false }]);
+    const first = await migrate({ pool, migrationsDir });
+    expect(first).toEqual([{ version: v1, alreadyApplied: false }]);
 
-      const second = await migrate({ pool, migrationsDir });
-      expect(second).toEqual([{ version: v1, alreadyApplied: true }]);
+    const second = await migrate({ pool, migrationsDir });
+    expect(second).toEqual([{ version: v1, alreadyApplied: true }]);
 
-      const row = await pool.query(
-        "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
-        [v1]
-      );
-      expect(row.rowCount).toBe(1);
-    });
+    const row = await pool.query("SELECT 1 FROM harness_schema_migrations WHERE version = $1", [
+      v1,
+    ]);
+    expect(row.rowCount).toBe(1);
+  });
 
-    it("applies migrations in lexical order", async () => {
-      if (!TEST_URL) return;
-      const vA = `001_${schemaPrefix}`;
-      const vB = `002_${schemaPrefix}`;
-      await writeFile(
-        join(migrationsDir, `${vB}.sql`),
-        `CREATE TABLE ${schemaPrefix}_b (id INT PRIMARY KEY REFERENCES ${schemaPrefix}_a(id));`
-      );
-      await writeFile(
-        join(migrationsDir, `${vA}.sql`),
-        `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
-      );
-      // The 002 file references 001's table — if the runner applied them
-      // out of order the CREATE TABLE would fail on a missing FK target.
-      const applied = await migrate({ pool, migrationsDir });
-      expect(applied.map((m) => m.version)).toEqual([vA, vB]);
-    });
+  it("applies migrations in lexical order", async () => {
+    if (!TEST_URL) return;
+    const vA = `001_${schemaPrefix}`;
+    const vB = `002_${schemaPrefix}`;
+    await writeFile(
+      join(migrationsDir, `${vB}.sql`),
+      `CREATE TABLE ${schemaPrefix}_b (id INT PRIMARY KEY REFERENCES ${schemaPrefix}_a(id));`
+    );
+    await writeFile(
+      join(migrationsDir, `${vA}.sql`),
+      `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
+    );
+    // The 002 file references 001's table — if the runner applied them
+    // out of order the CREATE TABLE would fail on a missing FK target.
+    const applied = await migrate({ pool, migrationsDir });
+    expect(applied.map((m) => m.version)).toEqual([vA, vB]);
+  });
 
-    it("rolls a failing migration back and leaves harness_schema_migrations untouched", async () => {
-      if (!TEST_URL) return;
-      const vGood = `001_${schemaPrefix}`;
-      const vBad = `002_${schemaPrefix}`;
-      await writeFile(
-        join(migrationsDir, `${vGood}.sql`),
-        `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
-      );
-      await writeFile(
-        join(migrationsDir, `${vBad}.sql`),
-        `THIS IS NOT SQL AT ALL`
-      );
+  it("rolls a failing migration back and leaves harness_schema_migrations untouched", async () => {
+    if (!TEST_URL) return;
+    const vGood = `001_${schemaPrefix}`;
+    const vBad = `002_${schemaPrefix}`;
+    await writeFile(
+      join(migrationsDir, `${vGood}.sql`),
+      `CREATE TABLE ${schemaPrefix}_a (id INT PRIMARY KEY);`
+    );
+    await writeFile(join(migrationsDir, `${vBad}.sql`), `THIS IS NOT SQL AT ALL`);
 
-      await expect(migrate({ pool, migrationsDir })).rejects.toThrow();
+    await expect(migrate({ pool, migrationsDir })).rejects.toThrow();
 
-      const good = await pool.query(
-        "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
-        [vGood]
-      );
-      expect(good.rowCount).toBe(1);
-      const bad = await pool.query(
-        "SELECT 1 FROM harness_schema_migrations WHERE version = $1",
-        [vBad]
-      );
-      expect(bad.rowCount).toBe(0);
-    });
-  }
-);
+    const good = await pool.query("SELECT 1 FROM harness_schema_migrations WHERE version = $1", [
+      vGood,
+    ]);
+    expect(good.rowCount).toBe(1);
+    const bad = await pool.query("SELECT 1 FROM harness_schema_migrations WHERE version = $1", [
+      vBad,
+    ]);
+    expect(bad.rowCount).toBe(0);
+  });
+});

--- a/test/storage/postgres-store.integration.test.ts
+++ b/test/storage/postgres-store.integration.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import pg from "pg";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it
-} from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { migrate } from "../../src/storage/migrations/runner.js";
 import { PostgresHarnessStore } from "../../src/storage/postgres-store.js";
@@ -97,17 +89,17 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     await store.putDoc<Widget>(ns, "beta-2", {
       id: "beta-2",
       label: "b2",
-      count: 0
+      count: 0,
     });
     await store.putDoc<Widget>(ns, "alpha-1", {
       id: "alpha-1",
       label: "a1",
-      count: 0
+      count: 0,
     });
     await store.putDoc<Widget>(ns, "alpha-2", {
       id: "alpha-2",
       label: "a2",
-      count: 0
+      count: 0,
     });
 
     const all = await store.listDocs<Widget>(ns);
@@ -125,22 +117,22 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     await store.putDoc<Widget>(ns, "alpha_b1", {
       id: "alpha_b1",
       label: "u",
-      count: 0
+      count: 0,
     });
     await store.putDoc<Widget>(ns, "alphaXb1", {
       id: "alphaXb1",
       label: "x",
-      count: 0
+      count: 0,
     });
     await store.putDoc<Widget>(ns, "pct%tag", {
       id: "pct%tag",
       label: "p",
-      count: 0
+      count: 0,
     });
     await store.putDoc<Widget>(ns, "pctZtag", {
       id: "pctZtag",
       label: "z",
-      count: 0
+      count: 0,
     });
 
     const underscoreMatches = await store.listDocs<Widget>(ns, "alpha_");
@@ -169,20 +161,18 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     expect(all.map((e) => e.id)).toEqual(["a", "b", "c", "d"]);
 
     const tail = await store.readLog<{ id: string; v: number }>(ns, "r1", {
-      limit: 2
+      limit: 2,
     });
     expect(tail.map((e) => e.id)).toEqual(["c", "d"]);
 
     const afterB = await store.readLog<{ id: string; v: number }>(ns, "r1", {
-      after: "b"
+      after: "b",
     });
     expect(afterB.map((e) => e.id)).toEqual(["c", "d"]);
 
-    const unknownCursor = await store.readLog<{ id: string; v: number }>(
-      ns,
-      "r1",
-      { after: "does-not-exist" }
-    );
+    const unknownCursor = await store.readLog<{ id: string; v: number }>(ns, "r1", {
+      after: "does-not-exist",
+    });
     expect(unknownCursor).toEqual([]);
   });
 
@@ -198,13 +188,13 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     for (let i = 0; i < 256; i++) bytes[i] = i;
 
     const ref = await store.putBlob(ns, "bin-1", bytes, {
-      contentType: "application/octet-stream"
+      contentType: "application/octet-stream",
     });
     expect(ref).toMatchObject({
       ns,
       id: "bin-1",
       size: 256,
-      contentType: "application/octet-stream"
+      contentType: "application/octet-stream",
     });
 
     const loaded = await store.getBlob(ref);
@@ -219,7 +209,7 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     const manual: BlobRef = {
       ns,
       id: "txt-1",
-      size: payload.byteLength
+      size: payload.byteLength,
     };
     const loaded = await store.getBlob(manual);
     expect(new TextDecoder().decode(loaded)).toBe("hello postgres");
@@ -246,7 +236,7 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     for (let i = 0; i < 50; i++) {
       ops.push(
         store.mutate<{ count: number }>(ns, "fresh-ctr", (prev) => ({
-          count: (prev?.count ?? 0) + 1
+          count: (prev?.count ?? 0) + 1,
         }))
       );
     }
@@ -261,7 +251,7 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
     await store.putDoc<Widget>(ns, "ctr", {
       id: "ctr",
       label: "counter",
-      count: 0
+      count: 0,
     });
 
     const ops: Promise<Widget>[] = [];
@@ -270,7 +260,7 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
         store.mutate<Widget>(ns, "ctr", (prev) => ({
           id: "ctr",
           label: "counter",
-          count: (prev?.count ?? 0) + 1
+          count: (prev?.count ?? 0) + 1,
         }))
       );
     }
@@ -283,13 +273,11 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
   it("watch yields a ChangeEvent when putDoc writes to the watched key", async () => {
     if (!TEST_URL) return;
     const watcherStore = new PostgresHarnessStore({
-      connectionString: TEST_URL
+      connectionString: TEST_URL,
     });
     try {
       const events: ChangeEvent[] = [];
-      const iterator = watcherStore
-        .watch(ns, "watched")
-        [Symbol.asyncIterator]();
+      const iterator = watcherStore.watch(ns, "watched")[Symbol.asyncIterator]();
       const nextEvent = iterator.next();
 
       // Small delay so the LISTEN is registered before we trigger the write.
@@ -298,16 +286,12 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
       await store.putDoc<Widget>(ns, "watched", {
         id: "watched",
         label: "hi",
-        count: 1
+        count: 1,
       });
 
-      const result = await Promise.race<
-        IteratorResult<ChangeEvent> | "timeout"
-      >([
+      const result = await Promise.race<IteratorResult<ChangeEvent> | "timeout">([
         nextEvent,
-        new Promise<"timeout">((resolve) =>
-          setTimeout(() => resolve("timeout"), 3000)
-        )
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 3000)),
       ]);
 
       expect(result).not.toBe("timeout");
@@ -323,24 +307,18 @@ maybeDescribe(`PostgresHarnessStore (integration, ${TEST_URL ?? skipReason})`, (
   it("watch cleans up on iterator.return()", async () => {
     if (!TEST_URL) return;
     const watcherStore = new PostgresHarnessStore({
-      connectionString: TEST_URL
+      connectionString: TEST_URL,
     });
     try {
-      const iterator = watcherStore
-        .watch(ns, "watched-cleanup")
-        [Symbol.asyncIterator]();
+      const iterator = watcherStore.watch(ns, "watched-cleanup")[Symbol.asyncIterator]();
       // Prime the subscription and then close immediately.
       const firstNext = iterator.next();
       await new Promise((resolve) => setTimeout(resolve, 50));
       await iterator.return?.();
       // Calling .return again is safe, and the pending .next() resolves done.
-      const resolved = await Promise.race<
-        IteratorResult<ChangeEvent> | "timeout"
-      >([
+      const resolved = await Promise.race<IteratorResult<ChangeEvent> | "timeout">([
         firstNext,
-        new Promise<"timeout">((resolve) =>
-          setTimeout(() => resolve("timeout"), 1000)
-        )
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 1000)),
       ]);
       if (resolved !== "timeout") expect(resolved.done).toBe(true);
     } finally {

--- a/test/storage/postgres-store.unit.test.ts
+++ b/test/storage/postgres-store.unit.test.ts
@@ -22,7 +22,7 @@ function makePoolMock(
     values: unknown[] | undefined
   ) => { rows: unknown[]; rowCount?: number } = () => ({
     rows: [],
-    rowCount: 0
+    rowCount: 0,
   })
 ) {
   const calls: QueryCall[] = [];
@@ -36,7 +36,7 @@ function makePoolMock(
     }),
     release: vi.fn(() => {
       released.push(true);
-    })
+    }),
   };
 
   const pool = {
@@ -45,7 +45,7 @@ function makePoolMock(
       return Promise.resolve(responses(text, values));
     }),
     connect: vi.fn(() => Promise.resolve(client)),
-    end: vi.fn(() => Promise.resolve())
+    end: vi.fn(() => Promise.resolve()),
   };
 
   return { pool, client, calls, clientCalls, released };
@@ -57,33 +57,28 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool, calls } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       const result = await store.getDoc("widgets", "w1");
 
       expect(result).toBeNull();
       expect(calls).toHaveLength(1);
-      expect(calls[0]?.text).toMatch(
-        /SELECT doc FROM harness_docs WHERE ns = \$1 AND id = \$2/
-      );
+      expect(calls[0]?.text).toMatch(/SELECT doc FROM harness_docs WHERE ns = \$1 AND id = \$2/);
       expect(calls[0]?.values).toEqual(["widgets", "w1"]);
     });
 
     it("returns the row's doc when present", async () => {
       const { pool } = makePoolMock(() => ({
         rows: [{ doc: { id: "w1", hello: "world" } }],
-        rowCount: 1
+        rowCount: 1,
       }));
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
-      const result = await store.getDoc<{ id: string; hello: string }>(
-        "widgets",
-        "w1"
-      );
+      const result = await store.getDoc<{ id: string; hello: string }>("widgets", "w1");
       expect(result).toEqual({ id: "w1", hello: "world" });
     });
   });
@@ -93,16 +88,14 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool, calls } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       await store.putDoc("widgets", "w1", { v: 1 });
 
       expect(calls).toHaveLength(1);
       expect(calls[0]?.text).toMatch(/INSERT INTO harness_docs/);
-      expect(calls[0]?.text).toMatch(
-        /ON CONFLICT \(ns, id\)\s+DO UPDATE SET doc = EXCLUDED\.doc/
-      );
+      expect(calls[0]?.text).toMatch(/ON CONFLICT \(ns, id\)\s+DO UPDATE SET doc = EXCLUDED\.doc/);
       // doc is serialized to a JSONB string literal — third param.
       expect(calls[0]?.values?.[0]).toBe("widgets");
       expect(calls[0]?.values?.[1]).toBe("w1");
@@ -115,7 +108,7 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool, calls } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       await store.listDocs("widgets");
@@ -130,7 +123,7 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool, calls } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       await store.listDocs("widgets", "alpha_b%c\\d");
@@ -152,14 +145,12 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       });
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
-      const next = await store.mutate<{ count: number }>(
-        "widgets",
-        "ctr",
-        (prev) => ({ count: (prev?.count ?? 0) + 1 })
-      );
+      const next = await store.mutate<{ count: number }>("widgets", "ctr", (prev) => ({
+        count: (prev?.count ?? 0) + 1,
+      }));
 
       expect(next).toEqual({ count: 2 });
       const texts = clientCalls.map((c) => c.text);
@@ -177,7 +168,7 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool, clientCalls } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       await expect(
@@ -202,10 +193,8 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const originalClient = pg.Client;
       const fakeClient = Object.assign(new EventEmitter(), {
         connect: vi.fn((..._args: unknown[]) => Promise.resolve()),
-        query: vi.fn((..._args: unknown[]) =>
-          Promise.resolve({ rows: [], rowCount: 0 })
-        ),
-        end: vi.fn((..._args: unknown[]) => Promise.resolve())
+        query: vi.fn((..._args: unknown[]) => Promise.resolve({ rows: [], rowCount: 0 })),
+        end: vi.fn((..._args: unknown[]) => Promise.resolve()),
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (pg as any).Client = vi.fn(() => fakeClient);
@@ -215,7 +204,7 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
         const store = new PostgresHarnessStore({
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           pool: pool as any,
-          connectionString: "postgres://x"
+          connectionString: "postgres://x",
         });
 
         const iterator = store.watch("my-ns", "id1")[Symbol.asyncIterator]();
@@ -248,25 +237,17 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       for (const bad of unsafe) {
-        await expect(store.getDoc(bad, "ok")).rejects.toThrow(
+        await expect(store.getDoc(bad, "ok")).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.putDoc(bad, "ok", {})).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.deleteDoc(bad, "ok")).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.appendLog(bad, "ok", {})).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.putBlob(bad, "ok", new Uint8Array([1]))).rejects.toThrow(
           /Unsafe path segment/
         );
-        await expect(store.putDoc(bad, "ok", {})).rejects.toThrow(
-          /Unsafe path segment/
-        );
-        await expect(store.deleteDoc(bad, "ok")).rejects.toThrow(
-          /Unsafe path segment/
-        );
-        await expect(store.appendLog(bad, "ok", {})).rejects.toThrow(
-          /Unsafe path segment/
-        );
-        await expect(
-          store.putBlob(bad, "ok", new Uint8Array([1]))
-        ).rejects.toThrow(/Unsafe path segment/);
       }
     });
 
@@ -274,34 +255,24 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const { pool } = makePoolMock();
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        pool: pool as any
+        pool: pool as any,
       });
 
       for (const bad of unsafe) {
-        await expect(store.getDoc("ok", bad)).rejects.toThrow(
+        await expect(store.getDoc("ok", bad)).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.putDoc("ok", bad, {})).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.deleteDoc("ok", bad)).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.appendLog("ok", bad, {})).rejects.toThrow(/Unsafe path segment/);
+        await expect(store.putBlob("ok", bad, new Uint8Array([1]))).rejects.toThrow(
           /Unsafe path segment/
         );
-        await expect(store.putDoc("ok", bad, {})).rejects.toThrow(
-          /Unsafe path segment/
-        );
-        await expect(store.deleteDoc("ok", bad)).rejects.toThrow(
-          /Unsafe path segment/
-        );
-        await expect(store.appendLog("ok", bad, {})).rejects.toThrow(
-          /Unsafe path segment/
-        );
-        await expect(
-          store.putBlob("ok", bad, new Uint8Array([1]))
-        ).rejects.toThrow(/Unsafe path segment/);
       }
     });
   });
 
   describe("construction", () => {
     it("requires pool or connectionString", () => {
-      expect(() => new PostgresHarnessStore({})).toThrow(
-        /requires `pool` or `connectionString`/
-      );
+      expect(() => new PostgresHarnessStore({})).toThrow(/requires `pool` or `connectionString`/);
     });
   });
 
@@ -311,15 +282,13 @@ describe("PostgresHarnessStore (unit, mocked pg)", () => {
       const store = new PostgresHarnessStore({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         pool: pool as any,
-        connectionString: "postgres://x"
+        connectionString: "postgres://x",
       });
       const tooLong = "x".repeat(49);
       // Postgres truncates identifiers at 63 bytes. `harness_change_`
       // (15 chars) + 48-char ns = exactly 63 — anything longer loses
       // bytes off the tail so LISTEN and NOTIFY would disagree.
-      expect(() => store.watch(tooLong, "id1")).toThrow(
-        /ns exceeds 48 chars/
-      );
+      expect(() => store.watch(tooLong, "id1")).toThrow(/ns exceeds 48 chars/);
     });
   });
 });

--- a/test/stream-activity-renderer.test.ts
+++ b/test/stream-activity-renderer.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  createStreamActivityRenderer,
-  isQuietMode
-} from "../src/cli/stream-activity-renderer.js";
+import { createStreamActivityRenderer, isQuietMode } from "../src/cli/stream-activity-renderer.js";
 
 describe("isQuietMode", () => {
   const originalQuiet = process.env.RELAY_QUIET;
@@ -41,8 +38,8 @@ describe("createStreamActivityRenderer", () => {
     JSON.stringify({
       type: "assistant",
       message: {
-        content: [{ type: "tool_use", ...toolUse }]
-      }
+        content: [{ type: "tool_use", ...toolUse }],
+      },
     });
 
   it("renders tool_use events through the write sink", () => {
@@ -66,7 +63,7 @@ describe("createStreamActivityRenderer", () => {
     r.onLine(
       JSON.stringify({
         type: "assistant",
-        message: { content: [{ type: "text", text: "thinking" }] }
+        message: { content: [{ type: "text", text: "thinking" }] },
       })
     );
     r.flush();

--- a/test/ticket-decomposer.test.ts
+++ b/test/ticket-decomposer.test.ts
@@ -13,7 +13,7 @@ describe("ticket decomposer", () => {
       suggestedSpecialties: ["general"],
       estimatedTicketCount: 2,
       needsDesignDoc: false,
-      needsUserApproval: false
+      needsUserApproval: false,
     };
 
     const ticketPlan = buildTicketPlanFromPhases(plan, classification);
@@ -35,7 +35,7 @@ describe("ticket decomposer", () => {
       suggestedSpecialties: ["general"],
       estimatedTicketCount: 2,
       needsDesignDoc: false,
-      needsUserApproval: false
+      needsUserApproval: false,
     };
 
     const ticketPlan = buildTicketPlanFromPhases(plan, classification);

--- a/test/ticket.test.ts
+++ b/test/ticket.test.ts
@@ -5,7 +5,7 @@ import {
   linearizeTickets,
   getReadyTickets,
   initializeTicketLedger,
-  type TicketDefinition
+  type TicketDefinition,
 } from "../src/domain/ticket.js";
 
 const retryPolicy = { maxAgentAttempts: 2, maxTestFixLoops: 2 };
@@ -21,18 +21,13 @@ function ticket(id: string, deps: string[] = []): TicketDefinition {
     verificationCommands: [],
     docsToUpdate: [],
     dependsOn: deps,
-    retryPolicy
+    retryPolicy,
   };
 }
 
 describe("ticket DAG validation", () => {
   it("validates a valid DAG", () => {
-    const tickets = [
-      ticket("a"),
-      ticket("b", ["a"]),
-      ticket("c", ["a"]),
-      ticket("d", ["b", "c"])
-    ];
+    const tickets = [ticket("a"), ticket("b", ["a"]), ticket("c", ["a"]), ticket("d", ["b", "c"])];
 
     const result = validateTicketDag(tickets);
 
@@ -45,11 +40,7 @@ describe("ticket DAG validation", () => {
   });
 
   it("detects a cycle", () => {
-    const tickets = [
-      ticket("a", ["c"]),
-      ticket("b", ["a"]),
-      ticket("c", ["b"])
-    ];
+    const tickets = [ticket("a", ["c"]), ticket("b", ["a"]), ticket("c", ["b"])];
 
     const result = validateTicketDag(tickets);
 
@@ -80,11 +71,7 @@ describe("linearizeTickets", () => {
 
 describe("getReadyTickets", () => {
   it("returns tickets with all deps completed", () => {
-    const ledger = initializeTicketLedger([
-      ticket("a"),
-      ticket("b", ["a"]),
-      ticket("c")
-    ]);
+    const ledger = initializeTicketLedger([ticket("a"), ticket("b", ["a"]), ticket("c")]);
 
     // a and c should be ready (no deps or deps met)
     const ready = getReadyTickets(ledger);
@@ -96,10 +83,7 @@ describe("getReadyTickets", () => {
   });
 
   it("unblocks tickets when deps complete", () => {
-    const ledger = initializeTicketLedger([
-      ticket("a"),
-      ticket("b", ["a"])
-    ]);
+    const ledger = initializeTicketLedger([ticket("a"), ticket("b", ["a"])]);
 
     // Mark a as completed
     ledger[0].status = "completed";
@@ -111,11 +95,7 @@ describe("getReadyTickets", () => {
 
 describe("initializeTicketLedger", () => {
   it("sets correct initial statuses based on dependencies", () => {
-    const ledger = initializeTicketLedger([
-      ticket("a"),
-      ticket("b", ["a"]),
-      ticket("c")
-    ]);
+    const ledger = initializeTicketLedger([ticket("a"), ticket("b", ["a"]), ticket("c")]);
 
     expect(ledger[0].status).toBe("ready");
     expect(ledger[1].status).toBe("blocked");

--- a/test/tool-activity.test.ts
+++ b/test/tool-activity.test.ts
@@ -4,14 +4,12 @@ import {
   ACTIVITY_TOP_N,
   appendActivityCapped,
   describeToolUse,
-  parseClaudeStreamLine
+  parseClaudeStreamLine,
 } from "../src/domain/tool-activity.js";
 
 describe("describeToolUse", () => {
   it("renders Read with basename", () => {
-    expect(describeToolUse("Read", { file_path: "/abs/path/src/foo.ts" })).toBe(
-      "Reading foo.ts"
-    );
+    expect(describeToolUse("Read", { file_path: "/abs/path/src/foo.ts" })).toBe("Reading foo.ts");
   });
 
   it("renders Edit with basename", () => {
@@ -52,7 +50,7 @@ describe("parseClaudeStreamLine", () => {
   it("returns null for text chunks", () => {
     const line = JSON.stringify({
       type: "assistant",
-      message: { content: [{ type: "text", text: "hello" }] }
+      message: { content: [{ type: "text", text: "hello" }] },
     });
     expect(parseClaudeStreamLine(line)).toBeNull();
   });
@@ -63,9 +61,9 @@ describe("parseClaudeStreamLine", () => {
       message: {
         content: [
           { type: "text", text: "let me look" },
-          { type: "tool_use", name: "Read", input: { file_path: "src/foo.ts" } }
-        ]
-      }
+          { type: "tool_use", name: "Read", input: { file_path: "src/foo.ts" } },
+        ],
+      },
     });
     expect(parseClaudeStreamLine(line)).toBe("Reading foo.ts");
   });
@@ -85,7 +83,7 @@ describe("appendActivityCapped", () => {
   it("caps BEFORE appending (no momentary overshoot)", () => {
     const full = Array.from({ length: ACTIVITY_STACK_MAX }, (_, i) => ({
       text: `x${i}`,
-      ts: i
+      ts: i,
     }));
     const next = appendActivityCapped(full, { text: "new", ts: 99 });
     expect(next.length).toBe(ACTIVITY_STACK_MAX);

--- a/test/tracked-prs.test.ts
+++ b/test/tracked-prs.test.ts
@@ -28,8 +28,8 @@ describe("tracked-prs persistence (OSS-05)", () => {
           ci: "passing",
           review: "pending",
           prState: "open",
-          updatedAt: new Date().toISOString()
-        }
+          updatedAt: new Date().toISOString(),
+        },
       ];
       await store.writeTrackedPrs(channel.channelId, rows);
 
@@ -43,10 +43,7 @@ describe("tracked-prs persistence (OSS-05)", () => {
       // The on-disk file layout must match the shape the Rust crate expects
       // (an object with updatedAt + rows). Breaking the envelope would
       // silently blank the TUI tab.
-      const raw = await readFile(
-        join(dir, channel.channelId, "tracked-prs.json"),
-        "utf8"
-      );
+      const raw = await readFile(join(dir, channel.channelId, "tracked-prs.json"), "utf8");
       const parsed = JSON.parse(raw);
       expect(parsed.rows).toHaveLength(1);
       expect(typeof parsed.updatedAt).toBe("string");
@@ -86,8 +83,8 @@ describe("tracked-prs persistence (OSS-05)", () => {
           ci: null,
           review: null,
           prState: null,
-          updatedAt: now
-        }
+          updatedAt: now,
+        },
       ]);
       await store.writeTrackedPrs(channel.channelId, []);
       expect(await store.readTrackedPrs(channel.channelId)).toEqual([]);

--- a/test/verification-override.test.ts
+++ b/test/verification-override.test.ts
@@ -9,7 +9,7 @@ import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import {
   selectVerificationCommands,
-  VerificationRunner
+  VerificationRunner,
 } from "../src/execution/verification-runner.js";
 
 describe("selectVerificationCommands override signal", () => {
@@ -45,10 +45,7 @@ describe("VerificationRunner surfaces override in run() result", () => {
   it("marks overridden=true and records substitutedCommands when the agent's proposals are rejected", async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "ver-override-art-"));
     const storeRoot = await mkdtemp(join(tmpdir(), "ver-override-hs-"));
-    const artifactStore = new LocalArtifactStore(
-      artifactRoot,
-      new FileHarnessStore(storeRoot)
-    );
+    const artifactStore = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
     const runner = new VerificationRunner(new FakeCommandInvoker(), artifactStore);
 
     try {
@@ -57,7 +54,7 @@ describe("VerificationRunner surfaces override in run() result", () => {
         phaseId: "phase-1",
         repoRoot: process.cwd(),
         proposedCommands: ["rm -rf /tmp/nope"],
-        allowlistedCommands: ["pnpm test", "pnpm typecheck"]
+        allowlistedCommands: ["pnpm test", "pnpm typecheck"],
       });
 
       expect(result.overridden).toBe(true);
@@ -74,10 +71,7 @@ describe("VerificationRunner surfaces override in run() result", () => {
   it("keeps overridden=false and substitutedCommands empty on the happy path", async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "ver-override-art-"));
     const storeRoot = await mkdtemp(join(tmpdir(), "ver-override-hs-"));
-    const artifactStore = new LocalArtifactStore(
-      artifactRoot,
-      new FileHarnessStore(storeRoot)
-    );
+    const artifactStore = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
     const runner = new VerificationRunner(new FakeCommandInvoker(), artifactStore);
 
     try {
@@ -86,7 +80,7 @@ describe("VerificationRunner surfaces override in run() result", () => {
         phaseId: "phase-1",
         repoRoot: process.cwd(),
         proposedCommands: ["pnpm test"],
-        allowlistedCommands: ["pnpm test", "pnpm typecheck"]
+        allowlistedCommands: ["pnpm test", "pnpm typecheck"],
       });
 
       expect(result.overridden).toBe(false);
@@ -105,7 +99,7 @@ class FakeCommandInvoker implements CommandInvoker {
     return {
       stdout: `simulated ${invocation.args.join(" ")}`,
       stderr: "",
-      exitCode: 0
+      exitCode: 0,
     };
   }
 }

--- a/test/verification-runner.test.ts
+++ b/test/verification-runner.test.ts
@@ -9,7 +9,7 @@ import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import {
   selectVerificationCommands,
-  VerificationRunner
+  VerificationRunner,
 } from "../src/execution/verification-runner.js";
 
 describe("verification command selection", () => {
@@ -22,7 +22,7 @@ describe("verification command selection", () => {
     ).toEqual({
       commandsToRun: ["pnpm test", "pnpm typecheck"],
       rejected: ["rm -rf /tmp/nope"],
-      overridden: false
+      overridden: false,
     });
   });
 
@@ -30,7 +30,7 @@ describe("verification command selection", () => {
     expect(selectVerificationCommands([], ["pnpm typecheck"])).toEqual({
       commandsToRun: ["pnpm typecheck"],
       rejected: [],
-      overridden: false
+      overridden: false,
     });
   });
 });
@@ -40,17 +40,14 @@ describe("verification runner", () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), "relay-artifacts-"));
     const storeRoot = await mkdtemp(join(tmpdir(), "relay-artifacts-hs-"));
     const artifactStore = new LocalArtifactStore(artifactRoot, new FileHarnessStore(storeRoot));
-    const runner = new VerificationRunner(
-      new FakeCommandInvoker(),
-      artifactStore
-    );
+    const runner = new VerificationRunner(new FakeCommandInvoker(), artifactStore);
 
     try {
       const execution = await runner.executeCommand({
         runId: "run-1",
         phaseId: "phase-1",
         repoRoot: process.cwd(),
-        command: "pnpm typecheck"
+        command: "pnpm typecheck",
       });
 
       const file = await artifactStore.readCommandResult(execution.artifact.path);
@@ -63,11 +60,11 @@ describe("verification runner", () => {
     } finally {
       await rm(artifactRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
       await rm(storeRoot, {
         recursive: true,
-        force: true
+        force: true,
       });
     }
   });
@@ -78,7 +75,7 @@ class FakeCommandInvoker implements CommandInvoker {
     return {
       stdout: `simulated ${invocation.args.join(" ")}`,
       stderr: "",
-      exitCode: 0
+      exitCode: 0,
     };
   }
 }

--- a/test/workspace-registry-harness-store.test.ts
+++ b/test/workspace-registry-harness-store.test.ts
@@ -1,29 +1,14 @@
-import {
-  cp,
-  mkdtemp,
-  readFile,
-  rm,
-  stat,
-  writeFile
-} from "node:fs/promises";
+import { cp, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  WorkspaceRegistry,
-  buildWorkspaceId
-} from "../src/cli/workspace-registry.js";
+import { WorkspaceRegistry, buildWorkspaceId } from "../src/cli/workspace-registry.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
 import { STORE_NS } from "../src/storage/namespaces.js";
-import type {
-  BlobRef,
-  ChangeEvent,
-  HarnessStore,
-  ReadLogOptions
-} from "../src/storage/store.js";
+import type { BlobRef, ChangeEvent, HarnessStore, ReadLogOptions } from "../src/storage/store.js";
 
 /**
  * Minimal in-memory HarnessStore. Only the methods WorkspaceRegistry
@@ -59,11 +44,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.appendLog is not implemented");
   }
 
-  async readLog<T>(
-    _ns: string,
-    _id: string,
-    _opts?: ReadLogOptions
-  ): Promise<T[]> {
+  async readLog<T>(_ns: string, _id: string, _opts?: ReadLogOptions): Promise<T[]> {
     throw new Error("FakeHarnessStore.readLog is not implemented");
   }
 
@@ -75,11 +56,7 @@ class FakeHarnessStore implements HarnessStore {
     throw new Error("FakeHarnessStore.getBlob is not implemented");
   }
 
-  async mutate<T>(
-    ns: string,
-    id: string,
-    fn: (prev: T | null) => T
-  ): Promise<T> {
+  async mutate<T>(ns: string, id: string, fn: (prev: T | null) => T): Promise<T> {
     this.mutateCalls.push({ ns, id });
     const prev = (this.docs.get(this.key(ns, id)) as T | undefined) ?? null;
     const next = fn(prev);
@@ -117,7 +94,7 @@ describe("WorkspaceRegistry with HarnessStore injection", () => {
 
     expect(fake.mutateCalls).toContainEqual({
       ns: STORE_NS.workspace,
-      id: "registry"
+      id: "registry",
     });
 
     const rec = await fake.getDoc<{ updatedAt: string; count: number }>(
@@ -154,14 +131,10 @@ describe("WorkspaceRegistry with HarnessStore injection", () => {
     expect(resolvedA!.workspaceId).toBe(a.workspaceId);
 
     const all = await registry.list();
-    expect(all.map((w) => w.workspaceId).sort()).toEqual(
-      [a.workspaceId, b.workspaceId].sort()
-    );
+    expect(all.map((w) => w.workspaceId).sort()).toEqual([a.workspaceId, b.workspaceId].sort());
 
     // Unregistered path returns null
-    const missing = await registry.resolveForRepo(
-      join(relayDir, "does-not-exist")
-    );
+    const missing = await registry.resolveForRepo(join(relayDir, "does-not-exist"));
     expect(missing).toBeNull();
   });
 
@@ -225,12 +198,8 @@ describe("WorkspaceRegistry with HarnessStore injection", () => {
 
       // Operator-visible diagnostic was emitted.
       const warnings = warnSpy.mock.calls.map((c) => c.join(" "));
-      expect(
-        warnings.some((w) => w.includes("coordination-record mutate failed"))
-      ).toBe(true);
-      expect(
-        warnings.some((w) => w.includes("coordination store exploded"))
-      ).toBe(true);
+      expect(warnings.some((w) => w.includes("coordination-record mutate failed"))).toBe(true);
+      expect(warnings.some((w) => w.includes("coordination store exploded"))).toBe(true);
     } finally {
       warnSpy.mockRestore();
       mutateSpy.mockRestore();
@@ -249,7 +218,7 @@ describe("WorkspaceRegistry with HarnessStore injection", () => {
 
     const [entryX, entryY] = await Promise.all([
       registry.register(pathX),
-      registry.register(pathY)
+      registry.register(pathY),
     ]);
 
     expect(entryX.repoPath).toBe(pathX);
@@ -291,35 +260,24 @@ describe("WorkspaceRegistry reads legacy Rust-layout fixtures", () => {
   it("reads a pre-migration registry file from its Rust-compat path", async () => {
     const storeRoot = await mkdtemp(join(tmpdir(), "ws-reg-legacy-store-"));
     try {
-      const registry = new WorkspaceRegistry(
-        workDir,
-        new FileHarnessStore(storeRoot)
-      );
+      const registry = new WorkspaceRegistry(workDir, new FileHarnessStore(storeRoot));
 
       const doc = await registry.read();
       expect(doc.workspaces).toHaveLength(2);
-      expect(doc.workspaces.map((w) => w.workspaceId)).toEqual([
-        "ws-legacy-1",
-        "ws-legacy-2"
-      ]);
+      expect(doc.workspaces.map((w) => w.workspaceId)).toEqual(["ws-legacy-1", "ws-legacy-2"]);
       expect(doc.workspaces[0].repoPath).toBe("/home/user/projects/legacy-a");
 
       // The pre-migration fixture uses hand-picked workspaceIds that don't
       // match `buildWorkspaceId(repoPath)`, so `resolveForRepo` (which hashes
       // the path to look up) legitimately returns null — that's the current
       // contract, and the list above proves the data round-tripped.
-      const resolved = await registry.resolveForRepo(
-        "/home/user/projects/legacy-a"
-      );
+      const resolved = await registry.resolveForRepo("/home/user/projects/legacy-a");
       expect(resolved).toBeNull();
 
       // Coordination record is untouched by reads — only writes bump it.
-      await expect(
-        stat(join(storeRoot, "workspace", "registry.json"))
-      ).rejects.toThrow();
+      await expect(stat(join(storeRoot, "workspace", "registry.json"))).rejects.toThrow();
     } finally {
       await rm(storeRoot, { recursive: true, force: true });
     }
   });
 });
-

--- a/test/workspace-registry.test.ts
+++ b/test/workspace-registry.test.ts
@@ -10,7 +10,7 @@ import {
   readRegistry,
   registerWorkspace,
   resolveWorkspaceForRepo,
-  writeRegistry
+  writeRegistry,
 } from "../src/cli/workspace-registry.js";
 
 describe("workspace registry", () => {
@@ -32,10 +32,7 @@ describe("workspace registry", () => {
 
   it("registers and resolves workspaces via file-backed registry", async () => {
     // This test writes to the real global registry, so we use unique paths
-    const fakePath = join(
-      await mkdtemp(join(tmpdir(), "ws-reg-test-")),
-      "fake-repo"
-    );
+    const fakePath = join(await mkdtemp(join(tmpdir(), "ws-reg-test-")), "fake-repo");
 
     try {
       const entry = await registerWorkspace(fakePath);
@@ -58,9 +55,7 @@ describe("workspace registry", () => {
     } finally {
       // Clean up: remove our test entry from the global registry
       const registry = await readRegistry();
-      registry.workspaces = registry.workspaces.filter(
-        (w) => w.repoPath !== fakePath
-      );
+      registry.workspaces = registry.workspaces.filter((w) => w.repoPath !== fakePath);
       await writeRegistry(registry);
       await rm(fakePath, { recursive: true, force: true }).catch(() => {});
     }


### PR DESCRIPTION
## Summary
- Reformatted **149 files** via `prettier --write` (src/, test/, gui/src/, scripts/, *.md, docs/)
- Added `.prettierrc` + `.prettierignore` + `pnpm format` + `pnpm format:check` scripts
- Removed `continue-on-error: true` from CI `format-check` job → now blocking
- Added `.claude/` and `.agent-harness/` to `.gitignore`
- AGENTS.md line 56 updated: Prettier is now CI-enforced

## Context
Supersedes #61 (was on `feat/oss-18-prettier-reset-v2`, stale after multiple merges touched 79+ overlapping files). This version is a fresh reformat on top of current main.

## Test plan
- [x] `pnpm format:check` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] CI `format-check` now blocks on drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)