### PR TITLE
AL-2: Session lifecycle states + wall-clock watchdog

### DIFF
--- a/src/lifecycle/session-lifecycle.ts
+++ b/src/lifecycle/session-lifecycle.ts
@@ -1,0 +1,437 @@
+import { EventEmitter } from "node:events";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import type { TokenTracker } from "../budget/token-tracker.js";
+import { getRelayDir } from "../cli/paths.js";
+
+import {
+  DEFAULT_MAX_DURATION_MS,
+  LifecycleTransitionError,
+  TERMINAL_STATES,
+  VALID_TRANSITIONS,
+  type LifecycleFile,
+  type LifecycleState,
+  type PersistedTransition,
+  type TransitionEvent,
+} from "./types.js";
+
+export { LifecycleTransitionError } from "./types.js";
+export type { LifecycleState, TransitionEvent } from "./types.js";
+
+/**
+ * Options for constructing a {@link SessionLifecycle}. All fields are
+ * optional — the defaults produce a production-ready state machine with an
+ * 8h wall-clock budget and no token-budget wiring.
+ */
+export interface SessionLifecycleOptions {
+  /**
+   * Optional token tracker to wire budget-driven transitions. When
+   * attached, the lifecycle subscribes to its `onThreshold` bus and:
+   *
+   *   - 85% → `dispatching` transitions to `winding_down`
+   *   - 95% → any non-terminal state transitions to `killed`
+   *
+   * Other thresholds (50 / 100) are ignored. The lifecycle never touches
+   * the tracker's own state; re-fire suppression across restarts is
+   * {@link TokenTracker}'s responsibility via its own persisted
+   * `firedThresholds` set.
+   */
+  tracker?: TokenTracker;
+
+  /**
+   * Wall-clock budget in milliseconds. When the timer elapses the
+   * lifecycle transitions to `killed` with reason `"wall-clock-exceeded"`
+   * (unless already terminal). Defaults to 8h. Must be > 0.
+   */
+  maxDurationMs?: number;
+
+  /**
+   * Clock injection point. Defaults to `Date.now`. Tests pass a
+   * controllable clock so they can assert wall-clock behaviour without
+   * wall-clock waits. The clock is only consulted when stamping
+   * transition timestamps and the `startedAt` field.
+   */
+  clock?: () => number;
+
+  /**
+   * Override the `~/.relay` base directory. Tests use this with a tmp
+   * dir; production callers should leave it undefined.
+   */
+  rootDir?: string;
+
+  /**
+   * Timer factory. Defaults to `setTimeout`/`clearTimeout`. Tests can
+   * inject a fake-timer harness to drive the watchdog deterministically.
+   * If set, the lifecycle uses these instead of the Node globals.
+   */
+  setTimer?: (fn: () => void, ms: number) => NodeJS.Timeout | number;
+  clearTimer?: (handle: NodeJS.Timeout | number) => void;
+}
+
+/**
+ * Persisted, one-way state machine for an autonomous Relay session.
+ *
+ * Responsibilities:
+ *
+ *   1. Enforce the valid transition graph declared in
+ *      {@link VALID_TRANSITIONS}. Invalid transitions throw
+ *      {@link LifecycleTransitionError} — never silently no-op.
+ *   2. Persist state + the ordered transition log to
+ *      `~/.relay/sessions/<sessionId>/lifecycle.json` atomically (tmp +
+ *      rename). On construction, the file is replayed so a restart
+ *      resumes in whatever state it was in — a crash mid-winding-down
+ *      cannot silently re-open dispatching.
+ *   3. Fire transitions off the two kill triggers this ticket owns:
+ *        - {@link TokenTracker} threshold crossings (85 / 95)
+ *        - the wall-clock watchdog (default 8h)
+ *   4. Expose an `onTransition` event bus so AL-4's autonomous-loop
+ *      driver can react. The bus is a bare `EventEmitter` — same style
+ *      as AL-1's token tracker — and the two buses are independent; AL-4
+ *      subscribes to both.
+ *
+ * **Clean-kill semantics.** "kill" in this class means the lifecycle
+ * *state* transitions to `killed`. The autonomous loop observes the
+ * transition event and stops dispatching new tickets. The currently
+ * running ticket finishes on its own — the lifecycle never terminates
+ * subprocesses or mutates in-flight work. AL-2 is the signal; something
+ * else (AL-4 / the invoker layer) is the actuator.
+ */
+export class SessionLifecycle {
+  readonly sessionId: string;
+  readonly startedAt: number;
+  readonly maxDurationMs: number;
+
+  private _state: LifecycleState = "planning";
+  private readonly transitions: PersistedTransition[] = [];
+
+  private readonly emitter = new EventEmitter();
+  private readonly filePath: string;
+  private readonly clock: () => number;
+
+  // Write chain so two overlapping transition() calls can't race on the
+  // atomic rename. Same pattern as TokenTracker's writeChain.
+  private writeChain: Promise<void>;
+
+  private watchdogHandle: NodeJS.Timeout | number | null = null;
+  private readonly setTimer: (fn: () => void, ms: number) => NodeJS.Timeout | number;
+  private readonly clearTimer: (handle: NodeJS.Timeout | number) => void;
+
+  private unsubscribeTracker: (() => void) | null = null;
+  private closed = false;
+
+  constructor(sessionId: string, options: SessionLifecycleOptions = {}) {
+    if (!sessionId) {
+      throw new Error("SessionLifecycle: sessionId is required");
+    }
+
+    const maxDurationMs = options.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
+    if (!Number.isFinite(maxDurationMs) || maxDurationMs <= 0) {
+      throw new Error(
+        `SessionLifecycle: maxDurationMs must be a positive finite number (got ${maxDurationMs})`
+      );
+    }
+
+    this.sessionId = sessionId;
+    this.maxDurationMs = maxDurationMs;
+    this.clock = options.clock ?? Date.now;
+    this.startedAt = this.clock();
+
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
+
+    const root = options.rootDir ?? getRelayDir();
+    this.filePath = join(root, "sessions", sessionId, "lifecycle.json");
+
+    // Replay first so any caller that awaits a no-op promise (or our own
+    // transition chain) observes the resumed state. Transitions queue
+    // behind this.
+    this.writeChain = this.replay();
+
+    // Arm the watchdog immediately. If we resume into a terminal state,
+    // the arm call is a no-op. We only want the watchdog for sessions
+    // that still have work in front of them.
+    this.armWatchdog();
+
+    // Subscribe to the token tracker after replay is queued so any
+    // threshold crossing that arrives during replay is still handled in
+    // order (transitions are serialized on the write chain).
+    if (options.tracker) {
+      this.unsubscribeTracker = options.tracker.onThreshold((evt) => {
+        this.handleThreshold(evt.threshold);
+      });
+    }
+  }
+
+  /** Current lifecycle state. Reflects the last completed transition. */
+  get state(): LifecycleState {
+    return this._state;
+  }
+
+  /** Snapshot of the transition history in insertion order. */
+  getTransitions(): PersistedTransition[] {
+    return this.transitions.slice();
+  }
+
+  /**
+   * Attempt a transition to `next`. Throws {@link LifecycleTransitionError}
+   * synchronously if the edge isn't in {@link VALID_TRANSITIONS}. Otherwise
+   * resolves when the transition has been persisted to disk and emitted on
+   * the event bus.
+   *
+   * Serialized behind the internal write chain — two concurrent callers
+   * run in call order without racing on the atomic rename.
+   */
+  async transition(next: LifecycleState, reason?: string): Promise<void> {
+    if (this.closed) {
+      throw new Error("SessionLifecycle: cannot transition after close()");
+    }
+
+    // Validate synchronously against the *current* public state so
+    // callers get a predictable error path. We re-validate inside the
+    // chain against the serialized state to catch interleaved transitions
+    // that might have changed things while the caller awaited nothing.
+    this.assertValidTransition(this._state, next);
+
+    this.writeChain = this.writeChain.then(async () => {
+      // Re-check against the live state inside the chain — the previous
+      // queued transition may have shifted us.
+      this.assertValidTransition(this._state, next);
+
+      const from = this._state;
+      const ts = this.clock();
+      const at = new Date(ts).toISOString();
+      const record: PersistedTransition = reason
+        ? { from, to: next, reason, at }
+        : { from, to: next, at };
+
+      this._state = next;
+      this.transitions.push(record);
+
+      // Clear the watchdog on terminal transitions so a crashed timer
+      // can't fire a second transition after `done`.
+      if (TERMINAL_STATES.includes(next)) {
+        this.disarmWatchdog();
+      }
+
+      await this.persist();
+
+      const evt: TransitionEvent = reason ? { from, to: next, reason, ts } : { from, to: next, ts };
+      this.safeEmitTransition(evt);
+    });
+
+    await this.writeChain;
+  }
+
+  /**
+   * Subscribe to transition events. Returns an unsubscribe function.
+   * Multiple subscribers are supported — each gets the same event.
+   * Mirrors {@link TokenTracker.onThreshold} so AL-4 can wire both buses
+   * with a single pattern.
+   */
+  onTransition(listener: (evt: TransitionEvent) => void): () => void {
+    this.emitter.on("transition", listener);
+    return () => {
+      this.emitter.off("transition", listener);
+    };
+  }
+
+  /**
+   * Drain any queued transitions without closing. Useful when a test has
+   * triggered a transition via a fire-and-forget path (token-tracker
+   * threshold, wall-clock watchdog) and needs to assert on the post-
+   * transition state or persisted file.
+   */
+  async flush(): Promise<void> {
+    // The watchdog-kill and threshold-driven transitions extend
+    // `writeChain` inside a queued callback, so a single await of the
+    // current chain isn't enough — we loop until the chain stabilizes.
+    // One extra turn of the microtask queue guarantees the fire-and-
+    // forget `transition()` has installed its own chain link.
+    for (let i = 0; i < 8; i += 1) {
+      const before = this.writeChain;
+      await this.writeChain.catch(() => {});
+      // Allow any pending `void this.transition(...)` callbacks in
+      // handleThreshold / fireWallClockKill to have enqueued.
+      await Promise.resolve();
+      if (this.writeChain === before) break;
+    }
+  }
+
+  /**
+   * Flush any in-flight transition, clear the wall-clock watchdog, and
+   * unsubscribe from the token tracker. Idempotent. After close, further
+   * `transition()` calls throw.
+   */
+  async close(): Promise<void> {
+    if (this.closed) {
+      await this.writeChain.catch(() => {});
+      return;
+    }
+    this.closed = true;
+    this.disarmWatchdog();
+    if (this.unsubscribeTracker) {
+      this.unsubscribeTracker();
+      this.unsubscribeTracker = null;
+    }
+    await this.writeChain.catch(() => {});
+    this.emitter.removeAllListeners();
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private assertValidTransition(from: LifecycleState, to: LifecycleState): void {
+    const allowed = VALID_TRANSITIONS[from];
+    if (!allowed || !allowed.includes(to)) {
+      throw new LifecycleTransitionError(from, to);
+    }
+  }
+
+  private safeEmitTransition(evt: TransitionEvent): void {
+    const listeners = this.emitter.listeners("transition") as Array<(evt: TransitionEvent) => void>;
+    for (const listener of listeners) {
+      try {
+        listener(evt);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`SessionLifecycle: transition ${evt.from}->${evt.to} listener threw: ${msg}`);
+      }
+    }
+  }
+
+  private async replay(): Promise<void> {
+    let content: string;
+    try {
+      content = await readFile(this.filePath, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // Fresh session — stay in `planning`, nothing to replay. We
+        // defer the first write until the first transition so a tracker
+        // that's constructed and immediately closed leaves no residue.
+        return;
+      }
+      throw err;
+    }
+
+    let parsed: LifecycleFile;
+    try {
+      parsed = JSON.parse(content) as LifecycleFile;
+    } catch {
+      console.warn(
+        `SessionLifecycle: lifecycle.json for session ${this.sessionId} is corrupted; starting fresh`
+      );
+      return;
+    }
+
+    if (!this.looksValid(parsed)) {
+      console.warn(
+        `SessionLifecycle: lifecycle.json for session ${this.sessionId} has unexpected shape; starting fresh`
+      );
+      return;
+    }
+
+    this._state = parsed.state;
+    this.transitions.length = 0;
+    for (const t of parsed.transitions) {
+      this.transitions.push(t);
+    }
+  }
+
+  private looksValid(parsed: unknown): parsed is LifecycleFile {
+    if (!parsed || typeof parsed !== "object") return false;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.sessionId !== "string") return false;
+    if (typeof obj.state !== "string") return false;
+    if (!(obj.state in VALID_TRANSITIONS)) return false;
+    if (typeof obj.startedAt !== "string") return false;
+    if (!Array.isArray(obj.transitions)) return false;
+    for (const t of obj.transitions) {
+      if (!t || typeof t !== "object") return false;
+      const tt = t as Record<string, unknown>;
+      if (typeof tt.from !== "string" || !(tt.from in VALID_TRANSITIONS)) return false;
+      if (typeof tt.to !== "string" || !(tt.to in VALID_TRANSITIONS)) return false;
+      if (typeof tt.at !== "string") return false;
+    }
+    return true;
+  }
+
+  private async persist(): Promise<void> {
+    const file: LifecycleFile = {
+      sessionId: this.sessionId,
+      state: this._state,
+      startedAt: new Date(this.startedAt).toISOString(),
+      transitions: this.transitions,
+      maxDurationMs: this.maxDurationMs,
+    };
+    const dir = dirname(this.filePath);
+    await mkdir(dir, { recursive: true });
+    const tmp = `${this.filePath}.tmp.${process.pid}.${Date.now()}`;
+    await writeFile(tmp, JSON.stringify(file, null, 2), "utf8");
+    try {
+      await rename(tmp, this.filePath);
+    } catch (err) {
+      await rm(tmp, { force: true }).catch(() => {});
+      throw err;
+    }
+  }
+
+  private armWatchdog(): void {
+    if (this.watchdogHandle !== null) return;
+    if (TERMINAL_STATES.includes(this._state)) return;
+    // Fire after the *full* maxDurationMs from the startedAt clock sample.
+    // We don't subtract elapsed replay time — the spec treats the
+    // watchdog as wall-clock-from-construction.
+    this.watchdogHandle = this.setTimer(() => {
+      this.watchdogHandle = null;
+      this.fireWallClockKill();
+    }, this.maxDurationMs);
+    // When the host process uses real timers, unref so the watchdog
+    // doesn't keep the event loop alive past the session's lifetime.
+    const h = this.watchdogHandle as { unref?: () => void };
+    if (h && typeof h.unref === "function") {
+      h.unref();
+    }
+  }
+
+  private disarmWatchdog(): void {
+    if (this.watchdogHandle === null) return;
+    this.clearTimer(this.watchdogHandle);
+    this.watchdogHandle = null;
+  }
+
+  private fireWallClockKill(): void {
+    if (this.closed) return;
+    if (TERMINAL_STATES.includes(this._state)) return;
+    // Fire-and-forget: kick a killed transition onto the queue. If the
+    // current state doesn't allow `killed` (shouldn't happen — every
+    // non-terminal state has a `killed` edge) the serialized re-check
+    // surfaces the error on the write chain.
+    void this.transition("killed", "wall-clock-exceeded").catch((err) => {
+      console.warn(
+        `SessionLifecycle: wall-clock kill failed for session ${this.sessionId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    });
+  }
+
+  private handleThreshold(threshold: number): void {
+    if (this.closed) return;
+    if (threshold === 85) {
+      // Only wind-down from `dispatching`. If we're already past it
+      // (winding_down / audit) we respect the later state. If we're
+      // earlier (planning) we also leave it alone — planning hasn't
+      // started dispatching work yet, so "wind down" doesn't apply.
+      if (this._state === "dispatching") {
+        void this.transition("winding_down", "token-budget-85pct").catch(() => {});
+      }
+      return;
+    }
+    if (threshold === 95) {
+      // Hard stop from any non-terminal state.
+      if (!TERMINAL_STATES.includes(this._state)) {
+        void this.transition("killed", "token-budget-95pct-hard-stop").catch(() => {});
+      }
+    }
+  }
+}

--- a/src/lifecycle/types.ts
+++ b/src/lifecycle/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Autonomous-session lifecycle states (AL-2). See `session-lifecycle.ts` for
+ * the state machine that enforces valid transitions, and AL-4 for the
+ * autonomous-loop driver that observes these states to decide whether to
+ * keep dispatching tickets.
+ */
+export type LifecycleState =
+  | "planning"
+  | "dispatching"
+  | "winding_down"
+  | "audit"
+  | "done"
+  | "killed";
+
+/**
+ * The two lifecycle end-states. Once the machine is in either of these, no
+ * further transitions are allowed and the watchdog timer is cleared.
+ */
+export const TERMINAL_STATES: readonly LifecycleState[] = ["done", "killed"] as const;
+
+/**
+ * Valid forward transitions keyed by source state. The state machine is
+ * strictly one-way — there is no edge from a later state back to an
+ * earlier one, and terminal states have no outgoing edges.
+ */
+export const VALID_TRANSITIONS: Readonly<Record<LifecycleState, readonly LifecycleState[]>> = {
+  planning: ["dispatching", "killed"],
+  dispatching: ["winding_down", "killed"],
+  winding_down: ["audit", "done", "killed"],
+  audit: ["done", "killed"],
+  done: [],
+  killed: [],
+};
+
+/**
+ * Emitted on every successful transition. Listeners subscribe via
+ * `SessionLifecycle.onTransition()` and receive each transition exactly
+ * once in the order they happen.
+ */
+export interface TransitionEvent {
+  from: LifecycleState;
+  to: LifecycleState;
+  reason?: string;
+  /** `Date.now()`-style epoch millis at the moment the transition landed. */
+  ts: number;
+}
+
+/**
+ * Persisted record of a single transition. Same shape as `TransitionEvent`
+ * but serializes `ts` as an ISO-8601 string for human-readable
+ * `lifecycle.json` files.
+ */
+export interface PersistedTransition {
+  from: LifecycleState;
+  to: LifecycleState;
+  reason?: string;
+  at: string;
+}
+
+/**
+ * On-disk shape of `~/.relay/sessions/<sessionId>/lifecycle.json`. The
+ * machine overwrites this file atomically (tmp + rename) on every
+ * transition, so readers always see either the pre- or post-transition
+ * snapshot, never a torn intermediate.
+ */
+export interface LifecycleFile {
+  sessionId: string;
+  state: LifecycleState;
+  startedAt: string;
+  transitions: PersistedTransition[];
+  maxDurationMs: number;
+}
+
+/**
+ * Thrown by `SessionLifecycle.transition()` when the attempted target is
+ * not reachable from the current state. Includes both the current state
+ * and the attempted target so callers can render a useful message.
+ */
+export class LifecycleTransitionError extends Error {
+  readonly from: LifecycleState;
+  readonly to: LifecycleState;
+
+  constructor(from: LifecycleState, to: LifecycleState) {
+    super(`LifecycleTransitionError: cannot transition from "${from}" to "${to}"`);
+    this.name = "LifecycleTransitionError";
+    this.from = from;
+    this.to = to;
+  }
+}
+
+/** Default wall-clock budget: 8h. Matches the `--max-hours=8` CLI default. */
+export const DEFAULT_MAX_DURATION_MS = 8 * 60 * 60 * 1000;

--- a/test/lifecycle/session-lifecycle.test.ts
+++ b/test/lifecycle/session-lifecycle.test.ts
@@ -1,0 +1,562 @@
+import { mkdtemp, readFile, rm, stat, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TokenTracker } from "../../src/budget/token-tracker.js";
+import {
+  LifecycleTransitionError,
+  SessionLifecycle,
+  type TransitionEvent,
+} from "../../src/lifecycle/session-lifecycle.js";
+
+describe("SessionLifecycle", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-lifecycle-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe("valid transitions (happy path)", () => {
+    it("walks planning -> dispatching -> winding_down -> audit -> done", async () => {
+      const lifecycle = new SessionLifecycle("s-happy", { rootDir: root });
+      const events: TransitionEvent[] = [];
+      lifecycle.onTransition((evt) => events.push(evt));
+
+      expect(lifecycle.state).toBe("planning");
+
+      await lifecycle.transition("dispatching", "user-approved-plan");
+      expect(lifecycle.state).toBe("dispatching");
+
+      await lifecycle.transition("winding_down", "all-tickets-dispatched");
+      expect(lifecycle.state).toBe("winding_down");
+
+      await lifecycle.transition("audit", "queue-drained");
+      expect(lifecycle.state).toBe("audit");
+
+      await lifecycle.transition("done", "audit-passed");
+      expect(lifecycle.state).toBe("done");
+
+      expect(events.map((e) => [e.from, e.to])).toEqual([
+        ["planning", "dispatching"],
+        ["dispatching", "winding_down"],
+        ["winding_down", "audit"],
+        ["audit", "done"],
+      ]);
+      expect(events[0].reason).toBe("user-approved-plan");
+      expect(events[3].reason).toBe("audit-passed");
+
+      await lifecycle.close();
+    });
+
+    it("allows killed from every non-terminal state", async () => {
+      for (const start of ["planning", "dispatching", "winding_down", "audit"] as const) {
+        const id = `s-kill-${start}`;
+        const lifecycle = new SessionLifecycle(id, { rootDir: root });
+        // Walk to the target start state.
+        if (start === "dispatching") {
+          await lifecycle.transition("dispatching");
+        } else if (start === "winding_down") {
+          await lifecycle.transition("dispatching");
+          await lifecycle.transition("winding_down");
+        } else if (start === "audit") {
+          await lifecycle.transition("dispatching");
+          await lifecycle.transition("winding_down");
+          await lifecycle.transition("audit");
+        }
+        expect(lifecycle.state).toBe(start);
+        await lifecycle.transition("killed", "test");
+        expect(lifecycle.state).toBe("killed");
+        await lifecycle.close();
+      }
+    });
+
+    it("allows winding_down -> done (skip audit)", async () => {
+      const lifecycle = new SessionLifecycle("s-skip-audit", { rootDir: root });
+      await lifecycle.transition("dispatching");
+      await lifecycle.transition("winding_down");
+      await lifecycle.transition("done");
+      expect(lifecycle.state).toBe("done");
+      await lifecycle.close();
+    });
+  });
+
+  describe("invalid transitions", () => {
+    it("rejects planning -> winding_down (must pass through dispatching)", async () => {
+      const lifecycle = new SessionLifecycle("s-bad-1", { rootDir: root });
+      await expect(lifecycle.transition("winding_down")).rejects.toBeInstanceOf(
+        LifecycleTransitionError
+      );
+      expect(lifecycle.state).toBe("planning");
+      await lifecycle.close();
+    });
+
+    it("rejects planning -> audit", async () => {
+      const lifecycle = new SessionLifecycle("s-bad-2", { rootDir: root });
+      await expect(lifecycle.transition("audit")).rejects.toBeInstanceOf(LifecycleTransitionError);
+      await lifecycle.close();
+    });
+
+    it("rejects planning -> done", async () => {
+      const lifecycle = new SessionLifecycle("s-bad-3", { rootDir: root });
+      await expect(lifecycle.transition("done")).rejects.toBeInstanceOf(LifecycleTransitionError);
+      await lifecycle.close();
+    });
+
+    it("rejects dispatching -> audit (must pass through winding_down)", async () => {
+      const lifecycle = new SessionLifecycle("s-bad-4", { rootDir: root });
+      await lifecycle.transition("dispatching");
+      await expect(lifecycle.transition("audit")).rejects.toBeInstanceOf(LifecycleTransitionError);
+      expect(lifecycle.state).toBe("dispatching");
+      await lifecycle.close();
+    });
+
+    it("rejects backward transitions (winding_down -> dispatching)", async () => {
+      const lifecycle = new SessionLifecycle("s-back-1", { rootDir: root });
+      await lifecycle.transition("dispatching");
+      await lifecycle.transition("winding_down");
+      await expect(lifecycle.transition("dispatching")).rejects.toBeInstanceOf(
+        LifecycleTransitionError
+      );
+      expect(lifecycle.state).toBe("winding_down");
+      await lifecycle.close();
+    });
+
+    it("rejects transitions out of done", async () => {
+      const lifecycle = new SessionLifecycle("s-done-out", { rootDir: root });
+      await lifecycle.transition("dispatching");
+      await lifecycle.transition("winding_down");
+      await lifecycle.transition("done");
+      for (const target of [
+        "planning",
+        "dispatching",
+        "winding_down",
+        "audit",
+        "killed",
+      ] as const) {
+        await expect(lifecycle.transition(target)).rejects.toBeInstanceOf(LifecycleTransitionError);
+      }
+      expect(lifecycle.state).toBe("done");
+      await lifecycle.close();
+    });
+
+    it("rejects transitions out of killed", async () => {
+      const lifecycle = new SessionLifecycle("s-killed-out", { rootDir: root });
+      await lifecycle.transition("killed", "test");
+      for (const target of ["planning", "dispatching", "winding_down", "audit", "done"] as const) {
+        await expect(lifecycle.transition(target)).rejects.toBeInstanceOf(LifecycleTransitionError);
+      }
+      expect(lifecycle.state).toBe("killed");
+      await lifecycle.close();
+    });
+
+    it("LifecycleTransitionError carries current + attempted states", async () => {
+      const lifecycle = new SessionLifecycle("s-err-shape", { rootDir: root });
+      try {
+        await lifecycle.transition("done");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(LifecycleTransitionError);
+        const e = err as LifecycleTransitionError;
+        expect(e.from).toBe("planning");
+        expect(e.to).toBe("done");
+        expect(e.message).toContain("planning");
+        expect(e.message).toContain("done");
+      }
+      await lifecycle.close();
+    });
+  });
+
+  describe("token-budget integration", () => {
+    it("85% threshold transitions dispatching -> winding_down", async () => {
+      const tracker = new TokenTracker("s-budget-85", 1000, { rootDir: root });
+      const lifecycle = new SessionLifecycle("s-budget-85", { rootDir: root, tracker });
+      const events: TransitionEvent[] = [];
+      lifecycle.onTransition((evt) => events.push(evt));
+
+      await lifecycle.transition("dispatching");
+      expect(lifecycle.state).toBe("dispatching");
+
+      // Cross 50 (ignored) then 85 (should wind down). Stop before 95.
+      tracker.record(500, 0); // 50% — crosses 50 only
+      tracker.record(350, 0); // 85% — crosses 85
+      await tracker.flush();
+      await lifecycle.flush();
+
+      expect(lifecycle.state).toBe("winding_down");
+      const reasons = events.map((e) => e.reason);
+      expect(reasons).toContain("token-budget-85pct");
+
+      await lifecycle.close();
+      await tracker.close();
+    });
+
+    it("85% threshold is ignored when not in dispatching", async () => {
+      const tracker = new TokenTracker("s-budget-85-noop", 1000, { rootDir: root });
+      const lifecycle = new SessionLifecycle("s-budget-85-noop", {
+        rootDir: root,
+        tracker,
+      });
+      // Stay in planning — 85% should NOT move us anywhere.
+      tracker.record(900, 0); // crosses 50 and 85
+      await tracker.flush();
+      await lifecycle.flush();
+
+      expect(lifecycle.state).toBe("planning");
+      // But 95 still fires a kill from planning.
+      tracker.record(100, 0); // crosses 95 (and 100)
+      await tracker.flush();
+      await lifecycle.flush();
+      expect(lifecycle.state).toBe("killed");
+
+      await lifecycle.close();
+      await tracker.close();
+    });
+
+    it("95% threshold transitions any non-terminal state to killed", async () => {
+      const tracker = new TokenTracker("s-budget-95", 1000, { rootDir: root });
+      const lifecycle = new SessionLifecycle("s-budget-95", { rootDir: root, tracker });
+      await lifecycle.transition("dispatching");
+
+      tracker.record(1000, 0); // crosses 50, 85, 95, 100 in one go
+      await tracker.flush();
+      await lifecycle.flush();
+
+      // 85 fires first (winding_down), then 95 fires the kill.
+      expect(lifecycle.state).toBe("killed");
+      const reasons = lifecycle.getTransitions().map((t) => t.reason);
+      expect(reasons).toContain("token-budget-85pct");
+      expect(reasons).toContain("token-budget-95pct-hard-stop");
+
+      await lifecycle.close();
+      await tracker.close();
+    });
+
+    it("50% and 100% thresholds are ignored", async () => {
+      const tracker = new TokenTracker("s-budget-ignore", 1000, { rootDir: root });
+      const lifecycle = new SessionLifecycle("s-budget-ignore", {
+        rootDir: root,
+        tracker,
+      });
+      await lifecycle.transition("dispatching");
+      tracker.record(500, 0); // crosses only 50
+      await tracker.flush();
+      await lifecycle.flush();
+      expect(lifecycle.state).toBe("dispatching");
+
+      await lifecycle.close();
+      await tracker.close();
+    });
+  });
+
+  describe("wall-clock watchdog", () => {
+    it("fires a killed transition with reason wall-clock-exceeded", async () => {
+      // Fake timer harness: capture the scheduled callback instead of
+      // relying on a real setTimeout, so the test finishes in ms.
+      let scheduled: { fn: () => void; ms: number } | null = null;
+      let cleared = false;
+      const lifecycle = new SessionLifecycle("s-watchdog", {
+        rootDir: root,
+        maxDurationMs: 60_000,
+        setTimer: (fn, ms) => {
+          scheduled = { fn, ms };
+          return 1 as unknown as NodeJS.Timeout;
+        },
+        clearTimer: () => {
+          cleared = true;
+        },
+      });
+      await lifecycle.transition("dispatching");
+
+      expect(scheduled).not.toBeNull();
+      expect(scheduled!.ms).toBe(60_000);
+
+      // Advance time: manually invoke the captured timer callback.
+      scheduled!.fn();
+      await lifecycle.flush();
+
+      expect(lifecycle.state).toBe("killed");
+      const kill = lifecycle.getTransitions().find((t) => t.to === "killed");
+      expect(kill).toBeDefined();
+      expect(kill!.reason).toBe("wall-clock-exceeded");
+
+      // The terminal transition should have disarmed the watchdog via
+      // clearTimer, but since we already fired it, the handle is null
+      // and clearTimer is not called a second time. (The disarm on
+      // terminal transition is redundant when the watchdog just fired,
+      // but still covered in the close() test below.)
+      expect(cleared).toBe(false);
+
+      await lifecycle.close();
+    });
+
+    it("wall-clock kill fires independent of token budget", async () => {
+      // No tracker wired — watchdog must fire on its own.
+      let scheduled: (() => void) | null = null;
+      const lifecycle = new SessionLifecycle("s-watchdog-solo", {
+        rootDir: root,
+        maxDurationMs: 1_000,
+        setTimer: (fn) => {
+          scheduled = fn;
+          return 0 as unknown as NodeJS.Timeout;
+        },
+        clearTimer: () => {},
+      });
+      await lifecycle.transition("dispatching");
+      scheduled!();
+      await lifecycle.flush();
+      expect(lifecycle.state).toBe("killed");
+      await lifecycle.close();
+    });
+
+    it("close() clears the watchdog so no transition fires after close", async () => {
+      let scheduled: (() => void) | null = null;
+      let cleared = false;
+      const lifecycle = new SessionLifecycle("s-close-clears", {
+        rootDir: root,
+        maxDurationMs: 60_000,
+        setTimer: (fn) => {
+          scheduled = fn;
+          return 42 as unknown as NodeJS.Timeout;
+        },
+        clearTimer: (handle) => {
+          expect(handle).toBe(42);
+          cleared = true;
+        },
+      });
+
+      const events: TransitionEvent[] = [];
+      lifecycle.onTransition((evt) => events.push(evt));
+
+      await lifecycle.close();
+      expect(cleared).toBe(true);
+
+      // Firing the stale timer callback after close must NOT produce a
+      // transition (lifecycle is closed, state stays planning).
+      scheduled!();
+      // Give any rogue fire-and-forget a turn to fail.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(events).toEqual([]);
+      expect(lifecycle.state).toBe("planning");
+    });
+
+    it("rejects non-positive maxDurationMs", () => {
+      expect(() => new SessionLifecycle("s-bad-dur", { rootDir: root, maxDurationMs: 0 })).toThrow(
+        /maxDurationMs/
+      );
+      expect(() => new SessionLifecycle("s-bad-dur", { rootDir: root, maxDurationMs: -1 })).toThrow(
+        /maxDurationMs/
+      );
+      expect(
+        () => new SessionLifecycle("s-bad-dur", { rootDir: root, maxDurationMs: Number.NaN })
+      ).toThrow(/maxDurationMs/);
+    });
+  });
+
+  describe("persistence", () => {
+    it("round-trips: transition, close, reconstruct, state + transitions intact", async () => {
+      const id = "s-roundtrip";
+      const first = new SessionLifecycle(id, { rootDir: root });
+      await first.transition("dispatching", "user-approved");
+      await first.transition("winding_down", "budget-85");
+      await first.close();
+
+      const filePath = join(root, "sessions", id, "lifecycle.json");
+      const contents = JSON.parse(await readFile(filePath, "utf8"));
+      expect(contents.sessionId).toBe(id);
+      expect(contents.state).toBe("winding_down");
+      expect(contents.transitions).toHaveLength(2);
+      expect(contents.transitions[0].from).toBe("planning");
+      expect(contents.transitions[0].to).toBe("dispatching");
+      expect(contents.transitions[0].reason).toBe("user-approved");
+      expect(contents.maxDurationMs).toBeGreaterThan(0);
+
+      // Reconstruct and confirm state is resumed.
+      const second = new SessionLifecycle(id, { rootDir: root });
+      // Give replay a chance to finish.
+      await second.flush();
+      expect(second.state).toBe("winding_down");
+      expect(second.getTransitions()).toHaveLength(2);
+
+      // A subsequent transition should still work and append to the log.
+      await second.transition("audit");
+      expect(second.state).toBe("audit");
+      expect(second.getTransitions()).toHaveLength(3);
+      await second.close();
+
+      const final = JSON.parse(await readFile(filePath, "utf8"));
+      expect(final.state).toBe("audit");
+      expect(final.transitions).toHaveLength(3);
+    });
+
+    it("resuming in a terminal state does not arm the watchdog", async () => {
+      const id = "s-resume-terminal";
+      const first = new SessionLifecycle(id, { rootDir: root });
+      await first.transition("dispatching");
+      await first.transition("winding_down");
+      await first.transition("done");
+      await first.close();
+
+      const captured: Array<() => void> = [];
+      const second = new SessionLifecycle(id, {
+        rootDir: root,
+        setTimer: (fn) => {
+          captured.push(fn);
+          return 0 as unknown as NodeJS.Timeout;
+        },
+        clearTimer: () => {},
+      });
+      await second.flush();
+      // The watchdog is armed synchronously in the constructor before
+      // replay resolves — so a callback may have been captured. The key
+      // invariant is that firing it does NOT move a terminal state.
+      for (const fn of captured) {
+        fn();
+      }
+      await second.flush();
+      expect(second.state).toBe("done");
+      await second.close();
+    });
+
+    it("corrupted lifecycle.json: recover by starting fresh and log a warn", async () => {
+      const id = "s-corrupt";
+      const filePath = join(root, "sessions", id, "lifecycle.json");
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, "{not valid json", "utf8");
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const lifecycle = new SessionLifecycle(id, { rootDir: root });
+        await lifecycle.flush();
+        expect(lifecycle.state).toBe("planning");
+        expect(lifecycle.getTransitions()).toEqual([]);
+        expect(warnSpy).toHaveBeenCalled();
+        const msg = warnSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+        expect(msg.toLowerCase()).toContain("corrupt");
+
+        // A fresh transition on top of the recovered lifecycle works.
+        await lifecycle.transition("dispatching");
+        expect(lifecycle.state).toBe("dispatching");
+        await lifecycle.close();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("missing file is not an error — fresh session starts in planning", async () => {
+      const lifecycle = new SessionLifecycle("s-fresh", { rootDir: root });
+      await lifecycle.flush();
+      expect(lifecycle.state).toBe("planning");
+      // No file created until the first transition.
+      await expect(stat(join(root, "sessions", "s-fresh", "lifecycle.json"))).rejects.toThrow(
+        /ENOENT/
+      );
+      await lifecycle.close();
+    });
+
+    it("persists atomically — lifecycle.json is valid JSON after every transition", async () => {
+      const id = "s-atomic";
+      const lifecycle = new SessionLifecycle(id, { rootDir: root });
+      await lifecycle.transition("dispatching");
+      const mid = JSON.parse(await readFile(join(root, "sessions", id, "lifecycle.json"), "utf8"));
+      expect(mid.state).toBe("dispatching");
+      await lifecycle.transition("winding_down");
+      const after = JSON.parse(
+        await readFile(join(root, "sessions", id, "lifecycle.json"), "utf8")
+      );
+      expect(after.state).toBe("winding_down");
+      await lifecycle.close();
+    });
+  });
+
+  describe("event bus", () => {
+    it("multiple subscribers all receive each transition", async () => {
+      const lifecycle = new SessionLifecycle("s-multi", { rootDir: root });
+      const a: TransitionEvent[] = [];
+      const b: TransitionEvent[] = [];
+      lifecycle.onTransition((e) => a.push(e));
+      lifecycle.onTransition((e) => b.push(e));
+      await lifecycle.transition("dispatching");
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+      await lifecycle.close();
+    });
+
+    it("unsubscribe stops further events", async () => {
+      const lifecycle = new SessionLifecycle("s-unsub", { rootDir: root });
+      const events: TransitionEvent[] = [];
+      const off = lifecycle.onTransition((e) => events.push(e));
+      await lifecycle.transition("dispatching");
+      off();
+      await lifecycle.transition("winding_down");
+      expect(events.map((e) => e.to)).toEqual(["dispatching"]);
+      await lifecycle.close();
+    });
+
+    it("a throwing listener does not block other listeners or the transition", async () => {
+      const lifecycle = new SessionLifecycle("s-throwy", { rootDir: root });
+      const events: TransitionEvent[] = [];
+      lifecycle.onTransition(() => {
+        throw new Error("boom");
+      });
+      lifecycle.onTransition((e) => events.push(e));
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await lifecycle.transition("dispatching");
+      } finally {
+        warnSpy.mockRestore();
+      }
+      expect(lifecycle.state).toBe("dispatching");
+      expect(events).toHaveLength(1);
+      await lifecycle.close();
+    });
+  });
+
+  describe("close semantics", () => {
+    it("close() is idempotent", async () => {
+      const lifecycle = new SessionLifecycle("s-close-twice", { rootDir: root });
+      await lifecycle.close();
+      await expect(lifecycle.close()).resolves.toBeUndefined();
+    });
+
+    it("transition after close throws", async () => {
+      const lifecycle = new SessionLifecycle("s-closed", { rootDir: root });
+      await lifecycle.close();
+      await expect(lifecycle.transition("dispatching")).rejects.toThrow(/after close/);
+    });
+
+    it("close() unsubscribes from the token tracker", async () => {
+      const tracker = new TokenTracker("s-unsub-tracker", 1000, { rootDir: root });
+      const lifecycle = new SessionLifecycle("s-unsub-tracker", {
+        rootDir: root,
+        tracker,
+      });
+      await lifecycle.transition("dispatching");
+      await lifecycle.close();
+
+      // After close, a threshold crossing must NOT cause lifecycle work
+      // (it's already in `planning`-derived state, but more importantly
+      // the handler is unsubscribed and cannot throw/attempt a transition).
+      tracker.record(1000, 0);
+      await tracker.flush();
+      await tracker.close();
+      // No assertion on lifecycle state here — we simply must not crash
+      // or leak a post-close transition attempt. Flush-once to give any
+      // rogue async callback a turn.
+      await new Promise((r) => setTimeout(r, 5));
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects empty sessionId", () => {
+      expect(() => new SessionLifecycle("", { rootDir: root })).toThrow(/sessionId/);
+    });
+  });
+});


### PR DESCRIPTION
Closes #77

## Summary

Adds a persisted one-way state machine for autonomous Relay sessions. AL-4's autonomous loop will observe this machine to decide when to stop dispatching new tickets. AL-2 owns the state machine + the two kill triggers (token-budget thresholds via AL-1's bus, wall-clock elapsed). Transitions are one-way and persisted so a crash + restart can't silently resume dispatching when the session was supposed to be winding down.

- `src/lifecycle/types.ts` — state enum, transition graph, `LifecycleTransitionError`, persisted file shape.
- `src/lifecycle/session-lifecycle.ts` — `SessionLifecycle` class: transition validator, atomic tmp+rename persistence, replay, `onTransition` event bus, `TokenTracker` subscription (85% → `winding_down`, 95% → `killed`), injectable wall-clock watchdog.
- `test/lifecycle/session-lifecycle.test.ts` — 31 tests covering every transition + both kill paths.

Not wired into any CLI entry point. AL-3 will own `rly run --autonomous`; AL-4 will drive the loop.

## Test plan

- [x] State persisted at `~/.relay/sessions/<sessionId>/lifecycle.json` (round-trip test asserts on-disk shape + resume).
- [x] Transitions are one-way — tests cover every invalid edge (planning→audit, dispatching→audit, winding_down→dispatching, anything→done|killed when already terminal).
- [x] Wall-clock kill fires independent of token budget; kill is clean (state transition only, no subprocess kill). Injectable `setTimer` / `clearTimer` make this deterministic in tests.
- [x] Unit tests cover every transition + both kill paths (`pnpm exec vitest run test/lifecycle` → 31 passed).
- [x] `pnpm typecheck` clean.
- [x] `pnpm exec vitest run --exclude '.claude/**' --exclude 'gui/**'` → 521 passed, 22 skipped.
- [x] `pnpm dlx prettier --check` clean.
- [x] `pnpm build` clean.

## Deviations from the design sketch

None material. A few notes for review:

- Added a small `flush()` method to `SessionLifecycle` (not in the sketch) so tests can deterministically drain fire-and-forget transitions triggered by the token-tracker bus and the watchdog. It's an obvious test-seam analogue of `TokenTracker.flush()`; happy to rename or hide if you'd rather keep the public surface minimal.
- Added a `getTransitions()` snapshot accessor (not in the sketch). Used in tests to assert reasons on the persisted log. Can drop if you prefer tests read the file instead.
- Exposed `setTimer` / `clearTimer` as options so tests can drive the watchdog without real-time waits. The sketch only mentioned `clock`, but `clock` alone doesn't help with timer firing — the watchdog uses `setTimeout`, not polling.