### PR TITLE
OSS-21: Launch blockers (Postgres→roadmap, flaky test stabilization, npm name scope)

### DIFF
--- a/.changeset/oss-20-release-pipeline.md
+++ b/.changeset/oss-20-release-pipeline.md
@@ -1,5 +1,5 @@
 ---
-"relay": minor
+"@jcast90/relay": minor
 ---
 
 OSS-20: release pipeline. Adds Changesets-driven versioning with a Cargo.toml
@@ -7,4 +7,6 @@ sync script, `.github/workflows/release.yml` that publishes to npm + cuts
 per-OS GUI artifacts (`.dmg`, `.AppImage`, `.deb`, `.msi`) + creates a GitHub
 Release on `v*` tags. `install.sh` gains a Tauri-dep preflight on Linux with
 an interactive `apt-get install` offer. README has a proper Install section
-with the `npm install -g rly` / `npx rly@latest welcome` one-liner.
+with the `npm install -g @jcast90/relay` / `npx @jcast90/relay welcome`
+one-liner (package is `@jcast90/relay` because unscoped `relay` and `rly`
+are taken on npm — see OSS-21).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,29 @@ name: Release
 # Trigger: any pushed tag that looks like v0.1.0, v0.2.0-rc.1, etc.
 #
 # Fan-out:
-#   - release-npm      publishes the `relay` package to npm (and GitHub Packages)
+#   - release-npm      publishes the `@jcast90/relay` package to npm. Gated on
+#                      the `NPM_PUBLISH_ENABLED` repository variable (OSS-21):
+#                      the job always runs but only actually publishes when an
+#                      admin flips that toggle. That keeps the fan-out stable
+#                      while the package name is still being claimed on npm.
 #   - release-gui      matrix-builds the Tauri GUI on macOS / Linux / Windows and
-#                      uploads the OS-native installer artifacts
+#                      uploads the OS-native installer artifacts. Does NOT
+#                      depend on release-npm — GUI bundles ship on every tag
+#                      regardless of whether npm publish is enabled.
 #   - release-github   collects everything and cuts a GitHub Release, using the
-#                      matching CHANGELOG.md section as the release body
+#                      matching CHANGELOG.md section as the release body. Also
+#                      independent of release-npm.
 #
-# Admin-only secrets required:
-#   NPM_TOKEN          npm auth token with publish scope for `relay`
+# Admin-only secrets / variables:
+#   NPM_TOKEN                    npm auth token with publish scope for the
+#                                `@jcast90` scope. Only required once
+#                                NPM_PUBLISH_ENABLED is set to "true".
+#   vars.NPM_PUBLISH_ENABLED     repo-level variable (not a secret). Set to
+#                                "true" to actually publish to npm; anything
+#                                else (including unset) makes release-npm a
+#                                no-op. OSS-21: deferred because publish isn't
+#                                day-1; toggle when the scope and token are
+#                                both provisioned.
 #   (GITHUB_TOKEN is provided automatically by Actions; used for GitHub Packages
 #   mirror + Release creation.)
 #
@@ -39,16 +54,30 @@ jobs:
   release-npm:
     name: release-npm
     runs-on: ubuntu-latest
+    # OSS-21: npm publish is deferred. The job always runs (so the fan-out
+    # graph stays stable) but the publish steps short-circuit unless the
+    # repo-level `NPM_PUBLISH_ENABLED` variable is "true". This replaces the
+    # earlier "publish is day-1" assumption: both `relay` and `rly` were
+    # taken on npm, the package is now scoped as `@jcast90/relay`, and the
+    # admin will flip this toggle once the scope + token are provisioned.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Publish gate notice
+        if: vars.NPM_PUBLISH_ENABLED != 'true'
+        run: |
+          echo "NPM_PUBLISH_ENABLED is not set to 'true' — skipping npm publish steps."
+          echo "Set the repo variable to 'true' to publish @jcast90/relay on the next tag."
+
       - name: Setup pnpm
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 10
 
       - name: Setup Node.js (npm registry)
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -56,17 +85,21 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: pnpm build
 
       - name: Publish to npm
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: pnpm publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup Node.js (GitHub Packages)
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -74,15 +107,15 @@ jobs:
           scope: "@jcast90"
 
       - name: Publish mirror to GitHub Packages
-        # Best-effort mirror. GitHub Packages requires a scoped name, so we
-        # rewrite package.json on the fly to @jcast90/relay, publish, then
-        # discard. If this step fails we don't want to block the npm release.
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
+        # Best-effort mirror. `@jcast90/relay` is already a scoped name, so we
+        # just set publishConfig to the GitHub Packages registry and publish.
+        # If this step fails we don't want to block the npm release.
         continue-on-error: true
         run: |
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.name = '@jcast90/relay';
             pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
@@ -92,7 +125,9 @@ jobs:
 
   release-gui:
     name: release-gui (${{ matrix.platform.os }})
-    needs: release-npm
+    # OSS-21: GUI bundles do not depend on the npm publish. Removed the
+    # `needs: release-npm` — Tauri artifacts ship on every tag regardless of
+    # whether npm publish is enabled.
     strategy:
       fail-fast: false
       matrix:
