### PR TITLE
fix(release): use npm CLI on Node 24 for Trusted-Publisher publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,17 @@ jobs:
           version: 10.17.0
 
       - name: Setup Node.js (npm registry)
+        # Node 24 ships npm >= 11.5, which is the first line with native
+        # OIDC Trusted-Publisher support. Node 22 ships npm 10.x whose OIDC
+        # handling relies on pnpm's own exchange path — that path was the
+        # failure mode on the initial v0.1.0 tag (npm's token-exchange call
+        # silently no-op'd, the PUT landed unauthenticated, npm returned 404
+        # "@jcast90/relay@0.1.0 is not in this registry"). Matches npm's
+        # documented Trusted-Publishers workflow example.
         if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
@@ -108,13 +115,12 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        # Auth is OIDC via npm Trusted Publishers — the top-level
-        # `id-token: write` permission lets pnpm mint an OIDC token that npm
-        # exchanges for a short-lived publish credential. No NPM_TOKEN.
-        # `--provenance` attaches a signed build-provenance statement so
-        # consumers can verify the package was built in this workflow.
+        # Uses the npm CLI (not pnpm) for the actual publish — npm >= 11.5
+        # handles the OIDC → npm-token exchange natively, which pnpm 10.x
+        # does not do reliably for Trusted Publishers. `--provenance`
+        # attaches the sigstore attestation.
         if: vars.NPM_PUBLISH_ENABLED == 'true'
-        run: pnpm publish --no-git-checks --access public --provenance
+        run: npm publish --access public --provenance
 
       - name: Setup Node.js (GitHub Packages)
         if: vars.NPM_PUBLISH_ENABLED == 'true'


### PR DESCRIPTION
## Summary

The v0.1.0 tag publish kept 404-ing despite a correctly-configured Trusted Publisher binding (`jcast90/relay` + `release.yml`). Root cause: **pnpm 10.17 on Node 22 handles the sigstore provenance exchange correctly but its npm-token-exchange path for Trusted Publishers silently no-ops on npm 10.x.** The PUT lands unauthenticated and npm returns 404 `"@jcast90/relay@0.1.0 is not in this registry"` — npm's disguised "permission denied" for scoped packages.

## Fix

- Bump Node to **24** (ships npm ≥ 11.5, the first line with native OIDC for Trusted Publishers).
- Swap **`pnpm publish`** → **`npm publish --access public --provenance`** for the npm.org publish step. npm 11.5+ does the OIDC → npm-token exchange natively.
- Dependencies + build still run through pnpm; only the actual registry PUT changes.
- Matches npm's documented Trusted-Publisher workflow example: https://docs.npmjs.com/trusted-publishers

## What stays the same

- Trusted Publisher binding on npm — no changes needed.
- `--provenance` is preserved (npm docs recommend keeping it on).
- GH Packages mirror step unchanged (uses `GITHUB_TOKEN`, not OIDC).
- `release-gui` and `release-github` jobs unchanged.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the existing v0.1.0 workflow from the Actions tab (no new tag needed — tag points at PR #70's merge commit, and re-run picks up latest main for the workflow file itself)
  - Actually: re-runs of old workflow runs replay the workflow file **as it was at that commit**, so to pick up this fix you need either: (a) delete + re-cut the v0.1.0 tag on main after merging this PR, or (b) cut a new tag like v0.1.0-1.
- [ ] Verify `release-npm` completes without E404
- [ ] Verify `@jcast90/relay@0.1.0` appears on npm with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)