### PR TITLE
AL-0: Per-channel full-access mode + subprocess plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ rly claude
 Under the hood:
 
 - Claude launches with `--dangerously-skip-permissions`
-- Codex launches with `--full-auto` + workspace-write sandbox + `--ask-for-approval never`
+- Codex launches with `--sandbox workspace-write` + `--ask-for-approval never`
 - Internal scheduler-dispatched agents inherit via `RELAY_AUTO_APPROVE` propagated in the child env
 
 One-off: `rly claude --yolo` or `rly claude --auto-approve`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ You can expect an acknowledgement within **72 hours**. Please do not open a publ
 
 These are deliberate trade-offs, not bugs. Please don't report them as vulnerabilities.
 
-- **`RELAY_AUTO_APPROVE=1` disables every permission check** in Claude and Codex (`--dangerously-skip-permissions` / `--full-auto`). That is the entire point of the flag — it exists so multi-hour unattended runs don't stall on prompts. Use it only when you trust the tasks you're dispatching.
+- **`RELAY_AUTO_APPROVE=1` disables every permission check** in Claude and Codex (`--dangerously-skip-permissions` / `--sandbox workspace-write --ask-for-approval never`). That is the entire point of the flag — it exists so multi-hour unattended runs don't stall on prompts. Use it only when you trust the tasks you're dispatching.
 - **macOS Terminal spawning via `osascript`** requires the user to grant Automation permissions to their terminal once. Once granted, Relay can open Terminal tabs and run `rly claude` in them without further prompts. This is a feature (spawning associated-repo agents) not a privilege escalation.
 - **MCP tools run with the agent's full access.** Relay does not sandbox what Claude/Codex do inside a session — if the agent has shell access, so does anything it gets prompt-injected into running. Run Relay inside a dedicated workspace / user account if you need tighter isolation.
 - **Tokens live in `~/.relay/config.env`** with standard Unix permissions. `GITHUB_TOKEN`, `LINEAR_API_KEY`, `COMPOSIO_API_KEY`, and any other secrets you put there are readable by anything running as your user. If someone has read access to your home directory, they have your tokens.

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -116,8 +116,9 @@ pub struct Channel {
     /// Per-channel opt-in for unattended agent runs (AL-0). When `true`,
     /// agent subprocesses dispatched on behalf of this channel skip every
     /// permission prompt (Claude `--dangerously-skip-permissions`, Codex
-    /// `--full-auto`). Optional + `#[serde(default)]` so older channel files
-    /// that predate the flag keep deserializing as `false`.
+    /// `--sandbox workspace-write --ask-for-approval never`). Optional +
+    /// `#[serde(default)]` so older channel files that predate the flag keep
+    /// deserializing as `false`.
     #[serde(default)]
     pub full_access: Option<bool>,
     /// ISO 8601 timestamps. Optional for back-compat with channel files

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -113,6 +113,13 @@ pub struct Channel {
     /// Absence means no Linear mirror is configured.
     #[serde(default)]
     pub linear_project_id: Option<String>,
+    /// Per-channel opt-in for unattended agent runs (AL-0). When `true`,
+    /// agent subprocesses dispatched on behalf of this channel skip every
+    /// permission prompt (Claude `--dangerously-skip-permissions`, Codex
+    /// `--full-auto`). Optional + `#[serde(default)]` so older channel files
+    /// that predate the flag keep deserializing as `false`.
+    #[serde(default)]
+    pub full_access: Option<bool>,
     /// ISO 8601 timestamps. Optional for back-compat with channel files
     /// written before these fields were tracked.
     #[serde(default)]
@@ -905,6 +912,37 @@ mod tests {
         }"#;
         let ch: Channel = serde_json::from_str(json).unwrap();
         assert!(ch.linear_project_id.is_none());
+    }
+
+    #[test]
+    fn channel_with_full_access_true() {
+        let json = r#"{
+            "channelId":"c-1",
+            "name":"x",
+            "description":"",
+            "status":"active",
+            "members":[],
+            "pinnedRefs":[],
+            "fullAccess":true
+        }"#;
+        let ch: Channel = serde_json::from_str(json).unwrap();
+        assert_eq!(ch.full_access, Some(true));
+    }
+
+    #[test]
+    fn channel_back_compat_without_full_access() {
+        // Older channel files omit `fullAccess`. Must deserialize as None
+        // so consumers treating None as "off" get the safe default (AL-0).
+        let json = r#"{
+            "channelId":"c-1",
+            "name":"x",
+            "description":"",
+            "status":"active",
+            "members":[],
+            "pinnedRefs":[]
+        }"#;
+        let ch: Channel = serde_json::from_str(json).unwrap();
+        assert!(ch.full_access.is_none());
     }
 
     #[test]

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -361,6 +361,31 @@ fn unarchive_channel(channel_id: String) -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
+fn set_channel_full_access(
+    channel_id: String,
+    on: bool,
+) -> Result<serde_json::Value, String> {
+    // Mirrors `archive_channel` / `unarchive_channel`: defer to the CLI so
+    // there's a single code path that writes both the flag AND the decision
+    // entry (the audit trail required by AL-0). Tag the actor as "gui" so
+    // decisions recorded from the desktop app are distinguishable from CLI
+    // invocations in `rly decisions <channelId>`.
+    validate_id_segment(&channel_id, "channelId")?;
+    let state = if on { "on" } else { "off" };
+    cli_json(&[
+        "channel",
+        "set-full-access",
+        &channel_id,
+        state,
+        "--source",
+        "gui",
+        "--actor",
+        "gui",
+        "--json",
+    ])
+}
+
+#[tauri::command]
 fn update_channel_repos(
     channel_id: String,
     repos: Vec<RepoAssignmentInput>,
@@ -1878,6 +1903,7 @@ pub fn run() {
             create_channel,
             archive_channel,
             unarchive_channel,
+            set_channel_full_access,
             update_channel_repos,
             post_to_channel,
             create_session,

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -61,6 +61,8 @@ export const api = {
     }),
   archiveChannel: (channelId: string) => invoke<unknown>("archive_channel", { channelId }),
   unarchiveChannel: (channelId: string) => invoke<unknown>("unarchive_channel", { channelId }),
+  setChannelFullAccess: (channelId: string, on: boolean) =>
+    invoke<unknown>("set_channel_full_access", { channelId, on }),
   updateChannelRepos: (
     channelId: string,
     repos: { alias: string; workspaceId: string; repoPath: string }[]

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -127,6 +127,7 @@ export function CenterPane({
   return (
     <div className="panel">
       <PendingPlanCta channel={channel} refreshTick={refreshTick} onChanged={onRefresh} />
+      <ChannelHeader channel={channel} onRefresh={onRefresh} />
       <div className="tabs">
         <div className={`tab ${tab === "chat" ? "active" : ""}`} onClick={() => setTab("chat")}>
           Chat
@@ -164,6 +165,60 @@ export function CenterPane({
           <DecisionsView decisions={decisions} />
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Channel header strip — shows the channel name alongside channel-level
+ * controls. Today that's the AL-0 full-access toggle. The toggle writes to
+ * the CLI via `api.setChannelFullAccess`, which also records a decision
+ * entry, so flipping the switch here surfaces in the Decisions tab on the
+ * next refresh.
+ */
+function ChannelHeader({ channel, onRefresh }: { channel: Channel; onRefresh: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Local mirror of `channel.fullAccess` so the checkbox reflects the new
+  // value immediately after the invoke resolves — the parent refetches via
+  // `onRefresh`, but that round trip is async and the user expects instant
+  // feedback. When `channel` re-renders with updated data, this state is
+  // reseeded by the effect below.
+  const [current, setCurrent] = useState<boolean>(channel.fullAccess === true);
+  useEffect(() => {
+    setCurrent(channel.fullAccess === true);
+  }, [channel.channelId, channel.fullAccess]);
+
+  const toggle = async () => {
+    if (busy) return;
+    const next = !current;
+    setBusy(true);
+    setError(null);
+    try {
+      await api.setChannelFullAccess(channel.channelId, next);
+      setCurrent(next);
+      // Refresh so the Decisions tab picks up the audit entry the setter
+      // just wrote. Callers already debounce refreshes at the parent so
+      // this is safe to fire synchronously.
+      onRefresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="channel-header">
+      <span className="channel-header-name">{channel.name}</span>
+      <label
+        className="auto-approve"
+        title="Run dispatched agents with --dangerously-skip-permissions / --full-auto for this channel only. Scoped per-channel; other channels are unaffected."
+      >
+        <input type="checkbox" checked={current} disabled={busy} onChange={toggle} />
+        Full access
+      </label>
+      {error && <span className="composer-error">{error}</span>}
     </div>
   );
 }

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -192,6 +192,14 @@ function ChannelHeader({ channel, onRefresh }: { channel: Channel; onRefresh: ()
   const toggle = async () => {
     if (busy) return;
     const next = !current;
+    // Confirm before flipping — full-access silences every permission prompt
+    // for every future subprocess this channel spawns, which is strictly
+    // more impactful than a normal archive. Matches the conversational tone
+    // of Sidebar's archive confirm() (`Archive #foo?`).
+    const prompt = next
+      ? `Enable full access for #${channel.name}? All subprocesses spawned from this channel will run without permission prompts until this is turned off.`
+      : `Disable full access for #${channel.name}? Permission prompts will return for new subprocesses.`;
+    if (!confirm(prompt)) return;
     setBusy(true);
     setError(null);
     try {
@@ -213,12 +221,12 @@ function ChannelHeader({ channel, onRefresh }: { channel: Channel; onRefresh: ()
       <span className="channel-header-name">{channel.name}</span>
       <label
         className="auto-approve"
-        title="Run dispatched agents with --dangerously-skip-permissions / --full-auto for this channel only. Scoped per-channel; other channels are unaffected."
+        title="Runs dispatched agents with workspace-write sandbox and no approval prompts for this channel only. Scoped per-channel; other channels are unaffected."
       >
         <input type="checkbox" checked={current} disabled={busy} onChange={toggle} />
         Full access
       </label>
-      {error && <span className="composer-error">{error}</span>}
+      {error && <span className="channel-header-error">{error}</span>}
     </div>
   );
 }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -87,6 +87,21 @@ button.primary:disabled {
 }
 .panel:last-child { border-right: none; border-left: 1px solid var(--border); }
 
+/* Channel header strip in the CenterPane. Sits above the tabs and hosts
+   channel-level affordances (today: AL-0 full-access toggle). */
+.channel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.channel-header-name {
+  font-weight: 600;
+  font-size: 12px;
+}
+
 .panel-header {
   padding: 10px 12px;
   border-bottom: 1px solid var(--border);

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -101,6 +101,21 @@ button.primary:disabled {
   font-weight: 600;
   font-size: 12px;
 }
+/* Error span inside the channel-header strip. Distinct from
+   `.composer-error` (which floats above the message composer via absolute
+   positioning) — here we want a normal-flow chip sitting inline beside the
+   full-access toggle so it doesn't drift behind the tab strip. */
+.channel-header-error {
+  color: var(--error);
+  background: transparent;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 40ch;
+}
 
 .panel-header {
   padding: 10px 12px;

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -37,6 +37,10 @@ export type Channel = {
   // for back-compat with older channel files; when unset, UI falls back to
   // the first entry in `repoAssignments`.
   primaryWorkspaceId?: string;
+  // Per-channel opt-in for unattended agent runs (AL-0). When `true`, agent
+  // subprocesses dispatched for this channel skip permission prompts.
+  // Optional for back-compat; a missing field means "off".
+  fullAccess?: boolean;
   // ISO 8601; optional for back-compat with older channel files.
   createdAt?: string;
   updatedAt?: string;

--- a/install.sh
+++ b/install.sh
@@ -203,8 +203,8 @@ cat > "$TEMPLATE" <<'ENVEOF'
 # export HARNESS_LIVE=1
 
 # Set to 1 to run Claude / Codex fully unattended — no permission prompts.
-# Claude launches with --dangerously-skip-permissions; Codex with --full-auto
-# (workspace-write sandbox, --ask-for-approval never). Internal scheduler
+# Claude launches with --dangerously-skip-permissions; Codex with
+# --sandbox workspace-write and --ask-for-approval never. Internal scheduler
 # agents inherit. Use only when you trust the tasks being dispatched — this
 # lets the harness run for hours without intervention.
 # export RELAY_AUTO_APPROVE=1

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -31,6 +31,14 @@ interface CliAgentOptions {
    * achieves the same parity. (OSS-06)
    */
   onStreamLine?: (line: string) => void;
+  /**
+   * Per-channel "full access" opt-in (AL-0). When `true`, Claude runs with
+   * `--dangerously-skip-permissions` and Codex with `--full-auto` regardless
+   * of the `RELAY_AUTO_APPROVE` env var. Channels without the flag still
+   * honor the env-based auto-approve behavior. Undefined / false means
+   * "behave exactly as before" — no change for existing callers.
+   */
+  fullAccess?: boolean;
 }
 
 interface ParsedProviderResult {
@@ -112,6 +120,13 @@ abstract class CliAgentBase implements Agent {
   protected readonly model?: string;
   protected readonly invoker: CommandInvoker;
   protected readonly onStreamLine?: (line: string) => void;
+  /**
+   * Per-channel full-access flag (AL-0). When `true`, the provider-specific
+   * "skip every permission prompt" flag is threaded through regardless of
+   * the env-based `RELAY_AUTO_APPROVE`. Kept as a member so tests can
+   * assert on the constructed args without mutating `process.env`.
+   */
+  protected readonly fullAccess: boolean;
 
   constructor(options: CliAgentOptions) {
     this.id = options.id;
@@ -122,6 +137,7 @@ abstract class CliAgentBase implements Agent {
     this.model = options.model;
     this.invoker = options.invoker;
     this.onStreamLine = options.onStreamLine;
+    this.fullAccess = options.fullAccess === true;
   }
 
   async run(request: WorkRequest) {
@@ -157,10 +173,12 @@ export class CodexCliAgent extends CliAgentBase {
 
     await writeFile(schemaPath, JSON.stringify(agentResultJsonSchema, null, 2));
 
-    // When RELAY_AUTO_APPROVE is set, drop the read-only sandbox so the
-    // dispatched codex agent can actually make changes unattended. Stays
-    // read-only by default so nothing surprising happens on a casual run.
+    // When RELAY_AUTO_APPROVE is set OR the channel has opted in to
+    // full-access mode (AL-0), drop the read-only sandbox so the dispatched
+    // codex agent can actually make changes unattended. Stays read-only by
+    // default so nothing surprising happens on a casual run.
     const autoApprove =
+      this.fullAccess ||
       process.env.RELAY_AUTO_APPROVE === "1" ||
       process.env.RELAY_AUTO_APPROVE === "true" ||
       process.env.RELAY_AUTO_APPROVE === "yes";
@@ -222,9 +240,11 @@ export class CodexCliAgent extends CliAgentBase {
 export class ClaudeCliAgent extends CliAgentBase {
   protected async invokeProvider(prompt: string): Promise<ParsedProviderResult> {
     // When the user sets RELAY_AUTO_APPROVE=1 (or launched with --auto-approve
-    // / --yolo), internal dispatched agents run fully unattended. Otherwise
-    // we stay on the default permission mode and users will be prompted.
+    // / --yolo), or the channel has opted in to full-access mode (AL-0),
+    // internal dispatched agents run fully unattended. Otherwise we stay on
+    // the default permission mode and users will be prompted.
     const autoApprove =
+      this.fullAccess ||
       process.env.RELAY_AUTO_APPROVE === "1" ||
       process.env.RELAY_AUTO_APPROVE === "true" ||
       process.env.RELAY_AUTO_APPROVE === "yes";

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -33,10 +33,11 @@ interface CliAgentOptions {
   onStreamLine?: (line: string) => void;
   /**
    * Per-channel "full access" opt-in (AL-0). When `true`, Claude runs with
-   * `--dangerously-skip-permissions` and Codex with `--full-auto` regardless
-   * of the `RELAY_AUTO_APPROVE` env var. Channels without the flag still
-   * honor the env-based auto-approve behavior. Undefined / false means
-   * "behave exactly as before" — no change for existing callers.
+   * `--dangerously-skip-permissions` and Codex with `--sandbox
+   * workspace-write --ask-for-approval never` regardless of the
+   * `RELAY_AUTO_APPROVE` env var. Channels without the flag still honor the
+   * env-based auto-approve behavior. Undefined / false means "behave exactly
+   * as before" — no change for existing callers.
    */
   fullAccess?: boolean;
 }
@@ -122,9 +123,11 @@ abstract class CliAgentBase implements Agent {
   protected readonly onStreamLine?: (line: string) => void;
   /**
    * Per-channel full-access flag (AL-0). When `true`, the provider-specific
-   * "skip every permission prompt" flag is threaded through regardless of
-   * the env-based `RELAY_AUTO_APPROVE`. Kept as a member so tests can
-   * assert on the constructed args without mutating `process.env`.
+   * "skip every permission prompt" signals are threaded through regardless
+   * of the env-based `RELAY_AUTO_APPROVE` — Claude gets
+   * `--dangerously-skip-permissions`, Codex gets `--sandbox workspace-write
+   * --ask-for-approval never`. Kept as a member so tests can assert on the
+   * constructed args without mutating `process.env`.
    */
   protected readonly fullAccess: boolean;
 

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -63,9 +63,10 @@ interface AgentFactoryOptions {
   /**
    * Per-channel "full access" opt-in (AL-0). Threaded through to every
    * constructed agent so `--dangerously-skip-permissions` (Claude) /
-   * `--full-auto` (Codex) gets passed without requiring callers to set
-   * `RELAY_AUTO_APPROVE`. Callers resolving per-channel state (e.g.
-   * `dispatch()`) read `channel.fullAccess` once and forward it here.
+   * `--sandbox workspace-write --ask-for-approval never` (Codex) gets passed
+   * without requiring callers to set `RELAY_AUTO_APPROVE`. Callers resolving
+   * per-channel state (e.g. `dispatch()`) read `channel.fullAccess` once and
+   * forward it here.
    */
   fullAccess?: boolean;
 }

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -60,6 +60,14 @@ interface AgentFactoryOptions {
    * renderer per-agent (e.g. label it with the agent's displayName).
    */
   onStreamLineFor?: (spec: AgentSpec) => ((line: string) => void) | undefined;
+  /**
+   * Per-channel "full access" opt-in (AL-0). Threaded through to every
+   * constructed agent so `--dangerously-skip-permissions` (Claude) /
+   * `--full-auto` (Codex) gets passed without requiring callers to set
+   * `RELAY_AUTO_APPROVE`. Callers resolving per-channel state (e.g.
+   * `dispatch()`) read `channel.fullAccess` once and forward it here.
+   */
+  fullAccess?: boolean;
 }
 
 export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
@@ -87,6 +95,7 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
       model,
       invoker,
       onStreamLine,
+      fullAccess: options.fullAccess,
     });
   });
 }

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -264,6 +264,74 @@ export class ChannelStore {
   }
 
   /**
+   * Flip the per-channel `fullAccess` flag (AL-0). When set, agent
+   * subprocesses dispatched on behalf of this channel run with
+   * `--dangerously-skip-permissions` (Claude) / `--full-auto` (Codex) so
+   * they don't prompt for approval on every tool call. Scoping is
+   * per-channel, NOT per-workspace: two channels that happen to share a
+   * repo keep independent flags.
+   *
+   * Every toggle records a decision on the channel so the audit trail is
+   * durable — the entry shows up in `rly decisions <channelId>` and the GUI
+   * decisions tab. Returns the updated channel, or `null` when no channel
+   * matches the given id.
+   *
+   * @param channelId id of the channel to update
+   * @param on new value of the flag
+   * @param actor optional actor attribution for the decision entry. Defaults
+   *   to `"user"` / `"User"` — the CLI passes through an explicit actor when
+   *   one is available (e.g. the GUI's tauri command sets it to `"gui"`).
+   */
+  async setFullAccess(
+    channelId: string,
+    on: boolean,
+    actor?: { id?: string; name?: string; source?: string }
+  ): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
+    const existing = await this.getChannel(channelId);
+    if (!existing) return null;
+
+    const previous = existing.fullAccess === true;
+    const next = on === true;
+
+    // Persist the flag change first. The decision entry is strictly
+    // supplementary audit — if it fails for some reason we'd rather the
+    // flag itself be on disk so the spawner reads the correct value.
+    const updated: Channel = {
+      ...existing,
+      fullAccess: next,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeChannel(updated);
+
+    // Always record a decision — even for no-op toggles — so the audit
+    // trail shows the call was made. The acceptance criteria say "every
+    // set-full-access toggle", which we read as "every invocation of the
+    // setter", not "every observed state change".
+    const decidedBy = actor?.id ?? "user";
+    const decidedByName = actor?.name ?? "User";
+    const source = actor?.source ?? "cli";
+    const stateLabel = next ? "on" : "off";
+    await this.recordDecision(channelId, {
+      runId: null,
+      ticketId: null,
+      title: `Full-access mode turned ${stateLabel}`,
+      description:
+        `Channel ${channelId} full-access flag set to ${stateLabel} ` +
+        `(previous: ${previous ? "on" : "off"}).`,
+      rationale: `Agent subprocesses dispatched for this channel will ${
+        next ? "run with" : "no longer receive"
+      } --dangerously-skip-permissions (Claude) / --full-auto (Codex).`,
+      alternatives: [],
+      decidedBy,
+      decidedByName,
+      linkedArtifacts: [],
+    });
+
+    return updated;
+  }
+
+  /**
    * Bump a channel's `updatedAt` without patching any user-visible field.
    * Called from activity writes (postEntry, recordDecision) so the sidebar
    * can sort channels by most-recent activity. Silently no-ops if the

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -266,10 +266,10 @@ export class ChannelStore {
   /**
    * Flip the per-channel `fullAccess` flag (AL-0). When set, agent
    * subprocesses dispatched on behalf of this channel run with
-   * `--dangerously-skip-permissions` (Claude) / `--full-auto` (Codex) so
-   * they don't prompt for approval on every tool call. Scoping is
-   * per-channel, NOT per-workspace: two channels that happen to share a
-   * repo keep independent flags.
+   * `--dangerously-skip-permissions` (Claude) / `--sandbox workspace-write
+   * --ask-for-approval never` (Codex) so they don't prompt for approval on
+   * every tool call. Scoping is per-channel, NOT per-workspace: two channels
+   * that happen to share a repo keep independent flags.
    *
    * Every toggle records a decision on the channel so the audit trail is
    * durable — the entry shows up in `rly decisions <channelId>` and the GUI
@@ -321,7 +321,7 @@ export class ChannelStore {
         `(previous: ${previous ? "on" : "off"}).`,
       rationale: `Agent subprocesses dispatched for this channel will ${
         next ? "run with" : "no longer receive"
-      } --dangerously-skip-permissions (Claude) / --full-auto (Codex).`,
+      } --dangerously-skip-permissions (Claude) / --sandbox workspace-write --ask-for-approval never (Codex).`,
       alternatives: [],
       decidedBy,
       decidedByName,

--- a/src/cli/welcome.ts
+++ b/src/cli/welcome.ts
@@ -428,7 +428,8 @@ export async function runWelcome(options: WelcomeOptions): Promise<number> {
     p("");
     p(`${c.bold}RELAY_AUTO_APPROVE=1${c.reset}   skip every permission prompt — Claude launches`);
     p(`                       with --dangerously-skip-permissions, Codex with`);
-    p(`                       --full-auto. Required for multi-hour runs.`);
+    p(`                       --sandbox workspace-write --ask-for-approval never.`);
+    p(`                       Required for multi-hour runs.`);
     p("");
     p(`${c.bold}RELAY_USE_DIST=1${c.reset}       run compiled dist (faster startup) instead of`);
     p(`                       live TS source. Default is live source via tsx.`);

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -76,11 +76,12 @@ export interface Channel {
   /**
    * Per-channel opt-in for unattended agent runs. When `true`, subprocesses
    * Relay spawns on behalf of this channel are launched with
-   * `--dangerously-skip-permissions` (Claude) / `--full-auto` (Codex) so they
-   * don't prompt for permission on every tool call. Scoped per-channel —
-   * toggling this on one channel never affects another channel, even when
-   * both assign the same repo. Optional for back-compat with older channel
-   * files: a missing field is treated as `false` at every read site.
+   * `--dangerously-skip-permissions` (Claude) / `--sandbox workspace-write
+   * --ask-for-approval never` (Codex) so they don't prompt for permission on
+   * every tool call. Scoped per-channel — toggling this on one channel never
+   * affects another channel, even when both assign the same repo. Optional
+   * for back-compat with older channel files: a missing field is treated as
+   * `false` at every read site.
    */
   fullAccess?: boolean;
   createdAt: string;

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -73,6 +73,16 @@ export interface Channel {
    * means no mirror is configured; Relay still functions normally.
    */
   linearProjectId?: string;
+  /**
+   * Per-channel opt-in for unattended agent runs. When `true`, subprocesses
+   * Relay spawns on behalf of this channel are launched with
+   * `--dangerously-skip-permissions` (Claude) / `--full-auto` (Codex) so they
+   * don't prompt for permission on every tool call. Scoped per-channel —
+   * toggling this on one channel never affects another channel, even when
+   * both assign the same repo. Optional for back-compat with older channel
+   * files: a missing field is treated as `false` at every read site.
+   */
+  fullAccess?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -622,6 +622,54 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (sub === "set-full-access") {
+    const channelId = args[1];
+    const stateArg = args[2];
+    if (!channelId || !stateArg) {
+      console.error("Usage: rly channel set-full-access <channelId> <on|off>");
+      process.exitCode = 1;
+      return;
+    }
+
+    // Accept the few obvious spellings so callers don't have to guess.
+    // Anything else is an error — silent coercion of "maybe" to "off" would
+    // be a footgun for a flag that disables permission prompts.
+    let next: boolean;
+    if (stateArg === "on" || stateArg === "true" || stateArg === "1") {
+      next = true;
+    } else if (stateArg === "off" || stateArg === "false" || stateArg === "0") {
+      next = false;
+    } else {
+      console.error(`set-full-access: expected "on" or "off", got "${stateArg}".`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const sourceArg = parseNamedArg(args, "--source");
+    const actorName = parseNamedArg(args, "--actor");
+    const actor = {
+      source: sourceArg ?? "cli",
+      name: actorName ?? "CLI",
+      id: actorName ?? "cli",
+    };
+
+    const updated = await store.setFullAccess(channelId, next, actor);
+
+    if (args.includes("--json")) {
+      jsonOut(updated);
+    } else if (updated) {
+      console.log(
+        `Channel full-access ${updated.fullAccess ? "on" : "off"}: ${updated.name} (${
+          updated.channelId
+        })`
+      );
+    } else {
+      console.error(`Channel not found: ${channelId}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   if (sub === "update") {
     const channelId = args[1];
     if (!channelId) {
@@ -748,7 +796,9 @@ async function handleChannelCommand(args: string[]): Promise<void> {
   }
 
   if (!sub) {
-    console.error("Usage: rly channel <channelId|create|archive|unarchive|update|feed|post>");
+    console.error(
+      "Usage: rly channel <channelId|create|archive|unarchive|set-full-access|update|feed|post>"
+    );
     process.exitCode = 1;
     return;
   }
@@ -2135,7 +2185,7 @@ async function printTopLevelHelp(): Promise<void> {
     "",
     "Channels & sessions:",
     "  channels                 List channels (most-recently-active first)",
-    "  channel <subcommand>     Manage channels (create/update/archive/feed/post/...)",
+    "  channel <subcommand>     Manage channels (create/update/archive/set-full-access/feed/post/...)",
     "  session <subcommand>     Manage session transcripts",
     "  board <channelId>        Kanban view of tickets",
     "  decisions <channelId>    List decisions with rationale",

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -58,7 +58,8 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
 
   // Build agent registry with the per-channel full-access flag threaded
   // through so Claude gets `--dangerously-skip-permissions` / Codex gets
-  // `--full-auto` without requiring the machine-wide `RELAY_AUTO_APPROVE`.
+  // `--sandbox workspace-write --ask-for-approval never` without requiring
+  // the machine-wide `RELAY_AUTO_APPROVE`.
   const registry = new AgentRegistry();
   const agents = createLiveAgents({
     cwd: repoPath,

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -39,18 +39,10 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const defaultProvider = (process.env.HARNESS_PROVIDER ?? "claude") as "claude" | "codex";
   await registerAgentNames({ defaultProvider });
 
-  // Build agent registry
-  const registry = new AgentRegistry();
-  const agents = createLiveAgents({
-    cwd: repoPath,
-    defaultProvider,
-  });
-  for (const agent of agents) {
-    registry.register(agent);
-  }
-
-  // Resolve or create a channel
+  // Resolve or create a channel first — we need its `fullAccess` flag to
+  // decide whether agents should be constructed in unattended mode (AL-0).
   let channelId = input.channelId;
+  let channelFullAccess = false;
   if (!channelId) {
     const channel = await channelStore.createChannel({
       name: featureRequest.slice(0, 60),
@@ -58,6 +50,23 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
       workspaceIds: [workspaceId],
     });
     channelId = channel.channelId;
+    channelFullAccess = channel.fullAccess === true;
+  } else {
+    const existing = await channelStore.getChannel(channelId);
+    channelFullAccess = existing?.fullAccess === true;
+  }
+
+  // Build agent registry with the per-channel full-access flag threaded
+  // through so Claude gets `--dangerously-skip-permissions` / Codex gets
+  // `--full-auto` without requiring the machine-wide `RELAY_AUTO_APPROVE`.
+  const registry = new AgentRegistry();
+  const agents = createLiveAgents({
+    cwd: repoPath,
+    defaultProvider,
+    fullAccess: channelFullAccess,
+  });
+  for (const agent of agents) {
+    registry.register(agent);
   }
 
   const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);

--- a/test/agents/cli-agents-full-access.test.ts
+++ b/test/agents/cli-agents-full-access.test.ts
@@ -1,0 +1,199 @@
+import { writeFile } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ClaudeCliAgent, CodexCliAgent } from "../../src/agents/cli-agents.js";
+import type { CommandInvocation, CommandInvoker } from "../../src/agents/command-invoker.js";
+import type { WorkRequest } from "../../src/domain/agent.js";
+
+/**
+ * AL-0: the per-channel `fullAccess` flag must reach the subprocess launch
+ * as `--dangerously-skip-permissions` (Claude) / `--full-auto` (Codex),
+ * regardless of the host's `RELAY_AUTO_APPROVE` env var. These tests
+ * capture the args passed to a fake `CommandInvoker` and assert the right
+ * flag appears (or doesn't) under every combination of channel-flag +
+ * env-flag.
+ */
+
+class CaptureInvoker implements CommandInvoker {
+  public lastInvocation: CommandInvocation | null = null;
+
+  constructor(private readonly stdout: string) {}
+
+  async exec(invocation: CommandInvocation) {
+    this.lastInvocation = invocation;
+
+    // Codex writes its response to the `-o` path, so mirror the real CLI's
+    // contract: drop the JSON payload there before returning. Claude reads
+    // from stdout and needs no tempfile.
+    const outputFlagIdx = invocation.args.indexOf("-o");
+    if (outputFlagIdx >= 0) {
+      const outputPath = invocation.args[outputFlagIdx + 1];
+      if (outputPath) {
+        await writeFile(outputPath, this.stdout);
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    }
+
+    return { stdout: this.stdout, stderr: "", exitCode: 0 };
+  }
+}
+
+function makeWorkRequest(): WorkRequest {
+  return {
+    runId: "run-1",
+    phaseId: "phase-1",
+    kind: "implement_phase",
+    specialty: "general",
+    title: "test",
+    objective: "test",
+    acceptanceCriteria: [],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    context: [],
+    artifactContext: [],
+    attempt: 1,
+    maxAttempts: 3,
+    priorEvidence: [],
+  };
+}
+
+const AGENT_RESULT = JSON.stringify({
+  summary: "ok",
+  evidence: [],
+  proposedCommands: [],
+  blockers: [],
+});
+
+describe("cli-agents full-access flag (AL-0)", () => {
+  const priorEnv = process.env.RELAY_AUTO_APPROVE;
+
+  beforeEach(() => {
+    // Every test sets its own env expectation; start from a known-clean
+    // slate so the host's RELAY_AUTO_APPROVE never leaks into the assertions.
+    delete process.env.RELAY_AUTO_APPROVE;
+  });
+
+  afterEach(() => {
+    if (priorEnv === undefined) {
+      delete process.env.RELAY_AUTO_APPROVE;
+    } else {
+      process.env.RELAY_AUTO_APPROVE = priorEnv;
+    }
+  });
+
+  it("Claude: fullAccess=true threads --dangerously-skip-permissions even with env unset", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agent = new ClaudeCliAgent({
+      id: "a-1",
+      name: "A",
+      provider: "claude",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      fullAccess: true,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const args = invoker.lastInvocation?.args ?? [];
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("--permission-mode");
+  });
+
+  it("Claude: fullAccess=false + env unset uses default permission mode", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agent = new ClaudeCliAgent({
+      id: "a-1",
+      name: "A",
+      provider: "claude",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      fullAccess: false,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const args = invoker.lastInvocation?.args ?? [];
+    expect(args).not.toContain("--dangerously-skip-permissions");
+    expect(args).toContain("--permission-mode");
+  });
+
+  it("Claude: fullAccess omitted behaves as false", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agent = new ClaudeCliAgent({
+      id: "a-1",
+      name: "A",
+      provider: "claude",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const args = invoker.lastInvocation?.args ?? [];
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("Claude: env-based auto-approve still works when fullAccess is off (back-compat)", async () => {
+    process.env.RELAY_AUTO_APPROVE = "1";
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agent = new ClaudeCliAgent({
+      id: "a-1",
+      name: "A",
+      provider: "claude",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      fullAccess: false,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const args = invoker.lastInvocation?.args ?? [];
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("Codex: fullAccess=true threads --full-auto and --ask-for-approval never", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agent = new CodexCliAgent({
+      id: "a-1",
+      name: "A",
+      provider: "codex",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      fullAccess: true,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const args = invoker.lastInvocation?.args ?? [];
+    // Codex's "full access" is the combination of a writable sandbox +
+    // never-ask approval policy. Both signals need to be on the command line.
+    expect(args).toContain("workspace-write");
+    expect(args).toContain("--ask-for-approval");
+    expect(args[args.indexOf("--ask-for-approval") + 1]).toBe("never");
+  });
+
+  it("Codex: fullAccess=false keeps the default read-only sandbox", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agent = new CodexCliAgent({
+      id: "a-1",
+      name: "A",
+      provider: "codex",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      fullAccess: false,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const args = invoker.lastInvocation?.args ?? [];
+    expect(args).toContain("read-only");
+    expect(args).not.toContain("--ask-for-approval");
+  });
+});

--- a/test/agents/cli-agents-full-access.test.ts
+++ b/test/agents/cli-agents-full-access.test.ts
@@ -7,11 +7,11 @@ import type { WorkRequest } from "../../src/domain/agent.js";
 
 /**
  * AL-0: the per-channel `fullAccess` flag must reach the subprocess launch
- * as `--dangerously-skip-permissions` (Claude) / `--full-auto` (Codex),
- * regardless of the host's `RELAY_AUTO_APPROVE` env var. These tests
- * capture the args passed to a fake `CommandInvoker` and assert the right
- * flag appears (or doesn't) under every combination of channel-flag +
- * env-flag.
+ * as `--dangerously-skip-permissions` (Claude) / `--sandbox workspace-write
+ * --ask-for-approval never` (Codex), regardless of the host's
+ * `RELAY_AUTO_APPROVE` env var. These tests capture the args passed to a
+ * fake `CommandInvoker` and assert the right flag appears (or doesn't)
+ * under every combination of channel-flag + env-flag.
  */
 
 class CaptureInvoker implements CommandInvoker {
@@ -156,7 +156,7 @@ describe("cli-agents full-access flag (AL-0)", () => {
     expect(args).toContain("--dangerously-skip-permissions");
   });
 
-  it("Codex: fullAccess=true threads --full-auto and --ask-for-approval never", async () => {
+  it("Codex: fullAccess=true threads workspace-write sandbox and --ask-for-approval never", async () => {
     const invoker = new CaptureInvoker(AGENT_RESULT);
     const agent = new CodexCliAgent({
       id: "a-1",

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -85,6 +85,137 @@ describe("channel store", () => {
     }
   });
 
+  // --- AL-0: per-channel full-access flag --------------------------------
+
+  describe("setFullAccess", () => {
+    it("flips the fullAccess flag and records an audit decision", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+
+      try {
+        const channel = await store.createChannel({
+          name: "#fa",
+          description: "full-access",
+        });
+        // Default is false (field absent on disk).
+        expect(channel.fullAccess).toBeUndefined();
+
+        const on = await store.setFullAccess(channel.channelId, true);
+        expect(on?.fullAccess).toBe(true);
+
+        const fetched = await store.getChannel(channel.channelId);
+        expect(fetched?.fullAccess).toBe(true);
+
+        const off = await store.setFullAccess(channel.channelId, false);
+        expect(off?.fullAccess).toBe(false);
+
+        // Every call must record a decision — two toggles, two entries.
+        const decisions = await store.listDecisions(channel.channelId);
+        expect(decisions).toHaveLength(2);
+        expect(decisions[0].title).toMatch(/Full-access mode turned/);
+        expect(decisions[0].description).toContain(channel.channelId);
+
+        // Decisions also post a feed entry — verify the audit trail is
+        // visible to callers reading through the feed.
+        const feed = await store.readFeed(channel.channelId);
+        const decisionEntries = feed.filter((e) => e.type === "decision");
+        expect(decisionEntries).toHaveLength(2);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns null for an unknown channel without writing a decision", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+
+      try {
+        const result = await store.setFullAccess("does-not-exist", true);
+        expect(result).toBeNull();
+
+        // No channel => no decision side effects.
+        const decisions = await store.listDecisions("does-not-exist");
+        expect(decisions).toEqual([]);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("scopes the flag per-channel even when two channels share a repo", async () => {
+      // Acceptance criterion: toggling channel A does not affect channel B
+      // just because both point at the same repoPath.
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      const sharedRepo = {
+        alias: "repo",
+        workspaceId: "ws-shared",
+        repoPath: "/tmp/shared-repo",
+      };
+
+      try {
+        const a = await store.createChannel({
+          name: "#a",
+          description: "channel A",
+          repoAssignments: [sharedRepo],
+        });
+        const b = await store.createChannel({
+          name: "#b",
+          description: "channel B",
+          repoAssignments: [sharedRepo],
+        });
+
+        await store.setFullAccess(a.channelId, true);
+
+        const aFetched = await store.getChannel(a.channelId);
+        const bFetched = await store.getChannel(b.channelId);
+        expect(aFetched?.fullAccess).toBe(true);
+        // B must stay exactly as created — undefined, not accidentally
+        // flipped by any shared repoPath logic.
+        expect(bFetched?.fullAccess).toBeUndefined();
+
+        // Flipping B should also not regress A.
+        await store.setFullAccess(b.channelId, true);
+        const aAfter = await store.getChannel(a.channelId);
+        const bAfter = await store.getChannel(b.channelId);
+        expect(aAfter?.fullAccess).toBe(true);
+        expect(bAfter?.fullAccess).toBe(true);
+
+        // Each channel's decisions ledger is independent.
+        const aDecisions = await store.listDecisions(a.channelId);
+        const bDecisions = await store.listDecisions(b.channelId);
+        expect(aDecisions).toHaveLength(1);
+        expect(bDecisions).toHaveLength(1);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("records the supplied actor on the decision entry", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+
+      try {
+        const channel = await store.createChannel({
+          name: "#actor",
+          description: "actor test",
+        });
+
+        await store.setFullAccess(channel.channelId, true, {
+          id: "gui",
+          name: "gui",
+          source: "gui",
+        });
+
+        const decisions = await store.listDecisions(channel.channelId);
+        expect(decisions).toHaveLength(1);
+        expect(decisions[0].decidedBy).toBe("gui");
+        expect(decisions[0].decidedByName).toBe("gui");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("manages channel members (join/leave)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
     const store = new ChannelStore(dir);


### PR DESCRIPTION
## Summary

- Adds `fullAccess: boolean` to the Channel model (optional, default `false`). When set, agent subprocesses dispatched on behalf of that channel pass `--dangerously-skip-permissions` (Claude) / workspace-write + `--ask-for-approval never` (Codex) so autonomous runs don't stall on permission prompts.
- Scoping is **per-channel**: two channels sharing a repo keep independent flags. Every toggle records a decision on the channel store, so the audit trail is visible in both `rly decisions <id>` and the GUI decisions tab.
- Exposes the toggle as `rly channel set-full-access <id> <on|off>` and a "Full access" checkbox in the GUI channel header. The tauri command tags the actor as `gui` so CLI vs. GUI toggles are distinguishable in the decisions ledger.

Spawner plumbing threads the flag from `dispatch()` → `createLiveAgents()` → `ClaudeCliAgent` / `CodexCliAgent`. Existing `RELAY_AUTO_APPROVE` behavior is preserved; the new flag OR's onto the env-based check.

Back-compat: old channel files without `fullAccess` deserialize cleanly as `undefined` / `None` and are treated as `false` at every read site.

Closes #75

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm -C gui build`
- [x] `cargo check -p harness-data -p relay-gui`
- [x] `cargo test -p harness-data` (includes 2 new schema-drift tests for `full_access`)
- [x] `pnpm dlx prettier --check` on the documented glob
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 481 tests pass (was 475)
- [x] `setFullAccess` flips the flag and records an audit decision on every call
- [x] `setFullAccess("does-not-exist", …)` returns `null` without side effects
- [x] Two channels sharing a `repoPath` keep independent flags (acceptance criterion #3)
- [x] `ClaudeCliAgent` passes `--dangerously-skip-permissions` iff `fullAccess=true` OR `RELAY_AUTO_APPROVE=1`
- [x] `CodexCliAgent` switches to `workspace-write` + `--ask-for-approval never` under the same conditions
- [x] CLI + GUI affordance end-to-end (tauri command verified to assemble the right CLI invocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)