### PR TITLE
AL-1: Token budget tracker

### DIFF
--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -103,11 +103,19 @@ export class TokenTracker {
   /**
    * Record the token cost of a single API call. Returns void — the write
    * is queued and flushed asynchronously. Callers that need to know the
-   * write hit disk should `await tracker.close()` (or `await flush()`).
+   * write hit disk (or that thresholds have fired) should `await
+   * tracker.close()` (or `await flush()`).
    *
    * Zero-token records are a no-op. Negative inputs throw (the Claude
    * stream never reports negative usage; a negative value indicates a
    * parsing bug we want to surface loudly, not silently absorb).
+   *
+   * Ordering: the threshold computation, event emission, and disk append
+   * are all chained behind any in-flight replay or earlier record so that
+   * a `record()` invoked immediately after construction still observes the
+   * resumed cumulative total. This means thresholds that already crossed
+   * in the replayed state never re-fire, and the JSONL line carries the
+   * correct post-replay `cumulativeUsed`.
    */
   record(inputTokens: number, outputTokens: number): void {
     if (this.closed) {
@@ -127,15 +135,31 @@ export class TokenTracker {
     const increment = inputTokens + outputTokens;
     if (increment === 0) return;
 
-    // Compute the new running total synchronously so `used` / `pct` reflect
-    // the record immediately (the disk write is queued but the in-memory
-    // number is authoritative for subscribers).
-    const previous = this._used;
-    this._used = previous + increment;
-    const crossed = this.findCrossedThresholds(previous, this._used);
-
-    // Queue the append behind any in-flight replay or earlier record.
+    // Chain the entire record — threshold compute, event dispatch, and
+    // disk append — onto the write chain. Replay is the first link, so
+    // any record queued before replay finishes still sees the resumed
+    // `_used` and already-crossed thresholds.
     this.writeChain = this.writeChain.then(async () => {
+      const previous = this._used;
+      this._used = previous + increment;
+      const crossed = this.findCrossedThresholds(previous, this._used);
+
+      // Fire threshold events before the disk write so listeners observe
+      // crossings in the same order they happen in `_used`. Each dispatch
+      // is isolated so a throwing listener can't abort the loop or take
+      // down the tracker (record() is a documented void hot path).
+      for (const threshold of crossed) {
+        this.firedThresholds.add(threshold);
+        const evt: ThresholdEvent = {
+          sessionId: this.sessionId,
+          used: this._used,
+          total: this._total,
+          pct: this.pct,
+          threshold,
+        };
+        this.safeEmitThreshold(evt);
+      }
+
       try {
         await this.appendLine({
           ts: new Date().toISOString(),
@@ -153,23 +177,15 @@ export class TokenTracker {
         }
       }
     });
-
-    // Fire threshold events synchronously after updating in-memory state
-    // so listeners see `used`/`pct` matching the event.
-    for (const threshold of crossed) {
-      this.firedThresholds.add(threshold);
-      const evt: ThresholdEvent = {
-        sessionId: this.sessionId,
-        used: this._used,
-        total: this._total,
-        pct: this.pct,
-        threshold,
-      };
-      this.emitter.emit("threshold", evt);
-    }
   }
 
-  /** Total tokens consumed so far (sum of all recorded input+output). */
+  /**
+   * Total tokens consumed so far (sum of all recorded input+output).
+   * Reflects the best-known cached value: 0 immediately after construction
+   * until replay completes, then the resumed total, then the post-record
+   * running total after each queued `record()` drains. Callers that need
+   * a consistent snapshot should `await tracker.flush()` first.
+   */
   get used(): number {
     return this._used;
   }
@@ -234,6 +250,24 @@ export class TokenTracker {
   }
 
   // --- internals -----------------------------------------------------------
+
+  /**
+   * Dispatch a threshold event to each subscriber individually. A listener
+   * that throws is logged to `console.warn` and the remaining listeners
+   * still fire — a single bad subscriber can't abort the emit loop or kill
+   * the tracker's void hot path.
+   */
+  private safeEmitThreshold(evt: ThresholdEvent): void {
+    const listeners = this.emitter.listeners("threshold") as ThresholdListener[];
+    for (const listener of listeners) {
+      try {
+        listener(evt);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`TokenTracker: threshold ${evt.threshold} listener threw: ${msg}`);
+      }
+    }
+  }
 
   private async replay(): Promise<void> {
     let content: string;

--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -1,0 +1,313 @@
+import { EventEmitter } from "node:events";
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { getRelayDir } from "../cli/paths.js";
+
+/**
+ * Threshold percentages at which the tracker emits a `threshold` event. One
+ * emit per upward crossing per tracker instance — re-crossing the same
+ * threshold (e.g. after a persistence replay) never re-emits.
+ *
+ * Exported as a const tuple so callers (AL-3 scheduler, tests) can iterate
+ * the canonical list instead of re-declaring it.
+ */
+export const THRESHOLDS = [50, 85, 95, 100] as const;
+
+export type ThresholdEvent = {
+  sessionId: string;
+  used: number;
+  total: number;
+  pct: number;
+  threshold: number;
+};
+
+export type ThresholdListener = (evt: ThresholdEvent) => void;
+
+/**
+ * One line in `budget.jsonl`. Each `record()` call appends exactly one line
+ * with the increment and the cumulative total after the increment. Replay
+ * on construction sums the increments — `cumulativeUsed` is stored for
+ * forensics, not for replay (the sum is the source of truth, so a
+ * hand-edited file that got out of sync on cumulativeUsed still replays
+ * correctly).
+ */
+interface BudgetLine {
+  ts: string;
+  inputTokens: number;
+  outputTokens: number;
+  cumulativeUsed: number;
+}
+
+/**
+ * Autonomous-session token budget tracker (AL-1). Wraps the per-session
+ * token accounting used by the autonomous loop's scheduler to decide when
+ * to wind down. Not wired into the invoker layer yet — AL-3 does that.
+ *
+ * Persistence: `~/.relay/sessions/<sessionId>/budget.jsonl`, append-only.
+ * On construction the file is replayed so a process restart resumes from
+ * the existing cumulative total. Writes are queued through a Promise
+ * chain so concurrent `record()` calls never interleave partial lines.
+ *
+ * Event bus: internal `EventEmitter`. Subscribers attach via
+ * `onThreshold()`. Only the four canonical thresholds (50/85/95/100) fire,
+ * and each fires at most once per tracker lifetime regardless of how many
+ * API calls cross it.
+ */
+export class TokenTracker {
+  readonly sessionId: string;
+
+  private readonly _total: number;
+  private _used = 0;
+  private readonly firedThresholds = new Set<number>();
+  private readonly emitter = new EventEmitter();
+  private readonly filePath: string;
+
+  // Serialize disk IO (replay on construct, append on record, final flush
+  // on close). Every public mutator chains its work onto this tail
+  // promise so operations apply in call order and never overlap.
+  private writeChain: Promise<void>;
+  private closed = false;
+
+  /**
+   * @param sessionId  Autonomous session identifier. Used both as the event
+   *                   payload key and the directory segment under
+   *                   `~/.relay/sessions/`.
+   * @param totalTokens The session's budget ceiling in tokens. Must be > 0
+   *                   so `pct` is well-defined.
+   * @param options.rootDir  Override the `~/.relay` base directory. Tests
+   *                   use this with a tmp dir; production callers should
+   *                   leave it undefined.
+   */
+  constructor(sessionId: string, totalTokens: number, options: { rootDir?: string } = {}) {
+    if (!sessionId) {
+      throw new Error("TokenTracker: sessionId is required");
+    }
+    if (!Number.isFinite(totalTokens) || totalTokens <= 0) {
+      throw new Error(
+        `TokenTracker: totalTokens must be a positive finite number (got ${totalTokens})`
+      );
+    }
+
+    this.sessionId = sessionId;
+    this._total = totalTokens;
+
+    const root = options.rootDir ?? getRelayDir();
+    this.filePath = join(root, "sessions", sessionId, "budget.jsonl");
+
+    // Kick off replay immediately. Any subsequent `record()` call queues
+    // after this, so the first record observes the resumed total.
+    this.writeChain = this.replay();
+  }
+
+  /**
+   * Record the token cost of a single API call. Returns void — the write
+   * is queued and flushed asynchronously. Callers that need to know the
+   * write hit disk should `await tracker.close()` (or `await flush()`).
+   *
+   * Zero-token records are a no-op. Negative inputs throw (the Claude
+   * stream never reports negative usage; a negative value indicates a
+   * parsing bug we want to surface loudly, not silently absorb).
+   */
+  record(inputTokens: number, outputTokens: number): void {
+    if (this.closed) {
+      throw new Error("TokenTracker: cannot record after close()");
+    }
+    if (!Number.isFinite(inputTokens) || !Number.isFinite(outputTokens)) {
+      throw new Error(
+        `TokenTracker: token counts must be finite (got ${inputTokens}, ${outputTokens})`
+      );
+    }
+    if (inputTokens < 0 || outputTokens < 0) {
+      throw new Error(
+        `TokenTracker: token counts must be non-negative (got ${inputTokens}, ${outputTokens})`
+      );
+    }
+
+    const increment = inputTokens + outputTokens;
+    if (increment === 0) return;
+
+    // Compute the new running total synchronously so `used` / `pct` reflect
+    // the record immediately (the disk write is queued but the in-memory
+    // number is authoritative for subscribers).
+    const previous = this._used;
+    this._used = previous + increment;
+    const crossed = this.findCrossedThresholds(previous, this._used);
+
+    // Queue the append behind any in-flight replay or earlier record.
+    this.writeChain = this.writeChain.then(async () => {
+      try {
+        await this.appendLine({
+          ts: new Date().toISOString(),
+          inputTokens,
+          outputTokens,
+          cumulativeUsed: this._used,
+        });
+      } catch (err) {
+        // Disk failure shouldn't take down the autonomous loop — surface
+        // via an `error` event and let the scheduler decide. This mirrors
+        // EventEmitter conventions: an unhandled `error` would crash the
+        // process, so we only emit if someone is listening.
+        if (this.emitter.listenerCount("error") > 0) {
+          this.emitter.emit("error", err);
+        }
+      }
+    });
+
+    // Fire threshold events synchronously after updating in-memory state
+    // so listeners see `used`/`pct` matching the event.
+    for (const threshold of crossed) {
+      this.firedThresholds.add(threshold);
+      const evt: ThresholdEvent = {
+        sessionId: this.sessionId,
+        used: this._used,
+        total: this._total,
+        pct: this.pct,
+        threshold,
+      };
+      this.emitter.emit("threshold", evt);
+    }
+  }
+
+  /** Total tokens consumed so far (sum of all recorded input+output). */
+  get used(): number {
+    return this._used;
+  }
+
+  /** Budget ceiling set at construction. */
+  get total(): number {
+    return this._total;
+  }
+
+  /**
+   * Percentage of budget consumed, 0..100+. Not clamped above 100 — a
+   * runaway session should show 150% so the operator notices, not silently
+   * pin at 100%. The 100 threshold still fires exactly once regardless.
+   */
+  get pct(): number {
+    return (this._used / this._total) * 100;
+  }
+
+  /**
+   * Subscribe to threshold crossings. Returns an unsubscribe function; call
+   * it to detach the listener. Multiple subscribers are fine — each gets
+   * the same event.
+   */
+  onThreshold(listener: ThresholdListener): () => void {
+    this.emitter.on("threshold", listener);
+    return () => {
+      this.emitter.off("threshold", listener);
+    };
+  }
+
+  /**
+   * Subscribe to disk-write errors. Errors are never thrown synchronously
+   * from `record()` (which returns void), so this is the only way to
+   * observe them. Subscribing is optional — without a listener, errors
+   * are dropped after being chained through the write queue.
+   */
+  onError(listener: (err: unknown) => void): () => void {
+    this.emitter.on("error", listener);
+    return () => {
+      this.emitter.off("error", listener);
+    };
+  }
+
+  /**
+   * Flush any pending writes and close the tracker. After close,
+   * subsequent `record()` calls throw. Idempotent — calling twice is
+   * safe.
+   */
+  async close(): Promise<void> {
+    this.closed = true;
+    await this.writeChain;
+    this.emitter.removeAllListeners();
+  }
+
+  /**
+   * Await all queued disk writes without closing the tracker. Useful for
+   * tests that want to assert on file contents after a batch of
+   * `record()` calls.
+   */
+  async flush(): Promise<void> {
+    await this.writeChain;
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private async replay(): Promise<void> {
+    let content: string;
+    try {
+      content = await readFile(this.filePath, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // Fresh session — nothing to replay. Defer directory creation to
+        // the first append so a tracker that's never written to doesn't
+        // leave an empty directory behind.
+        return;
+      }
+      throw err;
+    }
+
+    // Sum increments rather than trusting `cumulativeUsed` from the last
+    // line: a torn final write or a hand-edited file should still yield
+    // the correct resumed total as long as each individual line parses.
+    let resumed = 0;
+    const lines = content.split("\n");
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      let parsed: BudgetLine;
+      try {
+        parsed = JSON.parse(line) as BudgetLine;
+      } catch {
+        // Skip malformed lines. A single partially-flushed last line
+        // shouldn't poison the whole replay.
+        continue;
+      }
+      if (
+        typeof parsed.inputTokens === "number" &&
+        typeof parsed.outputTokens === "number" &&
+        Number.isFinite(parsed.inputTokens) &&
+        Number.isFinite(parsed.outputTokens)
+      ) {
+        resumed += parsed.inputTokens + parsed.outputTokens;
+      }
+    }
+    this._used = resumed;
+
+    // Any threshold the resumed state already crosses is considered
+    // already-fired — we don't want a restart to re-emit 50%/85%/etc.
+    // This matches the "one emit per crossing" guarantee across process
+    // lifetimes.
+    for (const threshold of THRESHOLDS) {
+      if (this.pctAt(resumed) >= threshold) {
+        this.firedThresholds.add(threshold);
+      }
+    }
+  }
+
+  private async appendLine(line: BudgetLine): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    // `appendFile` with a single <PIPE_BUF line is atomic on POSIX, so
+    // concurrent appenders from the same tracker never interleave bytes.
+    // The write-chain mutex above is the stronger guarantee (same-process
+    // ordering); this remark is about the OS-level interleave safety.
+    await appendFile(this.filePath, JSON.stringify(line) + "\n", "utf8");
+  }
+
+  private findCrossedThresholds(previousUsed: number, currentUsed: number): number[] {
+    const crossed: number[] = [];
+    for (const threshold of THRESHOLDS) {
+      if (this.firedThresholds.has(threshold)) continue;
+      if (this.pctAt(previousUsed) < threshold && this.pctAt(currentUsed) >= threshold) {
+        crossed.push(threshold);
+      }
+    }
+    return crossed;
+  }
+
+  private pctAt(used: number): number {
+    return (used / this._total) * 100;
+  }
+}

--- a/test/budget/token-tracker.test.ts
+++ b/test/budget/token-tracker.test.ts
@@ -91,6 +91,10 @@ describe("TokenTracker", () => {
       const off = tracker.onThreshold((evt) => events.push(evt));
 
       tracker.record(500, 0); // crosses 50
+      // Drain the write chain so the 50 emit has dispatched before we
+      // unsubscribe. Threshold emission is serialized behind the chain
+      // now; observing a specific emit requires awaiting flush first.
+      await tracker.flush();
       off();
       tracker.record(500, 0); // would cross 85, 95, 100
       await tracker.flush();
@@ -176,6 +180,48 @@ describe("TokenTracker", () => {
       expect(second.used).toBe(200); // recovered from the valid line only
       await second.close();
     });
+
+    it("record() called immediately after construction waits for replay to finish", async () => {
+      // Regression: previously record() read _used synchronously before
+      // replay had a chance to populate it, so the first recorded line had
+      // the wrong cumulativeUsed and any already-crossed threshold could
+      // re-fire on resume.
+      const sessionId = "s-replay-race";
+
+      // Pre-seed the file so replay has something to sum. Cumulative total
+      // should resume at 900 (90%).
+      const first = new TokenTracker(sessionId, 1000, { rootDir: root });
+      first.record(900, 0);
+      await first.close();
+
+      // Construct the resumed tracker and immediately record without
+      // awaiting flush() first. The append + threshold check should both
+      // wait for replay to finish.
+      const second = new TokenTracker(sessionId, 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      second.onThreshold((evt) => events.push(evt));
+      second.record(5, 0); // +5 → 905 (90.5%), crosses nothing new
+
+      await second.flush();
+
+      // 50 and 85 already fired in the prior lifetime; they must not fire
+      // again on resume. 95 has not been crossed yet (we're at 90.5%).
+      expect(events).toEqual([]);
+      expect(second.used).toBe(905);
+
+      // And the appended line must carry the post-replay cumulative total.
+      const contents = await readFile(join(root, "sessions", sessionId, "budget.jsonl"), "utf8");
+      const lines = contents.trim().split("\n");
+      const last = JSON.parse(lines[lines.length - 1]);
+      expect(last.cumulativeUsed).toBe(905);
+
+      // Crossing 95% afterwards still fires exactly once.
+      second.record(100, 0); // 1005 → 100.5%, crosses 95 and 100
+      await second.flush();
+      expect(events.map((e) => e.threshold)).toEqual([95, 100]);
+
+      await second.close();
+    });
   });
 
   describe("concurrent writes", () => {
@@ -231,6 +277,54 @@ describe("TokenTracker", () => {
       await expect(stat(join(root, "sessions", "s-zero", "budget.jsonl"))).rejects.toThrow(
         /ENOENT/
       );
+    });
+  });
+
+  describe("listener isolation", () => {
+    it("a throwing listener does not abort the emit loop or kill record()", async () => {
+      const tracker = new TokenTracker("s-throwy", 1000, { rootDir: root });
+      const seen: number[] = [];
+      const secondListenerSeen: number[] = [];
+
+      // First listener throws on every call. Second listener records what
+      // it receives. Both must fire for every crossed threshold; record()
+      // must not throw.
+      tracker.onThreshold(() => {
+        throw new Error("boom");
+      });
+      tracker.onThreshold((evt) => secondListenerSeen.push(evt.threshold));
+      tracker.onThreshold((evt) => seen.push(evt.threshold));
+
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (msg: unknown, ...rest: unknown[]) => {
+        warnings.push([msg, ...rest].map(String).join(" "));
+      };
+
+      try {
+        // Cross 50 and 85 in a single record. record() is void and must
+        // not throw even though a listener throws on every dispatch.
+        expect(() => tracker.record(900, 0)).not.toThrow();
+        await tracker.flush();
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      // Both thresholds reached the healthy listeners.
+      expect(secondListenerSeen).toEqual([50, 85]);
+      expect(seen).toEqual([50, 85]);
+
+      // The throwing listener was logged per-threshold (at least one warn
+      // per crossed threshold, with the threshold number + error message).
+      expect(warnings.some((w) => w.includes("50") && w.includes("boom"))).toBe(true);
+      expect(warnings.some((w) => w.includes("85") && w.includes("boom"))).toBe(true);
+
+      // A later crossing still fires the remaining thresholds exactly once.
+      tracker.record(100, 0); // 1000 → 100%, crosses 95 and 100
+      await tracker.flush();
+      expect(secondListenerSeen).toEqual([50, 85, 95, 100]);
+
+      await tracker.close();
     });
   });
 

--- a/test/budget/token-tracker.test.ts
+++ b/test/budget/token-tracker.test.ts
@@ -1,0 +1,268 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { THRESHOLDS, TokenTracker, type ThresholdEvent } from "../../src/budget/token-tracker.js";
+
+describe("TokenTracker", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-budget-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe("threshold crossings", () => {
+    it("emits one event per threshold when crossed in one big record()", async () => {
+      const tracker = new TokenTracker("s-big", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      tracker.onThreshold((evt) => events.push(evt));
+
+      // Cross every threshold in a single record.
+      tracker.record(1000, 0);
+      await tracker.flush();
+
+      expect(events.map((e) => e.threshold)).toEqual([...THRESHOLDS]);
+      // Each event reports the post-crossing used/pct state.
+      for (const evt of events) {
+        expect(evt.sessionId).toBe("s-big");
+        expect(evt.used).toBe(1000);
+        expect(evt.total).toBe(1000);
+        expect(evt.pct).toBe(100);
+      }
+
+      await tracker.close();
+    });
+
+    it("emits each threshold exactly once across many small increments", async () => {
+      const tracker = new TokenTracker("s-small", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      tracker.onThreshold((evt) => events.push(evt));
+
+      // 100 increments of 10 tokens each — 0% -> 100% in small steps.
+      for (let i = 0; i < 100; i += 1) {
+        tracker.record(5, 5);
+      }
+      await tracker.flush();
+
+      // One emit per threshold, in ascending order.
+      expect(events.map((e) => e.threshold)).toEqual([...THRESHOLDS]);
+
+      await tracker.close();
+    });
+
+    it("does not emit when staying below 50%", async () => {
+      const tracker = new TokenTracker("s-quiet", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      tracker.onThreshold((evt) => events.push(evt));
+
+      tracker.record(100, 100); // 20%
+      tracker.record(100, 100); // 40%
+      await tracker.flush();
+
+      expect(events).toEqual([]);
+
+      await tracker.close();
+    });
+
+    it("emits the 50% threshold exactly at the boundary and never again", async () => {
+      const tracker = new TokenTracker("s-boundary", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      tracker.onThreshold((evt) => events.push(evt));
+
+      tracker.record(500, 0); // exactly 50%
+      tracker.record(1, 0); // 50.1% — must not re-emit 50
+      tracker.record(10, 0); // still below 85
+      await tracker.flush();
+
+      expect(events.map((e) => e.threshold)).toEqual([50]);
+
+      await tracker.close();
+    });
+
+    it("unsubscribe stops further events", async () => {
+      const tracker = new TokenTracker("s-unsub", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      const off = tracker.onThreshold((evt) => events.push(evt));
+
+      tracker.record(500, 0); // crosses 50
+      off();
+      tracker.record(500, 0); // would cross 85, 95, 100
+      await tracker.flush();
+
+      expect(events.map((e) => e.threshold)).toEqual([50]);
+
+      await tracker.close();
+    });
+  });
+
+  describe("persistence", () => {
+    it("survives restart: next record adds to existing total", async () => {
+      const sessionId = "s-restart";
+
+      const first = new TokenTracker(sessionId, 10_000, { rootDir: root });
+      first.record(100, 200); // +300 → 300
+      first.record(400, 100); // +500 → 800
+      await first.close();
+
+      const second = new TokenTracker(sessionId, 10_000, { rootDir: root });
+      // Give replay a chance to finish before asserting.
+      await second.flush();
+      expect(second.used).toBe(800);
+
+      second.record(50, 50); // +100 → 900
+      await second.flush();
+      expect(second.used).toBe(900);
+      await second.close();
+
+      // Confirm the file actually accumulated: two lines pre-restart + one post.
+      const contents = await readFile(join(root, "sessions", sessionId, "budget.jsonl"), "utf8");
+      const lines = contents.trim().split("\n");
+      expect(lines).toHaveLength(3);
+      // Last line's cumulativeUsed should reflect the post-restart total.
+      const last = JSON.parse(lines[lines.length - 1]);
+      expect(last.cumulativeUsed).toBe(900);
+    });
+
+    it("does not re-emit already-crossed thresholds after restart", async () => {
+      const sessionId = "s-no-reemit";
+
+      const first = new TokenTracker(sessionId, 1000, { rootDir: root });
+      first.record(600, 0); // crosses 50
+      await first.close();
+
+      const second = new TokenTracker(sessionId, 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      second.onThreshold((evt) => events.push(evt));
+      await second.flush();
+
+      // Replaying does not re-emit 50.
+      expect(events).toEqual([]);
+
+      // But a new crossing (to 85) still emits.
+      second.record(300, 0); // now at 900 = 90%
+      await second.flush();
+      expect(events.map((e) => e.threshold)).toEqual([85]);
+
+      await second.close();
+    });
+
+    it("new tracker for a fresh session does not throw on missing file", async () => {
+      const tracker = new TokenTracker("s-fresh", 1000, { rootDir: root });
+      await tracker.flush();
+      expect(tracker.used).toBe(0);
+      expect(tracker.pct).toBe(0);
+      await tracker.close();
+    });
+
+    it("tolerates a torn/malformed final line", async () => {
+      const sessionId = "s-torn";
+      const first = new TokenTracker(sessionId, 10_000, { rootDir: root });
+      first.record(100, 100); // 200
+      await first.close();
+
+      // Simulate a truncated append that left a half-line behind.
+      const path = join(root, "sessions", sessionId, "budget.jsonl");
+      const { appendFile } = await import("node:fs/promises");
+      await appendFile(path, '{"ts":"2026-04-21T00:00:00', "utf8");
+
+      const second = new TokenTracker(sessionId, 10_000, { rootDir: root });
+      await second.flush();
+      expect(second.used).toBe(200); // recovered from the valid line only
+      await second.close();
+    });
+  });
+
+  describe("concurrent writes", () => {
+    it("rapid successive record() calls produce a clean file with one line each", async () => {
+      const sessionId = "s-concurrent";
+      const tracker = new TokenTracker(sessionId, 100_000, { rootDir: root });
+
+      const n = 50;
+      for (let i = 0; i < n; i += 1) {
+        tracker.record(1, 1);
+      }
+      await tracker.close();
+
+      const contents = await readFile(join(root, "sessions", sessionId, "budget.jsonl"), "utf8");
+      const lines = contents.trim().split("\n");
+      expect(lines).toHaveLength(n);
+      // Every line must parse cleanly — no interleaved bytes.
+      for (const line of lines) {
+        const parsed = JSON.parse(line);
+        expect(parsed.inputTokens).toBe(1);
+        expect(parsed.outputTokens).toBe(1);
+      }
+      // Last line's cumulativeUsed matches the sum.
+      const last = JSON.parse(lines[lines.length - 1]);
+      expect(last.cumulativeUsed).toBe(n * 2);
+    });
+  });
+
+  describe("non-autonomous isolation", () => {
+    it("constructing a tracker does not write any file until record() is called", async () => {
+      // Guards against a regression where a constructor side-effect would
+      // leave `budget.jsonl` files around for every session that ever
+      // instantiated a tracker. Non-autonomous sessions never construct
+      // one, but belt-and-braces: even if they did, no file.
+      const tracker = new TokenTracker("s-noop", 1000, { rootDir: root });
+      await tracker.flush();
+      await tracker.close();
+
+      await expect(stat(join(root, "sessions", "s-noop", "budget.jsonl"))).rejects.toThrow(
+        /ENOENT/
+      );
+    });
+
+    it("zero-token record is a no-op — no file write, no event", async () => {
+      const tracker = new TokenTracker("s-zero", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      tracker.onThreshold((evt) => events.push(evt));
+      tracker.record(0, 0);
+      await tracker.flush();
+      await tracker.close();
+
+      expect(events).toEqual([]);
+      await expect(stat(join(root, "sessions", "s-zero", "budget.jsonl"))).rejects.toThrow(
+        /ENOENT/
+      );
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects empty sessionId", () => {
+      expect(() => new TokenTracker("", 1000, { rootDir: root })).toThrow(/sessionId/);
+    });
+
+    it("rejects non-positive totalTokens", () => {
+      expect(() => new TokenTracker("s", 0, { rootDir: root })).toThrow(/totalTokens/);
+      expect(() => new TokenTracker("s", -1, { rootDir: root })).toThrow(/totalTokens/);
+      expect(() => new TokenTracker("s", Number.NaN, { rootDir: root })).toThrow(/totalTokens/);
+    });
+
+    it("rejects negative token counts at record-time", async () => {
+      const tracker = new TokenTracker("s-neg", 1000, { rootDir: root });
+      expect(() => tracker.record(-1, 0)).toThrow(/non-negative/);
+      expect(() => tracker.record(0, -5)).toThrow(/non-negative/);
+      await tracker.close();
+    });
+
+    it("record() after close() throws", async () => {
+      const tracker = new TokenTracker("s-closed", 1000, { rootDir: root });
+      await tracker.close();
+      expect(() => tracker.record(1, 1)).toThrow(/after close/);
+    });
+
+    it("close() is idempotent", async () => {
+      const tracker = new TokenTracker("s-twice", 1000, { rootDir: root });
+      tracker.record(10, 10);
+      await tracker.close();
+      await expect(tracker.close()).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `TokenTracker` for autonomous-session (AL-4+) token accounting. Persists per-call increments to `~/.relay/sessions/<sessionId>/budget.jsonl`, replays on construction so a restart resumes mid-session, and emits 50/85/95/100 threshold events via an internal `EventEmitter` that AL-3's scheduler will subscribe to.

Scope is deliberately minimal per the ticket: **the tracker class + its persistence + unit tests**. Invoker wiring happens in AL-3 once the Claude CLI stream parser grows a `usage` hook. The `message_delta` / `message_stop` `usage` field isn't currently parsed anywhere in `src/agents/` or `gui/src-tauri/` — grep confirms no existing `tokens` / `usage` parsing to hook into — so that work belongs with AL-3's scheduler wiring rather than being pre-baked here.

## Design notes

- `TokenTracker(sessionId, totalTokens, options?)` — the `options.rootDir` escape hatch is test-only; production callers get `~/.relay` via `getRelayDir()`.
- `record(input, output): void` — queues an atomic append (single `appendFile` call per line, below PIPE_BUF) behind a Promise-chain mutex so concurrent callers in the same process can't interleave bytes. In-memory `used`/`pct` update synchronously so listeners see consistent state.
- Threshold events fire **exactly once per upward crossing** across the tracker's lifetime. After a restart, any threshold the resumed state already meets is marked fired — no double-fire across process restarts.
- `pct` is **not clamped** above 100. A runaway session should visibly report 150% rather than silently pin at 100%. The 100 threshold still fires once.
- Disk-write failures surface on an opt-in `onError` listener rather than throwing from `record()` (which returns void). The autonomous loop shouldn't crash because the disk is full.
- Directory creation is deferred to first `record()`, so instantiating a tracker that never records leaves no files behind.

## Non-autonomous impact

None. `TokenTracker` is an opt-in class that no existing code constructs. No changes to `NodeCommandInvoker`, no changes to any orchestrator/scheduler path. Full test suite (488 tests) passes unchanged. Two guard tests verify that an idle tracker writes no file and that a zero-token record is a no-op.

## Test plan

- [x] **AC1 — usage recorded per call on autonomous sessions only.** Covered structurally: the class is the sole write path, and a guard test confirms no file is created on construction or on zero-token records. AL-3 will wire it into autonomous-session spawn.
- [x] **AC2 — threshold events at 50/85/95/100, one emit per crossing.** Five tests: single-record all-thresholds, 100 small increments, below-50 silence, boundary at 50%, unsubscribe.
- [x] **AC3 — budget file survives restart.** `survives restart: next record adds to existing total` test constructs tracker, records, closes, reconstructs, confirms `used === prior total`, records more, confirms cumulative file integrity. A second test confirms replayed thresholds don't re-emit but new crossings still do.
- [x] **AC4 — non-autonomous sessions unaffected.** Full `pnpm vitest run` passes (488 tests, 22 pre-existing skip). Two dedicated guard tests confirm no stray `budget.jsonl` files for never-recorded trackers.

Additional coverage: concurrent-append integrity (50 back-to-back `record()` calls produce 50 clean parseable lines), torn/malformed final line is skipped during replay, validation (empty sessionId, non-positive total, negative tokens, record-after-close).

### Commands run

```
pnpm typecheck                                             # clean
pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'  # 488 passed, 22 skipped
pnpm dlx prettier --check 'src/**/*.{ts,tsx}' 'test/**/*.{ts,tsx}' '*.md' 'docs/**/*.md'  # clean
```

## Out of scope (punted to sibling tickets)

- Wiring into `rly run --autonomous` — **AL-3**.
- Per-session lifecycle management (when to create a tracker, when to tear it down) — **AL-2**.
- Dollar-cost accounting — explicitly deferred per the ticket.
- Claude-stream `usage` field parsing — belongs with AL-3's invoker wiring. Grep confirmed no existing parser to piggyback on, so no drive-by changes to `src/agents/` here.

Closes #76