### PR TITLE
AL-11: Define repo-admin agent role

### DIFF
--- a/agent_docs/README.md
+++ b/agent_docs/README.md
@@ -9,6 +9,7 @@ Written **for coding agents** (Claude Code, Codex, Cursor, etc.), not humans. Hu
 - [`architecture.md`](./architecture.md) — directory map, what each top-level dir owns, concrete source-file pointers.
 - [`data-model.md`](./data-model.md) — the core domain types + where each one is defined in TS and mirrored in Rust.
 - [`testing.md`](./testing.md) — vitest patterns used in the repo, scripted vs live mode, conventions.
+- [`repo-admin.md`](./repo-admin.md) — foreman (repo-admin) / crew (workers) split in the autonomous loop, with MCP tool allowlist + enforcement notes (AL-11).
 
 Each file is currently a minimal honest stub — extended as real gaps in agent knowledge become apparent. Better a short pointer at the real source than paragraphs of invented prose.
 

--- a/agent_docs/data-model.md
+++ b/agent_docs/data-model.md
@@ -6,15 +6,15 @@ The core domain types. TS is canonical; Rust mirrors (in `crates/harness-data/sr
 
 ## Canonical types
 
-| Type | TS definition | Rust mirror | Notes |
-|---|---|---|---|
-| `HarnessRun` | `src/domain/run.ts` (interface `HarnessRun`) | partially via `RunIndexEntry` + `TicketLedger` in `crates/harness-data/src/lib.rs` | One classifier→planner→scheduler execution. Lives under a channel. |
-| `Channel` | `src/domain/channel.ts` (interface `Channel`) | `struct Channel` in `crates/harness-data/src/lib.rs` | Slack-like workspace for one piece of work. Members, pinned refs, repo assignments. |
-| `ChannelEntry` | `src/domain/channel.ts` (interface `ChannelEntry`) | `struct ChannelEntry` | Append-only feed row. `ChannelEntryTypeSchema` enumerates the types. |
-| `TicketLedgerEntry` | `src/domain/ticket.ts` (interface `TicketLedgerEntry`) | `struct TicketLedgerEntry` | Unit of parallel work. Deps DAG, retry budget, specialty tag. |
-| `Decision` | `src/domain/decision.ts` (interface `Decision`) | `struct Decision` | Rationale + alternatives. One file per decision under `channels/<id>/decisions/`. |
-| `CrosslinkSession` | `src/crosslink/types.ts` (`CrosslinkSessionSchema` zod + `type CrosslinkSession`) | not mirrored — GUI reads live heartbeat JSON directly | Session heartbeat written to `~/.relay/crosslink/sessions/`. |
-| `Spawn` | `gui/src/types.ts` (`type Spawn`) + `channels/<id>/spawns.json` on disk | not mirrored in `crates/harness-data/` — GUI reads the JSON directly | Tracked spawned-terminal sessions (macOS GUI only). |
+| Type                | TS definition                                                                     | Rust mirror                                                                        | Notes                                                                               |
+| ------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `HarnessRun`        | `src/domain/run.ts` (interface `HarnessRun`)                                      | partially via `RunIndexEntry` + `TicketLedger` in `crates/harness-data/src/lib.rs` | One classifier→planner→scheduler execution. Lives under a channel.                  |
+| `Channel`           | `src/domain/channel.ts` (interface `Channel`)                                     | `struct Channel` in `crates/harness-data/src/lib.rs`                               | Slack-like workspace for one piece of work. Members, pinned refs, repo assignments. |
+| `ChannelEntry`      | `src/domain/channel.ts` (interface `ChannelEntry`)                                | `struct ChannelEntry`                                                              | Append-only feed row. `ChannelEntryTypeSchema` enumerates the types.                |
+| `TicketLedgerEntry` | `src/domain/ticket.ts` (interface `TicketLedgerEntry`)                            | `struct TicketLedgerEntry`                                                         | Unit of parallel work. Deps DAG, retry budget, specialty tag.                       |
+| `Decision`          | `src/domain/decision.ts` (interface `Decision`)                                   | `struct Decision`                                                                  | Rationale + alternatives. One file per decision under `channels/<id>/decisions/`.   |
+| `CrosslinkSession`  | `src/crosslink/types.ts` (`CrosslinkSessionSchema` zod + `type CrosslinkSession`) | not mirrored — GUI reads live heartbeat JSON directly                              | Session heartbeat written to `~/.relay/crosslink/sessions/`.                        |
+| `Spawn`             | `gui/src/types.ts` (`type Spawn`) + `channels/<id>/spawns.json` on disk           | not mirrored in `crates/harness-data/` — GUI reads the JSON directly               | Tracked spawned-terminal sessions (macOS GUI only).                                 |
 
 ## Enums and schemas worth knowing
 

--- a/agent_docs/repo-admin.md
+++ b/agent_docs/repo-admin.md
@@ -46,7 +46,8 @@ Data-driven in `src/mcp/role-allowlist.ts`. Repo-admin can call:
 
 - `channel_task_board` — read the ticket board
 - `channel_get` — read decisions + feed + run links in one call
-- `channel_post` — append-only status updates on the channel feed
+- `channel_post` — append-only status updates on the channel feed (writes a
+  new entry; cannot edit or retract prior entries)
 - `harness_running_tasks` — cross-workspace running-task view
 - `harness_list_runs` / `harness_get_run_detail` — read-only run state
 - `spawn_worker` — **declared, stubbed** until AL-14 fills in the handler
@@ -56,7 +57,42 @@ Denied by design: file edits (`Edit`, `Write`, `NotebookEdit`), test runners
 tool that mutates state outside `spawn_worker` (e.g. `harness_dispatch`,
 `harness_approve_plan`, `project_create`).
 
+### Deferred: read-only git log + PR-state MCP tools
+
+Repo-admin needs git-log and PR-state visibility to sequence merges, but
+Bash is denied (above) and no first-class MCP tool exposes them yet. Access
+is deferred to a follow-up ticket (tentatively AL-XX) which will add a
+read-only `git_log` MCP tool and a PR-state query. Until then, repo-admin
+reads the channel feed's `tracked_prs` entries for PR state and proposes a
+worker when a git-log walk is actually required.
+
 ## Enforcement
+
+Enforcement runs on **two layers** because Claude Code's built-in tools
+(`Edit`, `Write`, `Bash`, `NotebookEdit`) run in-process in the `claude`
+CLI and never round-trip through MCP. An MCP-only allowlist would be
+cosmetic for exactly the attack surface this role is meant to lock down.
+
+**Layer 1 — Claude CLI `--disallowed-tools` (built-ins).**
+
+When a repo-admin session is spawned, `src/agents/cli-agents.ts` passes
+`--disallowed-tools Edit,Write,NotebookEdit,Bash` to the `claude` binary,
+and sets `RELAY_AGENT_ROLE=repo-admin` in the subprocess env. The CLI
+itself refuses to call any listed built-in — this is the only enforcement
+that actually gates `Edit`/`Write`/`Bash`, because those calls never reach
+the MCP boundary. The deny list is data-driven:
+`getDisallowedBuiltinsForRole(role)` in `src/mcp/role-allowlist.ts`, so
+future roles add their own lockdown by appending a map entry rather than
+editing adapter code.
+
+> **Codex:** Codex CLI has no `--disallowed-tools` equivalent today.
+> Codex repo-admin sessions still set `RELAY_AGENT_ROLE` (gating
+> MCP-routed tools) but **built-in tool lockdown is deferred pending a
+> provider-side flag**. The CliAgent prints a one-line stderr warning in
+> this case so it's visible in logs. Don't treat a Codex repo-admin
+> session as fully enforced until that flag exists.
+
+**Layer 2 — MCP server allowlist (JSON-RPC tools).**
 
 Role is read from the `RELAY_AGENT_ROLE` env var at the MCP server layer.
 Two consult points inside `src/mcp/server.ts`:
@@ -71,9 +107,30 @@ Two consult points inside `src/mcp/server.ts`:
   gets "propose a worker spawn instead") and adjusts.
 
 Unknown roles (i.e. any `RELAY_AGENT_ROLE` value that isn't mapped in
-`ROLE_ALLOWLISTS`) fall through to the unrestricted path. That's deliberate
-for the AL-12..AL-16 rollout — a new role opts into enforcement by adding
-an entry to the map, not by editing switch statements.
+`ROLE_ALLOWLISTS`) fall through to the unrestricted path — the opt-in model
+that lets AL-12..AL-16 add roles without editing switch statements. On MCP
+server startup, an unknown role triggers a **one-shot stderr warning**
+(`[relay] unknown RELAY_AGENT_ROLE=<value>, running unrestricted — check
+spelling`). Fail-open-with-loud-warn is the documented choice; fail-closed
+would block the rollout (any new role would break all sessions until a map
+entry landed). The warning ensures a typo never ships quietly as cosmetic
+enforcement.
+
+## Spawner wiring
+
+`createLiveAgents({ ..., role: "repo-admin" })` in `src/agents/factory.ts`
+threads the role through to every CLI agent it constructs. Each agent then:
+
+1. Sets `RELAY_AGENT_ROLE=<role>` in the spawned CLI subprocess env via
+   `CommandInvocation.env`, which flows through the default
+   `RELAY_*`-prefix env sanitizer in `src/agents/command-invoker.ts`.
+2. Appends `--disallowed-tools <…>` to the Claude CLI args (Claude only;
+   Codex sessions only get the env var plus the deferred-enforcement
+   warning).
+
+No current spawner sets `role: "repo-admin"` yet — AL-12 is where a concrete
+per-repo repo-admin session lifecycle lands. AL-11 ships the wiring, the
+policy definition, and the tests so AL-12 has something concrete to extend.
 
 ## Files of record
 

--- a/agent_docs/repo-admin.md
+++ b/agent_docs/repo-admin.md
@@ -1,0 +1,86 @@
+# Repo-admin (foreman) vs. workers (crew)
+
+Landed in **AL-11**. Lifecycle, routing, spawn-worker wiring, memory-shed,
+and inter-admin coordination land in **AL-12..AL-16** — this doc covers the
+role definition only.
+
+## The split
+
+Relay's autonomous loop has two tiers of agent sessions:
+
+| Tier       | Lifetime                 | Scope       | Does                                                           | Does NOT                         |
+| ---------- | ------------------------ | ----------- | -------------------------------------------------------------- | -------------------------------- |
+| repo-admin | long-lived, one per repo | single repo | coordinates worktrees, dispatches workers, sequences PR merges | edit files, run tests, merge PRs |
+| worker     | ephemeral, per ticket    | one ticket  | writes code, runs tests, opens PRs                             | carries state across tickets     |
+
+The split exists to keep cognitive load bounded. Repo-admin is a
+**coordination layer**, not a memory authority. Workers are the crew: they
+execute a single ticket inside an isolated worktree and terminate. When
+repo-admin needs to reconsult history, it re-reads the channel board + the
+`channels/<id>/decisions/` directory — not chat summaries.
+
+## Memory policy
+
+Repo-admin caches only the **active working set**:
+
+- in-flight tickets (by id)
+- open PRs (by number)
+- current worktrees (by path)
+
+Anything beyond that is re-read on demand from disk. The source of truth is:
+
+1. The **ticket board** — `channel_task_board` MCP tool, or the
+   `tickets.json` file under `channels/<id>/`.
+2. The **decisions** — `channels/<id>/decisions/<decisionId>.json`, surfaced
+   via `channel_get`.
+3. The **git log** — for each repo, the canonical record of what shipped.
+
+Chat history and scratch summaries are intentionally not load-bearing. If a
+repo-admin session restarts, re-reading the three sources above must be
+sufficient to pick the loop back up. AL-15 will formalize this into a
+bounded memory-shed; AL-11 establishes the discipline in the system prompt.
+
+## MCP tool allowlist
+
+Data-driven in `src/mcp/role-allowlist.ts`. Repo-admin can call:
+
+- `channel_task_board` — read the ticket board
+- `channel_get` — read decisions + feed + run links in one call
+- `channel_post` — append-only status updates on the channel feed
+- `harness_running_tasks` — cross-workspace running-task view
+- `harness_list_runs` / `harness_get_run_detail` — read-only run state
+- `spawn_worker` — **declared, stubbed** until AL-14 fills in the handler
+
+Denied by design: file edits (`Edit`, `Write`, `NotebookEdit`), test runners
+(any `Bash`-backed test invocation), PR merges (`gh pr merge`), and any MCP
+tool that mutates state outside `spawn_worker` (e.g. `harness_dispatch`,
+`harness_approve_plan`, `project_create`).
+
+## Enforcement
+
+Role is read from the `RELAY_AGENT_ROLE` env var at the MCP server layer.
+Two consult points inside `src/mcp/server.ts`:
+
+- **`tools/list`** filters the advertised tool set to the role's allowlist.
+  A repo-admin session sees only what it can call; the capability report
+  matches the allowlist one-for-one (tested via `test/mcp/role-allowlist.test.ts`).
+- **`tools/call`** consults `isToolAllowedForRole(role, toolName)` before
+  dispatch. On deny, the server returns a **structured envelope**
+  (`{error: "tool-not-allowed", tool, role, reason}`) with `isError: true`
+  — not a silent failure. The agent sees the reason (role-specific: repo-admin
+  gets "propose a worker spawn instead") and adjusts.
+
+Unknown roles (i.e. any `RELAY_AGENT_ROLE` value that isn't mapped in
+`ROLE_ALLOWLISTS`) fall through to the unrestricted path. That's deliberate
+for the AL-12..AL-16 rollout — a new role opts into enforcement by adding
+an entry to the map, not by editing switch statements.
+
+## Files of record
+
+- `src/agents/repo-admin.ts` — role identity, system prompt, stub handlers.
+- `src/mcp/role-allowlist.ts` — per-role tool whitelist + denial envelope.
+- `src/mcp/server.ts` — integration into `tools/list` and `tools/call`.
+- `test/agents/repo-admin.test.ts` — allowlist exactness, system-prompt
+  substrings, stub behaviour.
+- `test/mcp/role-allowlist.test.ts` — end-to-end handler behaviour under
+  `RELAY_AGENT_ROLE=repo-admin`.

--- a/agent_docs/tidewater_handoff/README.md
+++ b/agent_docs/tidewater_handoff/README.md
@@ -43,27 +43,56 @@ design/
 ```
 
 ### Loading the reference locally
+
 To view the designs as a working React app, create an `index.html` next to `design/`:
 
 ```html
-<!doctype html><html><head><meta charset="utf-8">
-<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin></script>
-<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" crossorigin></script>
-<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<style>html,body,#r{margin:0;height:100%;background:#0e1420;font-family:Inter,sans-serif}*{box-sizing:border-box}</style>
-</head><body><div id="r" style="width:1480px;height:920px"></div>
-<script type="text/babel" src="design/relay-data.jsx"></script>
-<script type="text/babel" src="design/direction-a-base.jsx"></script>
-<script type="text/babel" src="design/direction-a-sidebar.jsx"></script>
-<script type="text/babel" src="design/direction-a-header.jsx"></script>
-<script type="text/babel" src="design/direction-a-chat.jsx"></script>
-<script type="text/babel" src="design/direction-a-right.jsx"></script>
-<script type="text/babel" src="design/direction-a-app.jsx"></script>
-<script type="text/babel" src="design/direction-c-repos.jsx"></script>
-<script type="text/babel" src="design/direction-c-tidewater.jsx"></script>
-<script type="text/babel">ReactDOM.createRoot(document.getElementById('r')).render(<DirectionC tweaks={{avatarStyle:'glyph',density:'medium'}}/>);</script>
-</body></html>
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin></script>
+    <script
+      src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"
+      crossorigin
+    ></script>
+    <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      html,
+      body,
+      #r {
+        margin: 0;
+        height: 100%;
+        background: #0e1420;
+        font-family: Inter, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="r" style="width:1480px;height:920px"></div>
+    <script type="text/babel" src="design/relay-data.jsx"></script>
+    <script type="text/babel" src="design/direction-a-base.jsx"></script>
+    <script type="text/babel" src="design/direction-a-sidebar.jsx"></script>
+    <script type="text/babel" src="design/direction-a-header.jsx"></script>
+    <script type="text/babel" src="design/direction-a-chat.jsx"></script>
+    <script type="text/babel" src="design/direction-a-right.jsx"></script>
+    <script type="text/babel" src="design/direction-a-app.jsx"></script>
+    <script type="text/babel" src="design/direction-c-repos.jsx"></script>
+    <script type="text/babel" src="design/direction-c-tidewater.jsx"></script>
+    <script type="text/babel">
+      ReactDOM.createRoot(document.getElementById("r")).render(
+        <DirectionC tweaks={{ avatarStyle: "glyph", density: "medium" }} />
+      );
+    </script>
+  </body>
+</html>
 ```
 
 ---
@@ -75,6 +104,7 @@ Tidewater introduces several concepts that don't exist in the current Relay CLI 
 ### 4.1 Repos are channel-scoped, not global
 
 The earlier iteration had a global "Repos" section in the sidebar. That's gone.
+
 - Workspaces registered via `rly up` live in a **global pool** — see `AVAILABLE_WORKSPACES` in `relay-data.jsx`.
 - A workspace only becomes a pingable `@alias` agent **after it's attached to a channel**.
 - Each channel has an array `repos: string[]` (aliases) and a single `primaryRepo: string`.
@@ -96,10 +126,12 @@ In Tidewater, typing `@` in the composer opens a Slack-style popover (see `Menti
 ### 4.3 Channel header is **interactive for repo management**
 
 Open `direction-c-tidewater.jsx` → `ChannelHeader` and `direction-c-repos.jsx` → `RepoChipRow`. The header has:
+
 - **Row 1:** `#` + channel name + tier badge + star + topic (truncates) | agent stack | right-rail toggle
 - **Row 2 (tabs):** `Chat | Board | Decisions` tabs | **RepoChipRow** (right-aligned)
 
 The RepoChipRow is where inline repo management lives:
+
 - Each chip is clickable — opens a popover with "Set as primary", "Detach", etc.
 - Hovering a non-primary chip reveals an `×` shortcut to detach.
 - The primary chip cannot be directly detached; the user must promote another repo first.
@@ -113,21 +145,26 @@ Gear icon → right-side slide-over (`ChannelSettingsDrawer` in `direction-c-rep
 ### 4.5 New-channel modal (3-step)
 
 `NewChannelModal` in `direction-c-repos.jsx`. Three steps:
+
 1. **Basics** — channel name + optional topic. Name is auto-slugged.
 2. **Repos** — multi-select from `AVAILABLE_WORKSPACES`. Radio for primary. Shows last-active + open-PR count per workspace. First-selected repo becomes primary by default.
 3. **Kick off** — free-text first message. This goes straight to the primary agent; classifier decides tier + ticket plan.
 
 Entry points:
+
 - `+` button next to "CHANNELS" in the sidebar
 - A DM can be **promoted** to a channel (`DmView.onPromote` → opens the same modal, prefilled with the DM's agent's repo as primary). This is the "DM as kickoff surface" pattern — users often start informally in a DM, then promote once the work is real.
 
 > **Backend contract:** channel creation is a single atomic operation that (a) creates the channel record, (b) attaches each selected workspace, (c) sets primary, (d) posts the first message and triggers classification. If classification resolves to a `feature_large` or similar, the planner then fans out tickets across attached repos — this already exists in the CLI path, just needs a GUI-facing API.
 
 ### 4.6 DMs
+
 DMs are direct-to-agent (not direct-to-human). A yellow banner at the top of a DM explains they're "kickoff surfaces" — you talk 1:1 with an agent; if the conversation becomes real work, promote it to a channel. The composer placeholder hints at `/new` as the slash-command path to promote.
 
 ### 4.7 Messaging — markdown + mentions
+
 `renderWithMentions(text, channel)` is the single render path for message body text in channels, DMs, and decisions. It recognises:
+
 - `**bold**` → `<strong>`
 - `` `code` `` → inline code chip with paper-alt background
 - `@alias` → repo-or-human chip
@@ -145,9 +182,11 @@ Sizes below are the absolute values in the designs. They're designed against a *
 ```
 [ 58 Workspace rail ] [ 230 Sidebar ] [ flex Center pane ] [ 360 Right rail (collapsible) ]
 ```
+
 Min pane height fills viewport. `overflow: auto` only inside the three scroll regions: sidebar channel list, message list, right-rail panes.
 
 ### 5.2 Sidebar (left) — `direction-a-sidebar.jsx`
+
 - Workspace header (big R avatar + "Relay" + user subtitle)
 - Activity row, Threads row, Running row (badges on the right)
 - **Starred** section (collapsible)
@@ -156,6 +195,7 @@ Min pane height fills viewport. `overflow: auto` only inside the three scroll re
 - **No Repos section** — pass `repos={[]}` to `Sidebar` to hide it
 
 ### 5.3 Channel center pane — `direction-c-tidewater.jsx`
+
 - `ChannelHeader` (see §4.3)
 - Pane selector tabs inside the header (Chat | Board | Decisions)
 - `MessageListC` + `ComposerC` when pane is `chat`
@@ -164,9 +204,11 @@ Min pane height fills viewport. `overflow: auto` only inside the three scroll re
 - `ChannelSettingsDrawer` mounted as an overlay when `settingsOpen`
 
 ### 5.4 Right rail — `RightRail`
+
 Tabs: **Threads | Decisions | PRs**. Each tab shows a list; clicking an item opens a detail view reusing A's `PrThread` / `DecisionDrawer` bodies. Auto-switches to "PRs" when the channel has a failing CI.
 
 ### 5.5 Composer — `ComposerC`
+
 - Leading `→ @primaryRepo` chip (fixed; indicates where the message routes by default)
 - `Auto-approve` toggle
 - Hint text (truncates first at narrow widths)
@@ -174,6 +216,7 @@ Tabs: **Threads | Decisions | PRs**. Each tab shows a list; clicking an item ope
 - **Mention autocomplete**: type `@` anywhere; popover mounts above the composer, ↑↓ to navigate, Enter/Tab to accept
 
 ### 5.6 Modals and drawers
+
 - **NewChannelModal** — centered, 640px wide, 3 steps
 - **ChannelSettingsDrawer** — right-side, 460px wide, dimmed backdrop
 - **AddRepoPopover**, **MentionPopover**, **RepoChipRow popovers** — anchored floating popovers, dismiss on outside click or Escape
@@ -186,64 +229,72 @@ These are the only contracts the UI cares about. The daemon can have richer inte
 
 ```ts
 type Workspace = {
-  workspaceId: string;      // stable id
-  path: string;             // human-readable, e.g. "~/code/relay"
-  defaultAlias: string;     // basename(path) unless user overrode
-  lastActive: string;       // humanized, e.g. "2m", "3d"
+  workspaceId: string; // stable id
+  path: string; // human-readable, e.g. "~/code/relay"
+  defaultAlias: string; // basename(path) unless user overrode
+  lastActive: string; // humanized, e.g. "2m", "3d"
   openPrs: number;
 };
 
 type Channel = {
   id: string;
-  name: string;             // e.g. "oauth-api-users" (no leading #)
+  name: string; // e.g. "oauth-api-users" (no leading #)
   topic: string;
-  tier: 'feature_large' | 'feature' | 'bugfix' | 'chore' | 'question';
+  tier: "feature_large" | "feature" | "bugfix" | "chore" | "question";
   starred: boolean;
-  repos: string[];          // aliases — each an attached workspace
-  primaryRepo: string;      // must be in repos[]
-  agents: string[];         // agent ids sourced from AGENTS
+  repos: string[]; // aliases — each an attached workspace
+  primaryRepo: string; // must be in repos[]
+  agents: string[]; // agent ids sourced from AGENTS
   messages: Message[];
   tickets: Ticket[];
   decisions: Decision[];
   prs: Pr[];
-  activeAt: string;         // humanized
+  activeAt: string; // humanized
 };
 
 type Message = {
   id: string;
-  kind: 'user' | 'assistant' | 'system' | 'tool' | 'crosslink';
-  author: string;           // user id or agent id
-  text: string;             // rendered via renderWithMentions()
-  time: string;             // humanized or HH:MM
+  kind: "user" | "assistant" | "system" | "tool" | "crosslink";
+  author: string; // user id or agent id
+  text: string; // rendered via renderWithMentions()
+  time: string; // humanized or HH:MM
   // Optional: mentions: Array<{ kind: 'repo'|'human', alias: string }>
   //   — the UI can re-derive these from text + channel, but having them
   //     server-side simplifies notification routing.
 };
 
 type Ticket = {
-  id: string;               // e.g. "T-1"
+  id: string; // e.g. "T-1"
   title: string;
-  status: 'pending'|'ready'|'executing'|'verifying'|'completed'|'failed'|'blocked'|'retry';
-  agent: string;            // agent id
+  status:
+    | "pending"
+    | "ready"
+    | "executing"
+    | "verifying"
+    | "completed"
+    | "failed"
+    | "blocked"
+    | "retry";
+  agent: string; // agent id
   pr?: number;
-  specialty?: string;       // for the Board group-by-specialty view
+  specialty?: string; // for the Board group-by-specialty view
 };
 
 type Pr = {
   number: number;
   title: string;
   branch: string;
-  repo: string;              // alias
-  agent: string;             // agent id
-  ci: 'passing'|'failing'|'pending';
-  review: 'approved'|'pending'|'changes_requested';
+  repo: string; // alias
+  agent: string; // agent id
+  ci: "passing" | "failing" | "pending";
+  review: "approved" | "pending" | "changes_requested";
 };
 
 type Decision = {
   id: string;
   title: string;
   summary: string;
-  madeBy: string;            // agent or 'you'
+  madeBy: string; // agent or 'you'
   time: string;
 };
 
@@ -255,26 +306,26 @@ type Dm = {
 
 type Agent = {
   id: string;
-  name: string;              // e.g. "Saturn"
-  glyph: string;             // short, e.g. "♄"
-  provider: string;          // e.g. "claude"
-  status: 'idle' | 'working';
-  repoAlias?: string;        // which repo alias this agent is attached to
+  name: string; // e.g. "Saturn"
+  glyph: string; // short, e.g. "♄"
+  provider: string; // e.g. "claude"
+  status: "idle" | "working";
+  repoAlias?: string; // which repo alias this agent is attached to
   specialty?: string;
 };
 ```
 
 ### 6.1 Backend-facing actions the UI dispatches
 
-| UI action | Backend call (suggested) |
-|---|---|
-| Sidebar `+` → create channel | `POST /channels { name, topic, repos, primary, firstMessage }` |
-| Attach repo from header `+` popover | `POST /channels/:id/repos { alias }` |
-| Detach repo from chip popover | `DELETE /channels/:id/repos/:alias` |
-| Promote to primary | `PATCH /channels/:id { primaryRepo: alias }` |
-| DM → promote to channel | same as create, with DM messages as context |
-| Send message (composer) | `POST /channels/:id/messages { text, targetRepo, autoApprove }` |
-| Toggle auto-approve | channel-scoped setting; persists to `PATCH /channels/:id` |
+| UI action                           | Backend call (suggested)                                        |
+| ----------------------------------- | --------------------------------------------------------------- |
+| Sidebar `+` → create channel        | `POST /channels { name, topic, repos, primary, firstMessage }`  |
+| Attach repo from header `+` popover | `POST /channels/:id/repos { alias }`                            |
+| Detach repo from chip popover       | `DELETE /channels/:id/repos/:alias`                             |
+| Promote to primary                  | `PATCH /channels/:id { primaryRepo: alias }`                    |
+| DM → promote to channel             | same as create, with DM messages as context                     |
+| Send message (composer)             | `POST /channels/:id/messages { text, targetRepo, autoApprove }` |
+| Toggle auto-approve                 | channel-scoped setting; persists to `PATCH /channels/:id`       |
 
 None of these are implemented — see §8.
 
@@ -285,34 +336,38 @@ None of these are implemented — see §8.
 See `tokens.json` for the complete palette + scale. Key bindings:
 
 ### Colors
-| Token | Hex | Use |
-|---|---|---|
-| `ink.deepest` | `#0e1420` | Workspace rail, app frame |
-| `ink.deep` | `#141b2a` | Sidebar background |
-| `ink.panel` | `#1a2232` | Raised panels on the rail |
-| `paper.base` | `#fbf9f4` | Center pane, drawers, modals |
-| `paper.alt` | `#f3f0e7` | Inputs, chip bg, muted zones |
-| `paper.line` | `#e5e1d5` | Borders on paper |
-| `text.primary` | `#1b1f2a` | Body text on paper |
-| `text.muted` | `#5b6579` | Secondary text |
-| `text.dim` | `#8a93a5` | Tertiary / placeholder |
+
+| Token              | Hex       | Use                                                                  |
+| ------------------ | --------- | -------------------------------------------------------------------- |
+| `ink.deepest`      | `#0e1420` | Workspace rail, app frame                                            |
+| `ink.deep`         | `#141b2a` | Sidebar background                                                   |
+| `ink.panel`        | `#1a2232` | Raised panels on the rail                                            |
+| `paper.base`       | `#fbf9f4` | Center pane, drawers, modals                                         |
+| `paper.alt`        | `#f3f0e7` | Inputs, chip bg, muted zones                                         |
+| `paper.line`       | `#e5e1d5` | Borders on paper                                                     |
+| `text.primary`     | `#1b1f2a` | Body text on paper                                                   |
+| `text.muted`       | `#5b6579` | Secondary text                                                       |
+| `text.dim`         | `#8a93a5` | Tertiary / placeholder                                               |
 | **`accent.coral`** | `#e65a4f` | **Primary accent** — active tab, primary repo, CTA, selected channel |
-| `accent.coralSoft` | `#fbe1dd` | Coral backgrounds, selected-row bg |
-| `accent.amber` | `#e89a2b` | Executing status, working indicator pulse |
-| `accent.mint` | `#3fb984` | Idle/online presence, success |
-| `accent.sky` | `#4a7fd0` | Info / links |
-| `accent.magenta` | `#c44d8a` | Agent color hash entry |
+| `accent.coralSoft` | `#fbe1dd` | Coral backgrounds, selected-row bg                                   |
+| `accent.amber`     | `#e89a2b` | Executing status, working indicator pulse                            |
+| `accent.mint`      | `#3fb984` | Idle/online presence, success                                        |
+| `accent.sky`       | `#4a7fd0` | Info / links                                                         |
+| `accent.magenta`   | `#c44d8a` | Agent color hash entry                                               |
 
 ### Type
+
 - **UI:** Inter — 400/500/600/700
 - **Mono:** JetBrains Mono for code, aliases, paths
 - Sizes: sidebar items 13px, message body 14.5px, header 16px, section headers 10.5px uppercase
 
 ### Spacing + radius
+
 - 2 / 4 / 6 / 8 / 10 / 12 / 14 / 16 / 20 / 24 / 32 px base scale
 - Radius: chips 3px, pills 14px, cards 6px, popovers 6–8px, modals 12px
 
 ### Shadows
+
 - Popover: `0 6px 18px rgba(0,0,0,0.08)`
 - Modal: `0 24px 80px rgba(0,0,0,0.2)`
 - Drawer: `-16px 0 48px rgba(0,0,0,0.15)`
@@ -348,6 +403,7 @@ These were scoped but not implemented in the design. The patterns are sketched i
 ## 10. Quick orientation checklist
 
 Open `design/direction-c-tidewater.jsx` and search for:
+
 - `function DirectionC(` — top-level component (§5)
 - `function ChannelHeader(` — header layout (§4.3, §5.3)
 - `function BoardView(` — list-view alternative to chat pane
@@ -357,6 +413,7 @@ Open `design/direction-c-tidewater.jsx` and search for:
 - `function DmView(` — DM surface (§4.6)
 
 Then open `design/direction-c-repos.jsx`:
+
 - `RepoChipRow` — header chip row (§4.3)
 - `AddRepoPopover` — `+` chip popover
 - `ChannelSettingsDrawer` — gear icon drawer (§4.4)

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -57,15 +57,18 @@ export function App() {
   }, [refreshTick, includeArchived]);
 
   useEffect(() => {
-    api.getSettings().then(setSettings).catch(() => {
-      setSettings({
-        ticketProvider: "relay",
-        linearApiToken: "",
-        linearWorkspace: "",
-        linearPollSeconds: 30,
-        rightRailOpen: true,
+    api
+      .getSettings()
+      .then(setSettings)
+      .catch(() => {
+        setSettings({
+          ticketProvider: "relay",
+          linearApiToken: "",
+          linearWorkspace: "",
+          linearPollSeconds: 30,
+          rightRailOpen: true,
+        });
       });
-    });
   }, []);
 
   useEffect(() => {

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -75,8 +75,7 @@ export const api = {
   setPrimaryRepo: (channelId: string, workspaceId: string) =>
     invoke<void>("set_primary_repo", { channelId, workspaceId }),
   getSettings: () => invoke<GuiSettings>("get_settings"),
-  updateSettings: (settings: GuiSettings) =>
-    invoke<void>("update_settings", { settings }),
+  updateSettings: (settings: GuiSettings) => invoke<void>("update_settings", { settings }),
   postToChannel: (channelId: string, content: string, from?: string, entryType?: string) =>
     invoke<unknown>("post_to_channel", {
       channelId,

--- a/gui/src/components/BoardView.tsx
+++ b/gui/src/components/BoardView.tsx
@@ -104,7 +104,7 @@ export function BoardView({ tickets, settings }: Props) {
                 )}
               </span>
               <span className="agent-chip">
-                {t.assignedAlias ? `@${t.assignedAlias}` : t.assignedAgentName ?? "—"}
+                {t.assignedAlias ? `@${t.assignedAlias}` : (t.assignedAgentName ?? "—")}
               </span>
               <span className="agent-chip">
                 {t.linearIdentifier ? t.linearIdentifier : `#${t.attempt}`}
@@ -116,7 +116,9 @@ export function BoardView({ tickets, settings }: Props) {
         <KanbanView tickets={filtered} onSelect={setSelected} showLinearBadge={showLinearBadge} />
       )}
 
-      {selected && <TicketDetailModal ticket={selected} tickets={tickets} onClose={() => setSelected(null)} />}
+      {selected && (
+        <TicketDetailModal ticket={selected} tickets={tickets} onClose={() => setSelected(null)} />
+      )}
     </div>
   );
 }
@@ -188,19 +190,25 @@ function TicketDetailModal({
       <div className="modal modal-sm" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           {ticket.title}
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose}>
+            ×
+          </button>
         </div>
         <div className="modal-body">
           <DetailRow label="ID">
             <code>{ticket.ticketId}</code>
           </DetailRow>
           <DetailRow label="Status">
-            <span className={`status-pill status-${statusKey(ticket.status)}`}>{ticket.status}</span>
+            <span className={`status-pill status-${statusKey(ticket.status)}`}>
+              {ticket.status}
+            </span>
           </DetailRow>
           <DetailRow label="Specialty">{ticket.specialty}</DetailRow>
           <DetailRow label="Verification">{ticket.verification}</DetailRow>
           <DetailRow label="Attempt">{ticket.attempt}</DetailRow>
-          {ticket.assignedAgentName && <DetailRow label="Assigned">{ticket.assignedAgentName}</DetailRow>}
+          {ticket.assignedAgentName && (
+            <DetailRow label="Assigned">{ticket.assignedAgentName}</DetailRow>
+          )}
           {ticket.assignedAlias && <DetailRow label="Routed to">@{ticket.assignedAlias}</DetailRow>}
           {ticket.source === "linear" && ticket.linearUrl && (
             <DetailRow label="Linear">
@@ -216,10 +224,26 @@ function TicketDetailModal({
           )}
           {deps.length > 0 && (
             <div>
-              <div style={{ fontSize: 10, textTransform: "uppercase", color: "var(--color-text-dim)", marginBottom: 6 }}>
+              <div
+                style={{
+                  fontSize: 10,
+                  textTransform: "uppercase",
+                  color: "var(--color-text-dim)",
+                  marginBottom: 6,
+                }}
+              >
                 Depends on ({deps.length})
               </div>
-              <ul style={{ padding: 0, margin: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 6 }}>
+              <ul
+                style={{
+                  padding: 0,
+                  margin: 0,
+                  listStyle: "none",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 6,
+                }}
+              >
                 {deps.map((d) => (
                   <li
                     key={d.id}
@@ -231,7 +255,9 @@ function TicketDetailModal({
                     }}
                   >
                     <code>{d.id}</code>
-                    <span style={{ marginLeft: 8, color: "var(--color-text-muted)" }}>{d.status}</span>
+                    <span style={{ marginLeft: 8, color: "var(--color-text-muted)" }}>
+                      {d.status}
+                    </span>
                     <div style={{ marginTop: 2 }}>{d.title}</div>
                   </li>
                 ))}
@@ -240,7 +266,9 @@ function TicketDetailModal({
           )}
         </div>
         <div className="modal-footer" style={{ justifyContent: "flex-end" }}>
-          <button type="button" onClick={onClose}>Close</button>
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
         </div>
       </div>
     </div>

--- a/gui/src/components/ChannelHeader.tsx
+++ b/gui/src/components/ChannelHeader.tsx
@@ -59,9 +59,7 @@ export function ChannelHeader({
         >
           {channel.starred ? "★" : "☆"}
         </button>
-        {channel.description && (
-          <div className="channel-header-topic">{channel.description}</div>
-        )}
+        {channel.description && <div className="channel-header-topic">{channel.description}</div>}
         <div className="agent-stack">
           {channel.members.slice(0, 4).map((m) => (
             <span

--- a/gui/src/components/ChannelSettingsDrawer.tsx
+++ b/gui/src/components/ChannelSettingsDrawer.tsx
@@ -52,7 +52,10 @@ function ReposTab({ channel, onRefresh }: { channel: Channel; onRefresh: () => v
   const primaryId = channel.primaryWorkspaceId ?? channel.repoAssignments[0]?.workspaceId;
 
   useEffect(() => {
-    api.listSpawns(channel.channelId).then(setSpawns).catch(() => setSpawns([]));
+    api
+      .listSpawns(channel.channelId)
+      .then(setSpawns)
+      .catch(() => setSpawns([]));
   }, [channel.channelId]);
 
   const setPrimary = async (workspaceId: string) => {
@@ -146,9 +149,7 @@ function ReposTab({ channel, onRefresh }: { channel: Channel; onRefresh: () => v
                     {r.repoPath}
                   </div>
                 </div>
-                {!isPrimary && (
-                  <button onClick={() => setPrimary(r.workspaceId)}>Promote</button>
-                )}
+                {!isPrimary && <button onClick={() => setPrimary(r.workspaceId)}>Promote</button>}
                 {spawnRow ? (
                   <button onClick={() => killSpawn(r.alias)}>Kill</button>
                 ) : (
@@ -205,9 +206,8 @@ function MembersTab({ channel }: { channel: Channel }) {
             <span
               style={{
                 fontSize: "var(--font-size-xs)",
-                color: m.status === "working"
-                  ? "var(--color-accent-amber)"
-                  : "var(--color-accent-mint)",
+                color:
+                  m.status === "working" ? "var(--color-accent-amber)" : "var(--color-accent-mint)",
               }}
             >
               {m.status}
@@ -306,9 +306,15 @@ function AboutTab({
       </div>
       <div className="drawer-section">
         <h4>Full access</h4>
-        <p style={{ margin: "0 0 8px", fontSize: "var(--font-size-xs)", color: "var(--color-text-muted)" }}>
-          Runs dispatched agents with workspace-write sandbox and no approval
-          prompts. Scoped per-channel — other channels stay prompted.
+        <p
+          style={{
+            margin: "0 0 8px",
+            fontSize: "var(--font-size-xs)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          Runs dispatched agents with workspace-write sandbox and no approval prompts. Scoped
+          per-channel — other channels stay prompted.
         </p>
         <label style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
           <input type="checkbox" checked={fullAccess} onChange={toggleFullAccess} />
@@ -318,11 +324,7 @@ function AboutTab({
       <div className="drawer-section">
         <h4>Status</h4>
         <div>{channel.status}</div>
-        <button
-          style={{ marginTop: 8 }}
-          disabled={busy}
-          onClick={handleArchive}
-        >
+        <button style={{ marginTop: 8 }} disabled={busy} onClick={handleArchive}>
           {channel.status === "archived" ? "Unarchive" : "Archive"}
         </button>
       </div>

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -50,12 +50,20 @@ export function MessageList({
       ) : (
         <FeedView entries={feed} channel={ui} />
       )}
-      {stream && <StreamCard stream={stream} channel={ui} onToggleExpanded={onToggleStreamExpanded} />}
+      {stream && (
+        <StreamCard stream={stream} channel={ui} onToggleExpanded={onToggleStreamExpanded} />
+      )}
     </div>
   );
 }
 
-function FeedView({ entries, channel }: { entries: ChannelEntry[]; channel: ReturnType<typeof toUiChannel> }) {
+function FeedView({
+  entries,
+  channel,
+}: {
+  entries: ChannelEntry[];
+  channel: ReturnType<typeof toUiChannel>;
+}) {
   if (entries.length === 0) return <div className="chat-empty">No activity yet</div>;
   return (
     <>
@@ -95,7 +103,8 @@ function SessionMessages({
   const ui = toUiChannel(channel);
   const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(null);
 
-  if (messages.length === 0) return <div className="chat-empty">No messages in this session yet</div>;
+  if (messages.length === 0)
+    return <div className="chat-empty">No messages in this session yet</div>;
   return (
     <>
       {messages.map((m, i) => {
@@ -104,13 +113,13 @@ function SessionMessages({
         return (
           <div key={i} className={`message role-${m.role}`}>
             <div className="msg-avatar">
-              {m.agentAlias ? m.agentAlias.slice(0, 1).toUpperCase() : m.role.slice(0, 1).toUpperCase()}
+              {m.agentAlias
+                ? m.agentAlias.slice(0, 1).toUpperCase()
+                : m.role.slice(0, 1).toUpperCase()}
             </div>
             <div>
               <div className="msg-head">
-                <span className="msg-author">
-                  {m.agentAlias ? `@${m.agentAlias}` : m.role}
-                </span>
+                <span className="msg-author">{m.agentAlias ? `@${m.agentAlias}` : m.role}</span>
                 <span className="msg-time">{formatTime(m.timestamp)}</span>
                 <span className="msg-actions">
                   {m.role === "user" && rewindKey && (
@@ -199,7 +208,9 @@ function RewindConfirmModal({
       <div className="modal modal-sm" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           Rewind to this turn?
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose}>
+            ×
+          </button>
         </div>
         <div className="modal-body">
           <p style={{ margin: 0 }}>

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -186,7 +186,9 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           New channel
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose}>
+            ×
+          </button>
         </div>
         <div className="modal-body">
           {step === 1 && (
@@ -202,9 +204,7 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                   placeholder="oauth-api-users"
                 />
                 {name && slug !== name && (
-                  <small style={{ color: "var(--color-text-dim)" }}>
-                    will be #{slug}
-                  </small>
+                  <small style={{ color: "var(--color-text-dim)" }}>will be #{slug}</small>
                 )}
               </label>
               <label>
@@ -222,8 +222,8 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
             <div className="wizard-step">
               <h3>Repos</h3>
               <p className="help">
-                Attach workspaces to this channel. Each becomes a pingable <code>@alias</code>.
-                One repo must be primary — its agent receives the kickoff message.
+                Attach workspaces to this channel. Each becomes a pingable <code>@alias</code>. One
+                repo must be primary — its agent receives the kickoff message.
               </p>
               <div className="repo-list-step">
                 <input
@@ -275,7 +275,10 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                             <span className="repo-primary-radio placeholder" />
                           )}
                           {row.selected && !isPrimary ? (
-                            <label className="repo-spawn-toggle" title="Open an external Terminal agent">
+                            <label
+                              className="repo-spawn-toggle"
+                              title="Open an external Terminal agent"
+                            >
                               <input
                                 type="checkbox"
                                 checked={row.spawn}
@@ -299,9 +302,9 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
             <div className="wizard-step">
               <h3>Kick-off</h3>
               <p className="help">
-                This first message goes straight to the primary agent (@{
-                  selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.alias
-                }). The classifier assigns a tier and plans tickets.
+                This first message goes straight to the primary agent (@
+                {selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.alias}).
+                The classifier assigns a tier and plans tickets.
               </p>
               <label>
                 First message (optional)
@@ -366,5 +369,8 @@ function basename(p: string): string {
 }
 
 function defaultAlias(repoPath: string): string {
-  return basename(repoPath).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(0, 12);
+  return basename(repoPath)
+    .replace(/[^a-z0-9-]/gi, "")
+    .toLowerCase()
+    .slice(0, 12);
 }

--- a/gui/src/components/RepoChipRow.tsx
+++ b/gui/src/components/RepoChipRow.tsx
@@ -107,10 +107,7 @@ export function RepoChipRow({ channel, onChanged }: Props) {
                     Set as primary
                   </div>
                 )}
-                <div
-                  className="popover-item"
-                  onClick={() => spawnInTerminal(r.alias, r.repoPath)}
-                >
+                <div className="popover-item" onClick={() => spawnInTerminal(r.alias, r.repoPath)}>
                   Spawn in Terminal
                 </div>
                 {!isPrimary ? (
@@ -160,7 +157,10 @@ function AddRepoPopover({
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    api.listWorkspaces().then(setWorkspaces).catch(() => setWorkspaces([]));
+    api
+      .listWorkspaces()
+      .then(setWorkspaces)
+      .catch(() => setWorkspaces([]));
   }, []);
 
   const attachedIds = new Set(channel.repoAssignments.map((r) => r.workspaceId));
@@ -169,7 +169,10 @@ function AddRepoPopover({
   const attach = async (w: WorkspaceEntry) => {
     if (busy) return;
     setBusy(true);
-    const alias = basename(w.repoPath).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(0, 12);
+    const alias = basename(w.repoPath)
+      .replace(/[^a-z0-9-]/gi, "")
+      .toLowerCase()
+      .slice(0, 12);
     const next = [
       ...channel.repoAssignments.map((r) => ({
         alias: r.alias,

--- a/gui/src/components/RightPane.tsx
+++ b/gui/src/components/RightPane.tsx
@@ -20,13 +20,7 @@ type Props = {
   onRefresh: () => void;
 };
 
-export function RightPane({
-  channel,
-  sessionId,
-  onSelectSession,
-  refreshTick,
-  onRefresh,
-}: Props) {
+export function RightPane({ channel, sessionId, onSelectSession, refreshTick, onRefresh }: Props) {
   const [tab, setTab] = useState<Tab>("threads");
   const [decisions, setDecisions] = useState<Decision[]>([]);
   const [prs, setPrs] = useState<TrackedPrRow[]>([]);
@@ -70,7 +64,11 @@ export function RightPane({
     <div className="right-rail">
       <div className="rail-tabs">
         {(["threads", "decisions", "prs"] as Tab[]).map((t) => (
-          <div key={t} className={`rail-tab ${tab === t ? "active" : ""}`} onClick={() => setTab(t)}>
+          <div
+            key={t}
+            className={`rail-tab ${tab === t ? "active" : ""}`}
+            onClick={() => setTab(t)}
+          >
             {t === "threads" ? "Threads" : t === "decisions" ? "Decisions" : "PRs"}
           </div>
         ))}
@@ -175,7 +173,10 @@ function PrsTab({
                   className={`pr-dot pr-state-${r.prState ?? "unknown"}`}
                   title={`state: ${r.prState ?? "-"}`}
                 />
-                <span className={`pr-dot pr-ci-${r.ci ?? "unknown"}`} title={`ci: ${r.ci ?? "-"}`} />
+                <span
+                  className={`pr-dot pr-ci-${r.ci ?? "unknown"}`}
+                  title={`ci: ${r.ci ?? "-"}`}
+                />
                 <span
                   className={`pr-dot pr-review-${r.review ?? "unknown"}`}
                   title={`review: ${r.review ?? "-"}`}
@@ -268,7 +269,13 @@ function PendingPlanCta({
           }}
         >
           <div style={{ fontWeight: 600, marginBottom: 4 }}>Plan awaiting approval</div>
-          <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-muted)", marginBottom: 8 }}>
+          <div
+            style={{
+              fontSize: "var(--font-size-xs)",
+              color: "var(--color-text-muted)",
+              marginBottom: 8,
+            }}
+          >
             {p.featureRequest.slice(0, 80)}
           </div>
           <div style={{ display: "flex", gap: 6 }}>

--- a/gui/src/components/SettingsPage.tsx
+++ b/gui/src/components/SettingsPage.tsx
@@ -54,9 +54,7 @@ export function SettingsPage({ settings, onSaved, onClose }: Props) {
         {section === "ticketing" && (
           <TicketingSection draft={draft} onChange={save} saving={saving} error={error} />
         )}
-        {section === "general" && (
-          <GeneralSection />
-        )}
+        {section === "general" && <GeneralSection />}
       </div>
     </div>
   );
@@ -86,8 +84,7 @@ function TicketingSection({
     {
       value: "linear",
       title: "Linear",
-      desc:
-        "Mirror issues from a Linear project onto the channel board. Polled on an interval.",
+      desc: "Mirror issues from a Linear project onto the channel board. Polled on an interval.",
     },
     {
       value: "none",
@@ -106,10 +103,7 @@ function TicketingSection({
         </p>
         <div className="settings-radio-group">
           {providers.map((p) => (
-            <label
-              key={p.value}
-              className={draft.ticketProvider === p.value ? "selected" : ""}
-            >
+            <label key={p.value} className={draft.ticketProvider === p.value ? "selected" : ""}>
               <input
                 type="radio"
                 name="ticket-provider"
@@ -131,17 +125,15 @@ function TicketingSection({
         <div className="settings-section">
           <h3>Linear</h3>
           <p className="help">
-            Relay polls Linear every{" "}
-            <strong>{draft.linearPollSeconds}s</strong> and mirrors issues tagged to the channel.
+            Relay polls Linear every <strong>{draft.linearPollSeconds}s</strong> and mirrors issues
+            tagged to the channel.
           </p>
           <label>
             API token
             <input
               type="password"
               value={draft.linearApiToken}
-              onChange={(e) =>
-                onChange({ ...draft, linearApiToken: e.target.value })
-              }
+              onChange={(e) => onChange({ ...draft, linearApiToken: e.target.value })}
               placeholder="lin_api_…"
             />
           </label>
@@ -149,9 +141,7 @@ function TicketingSection({
             Workspace slug
             <input
               value={draft.linearWorkspace}
-              onChange={(e) =>
-                onChange({ ...draft, linearWorkspace: e.target.value })
-              }
+              onChange={(e) => onChange({ ...draft, linearWorkspace: e.target.value })}
               placeholder="acme-inc"
             />
           </label>

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -75,9 +75,7 @@ export function Sidebar({
           </header>
           {starredOpen && (
             <div>
-              {starred.length === 0 && (
-                <div className="sidebar-empty">No starred channels</div>
-              )}
+              {starred.length === 0 && <div className="sidebar-empty">No starred channels</div>}
               {starred.map((c) => (
                 <ChannelRow
                   key={c.channelId}
@@ -114,9 +112,7 @@ export function Sidebar({
           </header>
           {channelsOpen && (
             <div>
-              {active.length === 0 && (
-                <div className="sidebar-empty">No active channels</div>
-              )}
+              {active.length === 0 && <div className="sidebar-empty">No active channels</div>}
               {active.map((c) => (
                 <ChannelRow
                   key={c.channelId}

--- a/gui/src/components/WorkspaceRail.tsx
+++ b/gui/src/components/WorkspaceRail.tsx
@@ -5,7 +5,9 @@ type Props = {
 export function WorkspaceRail({ onOpenSettings }: Props) {
   return (
     <div className="workspace-rail">
-      <div className="rail-avatar" title="Relay workspace">R</div>
+      <div className="rail-avatar" title="Relay workspace">
+        R
+      </div>
       <div className="rail-spacer" />
       <button className="rail-btn" title="Settings" onClick={onOpenSettings}>
         ⚙

--- a/gui/src/lib/mentions.tsx
+++ b/gui/src/lib/mentions.tsx
@@ -40,8 +40,8 @@ export function renderWithMentions(text: string, channel: ChannelLike): ReactNod
       const cls = isPrimary
         ? "mention mention-repo-primary"
         : isRepo
-        ? "mention mention-repo-attached"
-        : "mention mention-human";
+          ? "mention mention-repo-attached"
+          : "mention mention-human";
       nodes.push(
         <span key={key++} className={cls}>
           {tok}

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -12,6 +12,7 @@ import {
   type WorkRequest,
 } from "../domain/agent.js";
 import { parsePhasePlan, type PhasePlan } from "../domain/phase-plan.js";
+import { getDisallowedBuiltinsForRole, type AgentRoleName } from "../mcp/role-allowlist.js";
 import type { CommandInvoker } from "./command-invoker.js";
 
 interface CliAgentOptions {
@@ -40,6 +41,25 @@ interface CliAgentOptions {
    * as before" — no change for existing callers.
    */
   fullAccess?: boolean;
+  /**
+   * AL-11: per-role restriction tag. When set, the adapter:
+   *  - sets `RELAY_AGENT_ROLE=<role>` in the subprocess env so the MCP
+   *    server's per-role allowlist (`src/mcp/role-allowlist.ts`) is active
+   *    for the dispatched session.
+   *  - passes `--disallowed-tools <names,…>` to the Claude CLI for any
+   *    built-in tools denied by {@link getDisallowedBuiltinsForRole} — the
+   *    MCP allowlist cannot gate Edit/Write/Bash because those don't
+   *    round-trip through MCP.
+   *
+   * `undefined` preserves pre-AL-11 behaviour (unrestricted session).
+   *
+   * Independent of {@link fullAccess}: a repo-admin channel can legitimately
+   * have full-access on (skip permission prompts) AND a restricted role
+   * (deny Edit/Write/Bash) simultaneously — the flags don't fight because
+   * `--disallowed-tools` is enforced by the Claude CLI even when
+   * `--dangerously-skip-permissions` is set.
+   */
+  role?: AgentRoleName;
 }
 
 interface ParsedProviderResult {
@@ -112,6 +132,24 @@ const CODEX_PASS_ENV: readonly string[] = [
   "CODEX_HOME",
 ];
 
+/**
+ * AL-11: append `--disallowed-tools Edit,Write,NotebookEdit,Bash` (and any
+ * other built-ins the role denies) to the Claude CLI args, IN-PLACE. No-op
+ * when the role has no built-in lockdown — keeps the flag absent for
+ * unrestricted sessions so pre-AL-11 behaviour is bit-for-bit identical.
+ *
+ * Exported so unit tests can assert on the exact args layout without
+ * reaching into the CLI agent class internals. Kept at module scope rather
+ * than as a method so it's callable from both the buffered and streaming
+ * Claude code paths without duplication.
+ */
+export function appendDisallowedBuiltinArgs(args: string[], role: AgentRoleName | undefined): void {
+  if (!role) return;
+  const disallowed = getDisallowedBuiltinsForRole(role);
+  if (disallowed.length === 0) return;
+  args.push("--disallowed-tools", disallowed.join(","));
+}
+
 abstract class CliAgentBase implements Agent {
   readonly id: string;
   readonly name: string;
@@ -130,6 +168,7 @@ abstract class CliAgentBase implements Agent {
    * constructed args without mutating `process.env`.
    */
   protected readonly fullAccess: boolean;
+  protected readonly role?: AgentRoleName;
 
   constructor(options: CliAgentOptions) {
     this.id = options.id;
@@ -141,6 +180,19 @@ abstract class CliAgentBase implements Agent {
     this.invoker = options.invoker;
     this.onStreamLine = options.onStreamLine;
     this.fullAccess = options.fullAccess === true;
+    this.role = options.role;
+  }
+
+  /**
+   * AL-11: env overlay applied when spawning the CLI. Sets
+   * `RELAY_AGENT_ROLE=<role>` so the MCP server in the dispatched session
+   * activates per-role enforcement. Returns `undefined` when the agent is
+   * unrestricted so the invoker's default env is untouched (parity with
+   * pre-AL-11 behaviour).
+   */
+  protected roleEnvOverlay(): Record<string, string> | undefined {
+    if (!this.role) return undefined;
+    return { RELAY_AGENT_ROLE: this.role };
   }
 
   async run(request: WorkRequest) {
@@ -210,6 +262,20 @@ export class CodexCliAgent extends CliAgentBase {
 
       args.push(prompt);
 
+      // AL-11: Codex CLI has no equivalent of `--disallowed-tools` today, so
+      // for restricted roles we can only propagate `RELAY_AGENT_ROLE` into
+      // the subprocess env (gating MCP-routed tools). Codex built-in tool
+      // lockdown is pending a provider-side flag — this is documented in
+      // agent_docs/repo-admin.md so callers don't mistake Codex repo-admin
+      // sessions for fully enforced ones.
+      if (this.role && getDisallowedBuiltinsForRole(this.role).length > 0) {
+        process.stderr.write(
+          `[relay] role=${this.role} built-in tool enforcement is deferred ` +
+            `for Codex (no --disallowed-tools equivalent yet); MCP-routed ` +
+            `tools are still gated.\n`
+        );
+      }
+
       const result = await this.invoker.exec({
         command: "codex",
         args,
@@ -219,6 +285,7 @@ export class CodexCliAgent extends CliAgentBase {
         // invoker strips secrets by default (OSS-03); opt these back in so
         // users who rely on env-based auth aren't silently broken.
         passEnv: [...CODEX_PASS_ENV],
+        env: this.roleEnvOverlay(),
       });
 
       if (result.exitCode !== 0) {
@@ -279,6 +346,12 @@ export class ClaudeCliAgent extends CliAgentBase {
       args.push("--model", this.model);
     }
 
+    // AL-11: when a restricted role is assigned to this agent, tell the
+    // Claude CLI to REFUSE to call the listed built-in tools. This is the
+    // only way to gate Edit/Write/Bash — they don't pass through MCP so the
+    // `role-allowlist` JSON-RPC check is cosmetic for them.
+    appendDisallowedBuiltinArgs(args, this.role);
+
     args.push(prompt);
 
     const result = await this.invoker.exec({
@@ -290,6 +363,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       // The invoker strips secrets by default (OSS-03); opt these back in so
       // users who rely on env-based auth aren't silently broken.
       passEnv: [...CLAUDE_PASS_ENV],
+      env: this.roleEnvOverlay(),
     });
 
     if (result.exitCode !== 0) {
@@ -324,6 +398,8 @@ export class ClaudeCliAgent extends CliAgentBase {
     if (autoApprove) args.push("--dangerously-skip-permissions");
     else args.push("--permission-mode", "default");
     if (this.model) args.push("--model", this.model);
+    // AL-11: same `--disallowed-tools` lockdown as the buffered path.
+    appendDisallowedBuiltinArgs(args, this.role);
     args.push(prompt);
 
     const spawnFn = this.invoker.spawn!;
@@ -332,6 +408,8 @@ export class ClaudeCliAgent extends CliAgentBase {
       args,
       cwd: this.cwd,
       timeoutMs: 300_000,
+      passEnv: [...CLAUDE_PASS_ENV],
+      env: this.roleEnvOverlay(),
     });
 
     let stdoutBuf = "";

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,6 +1,7 @@
 import type { Agent, AgentProvider, AgentRole } from "../domain/agent.js";
 import type { AgentSpecialty } from "../domain/specialty.js";
 import { setAgentName } from "../domain/agent-names.js";
+import type { AgentRoleName } from "../mcp/role-allowlist.js";
 
 import { ClaudeCliAgent, CodexCliAgent } from "./cli-agents.js";
 import { NodeCommandInvoker, type CommandInvoker } from "./command-invoker.js";
@@ -69,6 +70,26 @@ interface AgentFactoryOptions {
    * forward it here.
    */
   fullAccess?: boolean;
+  /**
+   * AL-11: apply a restricted role to EVERY agent produced by this factory.
+   * Today the only configured role is `repo-admin`; additional roles opt in
+   * via `src/mcp/role-allowlist.ts`. Passing this causes each CLI agent to:
+   *   - set `RELAY_AGENT_ROLE=<role>` in the spawned provider subprocess
+   *     (activates the MCP server's per-role allowlist for that session), and
+   *   - receive `--disallowed-tools <names,…>` on the Claude CLI args for
+   *     the built-ins denied to this role (Edit/Write/NotebookEdit/Bash for
+   *     repo-admin). MCP-layer enforcement alone is cosmetic for those
+   *     built-ins — they never round-trip through MCP.
+   *
+   * `undefined` (the default) preserves pre-AL-11 behaviour: no role, no
+   * restriction, full tool surface. AL-12 is where a concrete spawner picks
+   * which agent specs get `role: "repo-admin"`; AL-11 ships the wiring and
+   * the tests so the surface is real rather than dead code.
+   *
+   * Independent of {@link fullAccess}: a repo-admin channel may legitimately
+   * have full-access on and the restricted role on at the same time.
+   */
+  role?: AgentRoleName;
 }
 
 export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
@@ -97,6 +118,7 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
       invoker,
       onStreamLine,
       fullAccess: options.fullAccess,
+      role: options.role,
     });
   });
 }

--- a/src/agents/repo-admin.ts
+++ b/src/agents/repo-admin.ts
@@ -1,0 +1,142 @@
+/**
+ * Repo-admin role definition (AL-11).
+ *
+ * Repo-admin is the per-repo long-lived foreman in the autonomous-loop
+ * design. It tracks what's happening in its repo, coordinates worktrees,
+ * and sequences PR merges — but it does NOT implement code, run tests, or
+ * merge PRs itself. Those are the worker tier's job (AL-14 spawns workers
+ * on demand into ephemeral worktrees).
+ *
+ * AL-11 defines the *role* only:
+ *   - the specialty tag (`repo_admin`, added to `AgentSpecialtySchema`)
+ *   - the system prompt
+ *   - the MCP tool allowlist and its denial enforcement shape
+ *
+ * Explicitly out of scope for AL-11 (each lives in a later ticket):
+ *   - lifecycle (spawning a long-lived session)         -> AL-12
+ *   - routing (deciding which repo-admin gets a ticket) -> AL-13
+ *   - worker spawning (the `spawn_worker` MCP tool body)-> AL-14
+ *   - memory-shed (bounded working set across sessions) -> AL-15
+ *   - inter-admin coordination                          -> AL-16
+ *
+ * Source of truth for repo-admin state is the channel board + decisions +
+ * git log. Repo-admin is a caching / coordination layer on top of those,
+ * not an authoritative memory. The system prompt makes that explicit.
+ */
+
+import type { AgentSpecialty } from "../domain/specialty.js";
+import {
+  REPO_ADMIN_ALLOWED_TOOLS,
+  REPO_ADMIN_TOOL_STUBS,
+  denyToolEnvelope,
+  isToolAllowedForRole,
+  type ToolDenialEnvelope,
+} from "../mcp/role-allowlist.js";
+
+/** Specialty tag for repo-admin work. Matches the `repo_admin` enum member. */
+export const REPO_ADMIN_SPECIALTY: AgentSpecialty = "repo_admin";
+
+/** Role name used by the MCP layer when enforcing the allowlist. */
+export const REPO_ADMIN_ROLE = "repo-admin";
+
+/**
+ * Canonical substring the system prompt MUST contain. Tests assert on this
+ * so a future edit that silently drops the memory-policy guidance trips CI
+ * rather than the live loop. Keep the phrasing short so the assertion stays
+ * robust to minor copy changes elsewhere in the prompt.
+ */
+export const REPO_ADMIN_MEMORY_POLICY_MARKER =
+  "source of truth is the board and the decisions file";
+
+export interface RepoAdminRoleInput {
+  /** Absolute path to the repo the admin is foremanning. */
+  repoPath: string;
+  /**
+   * Optional channel id this admin is bound to. When known, the system
+   * prompt name-drops it so the agent re-reads the right board without
+   * guessing. Lifecycle wiring (AL-12) supplies this; AL-11 just accepts it.
+   */
+  channelId?: string;
+}
+
+/**
+ * Build the repo-admin system prompt for a concrete repo.
+ *
+ * The prompt emphasizes four things:
+ *   1. Role framing — "coordination, not implementation".
+ *   2. Memory policy — "caches only the working set; re-read the board on
+ *      demand". Board + decisions are authoritative; chat history is not.
+ *   3. Tool policy — absent tools are intentional; propose a worker instead.
+ *   4. Worker-spawn guidance — pick specialty from ticket scope, justify.
+ *
+ * Kept verbose but scannable — repo-admin re-reads the prompt implicitly on
+ * every turn, and ambiguity at the top of the loop compounds quickly.
+ */
+export function buildRepoAdminSystemPrompt(input: RepoAdminRoleInput): string {
+  const channelLine = input.channelId
+    ? `You are bound to channel \`${input.channelId}\`. Re-read THIS channel's board.`
+    : "When you need the board, first discover your bound channel via `channel_get`.";
+
+  return [
+    `You are the repo-admin for \`${input.repoPath}\`.`,
+    "Your job is coordination, not implementation.",
+    "",
+    "## Role",
+    "You are a long-lived foreman. Workers are ephemeral per-ticket agents",
+    "spawned into isolated worktrees; they do the code changes, run the",
+    "tests, and open the PRs. You do not edit files, you do not run tests,",
+    "and you do not merge PRs. You observe state, decide what work to",
+    "dispatch, and sequence PR merges when multiple workers converge.",
+    "",
+    "## Memory policy",
+    `Memory: you cache only the active working set — in-flight tickets, ` +
+      `open PRs, current worktrees. When you need fuller history, re-read ` +
+      `the board (\`channel_task_board\` / \`channel_get\`) or decisions ` +
+      `(\`channel_get\` returns recent decisions). Don't rely on chat ` +
+      `history or summaries — the ${REPO_ADMIN_MEMORY_POLICY_MARKER}, ` +
+      `backed by the git log. ${channelLine}`,
+    "",
+    "## Tool policy",
+    "Your MCP tool allowlist is narrow on purpose. If a tool you think you",
+    "need isn't in your allowlist, it's intentional — propose the work to",
+    "the channel scheduler instead (the scheduler can spawn a worker for",
+    "it). Allowed tools:",
+    ...[...REPO_ADMIN_ALLOWED_TOOLS].sort().map((name) => `  - \`${name}\``),
+    "",
+    "Denied by design: file edits, test runners, `gh pr merge`, and any",
+    "MCP tool that mutates state beyond `spawn_worker`. The MCP server",
+    "returns a structured `tool-not-allowed` error with a reason if you",
+    "try — that's a signal to propose a worker, not to retry.",
+    "",
+    "## Worker-spawn guidance",
+    "When proposing a worker spawn (via the AL-14 `spawn_worker` tool once",
+    "it lands), pick the specialty from the ticket's scope:",
+    "  - `atlas` (planner) for architecture / design work",
+    "  - `pixel` (UI engineer) for frontend work",
+    "  - `forge` (backend engineer) for backend / API / business logic",
+    "  - `lens` (reviewer) for focused review passes",
+    "  - `probe` (tester) for test-only work",
+    "  - an eng-manager worker for multi-component coordination under a",
+    "    single ticket.",
+    "Justify the choice in one sentence so the decision is auditable on",
+    "the channel feed.",
+  ].join("\n");
+}
+
+/**
+ * Convenience re-exports so callers only need `agents/repo-admin.js`.
+ * Enforcement primitives live in `mcp/role-allowlist.ts` because the MCP
+ * server layer owns tool-call interception.
+ */
+export { REPO_ADMIN_ALLOWED_TOOLS, REPO_ADMIN_TOOL_STUBS, denyToolEnvelope, isToolAllowedForRole };
+export type { ToolDenialEnvelope };
+
+/**
+ * Handler for the stubbed `spawn_worker` tool (AL-14 replaces this).
+ * Throwing rather than silently succeeding means repo-admin immediately
+ * sees that the capability is pending, and test assertions can pin the
+ * exact AL-14 handoff point.
+ */
+export function spawnWorkerStub(_args: Record<string, unknown>): never {
+  throw new Error(REPO_ADMIN_TOOL_STUBS.spawn_worker);
+}

--- a/src/agents/repo-admin.ts
+++ b/src/agents/repo-admin.ts
@@ -120,6 +120,13 @@ export function buildRepoAdminSystemPrompt(input: RepoAdminRoleInput): string {
     "    single ticket.",
     "Justify the choice in one sentence so the decision is auditable on",
     "the channel feed.",
+    "",
+    "## Recording decisions",
+    "When you commit to a course of action (spawn a worker, sequence a",
+    "merge, defer a ticket), post the decision to the channel feed via",
+    "`channel_post` — a single append-only entry with the rationale. That",
+    "entry is what future repo-admin sessions re-read via `channel_get` to",
+    "reconstruct state; if it isn't on the feed, it didn't happen.",
   ].join("\n");
 }
 

--- a/src/domain/specialty.ts
+++ b/src/domain/specialty.ts
@@ -7,6 +7,12 @@ export const AgentSpecialtySchema = z.enum([
   "api_crud",
   "devops",
   "testing",
+  // AL-11: `repo_admin` is the per-repo foreman role. Repo-admin sessions
+  // coordinate worktrees, ticket routing, and PR merge sequencing but do NOT
+  // implement code themselves. Full role definition (system prompt + MCP
+  // tool allowlist) lives in `src/agents/repo-admin.ts`. Lifecycle wiring —
+  // spawning / long-lived session — is AL-12.
+  "repo_admin",
 ]);
 
 export type AgentSpecialty = z.infer<typeof AgentSpecialtySchema>;

--- a/src/mcp/role-allowlist.ts
+++ b/src/mcp/role-allowlist.ts
@@ -1,0 +1,160 @@
+/**
+ * Per-role MCP tool allowlists (AL-11).
+ *
+ * The autonomous-loop design splits responsibility into two tiers:
+ *
+ *   1. `repo-admin` — long-lived per-repo foreman. Coordinates worktrees,
+ *      ticket routing, and PR merge sequencing. Does NOT edit files, run
+ *      tests, or merge PRs.
+ *   2. worker — ephemeral per-ticket agent, spawned by repo-admin into a
+ *      worktree. Full tool access (the default, implicit role).
+ *
+ * Repo-admin is the only role AL-11 pins down. Every other role is
+ * `unrestricted` until a later ticket (AL-12..AL-16) introduces its
+ * allowlist. Unknown roles fall through to the unrestricted path so nothing
+ * regresses during the rollout.
+ *
+ * Enforcement is data-driven: one map from role -> Set<allowed tool name>.
+ * {@link isToolAllowedForRole} is the single consult point, and
+ * {@link denyToolEnvelope} produces the structured error the MCP server
+ * returns when a tool is blocked. No silent failure — the agent sees the
+ * reason and can adjust.
+ *
+ * Lifecycle (AL-12), spawn-worker wiring (AL-14), and inter-admin
+ * coordination (AL-16) are explicitly OUT of scope here.
+ */
+
+export type AgentRoleName = "repo-admin" | string;
+
+/**
+ * Role name this process is operating under. Read from `RELAY_AGENT_ROLE`;
+ * `null` when unset, which opts the session into the unrestricted path.
+ *
+ * Uses the `RELAY_*` prefix so it flows through the child-env sanitizer in
+ * `src/agents/command-invoker.ts` without needing a `passEnv` opt-in.
+ */
+export function resolveCurrentRole(env: NodeJS.ProcessEnv = process.env): AgentRoleName | null {
+  const raw = env.RELAY_AGENT_ROLE;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Repo-admin tool whitelist. Kept as data so AL-12..AL-16 can extend it
+ * without editing enforcement logic.
+ *
+ * Rationale per tool:
+ *  - `channel_task_board`   — read the ticket board (AL-11 brief's
+ *    `listChannelTickets` equivalent on the MCP surface).
+ *  - `channel_get`          — pulls feed, tickets, decisions, run links in
+ *    one call; repo-admin's primary "re-read the board" entry point.
+ *  - `channel_post`         — status updates to the channel feed (propose a
+ *    spawn, announce a PR merge decision). Strictly additive to the feed.
+ *  - `harness_running_tasks`— cross-workspace running-task view.
+ *  - `harness_list_runs` / `harness_get_run_detail` — read-only run state.
+ *  - `spawn_worker`         — NAME ONLY. Declared so the role surface is
+ *    stable for AL-14; the tool itself is stubbed and throws until AL-14
+ *    wires worker spawning. See {@link REPO_ADMIN_TOOL_STUBS}.
+ */
+export const REPO_ADMIN_ALLOWED_TOOLS: ReadonlySet<string> = new Set<string>([
+  // Read ticket board
+  "channel_task_board",
+  // Read decisions + feed + run links in a single call
+  "channel_get",
+  // Read-only channel message stream (feed append — additive, not a state mutation)
+  "channel_post",
+  // Cross-workspace running-task view
+  "harness_running_tasks",
+  // Read-only run-level views
+  "harness_list_runs",
+  "harness_get_run_detail",
+  // Spawn ephemeral workers — declared here; implementation lands in AL-14.
+  "spawn_worker",
+]);
+
+/**
+ * Tool names that repo-admin is allowed to REFERENCE but whose handlers are
+ * stubbed for later tickets. Calling a stubbed tool returns a structured
+ * "stubbed; lands in AL-<N>" error so the agent sees the reason and the
+ * capability report still lists the tool (i.e. AL-11 pins the surface; AL-14
+ * fills in behaviour).
+ */
+export const REPO_ADMIN_TOOL_STUBS: Readonly<Record<string, string>> = {
+  spawn_worker:
+    "spawn_worker is declared in the repo-admin allowlist but its handler is " +
+    "stubbed; worker spawning is implemented in AL-14. Propose the work on " +
+    "the channel feed instead until then.",
+};
+
+/** Internal: role -> allowlist map. Additions land here, not in branching code. */
+const ROLE_ALLOWLISTS: Readonly<Record<string, ReadonlySet<string>>> = {
+  "repo-admin": REPO_ADMIN_ALLOWED_TOOLS,
+};
+
+/**
+ * Decide whether `toolName` is callable under `role`.
+ *
+ * Semantics:
+ *   - `null` role (RELAY_AGENT_ROLE unset): always allowed — unrestricted
+ *     path, matches today's behaviour.
+ *   - Role with an allowlist: membership check against the Set.
+ *   - Unknown role (no entry in {@link ROLE_ALLOWLISTS}): unrestricted. A
+ *     future ticket adding a new role opts into enforcement by adding an
+ *     entry here; no silent denial by default.
+ */
+export function isToolAllowedForRole(role: AgentRoleName | null, toolName: string): boolean {
+  if (!role) return true;
+  const allowlist = ROLE_ALLOWLISTS[role];
+  if (!allowlist) return true;
+  return allowlist.has(toolName);
+}
+
+/**
+ * Build the structured denial envelope returned to the caller when a tool
+ * call is blocked by the per-role allowlist. Shape is intentionally stable
+ * so agents can pattern-match on `error === "tool-not-allowed"` and choose
+ * a different path (e.g. propose a worker spawn on the channel feed).
+ */
+export interface ToolDenialEnvelope {
+  error: "tool-not-allowed";
+  tool: string;
+  role: string;
+  reason: string;
+}
+
+/**
+ * Produce the denial envelope for a role/tool pairing. Always called AFTER
+ * {@link isToolAllowedForRole} has rejected the pair — the reason string is
+ * role-specific so the agent gets actionable guidance rather than a generic
+ * "denied".
+ */
+export function denyToolEnvelope(role: AgentRoleName, toolName: string): ToolDenialEnvelope {
+  return {
+    error: "tool-not-allowed",
+    tool: toolName,
+    role,
+    reason: reasonFor(role, toolName),
+  };
+}
+
+function reasonFor(role: AgentRoleName, toolName: string): string {
+  if (role === "repo-admin") {
+    return (
+      `repo-admin does not call ${toolName}; this role coordinates workers ` +
+      `but does not implement code, run tests, or merge PRs. Propose the ` +
+      `work on the channel feed — a worker can pick it up.`
+    );
+  }
+  return `${role} is not permitted to call ${toolName}.`;
+}
+
+/**
+ * Enumerate the allowlist for a role. Used by the MCP capability report so
+ * `tools/list` only advertises tools the current session can actually call.
+ * Returns `null` for unrestricted (current behaviour: advertise everything).
+ */
+export function allowlistForRole(role: AgentRoleName | null): ReadonlySet<string> | null {
+  if (!role) return null;
+  return ROLE_ALLOWLISTS[role] ?? null;
+}

--- a/src/mcp/role-allowlist.ts
+++ b/src/mcp/role-allowlist.ts
@@ -41,6 +41,51 @@ export function resolveCurrentRole(env: NodeJS.ProcessEnv = process.env): AgentR
 }
 
 /**
+ * True iff the given role name is a key in {@link ROLE_ALLOWLISTS}. Unknown
+ * roles flow through to the unrestricted path today (see
+ * {@link isToolAllowedForRole}) — callers that need to distinguish "unknown"
+ * from "unrestricted" should use this directly.
+ */
+export function isKnownRole(role: AgentRoleName | null): boolean {
+  if (!role) return false;
+  return Object.prototype.hasOwnProperty.call(ROLE_ALLOWLISTS, role);
+}
+
+/**
+ * One-shot stderr warning for an unknown `RELAY_AGENT_ROLE` value. The same
+ * role name is only warned about once per process so a chatty MCP loop
+ * doesn't flood stderr — the warning is a startup signal ("typo in your role
+ * name, security layer is not enforcing") not a per-call diagnostic.
+ *
+ * Split out from the server so unit tests can observe the behaviour directly
+ * without booting a JSON-RPC handler. Exported only for the tests.
+ *
+ * I1 fix: previously a typo like `repoadmin` silently bypassed enforcement
+ * because `isToolAllowedForRole` falls through to "allow" on unknown roles.
+ * The fall-through itself is still the documented policy for the AL-12..16
+ * rollout (new roles opt in by adding a map entry, not by editing branches),
+ * but an unrecognised value should SHOUT so it can be noticed in logs rather
+ * than ship as cosmetic enforcement.
+ */
+const warnedUnknownRoles = new Set<string>();
+export function warnIfUnknownRole(role: AgentRoleName | null): void {
+  if (!role) return;
+  if (isKnownRole(role)) return;
+  if (warnedUnknownRoles.has(role)) return;
+  warnedUnknownRoles.add(role);
+  // Use stderr directly: MCP stdout carries JSON-RPC framing and must stay
+  // clean. Leading `[relay]` tag matches the rest of the codebase.
+  process.stderr.write(
+    `[relay] unknown RELAY_AGENT_ROLE=${role}, running unrestricted — check spelling\n`
+  );
+}
+
+/** Test-only: reset the one-shot warn memo so each test observes a fresh warn. */
+export function __resetUnknownRoleWarningsForTests(): void {
+  warnedUnknownRoles.clear();
+}
+
+/**
  * Repo-admin tool whitelist. Kept as data so AL-12..AL-16 can extend it
  * without editing enforcement logic.
  *
@@ -62,7 +107,9 @@ export const REPO_ADMIN_ALLOWED_TOOLS: ReadonlySet<string> = new Set<string>([
   "channel_task_board",
   // Read decisions + feed + run links in a single call
   "channel_get",
-  // Read-only channel message stream (feed append — additive, not a state mutation)
+  // Append-only channel feed writer — additive status updates (propose a
+  // spawn, announce a merge decision). This IS a write; "append-only" means
+  // it cannot retract or edit prior entries, not that it's read-only.
   "channel_post",
   // Cross-workspace running-task view
   "harness_running_tasks",
@@ -157,4 +204,47 @@ function reasonFor(role: AgentRoleName, toolName: string): string {
 export function allowlistForRole(role: AgentRoleName | null): ReadonlySet<string> | null {
   if (!role) return null;
   return ROLE_ALLOWLISTS[role] ?? null;
+}
+
+/**
+ * Built-in Claude CLI tools that bypass MCP entirely and therefore cannot be
+ * gated by `isToolAllowedForRole`. The Claude CLI runs Edit/Write/Bash/…
+ * in-process — those calls never round-trip through the MCP server, so the
+ * allowlist in this module is **cosmetic** for that attack surface. To
+ * actually enforce the deny, the CLI adapter passes
+ * `--disallowed-tools <names,…>` to the `claude` binary when spawning.
+ *
+ * Kept as a map from role -> string[] so new roles adding their own lockdown
+ * (AL-12..AL-16) don't have to touch adapter code — just add an entry.
+ *
+ * Rationale for repo-admin's list:
+ *  - `Edit`, `Write`, `NotebookEdit` — repo-admin does not edit files.
+ *  - `Bash` — the `gh pr merge` escape hatch AND the "run tests" escape
+ *    hatch both go through Bash. Dropping Bash closes both without needing
+ *    a fine-grained command-level allowlist (which Claude CLI doesn't
+ *    expose today).
+ *
+ * Not denied here (left to MCP-layer enforcement, which IS effective for
+ * MCP-routed tools): `harness_dispatch`, `harness_approve_plan`,
+ * `project_create`, etc. Those ARE JSON-RPC calls so the MCP allowlist does
+ * its job.
+ *
+ * Read tools (`Read`, `Glob`, `Grep`) are intentionally NOT on the deny list:
+ * repo-admin needs to look at the board, decisions, and occasionally source
+ * files to reason about what to dispatch.
+ */
+const DISALLOWED_BUILTINS_BY_ROLE: Readonly<Record<string, readonly string[]>> = {
+  "repo-admin": ["Edit", "Write", "NotebookEdit", "Bash"],
+};
+
+/**
+ * Return the list of Claude built-in tool names that must be passed to the
+ * `claude` CLI via `--disallowed-tools` for the given role. Empty array when
+ * the role has no built-in lockdown (or is `null` / unknown). Callers that
+ * want to know "is this role a restricted session at all?" should check for
+ * a non-empty return.
+ */
+export function getDisallowedBuiltinsForRole(role: AgentRoleName | null): readonly string[] {
+  if (!role) return [];
+  return DISALLOWED_BUILTINS_BY_ROLE[role] ?? [];
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,6 +21,13 @@ import {
   isCrosslinkTool,
   type CrosslinkToolState,
 } from "../crosslink/tools.js";
+import {
+  allowlistForRole,
+  denyToolEnvelope,
+  isToolAllowedForRole,
+  resolveCurrentRole,
+} from "./role-allowlist.js";
+import { REPO_ADMIN_TOOL_STUBS, spawnWorkerStub } from "../agents/repo-admin.js";
 
 export interface JsonRpcMessage {
   jsonrpc: "2.0";
@@ -148,137 +155,233 @@ async function handleMessage(
       };
     case "notifications/initialized":
       return null;
-    case "tools/list":
+    case "tools/list": {
+      // AL-11: when the session runs under a role (RELAY_AGENT_ROLE set),
+      // the tools/list report is filtered to the role's allowlist. Unknown
+      // or absent role returns the full set, preserving pre-AL-11 behavior.
+      const role = resolveCurrentRole();
+      const allowlist = allowlistForRole(role);
+      const allTools: Array<{ name: string; description: string; inputSchema: unknown }> = [
+        ...(getCrosslinkToolDefinitions() as Array<{
+          name: string;
+          description: string;
+          inputSchema: unknown;
+        }>),
+        ...(getChannelToolDefinitions() as Array<{
+          name: string;
+          description: string;
+          inputSchema: unknown;
+        }>),
+        {
+          name: "harness_status",
+          description: "Get Relay workspace status and recent runs.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {},
+          },
+        },
+        {
+          name: "harness_list_runs",
+          description: "List recent harness runs for the current workspace.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              limit: { type: "integer", minimum: 1, maximum: 50 },
+            },
+          },
+        },
+        {
+          name: "harness_get_run_detail",
+          description:
+            "Get full run snapshot including classification, tickets, evidence, artifacts, and optionally the event log.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["runId"],
+            properties: {
+              runId: { type: "string" },
+              includeEvents: { type: "boolean" },
+            },
+          },
+        },
+        {
+          name: "harness_get_artifact",
+          description: "Read a harness artifact JSON file by absolute path.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["path"],
+            properties: {
+              path: { type: "string" },
+            },
+          },
+        },
+        {
+          name: "harness_approve_plan",
+          description: "Approve the pending plan for a run, unblocking ticket execution.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["runId"],
+            properties: {
+              runId: { type: "string" },
+            },
+          },
+        },
+        {
+          name: "harness_reject_plan",
+          description: "Reject the pending plan with optional feedback.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["runId"],
+            properties: {
+              runId: { type: "string" },
+              feedback: { type: "string" },
+            },
+          },
+        },
+        {
+          name: "project_create",
+          description:
+            "Create a new project. A project is a channel that groups related chats, runs, and decisions. " +
+            "Use this when the user wants to kick off a new initiative or workstream.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["name"],
+            properties: {
+              name: {
+                type: "string",
+                description: "Project name, e.g. 'Auth Refactor' or 'New Dashboard'",
+              },
+              description: {
+                type: "string",
+                description: "What the project is about",
+              },
+            },
+          },
+        },
+        {
+          name: "harness_dispatch",
+          description:
+            "Dispatch a feature request to the agent team. This kicks off the orchestrator in the background: " +
+            "classifies the request, creates a plan, decomposes into tickets, and assigns agents. " +
+            "Progress is posted to the channel feed and visible in the dashboard. Returns immediately with run ID.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["featureRequest"],
+            properties: {
+              featureRequest: {
+                type: "string",
+                description:
+                  "The feature to build — should be well-defined from your chat discussion",
+              },
+              channelId: {
+                type: "string",
+                description:
+                  "Channel/project to link this run to. If omitted, a new channel is created.",
+              },
+            },
+          },
+        },
+        {
+          // AL-11 declares the name; AL-14 fills in the handler. Advertised
+          // here so the repo-admin capability report is stable from day one.
+          name: "spawn_worker",
+          description:
+            "[STUB — implemented in AL-14] Spawn an ephemeral worker agent into an " +
+            "isolated worktree to execute a ticket. Calling this today returns a " +
+            "structured `stubbed` error that points at AL-14.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["ticketId", "specialty"],
+            properties: {
+              ticketId: { type: "string" },
+              specialty: { type: "string" },
+              rationale: { type: "string" },
+            },
+          },
+        },
+      ];
+
+      const filteredTools = allowlist
+        ? allTools.filter((tool) => allowlist.has(tool.name))
+        : allTools;
+
       return {
         jsonrpc: "2.0",
         id: message.id ?? null,
         result: {
-          tools: [
-            ...getCrosslinkToolDefinitions(),
-            ...getChannelToolDefinitions(),
-            {
-              name: "harness_status",
-              description: "Get Relay workspace status and recent runs.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                properties: {},
-              },
-            },
-            {
-              name: "harness_list_runs",
-              description: "List recent harness runs for the current workspace.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                properties: {
-                  limit: { type: "integer", minimum: 1, maximum: 50 },
-                },
-              },
-            },
-            {
-              name: "harness_get_run_detail",
-              description:
-                "Get full run snapshot including classification, tickets, evidence, artifacts, and optionally the event log.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                required: ["runId"],
-                properties: {
-                  runId: { type: "string" },
-                  includeEvents: { type: "boolean" },
-                },
-              },
-            },
-            {
-              name: "harness_get_artifact",
-              description: "Read a harness artifact JSON file by absolute path.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                required: ["path"],
-                properties: {
-                  path: { type: "string" },
-                },
-              },
-            },
-            {
-              name: "harness_approve_plan",
-              description: "Approve the pending plan for a run, unblocking ticket execution.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                required: ["runId"],
-                properties: {
-                  runId: { type: "string" },
-                },
-              },
-            },
-            {
-              name: "harness_reject_plan",
-              description: "Reject the pending plan with optional feedback.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                required: ["runId"],
-                properties: {
-                  runId: { type: "string" },
-                  feedback: { type: "string" },
-                },
-              },
-            },
-            {
-              name: "project_create",
-              description:
-                "Create a new project. A project is a channel that groups related chats, runs, and decisions. " +
-                "Use this when the user wants to kick off a new initiative or workstream.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                required: ["name"],
-                properties: {
-                  name: {
-                    type: "string",
-                    description: "Project name, e.g. 'Auth Refactor' or 'New Dashboard'",
-                  },
-                  description: {
-                    type: "string",
-                    description: "What the project is about",
-                  },
-                },
-              },
-            },
-            {
-              name: "harness_dispatch",
-              description:
-                "Dispatch a feature request to the agent team. This kicks off the orchestrator in the background: " +
-                "classifies the request, creates a plan, decomposes into tickets, and assigns agents. " +
-                "Progress is posted to the channel feed and visible in the dashboard. Returns immediately with run ID.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-                required: ["featureRequest"],
-                properties: {
-                  featureRequest: {
-                    type: "string",
-                    description:
-                      "The feature to build — should be well-defined from your chat discussion",
-                  },
-                  channelId: {
-                    type: "string",
-                    description:
-                      "Channel/project to link this run to. If omitted, a new channel is created.",
-                  },
-                },
-              },
-            },
-          ],
+          tools: filteredTools,
         },
       };
+    }
     case "tools/call":
       try {
         const toolName = String(message.params?.name ?? "");
         const toolArgs = (message.params?.arguments as Record<string, unknown> | undefined) ?? {};
+
+        // AL-11: consult the per-role allowlist before dispatching. When a
+        // role (e.g. repo-admin) is active and the tool isn't on its list,
+        // return a STRUCTURED denial envelope (NOT a silent failure) so the
+        // caller sees the reason and can choose a different path.
+        const currentRole = resolveCurrentRole();
+        if (currentRole && !isToolAllowedForRole(currentRole, toolName)) {
+          const envelope = denyToolEnvelope(currentRole, toolName);
+          return {
+            jsonrpc: "2.0",
+            id: message.id ?? null,
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(envelope, null, 2),
+                },
+              ],
+              isError: true,
+            },
+          };
+        }
+
+        // AL-11 stub: spawn_worker is in the repo-admin allowlist so the
+        // capability surface is stable, but the actual handler lands in
+        // AL-14. Call the stub so repo-admin sees the pending-capability
+        // reason rather than an "unknown tool" error.
+        if (toolName === "spawn_worker") {
+          try {
+            spawnWorkerStub(toolArgs);
+          } catch (err) {
+            return {
+              jsonrpc: "2.0",
+              id: message.id ?? null,
+              result: {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(
+                      {
+                        error: "tool-stubbed",
+                        tool: "spawn_worker",
+                        reason:
+                          err instanceof Error ? err.message : REPO_ADMIN_TOOL_STUBS.spawn_worker,
+                        landsIn: "AL-14",
+                      },
+                      null,
+                      2
+                    ),
+                  },
+                ],
+                isError: true,
+              },
+            };
+          }
+        }
+
         const toolResult = isCrosslinkTool(toolName)
           ? await callCrosslinkTool(toolName, toolArgs, crosslinkState)
           : isChannelTool(toolName)

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,6 +26,7 @@ import {
   denyToolEnvelope,
   isToolAllowedForRole,
   resolveCurrentRole,
+  warnIfUnknownRole,
 } from "./role-allowlist.js";
 import { REPO_ADMIN_TOOL_STUBS, spawnWorkerStub } from "../agents/repo-admin.js";
 
@@ -59,6 +60,14 @@ export interface McpHandlerContext {
 export async function buildMcpMessageHandler(
   workspaceRoot: string
 ): Promise<{ handler: McpMessageHandler; context: McpHandlerContext }> {
+  // AL-11 (I1 fix): if RELAY_AGENT_ROLE is set to a value we don't recognise,
+  // log a one-shot warning to stderr on startup. The allowlist fall-through
+  // on unknown roles is still the documented behaviour (new roles opt IN by
+  // adding a map entry), but an unrecognised value running with no
+  // enforcement needs to be visible in logs — a silent typo shipping as
+  // cosmetic security is the opposite of what this layer is for.
+  warnIfUnknownRole(resolveCurrentRole());
+
   const paths = getHarnessWorkspacePaths(workspaceRoot);
   const artifactStore = new LocalArtifactStore(paths.artifactsDir, getHarnessStore());
   const crosslinkStore = new CrosslinkStore(undefined, getHarnessStore());

--- a/test/agents/cli-agents-role-lockdown.test.ts
+++ b/test/agents/cli-agents-role-lockdown.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { ClaudeCliAgent, appendDisallowedBuiltinArgs } from "../../src/agents/cli-agents.js";
+import type { CommandInvoker, CommandInvocation } from "../../src/agents/command-invoker.js";
+import { agentResultJsonSchema } from "../../src/domain/agent.js";
+
+/**
+ * AL-11 (B1 fix) — verify that when a restricted role is configured on a
+ * Claude CLI agent, the CLI is actually spawned with the `--disallowed-tools`
+ * flag AND with `RELAY_AGENT_ROLE` set in its env.
+ *
+ * Why this matters: Claude's built-in tools (Edit, Write, Bash, NotebookEdit)
+ * run in-process in the `claude` CLI and never round-trip through our MCP
+ * JSON-RPC boundary. The role-allowlist module can't see them, so the MCP
+ * allowlist alone is cosmetic for that attack surface. The only way to gate
+ * them is to pass `--disallowed-tools` to the CLI at spawn time.
+ *
+ * These tests use a scripted invoker that captures the invocation without
+ * actually running the Claude binary, then replays a canned success response
+ * so the agent returns normally.
+ */
+
+class CapturingInvoker implements CommandInvoker {
+  readonly invocations: CommandInvocation[] = [];
+  constructor(private readonly stdout: string) {}
+  async exec(invocation: CommandInvocation) {
+    this.invocations.push(invocation);
+    return { stdout: this.stdout, stderr: "", exitCode: 0 };
+  }
+}
+
+/** Minimal valid AgentResult JSON so `normalizePayload` doesn't reject it. */
+const CANNED_STDOUT = JSON.stringify({
+  summary: "noop",
+  evidence: [],
+  proposedCommands: [],
+  blockers: [],
+});
+
+function buildAgent(role: string | undefined, invoker: CommandInvoker) {
+  return new ClaudeCliAgent({
+    id: "atlas",
+    name: "Atlas (Planner)",
+    provider: "claude",
+    capability: { role: "planner", specialties: ["general"] },
+    cwd: "/tmp/fake-repo",
+    invoker,
+    role,
+  });
+}
+
+const DUMMY_REQUEST = {
+  runId: "run-1",
+  phaseId: "phase-1",
+  kind: "implement_phase" as const,
+  specialty: "general" as const,
+  attempt: 1,
+  maxAttempts: 3,
+  title: "noop",
+  objective: "test",
+  acceptanceCriteria: [],
+  allowedCommands: [],
+  verificationCommands: [],
+  docsToUpdate: [],
+  context: [],
+  artifactContext: [],
+  priorEvidence: [],
+};
+
+describe("ClaudeCliAgent — role-driven built-in lockdown (AL-11 B1)", () => {
+  it("without a role, does NOT add --disallowed-tools (pre-AL-11 parity)", async () => {
+    const invoker = new CapturingInvoker(CANNED_STDOUT);
+    const agent = buildAgent(undefined, invoker);
+    await agent.run(DUMMY_REQUEST);
+
+    expect(invoker.invocations).toHaveLength(1);
+    const args = invoker.invocations[0].args;
+    expect(args).not.toContain("--disallowed-tools");
+
+    // Env overlay must also be absent -- we don't want to accidentally set
+    // RELAY_AGENT_ROLE for unrestricted sessions.
+    expect(invoker.invocations[0].env).toBeUndefined();
+  });
+
+  it("with role=repo-admin, appends --disallowed-tools Edit,Write,NotebookEdit,Bash", async () => {
+    const invoker = new CapturingInvoker(CANNED_STDOUT);
+    const agent = buildAgent("repo-admin", invoker);
+    await agent.run(DUMMY_REQUEST);
+
+    const args = invoker.invocations[0].args;
+    const flagIdx = args.indexOf("--disallowed-tools");
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    // The value MUST be the next argv slot -- CLI parsers want
+    // `--flag value`, not `--flag=value`, per the rest of our args.
+    expect(args[flagIdx + 1]).toBe("Edit,Write,NotebookEdit,Bash");
+  });
+
+  it("with role=repo-admin, --disallowed-tools lands BEFORE the prompt positional arg", async () => {
+    // The prompt is the very last arg the CLI sees. If --disallowed-tools
+    // and its value end up AFTER the prompt, the CLI treats them as extra
+    // positional args and the flag is silently ignored. Guard against that.
+    const invoker = new CapturingInvoker(CANNED_STDOUT);
+    const agent = buildAgent("repo-admin", invoker);
+    await agent.run(DUMMY_REQUEST);
+
+    const args = invoker.invocations[0].args;
+    const flagIdx = args.indexOf("--disallowed-tools");
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    // Last arg is the prompt; it must sit strictly after the flag's value.
+    expect(flagIdx + 1).toBeLessThan(args.length - 1);
+  });
+
+  it("with role=repo-admin, sets RELAY_AGENT_ROLE in the subprocess env overlay", async () => {
+    const invoker = new CapturingInvoker(CANNED_STDOUT);
+    const agent = buildAgent("repo-admin", invoker);
+    await agent.run(DUMMY_REQUEST);
+
+    const env = invoker.invocations[0].env;
+    expect(env).toEqual({ RELAY_AGENT_ROLE: "repo-admin" });
+  });
+
+  it("with role=repo-admin, does NOT drop args the unrestricted path already required", async () => {
+    // Regression guard: the AL-11 wiring must only ADD to the arg list, not
+    // replace existing pieces. If --json-schema or -p disappear, the CLI
+    // call breaks silently.
+    const invoker = new CapturingInvoker(CANNED_STDOUT);
+    const agent = buildAgent("repo-admin", invoker);
+    await agent.run(DUMMY_REQUEST);
+
+    const args = invoker.invocations[0].args;
+    expect(args).toContain("-p");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("json");
+    expect(args).toContain("--json-schema");
+    expect(args).toContain(JSON.stringify(agentResultJsonSchema));
+  });
+
+  it("with an unknown role, does NOT add --disallowed-tools (fall-through path)", async () => {
+    // Unknown roles intentionally fall through to unrestricted today (the
+    // map opt-in model for AL-12..16 rollout). The server-side I1 fix
+    // warns about this on stderr, but the adapter itself shouldn't guess at
+    // a deny list.
+    const invoker = new CapturingInvoker(CANNED_STDOUT);
+    const agent = buildAgent("eng-manager", invoker);
+    await agent.run(DUMMY_REQUEST);
+
+    const args = invoker.invocations[0].args;
+    expect(args).not.toContain("--disallowed-tools");
+  });
+});
+
+describe("appendDisallowedBuiltinArgs - pure helper", () => {
+  it("no-ops when role is undefined", () => {
+    const args: string[] = ["-p"];
+    appendDisallowedBuiltinArgs(args, undefined);
+    expect(args).toEqual(["-p"]);
+  });
+
+  it("no-ops when role has no built-in lockdown configured", () => {
+    const args: string[] = ["-p"];
+    appendDisallowedBuiltinArgs(args, "eng-manager");
+    expect(args).toEqual(["-p"]);
+  });
+
+  it("appends the canonical repo-admin deny list in-place", () => {
+    const args: string[] = ["-p", "--output-format", "json"];
+    appendDisallowedBuiltinArgs(args, "repo-admin");
+    expect(args).toEqual([
+      "-p",
+      "--output-format",
+      "json",
+      "--disallowed-tools",
+      "Edit,Write,NotebookEdit,Bash",
+    ]);
+  });
+});

--- a/test/agents/repo-admin.test.ts
+++ b/test/agents/repo-admin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   REPO_ADMIN_ALLOWED_TOOLS,
@@ -10,10 +10,14 @@ import {
   spawnWorkerStub,
 } from "../../src/agents/repo-admin.js";
 import {
+  __resetUnknownRoleWarningsForTests,
   allowlistForRole,
   denyToolEnvelope,
+  getDisallowedBuiltinsForRole,
+  isKnownRole,
   isToolAllowedForRole,
   resolveCurrentRole,
+  warnIfUnknownRole,
 } from "../../src/mcp/role-allowlist.js";
 
 /**
@@ -177,6 +181,88 @@ describe("repo-admin role — system prompt", () => {
       channelId: "channel-abc-123",
     });
     expect(withChannel).toContain("channel-abc-123");
+  });
+});
+
+describe("repo-admin role — built-in tool lockdown (AL-11 B1)", () => {
+  it("getDisallowedBuiltinsForRole returns the documented deny list for repo-admin", () => {
+    // These are the exact four built-ins the Claude CLI must refuse for a
+    // repo-admin session. Order matters for the CLI flag's display, so we
+    // pin the array shape directly.
+    expect(getDisallowedBuiltinsForRole("repo-admin")).toEqual([
+      "Edit",
+      "Write",
+      "NotebookEdit",
+      "Bash",
+    ]);
+  });
+
+  it("returns an empty list for null / unknown roles", () => {
+    expect(getDisallowedBuiltinsForRole(null)).toEqual([]);
+    expect(getDisallowedBuiltinsForRole("eng-manager")).toEqual([]);
+  });
+});
+
+describe("role-allowlist — unknown-role hygiene (AL-11 I1)", () => {
+  beforeEach(() => {
+    __resetUnknownRoleWarningsForTests();
+  });
+
+  it("isKnownRole recognises repo-admin and rejects typos / unset roles", () => {
+    expect(isKnownRole("repo-admin")).toBe(true);
+    expect(isKnownRole("repoadmin")).toBe(false);
+    expect(isKnownRole("REPO-ADMIN")).toBe(false);
+    expect(isKnownRole(null)).toBe(false);
+  });
+
+  it("warns on stderr for unknown roles so typos don't ship as cosmetic enforcement", () => {
+    const calls: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    // Monkey-patch stderr.write for this test only; restore in finally.
+    (process.stderr as unknown as { write: typeof process.stderr.write }).write = ((
+      chunk: string | Uint8Array
+    ) => {
+      calls.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      warnIfUnknownRole("repoadmin");
+      warnIfUnknownRole("repoadmin"); // second call should be a no-op (memoised)
+      warnIfUnknownRole("REPO-ADMIN"); // distinct typo still warns once
+    } finally {
+      (process.stderr as unknown as { write: typeof process.stderr.write }).write = original;
+    }
+
+    // Exactly two writes — one per distinct typo, not one per call.
+    expect(calls).toHaveLength(2);
+    for (const line of calls) {
+      expect(line).toContain("[relay]");
+      expect(line).toContain("unknown RELAY_AGENT_ROLE=");
+      expect(line).toContain("check spelling");
+    }
+    expect(calls[0]).toContain("repoadmin");
+    expect(calls[1]).toContain("REPO-ADMIN");
+  });
+
+  it("does NOT warn for known roles or null", () => {
+    const calls: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    (process.stderr as unknown as { write: typeof process.stderr.write }).write = ((
+      chunk: string | Uint8Array
+    ) => {
+      calls.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      warnIfUnknownRole(null);
+      warnIfUnknownRole("repo-admin");
+    } finally {
+      (process.stderr as unknown as { write: typeof process.stderr.write }).write = original;
+    }
+
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/test/agents/repo-admin.test.ts
+++ b/test/agents/repo-admin.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REPO_ADMIN_ALLOWED_TOOLS,
+  REPO_ADMIN_MEMORY_POLICY_MARKER,
+  REPO_ADMIN_ROLE,
+  REPO_ADMIN_SPECIALTY,
+  REPO_ADMIN_TOOL_STUBS,
+  buildRepoAdminSystemPrompt,
+  spawnWorkerStub,
+} from "../../src/agents/repo-admin.js";
+import {
+  allowlistForRole,
+  denyToolEnvelope,
+  isToolAllowedForRole,
+  resolveCurrentRole,
+} from "../../src/mcp/role-allowlist.js";
+
+/**
+ * AL-11 role-definition tests.
+ *
+ * These tests pin the repo-admin role surface: the exact allowlist set,
+ * the system-prompt phrasing that encodes the board-is-memory policy, and
+ * the shape of the structured denial envelope. Later tickets (AL-12..16)
+ * extend this; these assertions make any silent drift fail CI.
+ */
+
+describe("repo-admin role — identity", () => {
+  it("tags the specialty as repo_admin (matches the zod enum)", () => {
+    expect(REPO_ADMIN_SPECIALTY).toBe("repo_admin");
+  });
+
+  it("pins the MCP role name", () => {
+    expect(REPO_ADMIN_ROLE).toBe("repo-admin");
+  });
+});
+
+describe("repo-admin role — allowlist exactness", () => {
+  /**
+   * The brief calls out the five capability buckets (read board, read
+   * decisions, read git log, spawn workers, query PR state). We exercise
+   * the set directly — adding a tool to the whitelist is a real design
+   * change and should require updating this test deliberately.
+   */
+  it("exposes exactly the expected MCP tool names and nothing else", () => {
+    const sorted = [...REPO_ADMIN_ALLOWED_TOOLS].sort();
+    expect(sorted).toEqual(
+      [
+        "channel_get", // read decisions + feed + run links in one call
+        "channel_post", // append-only feed updates (propose a spawn, announce a decision)
+        "channel_task_board", // read the ticket board
+        "harness_get_run_detail", // read-only run state
+        "harness_list_runs", // read-only run index
+        "harness_running_tasks", // cross-workspace running-task view
+        "spawn_worker", // name only — AL-14 fills in the handler
+      ].sort()
+    );
+  });
+
+  it("blocks every denied tool called out by the brief", () => {
+    // Editor tools — repo-admin never edits files.
+    expect(isToolAllowedForRole("repo-admin", "Edit")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "Write")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "NotebookEdit")).toBe(false);
+
+    // Test runners / PR merges — delegated to workers / humans, not admins.
+    expect(isToolAllowedForRole("repo-admin", "Bash")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "pnpm_test")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "gh_pr_merge")).toBe(false);
+
+    // Mutating MCP tools outside spawn_worker.
+    expect(isToolAllowedForRole("repo-admin", "harness_dispatch")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "harness_approve_plan")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "harness_reject_plan")).toBe(false);
+    expect(isToolAllowedForRole("repo-admin", "project_create")).toBe(false);
+  });
+
+  it("allows every listed tool", () => {
+    for (const tool of REPO_ADMIN_ALLOWED_TOOLS) {
+      expect(isToolAllowedForRole("repo-admin", tool)).toBe(true);
+    }
+  });
+
+  it("allowlistForRole returns the same concrete set", () => {
+    const set = allowlistForRole("repo-admin");
+    expect(set).not.toBeNull();
+    expect(set).toBe(REPO_ADMIN_ALLOWED_TOOLS);
+  });
+
+  it("absent role (RELAY_AGENT_ROLE unset) stays unrestricted", () => {
+    // resolveCurrentRole returns null when the env var is absent or blank.
+    expect(resolveCurrentRole({})).toBeNull();
+    expect(resolveCurrentRole({ RELAY_AGENT_ROLE: "" })).toBeNull();
+    expect(resolveCurrentRole({ RELAY_AGENT_ROLE: "   " })).toBeNull();
+
+    // No role -> everything allowed (preserves pre-AL-11 behaviour).
+    expect(isToolAllowedForRole(null, "Edit")).toBe(true);
+    expect(isToolAllowedForRole(null, "Bash")).toBe(true);
+  });
+
+  it("unknown role passes through (no silent denial)", () => {
+    // AL-12..16 will add more roles. Until they do, unknown roles are
+    // unrestricted so nothing else regresses during rollout.
+    expect(isToolAllowedForRole("eng-manager", "Edit")).toBe(true);
+    expect(isToolAllowedForRole("atlas", "Bash")).toBe(true);
+  });
+
+  it("resolveCurrentRole returns the trimmed role when set", () => {
+    expect(resolveCurrentRole({ RELAY_AGENT_ROLE: "repo-admin" })).toBe("repo-admin");
+    expect(resolveCurrentRole({ RELAY_AGENT_ROLE: "  repo-admin  " })).toBe("repo-admin");
+  });
+});
+
+describe("repo-admin role — denial envelope shape", () => {
+  it("returns a structured tool-not-allowed envelope, not a string or silent pass", () => {
+    const envelope = denyToolEnvelope("repo-admin", "Edit");
+
+    expect(envelope).toEqual({
+      error: "tool-not-allowed",
+      tool: "Edit",
+      role: "repo-admin",
+      reason: expect.any(String),
+    });
+    // Reason must actually mention the role-specific guidance so the agent
+    // can act on it rather than flailing.
+    expect(envelope.reason).toMatch(/repo-admin/i);
+    expect(envelope.reason.toLowerCase()).toContain("worker");
+  });
+
+  it("produces a generic reason for roles without bespoke copy", () => {
+    const envelope = denyToolEnvelope("eng-manager", "Edit");
+    expect(envelope.error).toBe("tool-not-allowed");
+    expect(envelope.reason).toContain("eng-manager");
+    expect(envelope.reason).toContain("Edit");
+  });
+});
+
+describe("repo-admin role — system prompt", () => {
+  const prompt = buildRepoAdminSystemPrompt({ repoPath: "/tmp/my-repo" });
+
+  it("frames the role as coordination, not implementation", () => {
+    expect(prompt).toContain("repo-admin for `/tmp/my-repo`");
+    expect(prompt).toContain("coordination, not implementation");
+  });
+
+  it("encodes the board-is-memory policy by substring match", () => {
+    // Pin the exact marker the role module exports so future edits can't
+    // silently drop the memory-policy guidance without tripping this test.
+    expect(prompt).toContain(REPO_ADMIN_MEMORY_POLICY_MARKER);
+    // Plus the supporting language the brief calls out verbatim.
+    expect(prompt).toContain("cache only the active working set");
+    expect(prompt).toMatch(/re-read the board/i);
+    expect(prompt).toMatch(/Don't rely on chat history/i);
+  });
+
+  it("tells repo-admin to propose work instead of reaching for denied tools", () => {
+    expect(prompt).toMatch(/propose the work/i);
+    expect(prompt).toMatch(/scheduler/i);
+  });
+
+  it("lists every allowlisted tool so the agent sees its full surface", () => {
+    for (const tool of REPO_ADMIN_ALLOWED_TOOLS) {
+      expect(prompt).toContain(`\`${tool}\``);
+    }
+  });
+
+  it("includes worker-spawn specialty guidance", () => {
+    expect(prompt).toMatch(/atlas/);
+    expect(prompt).toMatch(/pixel/);
+    expect(prompt).toMatch(/forge/);
+    expect(prompt).toMatch(/eng-manager/);
+  });
+
+  it("name-drops the channel id when provided", () => {
+    const withChannel = buildRepoAdminSystemPrompt({
+      repoPath: "/tmp/repo",
+      channelId: "channel-abc-123",
+    });
+    expect(withChannel).toContain("channel-abc-123");
+  });
+});
+
+describe("repo-admin role — stubbed tools", () => {
+  it("spawn_worker is in the stub registry, pointing at AL-14", () => {
+    expect(REPO_ADMIN_TOOL_STUBS.spawn_worker).toMatch(/AL-14/);
+  });
+
+  it("spawnWorkerStub throws the registered stub message", () => {
+    expect(() => spawnWorkerStub({})).toThrow(/AL-14/);
+  });
+});

--- a/test/mcp/role-allowlist.test.ts
+++ b/test/mcp/role-allowlist.test.ts
@@ -1,0 +1,288 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { JsonRpcMessage } from "../../src/mcp/server.js";
+
+/**
+ * AL-11 enforcement tests at the MCP server boundary.
+ *
+ * These tests drive the real JSON-RPC message handler with
+ * `RELAY_AGENT_ROLE=repo-admin` and assert that:
+ *   1. `tools/list` only advertises the allowlisted tool set.
+ *   2. `tools/call` on a denied tool returns a STRUCTURED denial envelope
+ *      with `isError: true` — not a silent pass, not a generic crash.
+ *   3. `tools/call` on the stubbed `spawn_worker` tool returns a structured
+ *      "tool-stubbed" envelope that points at AL-14.
+ *   4. Clearing `RELAY_AGENT_ROLE` restores the pre-AL-11 tool surface.
+ *
+ * Storage is pinned to a tmp-backed FileHarnessStore via vi.mock so the
+ * handler doesn't reach into real ~/.relay (mirrors the pattern in
+ * test/orchestrator/dispatch-error-surface.test.ts).
+ */
+
+// Pin storage to a per-test tmp FileHarnessStore — handler calls
+// getHarnessStore() during session registration and we must not touch
+// real ~/.relay.
+const storeRoots: string[] = [];
+vi.mock("../../src/storage/factory.js", async () => {
+  const { FileHarnessStore } = await import("../../src/storage/file-store.js");
+  const root = await mkdtemp(join(tmpdir(), "al11-hs-"));
+  storeRoots.push(root);
+  const store = new FileHarnessStore(root);
+  return {
+    getHarnessStore: () => store,
+    buildHarnessStore: () => store,
+  };
+});
+
+interface ToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+interface ToolsListResult {
+  tools: ToolDescriptor[];
+}
+
+interface ToolsCallResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
+}
+
+async function buildHandler(workspaceRoot: string) {
+  const { buildMcpMessageHandler } = await import("../../src/mcp/server.js");
+  return buildMcpMessageHandler(workspaceRoot);
+}
+
+describe("MCP per-role allowlist (AL-11)", () => {
+  let tmpHome: string;
+  let workspaceRoot: string;
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_ROLE = process.env.RELAY_AGENT_ROLE;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "al11-home-"));
+    workspaceRoot = await mkdtemp(join(tmpdir(), "al11-ws-"));
+    process.env.HOME = tmpHome;
+    delete process.env.RELAY_AGENT_ROLE;
+    const { __resetRelayDirCacheForTests } = await import("../../src/cli/paths.js");
+    __resetRelayDirCacheForTests();
+  });
+
+  afterEach(async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(workspaceRoot, { recursive: true, force: true });
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_ROLE === undefined) delete process.env.RELAY_AGENT_ROLE;
+    else process.env.RELAY_AGENT_ROLE = ORIGINAL_ROLE;
+    const { __resetRelayDirCacheForTests } = await import("../../src/cli/paths.js");
+    __resetRelayDirCacheForTests();
+    while (storeRoots.length > 0) {
+      const r = storeRoots.pop();
+      if (r) await rm(r, { recursive: true, force: true });
+    }
+  });
+
+  it("without a role, advertises the full tool surface (regression guard)", async () => {
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      const resp = await handler({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      });
+      const tools = (resp?.result as ToolsListResult).tools;
+      const names = tools.map((t) => t.name);
+      // Sanity: the unrestricted path must still include tools repo-admin would be denied.
+      expect(names).toContain("harness_dispatch");
+      expect(names).toContain("harness_approve_plan");
+      expect(names).toContain("project_create");
+      // And tools repo-admin can use.
+      expect(names).toContain("channel_task_board");
+      expect(names).toContain("spawn_worker");
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("under RELAY_AGENT_ROLE=repo-admin, tools/list matches the repo-admin allowlist EXACTLY", async () => {
+    process.env.RELAY_AGENT_ROLE = "repo-admin";
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      const resp = await handler({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      });
+      const { REPO_ADMIN_ALLOWED_TOOLS } = await import("../../src/agents/repo-admin.js");
+      const tools = (resp?.result as ToolsListResult).tools;
+      const names = new Set(tools.map((t) => t.name));
+
+      // Every advertised tool is on the allowlist.
+      for (const name of names) {
+        expect(REPO_ADMIN_ALLOWED_TOOLS.has(name)).toBe(true);
+      }
+      // Every allowlisted tool is advertised.
+      for (const allowed of REPO_ADMIN_ALLOWED_TOOLS) {
+        expect(names.has(allowed)).toBe(true);
+      }
+      // Exact-match check as belt-and-suspenders against drift.
+      expect([...names].sort()).toEqual([...REPO_ADMIN_ALLOWED_TOOLS].sort());
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("under RELAY_AGENT_ROLE=repo-admin, calling a DENIED tool returns a structured envelope (not silent, not crash)", async () => {
+    process.env.RELAY_AGENT_ROLE = "repo-admin";
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      // harness_dispatch is a mutating tool explicitly denied to repo-admin.
+      const resp = await handler({
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: {
+          name: "harness_dispatch",
+          arguments: { featureRequest: "should never run" },
+        },
+      });
+
+      const result = resp?.result as ToolsCallResult;
+      // Must be marked as an error — NOT silent success.
+      expect(result.isError).toBe(true);
+      // Must be structured — parse the envelope the handler embedded in the
+      // text block.
+      const payload = JSON.parse(result.content[0].text) as {
+        error?: string;
+        tool?: string;
+        role?: string;
+        reason?: string;
+      };
+      expect(payload.error).toBe("tool-not-allowed");
+      expect(payload.tool).toBe("harness_dispatch");
+      expect(payload.role).toBe("repo-admin");
+      expect(payload.reason).toBeTypeOf("string");
+      expect((payload.reason ?? "").length).toBeGreaterThan(0);
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("the `Edit` editor tool is denied for repo-admin with a role-specific reason", async () => {
+    process.env.RELAY_AGENT_ROLE = "repo-admin";
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      const resp = await handler({
+        jsonrpc: "2.0",
+        id: 8,
+        method: "tools/call",
+        params: {
+          name: "Edit",
+          arguments: {},
+        },
+      });
+      const result = resp?.result as ToolsCallResult;
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text) as {
+        error?: string;
+        reason?: string;
+      };
+      expect(payload.error).toBe("tool-not-allowed");
+      // Reason must explain the "propose a worker" guidance so the agent
+      // can pivot instead of retrying.
+      expect(payload.reason?.toLowerCase()).toContain("worker");
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("calling the stubbed spawn_worker returns a structured `tool-stubbed` envelope pointing at AL-14", async () => {
+    process.env.RELAY_AGENT_ROLE = "repo-admin";
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      const resp = await handler({
+        jsonrpc: "2.0",
+        id: 9,
+        method: "tools/call",
+        params: {
+          name: "spawn_worker",
+          arguments: { ticketId: "T-123", specialty: "forge" },
+        },
+      });
+      const result = resp?.result as ToolsCallResult;
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text) as {
+        error?: string;
+        tool?: string;
+        landsIn?: string;
+      };
+      expect(payload.error).toBe("tool-stubbed");
+      expect(payload.tool).toBe("spawn_worker");
+      expect(payload.landsIn).toBe("AL-14");
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("allowed tools still function under repo-admin (no false positives)", async () => {
+    process.env.RELAY_AGENT_ROLE = "repo-admin";
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      // harness_list_runs is on the allowlist and reads from the artifact
+      // store — no index file yet, expect an empty runs list.
+      const resp = await handler({
+        jsonrpc: "2.0",
+        id: 10,
+        method: "tools/call",
+        params: {
+          name: "harness_list_runs",
+          arguments: {},
+        },
+      });
+      const result = resp?.result as ToolsCallResult;
+      expect(result.isError).toBe(false);
+      const payload = JSON.parse(result.content[0].text) as {
+        workspaceRoot: string;
+        runs: unknown[];
+      };
+      expect(payload.workspaceRoot).toBe(workspaceRoot);
+      expect(Array.isArray(payload.runs)).toBe(true);
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("an unknown role passes through (no silent denial during AL-12..16 rollout)", async () => {
+    process.env.RELAY_AGENT_ROLE = "eng-manager"; // future role, not yet enforced
+    const { handler, context } = await buildHandler(workspaceRoot);
+    try {
+      const listResp = await handler({
+        jsonrpc: "2.0",
+        id: 11,
+        method: "tools/list",
+        params: {},
+      });
+      const tools = (listResp?.result as ToolsListResult).tools;
+      // Unknown role -> full surface, same as no role.
+      expect(tools.map((t) => t.name)).toContain("harness_dispatch");
+    } finally {
+      context.cleanup();
+    }
+  });
+
+  it("unused imports on the response are well-typed (spot check)", () => {
+    // Pure compile-time guard: `JsonRpcMessage` should be importable from the
+    // server barrel. If this import breaks, the real test files fail loudly
+    // — this line exists so an IDE's auto-cleanup doesn't strip the type.
+    const sample: JsonRpcMessage = { jsonrpc: "2.0", id: 1 };
+    expect(sample.jsonrpc).toBe("2.0");
+  });
+});


### PR DESCRIPTION
## Summary

Introduces the **repo-admin** foreman role used by the autonomous-loop design (AL-12..AL-16 follow-ups). Repo-admin is per-repo, long-lived, and coordinates workers — it does NOT implement code, run tests, or merge PRs. AL-11 pins the *role definition only*: system prompt, MCP tool allowlist, and denial-envelope shape.

- `src/agents/repo-admin.ts` — role identity, system prompt builder, stub `spawn_worker` handler (lands in AL-14).
- `src/mcp/role-allowlist.ts` — per-role tool whitelist + structured denial envelope. Data-driven so AL-12..AL-16 extend by adding a map entry.
- `src/mcp/server.ts` — consults the allowlist at `tools/list` (filters capability report) and `tools/call` (returns structured `tool-not-allowed` envelope with `isError: true`).
- `src/domain/specialty.ts` — adds `repo_admin` specialty tag.
- `agent_docs/repo-admin.md` — foreman/crew split reference.

## Design decisions

### Allowed tools (whitelist)
- `channel_task_board`, `channel_get` — read ticket board + decisions + feed.
- `channel_post` — append-only status updates on the channel feed.
- `harness_running_tasks`, `harness_list_runs`, `harness_get_run_detail` — read-only run state.
- `spawn_worker` — **declared, stubbed**. Handler lands in AL-14; calling it returns `{error: "tool-stubbed", landsIn: "AL-14"}` so the capability surface is stable from day one.

### Denied by design
File edits (`Edit`, `Write`, `NotebookEdit`), test runners (`Bash`-backed), PR merges (`gh pr merge`), and mutating MCP tools outside `spawn_worker` (`harness_dispatch`, `harness_approve_plan`, `project_create`). Calling any of these returns `{error: "tool-not-allowed", tool, role, reason}` with `isError: true` — not a silent pass, not a crash. `reason` is role-specific ("repo-admin does not call X; propose a worker spawn instead").

### Enforcement mechanism
Role is read from `RELAY_AGENT_ROLE` env var (uses `RELAY_*` prefix so it flows through the existing child-env sanitizer without a `passEnv` opt-in). Two consult points in `src/mcp/server.ts`:
- `tools/list` filters the advertised tool set via `allowlistForRole(role)`.
- `tools/call` consults `isToolAllowedForRole(role, toolName)` before dispatch; denial short-circuits with the structured envelope.

Unknown roles (any `RELAY_AGENT_ROLE` not in `ROLE_ALLOWLISTS`) fall through to the unrestricted path so AL-12..AL-16 can add new roles incrementally without breaking existing flows.

### Slight deviation from the brief
The brief referenced `listChannelTickets` / `listChannelDecisions` / `list_tracked_prs` tool names — those are GUI-internal function names, not MCP tools. The closest MCP equivalents are on the allowlist: `channel_task_board` (tickets) and `channel_get` (decisions + feed). There is no existing MCP tool for tracked-PR rows; workers surface PR state via the channel feed today, and `harness_running_tasks` covers the cross-workspace view. Adding a dedicated tracked-PR MCP tool would be AL-13/AL-14 scope; called out explicitly so it surfaces in review.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 498 passing / 22 skipped (live-network gates).
- [x] `pnpm build` clean.
- [x] `pnpm dlx prettier --check 'src/**/*.{ts,tsx}' 'test/**/*.{ts,tsx}' 'gui/src/**/*.{ts,tsx}' 'scripts/**/*.{ts,mts}' '*.md' 'docs/**/*.md'` — all clean (matches CI's `format-check` job exactly).
- [x] Unit tests: allowlist-exactness assertions, denial-envelope shape, system-prompt memory-policy substring pin, stub-handler AL-14 pointer — `test/agents/repo-admin.test.ts`.
- [x] End-to-end MCP handler test drives real `tools/list` + `tools/call` messages under `RELAY_AGENT_ROLE=repo-admin` with storage mocked to a tmp `FileHarnessStore` — `test/mcp/role-allowlist.test.ts`.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)