@@ -177,7 +212,10 @@ jobs:
 
   release-github:
     name: release-github
-    needs: [release-npm, release-gui]
+    # OSS-21: The GitHub Release depends only on GUI bundles (the artifacts
+    # it uploads), not on npm publish. Dropping `release-npm` here means a
+    # tag still cuts a Release when NPM_PUBLISH_ENABLED is off.
+    needs: [release-gui]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to **Relay** (`rly`) are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Workspace versions are kept in lockstep across the npm package (`relay`), the
-Tauri GUI frontend (`gui/package.json`), and every `Cargo.toml` in the workspace
-(`tui/`, `gui/src-tauri/`, `crates/harness-data/`). The `pnpm changeset-version`
-script runs `changeset version` then `scripts/sync-versions.mjs` to keep them
-aligned.
+Workspace versions are kept in lockstep across the npm package
+(`@jcast90/relay`), the Tauri GUI frontend (`gui/package.json`), and every
+`Cargo.toml` in the workspace (`tui/`, `gui/src-tauri/`,
+`crates/harness-data/`). The `pnpm changeset-version` script runs
+`changeset version` then `scripts/sync-versions.mjs` to keep them aligned.
 
 ## [Unreleased]
 
@@ -34,10 +34,12 @@ launch-prep push; there was no prior tagged release, so this is the initial one.
   → `cmd`) paths are all wired; no-supported-terminal fallback posts a system
   channel-feed entry telling the user to run `rly claude` in the repo manually.
 - **OSS-20** — Release pipeline: Changesets-driven versioning with a Cargo sync
-  script, `.github/workflows/release.yml` that publishes to npm + builds per-OS
-  GUI artifacts (macOS `.dmg`, Linux `.AppImage` + `.deb`, Windows `.msi`) + cuts
-  a GitHub Release on `v*` tags. `install.sh` gained a preflight that checks for
-  `node >= 20`, `pnpm`, `cargo`, and the Linux Tauri system libraries.
+  script, `.github/workflows/release.yml` that (when enabled via
+  `NPM_PUBLISH_ENABLED`, see OSS-21 below) publishes to npm + always builds
+  per-OS GUI artifacts (macOS `.dmg`, Linux `.AppImage` + `.deb`, Windows
+  `.msi`) + cuts a GitHub Release on `v*` tags. `install.sh` gained a preflight
+  that checks for `node >= 20`, `pnpm`, `cargo`, and the Linux Tauri system
+  libraries.
 
 ### Changed
 
@@ -68,12 +70,29 @@ launch-prep push; there was no prior tagged release, so this is the initial one.
 
 - **OSS-11** — Flaky-test stabilization: orchestrator tests now consistently
   run under scripted mode regardless of the host shell's `HARNESS_LIVE` value.
+- **OSS-21** — Second flake pass on `verification-override-feed.test.ts` and
+  the orchestrator-v2 channel-mirror assertions: replaced single-snapshot
+  reads of the channel feed / board with a short polling helper so
+  atomic-rename visibility on Linux CI can't race the assertion.
 
 ### Infrastructure
 
 - **OSS-19** — Removed all legacy `agent-harness` references (bin alias,
   `~/.agent-harness` auto-migration, `AGENT_HARNESS_*` env fallbacks, doc
   mentions). `rly` is the sole CLI; `~/.relay/` is the sole data path.
+- **OSS-21** — Launch-blocker triage:
+  - Storage: `HARNESS_STORE=postgres` no longer throws. The factory warns
+    once and falls back to the file backend so old docs / scripts don't
+    crash. The `PostgresHarnessStore` source stays in-tree as a stub for
+    the Roadmap (multi-agent coordination via `LISTEN/NOTIFY`) — it is no
+    longer claimed as a shipping backend anywhere in docs.
+  - npm: package name changed from unscoped `relay` to `@jcast90/relay`
+    (both `relay` and `rly` were taken on npm). Scope is permanent.
+  - Release pipeline: `release-npm` is now gated on the repo variable
+    `NPM_PUBLISH_ENABLED` so the job is a safe no-op until an admin
+    explicitly enables it. `release-gui` and `release-github` no longer
+    depend on `release-npm` — GUI bundles and the GitHub Release ship on
+    every tag regardless of npm publish state.
 
 [Unreleased]: https://github.com/jcast90/relay/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jcast90/relay/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Relay turns a sentence, a GitHub issue URL, or a Linear ticket into a **running plan of AI-coded work** — with tickets, verification loops, live PR tracking, and optional human approval gates. Sessions run inside your normal Claude or Codex CLI; Relay wraps them with an MCP server that records everything into Slack-style **channels** you can query later.
 
-**Suitable for individual developers and for teams working inside a company.** Relay runs entirely on your machine (or on infrastructure you control). There is no hosted Relay service, no telemetry, and no phone-home — state stays in `~/.relay/` on disk (optionally backed by your own Postgres). What it's built for:
+**Suitable for individual developers and for teams working inside a company.** Relay runs entirely on your machine. There is no hosted Relay service, no telemetry, and no phone-home — all state stays in `~/.relay/` on disk. What it's built for:
 
 - **Agent orchestration** — classify, plan, decompose, dispatch, and verify. One request turns into a supervised workflow.
 - **Multi-repo coordination** — sessions running in different repos can discover each other, message, and share context via the crosslink MCP tools.
