### PR TITLE
release(0.1.2): fix GUI upload globs + bump versions + README cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,21 +156,27 @@ jobs:
       fail-fast: false
       matrix:
         platform:
+          # Tauri writes bundles to the workspace-shared `target/` at the
+          # repo root (Cargo.lock lives at the root, so this is a single
+          # Cargo workspace shared across tui/, crates/harness-data/, and
+          # gui/src-tauri/). The earlier `gui/src-tauri/target/...` globs
+          # never matched — upload-artifact warned and uploaded nothing,
+          # leaving the GitHub Release with zero installers.
           - os: macos-latest
             rust_target: aarch64-apple-darwin
             artifact_glob: |
-              gui/src-tauri/target/release/bundle/dmg/*.dmg
-              gui/src-tauri/target/release/bundle/macos/*.app.tar.gz
+              target/release/bundle/dmg/*.dmg
+              target/release/bundle/macos/*.app.tar.gz
           - os: ubuntu-22.04
             rust_target: x86_64-unknown-linux-gnu
             artifact_glob: |
-              gui/src-tauri/target/release/bundle/appimage/*.AppImage
-              gui/src-tauri/target/release/bundle/deb/*.deb
+              target/release/bundle/appimage/*.AppImage
+              target/release/bundle/deb/*.deb
           - os: windows-latest
             rust_target: x86_64-pc-windows-msvc
             artifact_glob: |
-              gui/src-tauri/target/release/bundle/msi/*.msi
-              gui/src-tauri/target/release/bundle/nsis/*.exe
+              target/release/bundle/msi/*.msi
+              target/release/bundle/nsis/*.exe
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ Workspace versions are kept in lockstep across the npm package
 
 _Nothing yet._
 
+## [0.1.2] - 2026-04-22
+
+### Fixed
+
+- Release workflow now uploads Tauri GUI bundles to the GitHub Release.
+  The upload glob pointed at `gui/src-tauri/target/release/bundle/...`
+  but this is a Cargo workspace with a shared `target/` at the repo
+  root, so Tauri's actual output (`target/release/bundle/...`) was
+  being silently dropped by `upload-artifact`'s `if-no-files-found: warn`.
+  The `v0.1.0` and `v0.1.1` releases shipped with zero installers; this
+  is the first release with `.dmg` / `.AppImage` / `.deb` / `.msi`
+  downloads attached.
+
+### Changed
+
+- README: removed the "coming soon" banners now that npm publish is
+  live; documented that pre-release GUI installers are unsigned.
+
 ## [0.1.0] - 2026-04-22
 
 First public OSS release. Everything below was done under the `OSS-01..23` hardening +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -3122,7 +3122,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "arboard",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ CLI: **`rly`**.
 
 ## Install
 
-### Quick start _(coming soon — blocked on first tagged release)_
-
-Once `v0.1.0` ships to npm, this will be the one-liner:
+### Quick start
 
 ```bash
 npm install -g @jcast90/relay
@@ -78,7 +76,7 @@ The npm package is published under the `@jcast90` scope because both
 unscoped `relay` and `rly` were already taken on npm when Relay shipped.
 The binary exposed on `$PATH` is still `rly`.
 
-### From source _(available today)_
+### From source
 
 ```bash
 git clone https://github.com/jcast90/relay
@@ -93,9 +91,14 @@ Prereq checks (`node >= 20`, `pnpm`, `git`; plus `cargo` if you add `--with-tui`
 - `--with-gui` also builds the Tauri desktop app. On Linux, the preflight will offer to `apt-get install` the required system libraries if they're missing.
 - `--skip-link` skips the global link (useful in CI).
 
-### GUI app _(coming soon)_
+### GUI app
 
-Download the `.dmg` / `.AppImage` / `.deb` / `.msi` from the [latest release](https://github.com/jcast90/relay/releases/latest).
+Download the `.dmg` (macOS) / `.AppImage` + `.deb` (Linux) / `.msi` (Windows) from the [latest release](https://github.com/jcast90/relay/releases/latest).
+
+> **Note:** pre-release builds are **unsigned**. macOS will show a
+> Gatekeeper warning on first open — right-click → _Open_ the first
+> time. Windows SmartScreen will ask for a click-through. Code
+> signing + notarization is on the [Roadmap](#roadmap).
 
 ### Manual
 
@@ -534,9 +537,8 @@ Honest snapshot — most of these haven't started. Order is rough priority, not 
 - **Postgres backend for multi-agent coordination** _(exploratory, stubbed)_ — the file backend serializes writes per-host via tmp+rename atomics. A Postgres-backed `HarnessStore` would let multiple agents (same box or different) share state through `LISTEN/NOTIFY` cross-agent decision broadcasts and row-locked decision writes. Postgres here runs locally (`brew install postgresql && createdb relay`) or remote — this isn't a cloud-only feature. Source stub lives at `src/storage/postgres-store.ts`; not wired into the factory and the integration tests are skipped.
 - **Pod executor (Kubernetes)** _(exploratory)_ — verification runs off the dev box in per-ticket pods. Prototype was removed in OSS-08 until it's wired end-to-end again.
 - **S3 artifacts** _(exploratory)_ — moving ticket evidence off the local filesystem so it survives pod/host churn. Pairs with the pod executor.
-- **Distribution: Homebrew tap + winget manifest** _(planned)_ — for one-line `brew install rly` / `winget install rly` after the first tagged release.
+- **Distribution: Homebrew tap + winget manifest** _(planned)_ — for one-line `brew install rly` / `winget install rly` on top of the existing `npm install -g @jcast90/relay` path.
 - **Code signing + notarization** _(planned)_ — macOS `.dmg` (Developer ID + `notarytool`) and Windows `.msi` (Authenticode) so downloads don't need right-click-open / SmartScreen bypass. Requires paid certificates and a secret-management pass in the release workflow.
-- **npm publish** _(planned, name resolved)_ — the package is published as `@jcast90/relay` once an admin toggles the `NPM_PUBLISH_ENABLED` repo variable. Unscoped `relay` and `rly` are both taken on npm so the scope is permanent.
 - **Cost guardrails** _(in design)_ — token usage tracking per run, per ticket, per channel, with a soft cap that pauses scheduling when hit. Prerequisite to making `RELAY_AUTO_APPROVE=1` safer for multi-hour runs.
 - **Integration test coverage off macOS** _(in progress)_ — Linux and Windows spawn paths are compile-checked but only smoke-tested; promoting them to the fast CI tier is the gate to tagging cross-platform releases.
 

--- a/crates/harness-data/Cargo.toml
+++ b/crates/harness-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-data"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-gui",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-gui"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jcast90/relay",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
   "license": "MIT",
   "private": false,

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-tui"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Three linked fixes for a clean v0.1.2 release.

### 1. GUI upload globs (why v0.1.0 / v0.1.1 had zero installers)

Matrix upload globs pointed at `gui/src-tauri/target/release/bundle/...` but this is a **single Cargo workspace** with a shared `target/` at the repo root (Cargo.lock lives there). Tauri writes bundles to `target/release/bundle/...` and `upload-artifact`'s `if-no-files-found: warn` silently dropped every file. Fix: drop the `gui/src-tauri/` prefix from all six matrix globs.

**Evidence from the v0.1.0 run log:**
```
Built application at: /Users/runner/work/relay/relay/target/release/relay-gui
Bundling Relay_0.1.0_aarch64.dmg (/Users/runner/work/relay/relay/target/release/bundle/dmg/Relay_0.1.0_aarch64.dmg)
Upload GUI artifacts: No files were found with the provided path:
  gui/src-tauri/target/release/bundle/dmg/*.dmg
```

### 2. Version bump 0.1.0 → 0.1.2

Lockstepped across:
- `package.json`
- `gui/package.json`
- `tui/Cargo.toml`
- `gui/src-tauri/Cargo.toml`
- `crates/harness-data/Cargo.toml`
- `Cargo.lock` (regenerated via `cargo check --workspace`)

Skipping 0.1.1: that tag was cut against a stale `package.json` and silently republished `0.1.0` to npm. Jumping to 0.1.2 restores a clean tag ↔ published-version mapping.

### 3. README cleanup

- Dropped the **"Quick start _(coming soon — blocked on first tagged release)_"** banner — npm publish is live.
- Rewrote the GUI-app section to document that pre-release installers are **unsigned** (Gatekeeper / SmartScreen warning on first open).
- Removed the now-done **"npm publish _(planned)_"** roadmap entry.

CHANGELOG has a new `[0.1.2]` section describing the GUI-download fix as the user-visible change.

## Test plan

- [ ] Merge this PR
- [ ] `git tag v0.1.2 main && git push origin v0.1.2`
- [ ] Watch the release workflow: `release-npm` publishes `@jcast90/relay@0.1.2`, `release-gui` matrix uploads per-OS bundles, `release-github` attaches `.dmg` + `.app.tar.gz` + `.AppImage` + `.deb` + `.msi` + `.exe` to the Release page.
- [ ] Open https://github.com/jcast90/relay/releases/latest — confirm non-empty asset list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)