@@ -46,6 +46,8 @@ CLI: **`rly`**.
 - [Architecture](#architecture)
 - [Development](#development)
 - [Contributing](#contributing)
+- [Known limits](#known-limits)
+- [Roadmap](#roadmap)
 - [License](#license)
 
 ## Install
@@ -55,15 +57,19 @@ CLI: **`rly`**.
 Once `v0.1.0` ships to npm, this will be the one-liner:
 
 ```bash
-npm install -g rly
+npm install -g @jcast90/relay
 rly welcome
 ```
 
 …or without globally installing:
 
 ```bash
-npx rly@latest welcome
+npx @jcast90/relay welcome
 ```
+
+The npm package is published under the `@jcast90` scope because both
+unscoped `relay` and `rly` were already taken on npm when Relay shipped.
+The binary exposed on `$PATH` is still `rly`.
 
 ### From source _(available today)_
 
@@ -233,7 +239,7 @@ Statuses: `pending | blocked | ready | executing | verifying | retry | completed
 
 ### Decisions
 
-First-class records with rationale + alternatives, written to `channels/<id>/decisions/<id>.json`. Each write is atomic (temp-rename) and also mirrored through the `HarnessStore` coordination layer so Postgres `LISTEN/NOTIFY` consumers can observe new decisions without tailing the filesystem.
+First-class records with rationale + alternatives, written to `channels/<id>/decisions/<id>.json`. Each write is atomic (temp-rename) — readers (TUI, GUI, other CLI invocations) see a consistent file or the previous version, never a torn one.
 
 ### Named agents
 
@@ -376,14 +382,11 @@ One-off: `rly claude --yolo` or `rly claude --auto-approve`.
 
 ## Storage & execution backends
 
-### HarnessStore (pluggable)
+### Storage
 
-All state — runs, tickets, decisions, crosslink messages, agent-names, workspace registry, session transcripts — goes through a single `HarnessStore` interface (`src/storage/store.ts`). Today:
+Relay stores everything in `~/.relay/` as JSON/JSONL files (atomic writes via tmp+rename). One backend, no DB required. All state — runs, tickets, decisions, crosslink messages, agent-names, workspace registry, session transcripts — goes through a single `HarnessStore` interface (`src/storage/store.ts`) so a future backend can slot in without rewriting handlers.
 
-- **FileHarnessStore** — default. JSON / JSONL under `~/.relay/`.
-- **PostgresHarnessStore** — opt-in via config (T-402). Adds `LISTEN/NOTIFY` for cross-agent coordination.
-
-The interface is intentionally small (docs, changefeeds, logs, blobs) so adding a third backend is bounded work.
+File backend is all that ships today. A Postgres backend (`src/storage/postgres-store.ts`) is **stubbed in-tree** for future multi-agent coordination — `LISTEN/NOTIFY` decision broadcasts and row-locked writes — but **not wired yet**; `HARNESS_STORE=postgres` currently warns and falls back to the file backend. See the [Roadmap](#roadmap).
 
 ### Executor
 
@@ -511,11 +514,23 @@ See [`AGENTS.md`](./AGENTS.md) for the coding-agent conventions.
 
 A **`CLAUDE.md`** at the repo root (when present) tells any Claude agent working in this codebase — including `rly claude` itself — what conventions to follow.
 
-## Known limits / roadmap
+## Known limits
 
 - **Spawn is cross-platform but lightly tested off macOS.** macOS is daily-driven; Linux and Windows branches are compile-checked and unit-tested but real-device integration testing is still the gate before tagging a release.
 - **Cost guardrails not yet implemented.** Token usage isn't tracked or capped. Use `RELAY_AUTO_APPROVE=1` with care.
-- **Postgres backend is opt-in, file-only is default.** The coordination features (`LISTEN/NOTIFY` cross-agent decision broadcasts) activate when Postgres is configured.
+
+## Roadmap
+
+Honest snapshot — most of these haven't started. Order is rough priority, not commitment.
+
+- **Postgres backend for multi-agent coordination** _(exploratory, stubbed)_ — the file backend serializes writes per-host via tmp+rename atomics. A Postgres-backed `HarnessStore` would let multiple agents (same box or different) share state through `LISTEN/NOTIFY` cross-agent decision broadcasts and row-locked decision writes. Postgres here runs locally (`brew install postgresql && createdb relay`) or remote — this isn't a cloud-only feature. Source stub lives at `src/storage/postgres-store.ts`; not wired into the factory and the integration tests are skipped.
+- **Pod executor (Kubernetes)** _(exploratory)_ — verification runs off the dev box in per-ticket pods. Prototype was removed in OSS-08 until it's wired end-to-end again.
+- **S3 artifacts** _(exploratory)_ — moving ticket evidence off the local filesystem so it survives pod/host churn. Pairs with the pod executor.
+- **Distribution: Homebrew tap + winget manifest** _(planned)_ — for one-line `brew install rly` / `winget install rly` after the first tagged release.
+- **Code signing + notarization** _(planned)_ — macOS `.dmg` (Developer ID + `notarytool`) and Windows `.msi` (Authenticode) so downloads don't need right-click-open / SmartScreen bypass. Requires paid certificates and a secret-management pass in the release workflow.
+- **npm publish** _(planned, name resolved)_ — the package is published as `@jcast90/relay` once an admin toggles the `NPM_PUBLISH_ENABLED` repo variable. Unscoped `relay` and `rly` are both taken on npm so the scope is permanent.
+- **Cost guardrails** _(in design)_ — token usage tracking per run, per ticket, per channel, with a soft cap that pauses scheduling when hit. Prerequisite to making `RELAY_AUTO_APPROVE=1` safer for multi-hour runs.
+- **Integration test coverage off macOS** _(in progress)_ — Linux and Windows spawn paths are compile-checked but only smoke-tested; promoting them to the fast CI tier is the gate to tagging cross-platform releases.
 
 ## License
 

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -23,7 +23,7 @@ Top-level layout of the repo. One line per directory, pointing at the concrete s
 - **`channels/`** — `channel-store.ts` owns feed / tickets / decisions; `ao-notifier.ts` bridges to Composio's AO orchestrator.
 - **`integrations/`** — AO plugins: tracker (GitHub/Linear), scm (PR watcher), pr-poller, env-mutex.
 - **`execution/`** — `executor.ts` abstraction, `local-child-process-executor.ts`.
-- **`storage/`** — `HarnessStore` interface in `store.ts`, `FileHarnessStore` and `PostgresHarnessStore` backends.
+- **`storage/`** — `HarnessStore` interface in `store.ts`. `FileHarnessStore` is the only shipping backend; `PostgresHarnessStore` is stubbed for future multi-agent coordination (see the Roadmap in the root README) and not wired through `factory.ts`.
 - **`domain/`** — shared TS types and zod schemas. Canonical source for shapes; Rust side mirrors these.
 - **`mcp/`** — MCP server + tool definitions (harness / channel / crosslink tool groups).
 - **`crosslink/`** — session discovery, messaging between live agents, hook generation for Claude/Codex.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,7 @@ All three dashboards (CLI / TUI / GUI) read the same files. No synchronisation l
   agent-names.json            # display-name registry
 ```
 
-Opting in to Postgres (`PostgresHarnessStore`) keeps the same on-disk layout and adds `LISTEN/NOTIFY` on top for cross-agent coordination.
+Today the file backend is the only one that ships. A Postgres backend is stubbed in source (`src/storage/postgres-store.ts`) for future multi-agent coordination but isn't wired yet — see the [Roadmap](../README.md#roadmap).
 
 ## Troubleshooting
 

--- a/docs/storage-injection.md
+++ b/docs/storage-injection.md
@@ -1,21 +1,23 @@
 # Storage Injection
 
 Relay's persistent state lives behind a single interface, `HarnessStore`
-(`src/storage/store.ts`). Two implementations ship today:
+(`src/storage/store.ts`). **Today, File backend only.**
 
-- **`FileHarnessStore`** — rooted at `~/.relay/`, atomic JSON/JSONL writes. The
-  default, and the right choice for solo dev, CI, and single-host deployments.
-- **`PostgresHarnessStore`** — backed by your own Postgres. Use this for
-  multi-agent deployments where `LISTEN/NOTIFY` broadcasts and row-locked
-  decision writes matter. Select it via `HARNESS_STORE=postgres` +
-  `HARNESS_POSTGRES_URL`.
+- **`FileHarnessStore`** — rooted at `~/.relay/`, atomic JSON/JSONL writes.
+  The default, and the only implementation wired into the factory.
+
+A `PostgresHarnessStore` stub lives at `src/storage/postgres-store.ts` for
+future multi-agent coordination (`LISTEN/NOTIFY` cross-agent decision
+broadcasts, row-locked decision writes), but it isn't wired through the
+factory. See the [Roadmap](../README.md#roadmap).
 
 ## Goal
 
-Let the harness run against a local filesystem during development and
-against Postgres in shared deployments by changing an environment variable,
-not by editing handlers. All backend selection flows through one place:
-`buildHarnessStore()` in `src/storage/factory.ts`.
+Let the harness run against a local filesystem today without forcing every
+handler to know how the state is stored. All backend selection flows
+through one place: `buildHarnessStore()` in `src/storage/factory.ts`. The
+single-interface shape keeps a future backend drop-in work rather than a
+handler rewrite.
 
 ## Composition root
 
@@ -33,11 +35,17 @@ global side-effect.
 
 ## Environment
 
-| `HARNESS_STORE` | Behavior                                                    |
-| --------------- | ----------------------------------------------------------- |
-| unset / `file`  | `FileHarnessStore` at `getRelayDir()` (usually `~/.relay/`) |
-| `postgres`      | Throws `NotImplementedError` until T-402 lands              |
-| `sqlite`        | Throws `NotImplementedError` (no tracking ticket yet)       |
+| `HARNESS_STORE`          | Behavior                                                    |
+| ------------------------ | ----------------------------------------------------------- |
+| unset / `file`           | `FileHarnessStore` at `getRelayDir()` (usually `~/.relay/`) |
+| `postgres` / `sqlite`    | Warns once, falls back to the file backend (see below)      |
+| any other value          | Silently falls back to the file backend                     |
+
+The factory never throws on an unsupported backend — old docs and user
+scripts still reference `HARNESS_STORE=postgres`, and crashing those
+callers on startup would be a worse experience than quietly degrading. A
+one-line `console.warn` fires when a recognized-but-unimplemented kind is
+requested, so operators see the degradation.
 
 ## Legacy stores (unmigrated)
 
@@ -68,14 +76,24 @@ Other `node:fs/promises` importers in `src/` (bootstrap, config, agent
 wrapper, MCP server, scripted invoker, etc.) are not storage backends —
 they don't migrate and aren't part of the allowlist.
 
-## Adding a new backend
+## Future work
+
+The `PostgresHarnessStore` stub at `src/storage/postgres-store.ts` would,
+when wired:
+
+- Replace mtime polling in `watch` with `LISTEN/NOTIFY` so multiple agents
+  (same host or different) see decision writes without filesystem tailing.
+- Use Postgres advisory locks instead of the in-process promise mutex in
+  `mutate`, so cross-process coordination is a first-class primitive.
+
+Postgres here is not a cloud requirement — it runs fine locally
+(`brew install postgresql && createdb relay`). The value is multi-agent
+coordination, not cloud. Wiring this up is tracked in the
+[Roadmap](../README.md#roadmap).
+
+## Adding a new backend (for reference)
 
 1. Implement `HarnessStore` in a new file under `src/storage/`.
 2. Widen `StoreKind` in `factory.ts` if a new env value is needed.
 3. Wire it into `buildHarnessStore()` behind its `StoreKind`.
-4. Replace the `NotImplementedError` throw.
-
-The Postgres impl (T-402) will use `LISTEN/NOTIFY` instead of mtime polling
-for `watch`, and Postgres advisory locks instead of the in-process promise
-mutex for `mutate`. The interface contract is designed to accommodate both
-without changes.
+4. Drop the warn-and-fallback branch for that kind.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "relay",
+  "name": "@jcast90/relay",
   "version": "0.1.0",
   "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
   "license": "MIT",

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -14,10 +14,14 @@ export interface StoreFactoryOptions {
 }
 
 /**
- * Thrown when a store kind is recognized but not yet implemented. The message
- * points at the tracking ticket (where one exists) so operators know where to
- * follow up instead of filing duplicate bugs. SQLite has no tracking ticket
- * yet (TBD); postgres points at T-402.
+ * Retained for source-level compatibility with callers that imported this
+ * symbol before OSS-21 made `file` the only shipping backend. The factory no
+ * longer throws this error at runtime — unsupported `HARNESS_STORE` values
+ * warn and fall back to the file backend (see `buildHarnessStore` below).
+ *
+ * Kept exported so existing `import { NotImplementedError }` call sites keep
+ * compiling; it will be removed alongside the Postgres/SQLite placeholder
+ * branches in a follow-up cleanup PR.
  */
 export class NotImplementedError extends Error {
   constructor(message: string) {
@@ -78,23 +82,25 @@ function resolveKind(explicit: StoreKind | undefined): StoreKind {
  * argument and must not call this factory directly.
  *
  * Precedence: `opts.kind` > `HARNESS_STORE` env > default `"file"`.
+ *
+ * Only the `"file"` backend ships today (OSS-21). Any other kind — whether
+ * from the env var or an explicit opts.kind — logs a one-line warning and
+ * falls back to file. We deliberately do not throw here: old docs and user
+ * scripts still reference `HARNESS_STORE=postgres`, and crashing those
+ * callers on startup would be a worse experience than quietly degrading to
+ * the working backend. The Postgres/SQLite code remains in-tree as a
+ * placeholder for the roadmap; see README's Roadmap section.
  */
 export function buildHarnessStore(opts: StoreFactoryOptions = {}): HarnessStore {
   const kind = resolveKind(opts.kind);
 
-  if (kind === "file") {
-    return new FileHarnessStore(opts.fileRoot ?? getRelayDir());
-  }
-
-  if (kind === "postgres") {
-    throw new NotImplementedError(
-      "PostgresHarnessStore is T-402 (not yet implemented); use HARNESS_STORE=file."
+  if (kind !== "file") {
+    console.warn(
+      `Only the 'file' storage backend is implemented today. HARNESS_STORE='${kind}' ignored; using file backend.`
     );
   }
 
-  throw new NotImplementedError(
-    "SqliteHarnessStore is not yet implemented; use HARNESS_STORE=file."
-  );
+  return new FileHarnessStore(opts.fileRoot ?? getRelayDir());
 }
 
 // Module-level singleton. Handlers migrating off direct `fs/promises` (T-101+)

--- a/test/orchestrator-v2.test.ts
+++ b/test/orchestrator-v2.test.ts
@@ -23,6 +23,36 @@ import { ScriptedInvoker } from "../src/simulation/scripted-invoker.js";
 // for the non-orchestrator writers (poller, scheduler tail, filesystem lag).
 const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 } as const;
 
+/**
+ * Poll `fn` until it returns a truthy value or `timeoutMs` elapses. OSS-21:
+ * mirror the pattern from `verification-override-feed.test.ts` so cross-
+ * process visibility races (atomic tmp-rename visible to a fresh
+ * directory-read on Linux CI) surface as a crisp timeout instead of a flaky
+ * single-snapshot assertion. Orchestrator-v2 already drains its tracked
+ * writes before returning, so this is defensive — the timeout budget is
+ * small and the happy path resolves on the first iteration.
+ */
+async function waitFor<T>(
+  fn: () => Promise<T | undefined> | T | undefined,
+  opts: { timeoutMs?: number; intervalMs?: number; label?: string } = {}
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 2000;
+  const intervalMs = opts.intervalMs ?? 20;
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const value = await fn();
+    if (value !== undefined && value !== null && value !== false) {
+      return value as T;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `waitFor timed out after ${timeoutMs}ms${opts.label ? `: ${opts.label}` : ""}`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
 function buildOrchestrator(
   cwd: string,
   artifactsDir: string,
@@ -181,7 +211,13 @@ describe("OrchestratorV2 integration", () => {
       );
 
       expect(run.channelId).not.toBeNull();
-      const boardTickets = await channelStore.readChannelTickets(run.channelId!);
+      const boardTickets = await waitFor(
+        async () => {
+          const tickets = await channelStore.readChannelTickets(run.channelId!);
+          return tickets.length === run.ticketLedger.length ? tickets : undefined;
+        },
+        { timeoutMs: 2000, intervalMs: 20, label: "channel board mirror settled" }
+      );
       expect(boardTickets.length).toBe(run.ticketLedger.length);
       for (const entry of boardTickets) {
         expect(entry.runId).toBe(run.id);
@@ -209,7 +245,13 @@ describe("OrchestratorV2 integration", () => {
 
       expect(run.classification!.tier).toBe("trivial");
       expect(run.channelId).not.toBeNull();
-      const boardTickets = await channelStore.readChannelTickets(run.channelId!);
+      const boardTickets = await waitFor(
+        async () => {
+          const tickets = await channelStore.readChannelTickets(run.channelId!);
+          return tickets.length > 0 ? tickets : undefined;
+        },
+        { timeoutMs: 2000, intervalMs: 20, label: "trivial fast-track board mirror settled" }
+      );
       expect(boardTickets.length).toBeGreaterThan(0);
       expect(boardTickets[0].runId).toBe(run.id);
     } finally {

--- a/test/orchestrator/verification-override-feed.test.ts
+++ b/test/orchestrator/verification-override-feed.test.ts
@@ -4,6 +4,38 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+/**
+ * Poll `fn` until it returns a defined / truthy value, or `timeoutMs`
+ * elapses. Used to make feed-observation assertions deterministic in the
+ * face of scheduler best-effort writes: `TicketScheduler` drains its own
+ * tracked post-calls via `waitForPendingWrites` before `executeAll`
+ * resolves (OSS-11), but the atomic tmp-rename underneath `postEntry` can
+ * still take a tick for the rename to appear to a directory-read on Linux
+ * CI. Rather than chain `setImmediate` hacks, poll the observable and
+ * fail with a crisp timeout message if the entry never lands.
+ */
+async function waitFor<T>(
+  fn: () => Promise<T | undefined> | T | undefined,
+  opts: { timeoutMs?: number; intervalMs?: number; label?: string } = {}
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 2000;
+  const intervalMs = opts.intervalMs ?? 20;
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const value = await fn();
+    if (value !== undefined && value !== null && value !== false) {
+      return value as T;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `waitFor timed out after ${timeoutMs}ms${opts.label ? `: ${opts.label}` : ""}`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
 import { NodeCommandInvoker } from "../../src/agents/command-invoker.js";
 import { createLiveAgents } from "../../src/agents/factory.js";
 import { AgentRegistry } from "../../src/agents/registry.js";
@@ -157,21 +189,29 @@ describe("TicketScheduler verification override surfaces to channel feed", () =>
     await scheduler.executeAll(run);
 
     // `executeAll` drains the scheduler's tracked best-effort writes before
-    // returning (see TicketScheduler.waitForPendingWrites), so the override
-    // feed entry is visible here without a sleep workaround.
-    const entries = await channelStore.readFeed(channel.channelId);
-    const override = entries.find(
-      (e) => e.type === "status_update" && e.content.startsWith("Verification override")
+    // returning (see TicketScheduler.waitForPendingWrites, OSS-11), but the
+    // tmp-rename underneath `postEntry` can still take a moment to appear to
+    // a fresh `readFeed` on Linux CI. Poll the feed instead of snapshotting
+    // it once — the assertion is still tight (2s budget) but deterministic
+    // across the OSS-21 flake window.
+    const override = await waitFor(
+      async () => {
+        const entries = await channelStore.readFeed(channel.channelId);
+        return entries.find(
+          (e) => e.type === "status_update" && e.content.startsWith("Verification override")
+        );
+      },
+      { timeoutMs: 2000, intervalMs: 20, label: "verification override feed entry" }
     );
-    expect(override).toBeDefined();
-    expect(override!.fromDisplayName).toBe("Verifier");
-    expect(override!.metadata.runId).toBe(run.id);
-    expect(override!.metadata.ticketId).toBe("t_override");
+
+    expect(override.fromDisplayName).toBe("Verifier");
+    expect(override.metadata.runId).toBe(run.id);
+    expect(override.metadata.ticketId).toBe("t_override");
     // The verifier tag encodes both the pass/fail state and the override.
-    expect(String(override!.metadata.verification)).toMatch(
+    expect(String(override.metadata.verification)).toMatch(
       /passed-with-override|failed-with-override/
     );
-    expect(override!.metadata.rejectedCommands).toEqual(["rm -rf /tmp/nope"]);
-    expect(override!.metadata.substitutedCommands).toEqual(["echo allowlisted"]);
+    expect(override.metadata.rejectedCommands).toEqual(["rm -rf /tmp/nope"]);
+    expect(override.metadata.substitutedCommands).toEqual(["echo allowlisted"]);
   }, 30_000);
 });

--- a/test/storage/factory.test.ts
+++ b/test/storage/factory.test.ts
@@ -2,10 +2,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FileHarnessStore } from "../../src/storage/file-store.js";
-import { buildHarnessStore, NotImplementedError } from "../../src/storage/factory.js";
+import { buildHarnessStore } from "../../src/storage/factory.js";
 import { getHarnessStore } from "../../src/index.js";
 
 describe("buildHarnessStore", () => {
@@ -38,59 +38,87 @@ describe("buildHarnessStore", () => {
     expect(store).toBeInstanceOf(FileHarnessStore);
   });
 
-  it("throws NotImplementedError pointing at T-402 when HARNESS_STORE=postgres", () => {
-    process.env["HARNESS_STORE"] = "postgres";
-    expect(() => buildHarnessStore()).toThrow(NotImplementedError);
-    expect(() => buildHarnessStore()).toThrow(/T-402/);
+  it("warns and falls back to FileHarnessStore when HARNESS_STORE=postgres", () => {
+    // OSS-21: Postgres moved to Roadmap; setting the env should warn + degrade
+    // rather than throw so old scripts don't crash.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      process.env["HARNESS_STORE"] = "postgres";
+      const store = buildHarnessStore();
+      expect(store).toBeInstanceOf(FileHarnessStore);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toMatch(/HARNESS_STORE='postgres' ignored/);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
-  it("throws NotImplementedError mentioning sqlite when HARNESS_STORE=sqlite", () => {
-    process.env["HARNESS_STORE"] = "sqlite";
-    expect(() => buildHarnessStore()).toThrow(NotImplementedError);
-    expect(() => buildHarnessStore()).toThrow(/sqlite/i);
+  it("warns and falls back to FileHarnessStore when HARNESS_STORE=sqlite", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      process.env["HARNESS_STORE"] = "sqlite";
+      const store = buildHarnessStore();
+      expect(store).toBeInstanceOf(FileHarnessStore);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toMatch(/HARNESS_STORE='sqlite' ignored/);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
-  it("throws NotImplementedError for explicit opts.kind=sqlite (same guard path)", () => {
-    expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(NotImplementedError);
-    expect(() => buildHarnessStore({ kind: "sqlite" })).toThrow(/sqlite/i);
+  it("warns and falls back for explicit opts.kind=sqlite", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const store = buildHarnessStore({ kind: "sqlite" });
+      expect(store).toBeInstanceOf(FileHarnessStore);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
-  it("throws NotImplementedError for explicit opts.kind=postgres with postgresUrl (same guard path)", () => {
-    // Proves env-driven and opts-driven paths both flow through the same
-    // NotImplementedError guard — not a separate opts-only branch.
-    expect(() =>
-      buildHarnessStore({
+  it("warns and falls back for explicit opts.kind=postgres (env + opts both degrade through the same branch)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const store = buildHarnessStore({
         kind: "postgres",
         postgresUrl: "postgres://example/db",
-      })
-    ).toThrow(NotImplementedError);
-    expect(() =>
-      buildHarnessStore({
-        kind: "postgres",
-        postgresUrl: "postgres://example/db",
-      })
-    ).toThrow(/T-402/);
+      });
+      expect(store).toBeInstanceOf(FileHarnessStore);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("falls through to file default when HARNESS_STORE is an unrecognized value", () => {
     // Pins current behavior: `HARNESS_STORE=garbage` silently falls back to
-    // "file" rather than throwing. If a future refactor tightens this to
-    // throw-on-unknown, updating this test should be a conscious decision.
+    // "file" without a warning — unrecognized values are treated as "user
+    // didn't set the var" rather than "user asked for an unimplemented
+    // backend". If a future refactor tightens this to warn-on-unknown,
+    // updating this test should be a conscious decision.
     process.env["HARNESS_STORE"] = "garbage";
     const store = buildHarnessStore();
     expect(store).toBeInstanceOf(FileHarnessStore);
   });
 
-  it("explicit opts.kind overrides env and opts.fileRoot roots the store there", async () => {
+  it("explicit opts.kind=file with fileRoot overrides env and roots the store there", async () => {
     process.env["HARNESS_STORE"] = "postgres";
-    const store = buildHarnessStore({ kind: "file", fileRoot: tmpRoot });
-    expect(store).toBeInstanceOf(FileHarnessStore);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const store = buildHarnessStore({ kind: "file", fileRoot: tmpRoot });
+      expect(store).toBeInstanceOf(FileHarnessStore);
 
-    // Confirm fileRoot actually landed — a round-trip write shows up on disk
-    // under tmpRoot rather than the default relay dir.
-    await store.putDoc("canary", "probe", { ok: true });
-    const loaded = await store.getDoc<{ ok: boolean }>("canary", "probe");
-    expect(loaded).toEqual({ ok: true });
+      // Confirm fileRoot actually landed — a round-trip write shows up on disk
+      // under tmpRoot rather than the default relay dir.
+      await store.putDoc("canary", "probe", { ok: true });
+      const loaded = await store.getDoc<{ ok: boolean }>("canary", "probe");
+      expect(loaded).toEqual({ ok: true });
+      // opts.kind="file" wins over env, so no warning should fire.
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Three launch blockers triaged before the first tagged release.

### Fix 1 — Stop claiming Postgres ships
- `src/storage/factory.ts`: `HARNESS_STORE=postgres|sqlite` no longer throws. The factory logs a one-line `console.warn` and falls back to the file backend so old docs / user scripts don't crash.
- README: dropped the "optionally backed by your own Postgres" line from the pitch; Storage section now leads with "File backend is all that ships today" and frames the Postgres impl as a stubbed-in-tree future backend for multi-agent coordination (local or remote — not cloud-only). New "## Roadmap" section lists Postgres, pod executor, S3 artifacts, Homebrew tap, winget, code signing + notarization, npm publish, cost guardrails, and off-macOS test coverage, each honestly tagged _planned / in design / exploratory_.
- `docs/storage-injection.md`: rewritten for the single-backend reality. "File vs Postgres — when to use which" framing is gone; the `PostgresHarnessStore` stub is called out as future work only.
- `docs/getting-started.md`, `agent_docs/architecture.md`: matching one-line updates.
- `PostgresHarnessStore` source + migrations + the factory's placeholder `StoreKind` stay in-tree; deletion is a bigger PR.

### Fix 2 — Stabilize `verification-override-feed.test.ts`
- Replaced the single-snapshot `channelStore.readFeed` read + `expect(override).toBeDefined()` with an inline `waitFor` helper (polls every 20ms, 2s budget). The scheduler already drains tracked best-effort writes via `waitForPendingWrites` (OSS-11), but the atomic tmp-rename under `postEntry` can still take a tick to appear to a fresh directory-read on Linux CI. The race now surfaces as a crisp timeout with a clear label rather than a flaky assertion.
- Applied the same pattern defensively to the two `channelStore.readChannelTickets` assertions in `test/orchestrator-v2.test.ts` (the ENOTEMPTY-adjacent tests OSS-11 flagged). Happy path resolves on the first iteration.

### Fix 3 — npm package name → `@jcast90/relay` (scoped)
- `package.json.name`: `relay` → `@jcast90/relay`. Unscoped `relay` and `rly` are both taken on npm; `@jcast90` is permanent and unblocks `npm publish --access public` whenever an admin enables publish.
- `.github/workflows/release.yml`:
  - `release-npm` now gated on repo variable `NPM_PUBLISH_ENABLED`. Job always runs (fan-out graph stable) but publish steps short-circuit unless `vars.NPM_PUBLISH_ENABLED == 'true'`.
  - `release-gui` and `release-github` no longer depend on `release-npm`. GUI bundles and the GitHub Release ship on every tag regardless of npm publish state.
  - GitHub Packages mirror no longer rewrites the package name — already scoped.
  - Header comment block updated to document the gate + revised fan-out contract.
- README Install: `npm install -g @jcast90/relay` / `npx @jcast90/relay welcome`. One-line note on why the scope exists. Binary on `$PATH` is still `rly`.
- `.changeset/oss-20-release-pipeline.md`, `CHANGELOG.md`: scoped name + the new OSS-21 entries.

## Test plan
- [x] `pnpm test` — 470 pass / 21 skipped, all green locally.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build` — clean.
- [x] Previously-flaky test: 3 consecutive runs, all pass deterministically.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — OK.
- [x] `rg 'PostgresHarnessStore|HARNESS_STORE=postgres|Postgres backend'` across README/docs — every remaining mention is now in a Roadmap or "stubbed for future work" context.
- [ ] CI: fast PR tier (`ci.yml`) green.
- [ ] Integration tier: unchanged (Postgres stub still compiles, postgres integration tests still skip without `HARNESS_TEST_POSTGRES_URL`).

## Notes for reviewer
- Do **not** merge — user asked for a draft only.
- The release workflow's publish gate requires an admin to add repo variable `NPM_PUBLISH_ENABLED=true` + secret `NPM_TOKEN` before any tag actually publishes to npm. Until then, tags cut a GitHub Release + GUI bundles; npm publish is a no-op with a "skipping" notice.
- `PostgresHarnessStore` and its migrations stay in-tree untouched so the stub keeps compiling and the integration tests keep skipping. A follow-up PR can delete them if the decision hardens to "never Postgres" rather than "Postgres is Roadmap".

🤖 Generated with [Claude Code](https://claude.com/claude-code)