### PR TITLE
Tidewater GUI rebuild — full Slack-style chat shell

### DIFF
--- a/agent_docs/tidewater_handoff/README.md
+++ b/agent_docs/tidewater_handoff/README.md
@@ -1,0 +1,367 @@
+# Handoff — Relay "Tidewater" GUI
+
+> **Read me first:** this bundle is the design spec for Relay's Slack-style desktop GUI. It's the output of a design exploration; the HTML files are **references, not code to ship**. Your job is to recreate the designs in Relay's Tauri app using its existing patterns.
+
+---
+
+## 1. What Relay is (context)
+
+Relay is a CLI + daemon that runs **coding agents on your repositories**. Each repo becomes a workspace registered with `rly up`; agents spawn inside that workspace, operate on the code, open PRs, and report back. The Tauri GUI in this handoff is the surface humans use to talk to those agents — a Slack-inspired chat app where **channels are scoped to one or more repos** and **the people you message in a channel are both humans and repo-attached agents**.
+
+If you're unfamiliar with Relay, the important thing to internalize is this: **a channel is not just a conversation, it's a repo-scoped execution context.** When you ping `@relay` in `#oauth-api-users`, you are addressing an agent running in the `relay` repo's workspace. That agent can plan tickets, write code, open PRs, and post back — and other attached repos' agents (say `@flowtide`) can be pinged from the same channel to coordinate cross-repo changes.
+
+## 2. What to build — the Tidewater GUI
+
+Recreate **Direction C (Tidewater)** in a new or existing Tauri shell. Tidewater is the final visual/interaction design. The other design files (`direction-a-*.jsx`, the design canvas, the design-only `new-channel` and `settings` artboards) are reference and dependency only — you do not need to ship the design canvas or any of the A/B alternates.
+
+**Stack assumption:** Tauri + a React frontend (the design files are all JSX). If the Tauri project uses a different frontend framework (Svelte, Solid, vanilla web components), port the designs faithfully using that framework's conventions — the design files are the visual source of truth, not the implementation.
+
+**Fidelity: high.** Pixel-accurate colors, typography, spacing, interaction states, and microcopy are intentional. `tokens.json` is the extracted palette + scale; use it to generate CSS vars or a theme object.
+
+---
+
+## 3. The design files
+
+Everything in `design/` can be opened locally — copy the folder somewhere, add the HTML loader below, and you have a working prototype.
+
+```
+design/
+├── relay-data.jsx          # Mock data: AGENTS, CHANNELS, DMS, ACTIVITY,
+│                           #   REPOS (deprecated global list), AVAILABLE_WORKSPACES
+├── design-canvas.jsx       # Canvas wrapper for multi-artboard layout (reference only)
+├── direction-a-base.jsx    # Tide palette (A object), icon set (I), Avatar, agent color hash,
+│                           #   WorkspaceRail — imported by Tidewater
+├── direction-a-sidebar.jsx # Left sidebar (Activity / Starred / Channels / DMs) — reused by C
+├── direction-a-header.jsx  # A's header (C does NOT use this — C has its own ChannelHeader)
+├── direction-a-chat.jsx    # A's MessageList + Composer — C overrides both with its own
+├── direction-a-right.jsx   # A's right-pane bodies (PrThread, DecisionDrawer) — reused by C
+├── direction-a-app.jsx     # A's top-level App — reference only
+├── direction-c-repos.jsx   # ★ C-specific: RepoChipRow, ChannelSettingsDrawer,
+│                           #   NewChannelModal, MentionPopover, renderWithMentions
+└── direction-c-tidewater.jsx # ★ C's main component: DirectionC, ChannelHeader, BoardView,
+                              #   DecisionsView, MessageListC, ComposerC, RightRail, DmView
+```
+
+### Loading the reference locally
+To view the designs as a working React app, create an `index.html` next to `design/`:
+
+```html
+<!doctype html><html><head><meta charset="utf-8">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" crossorigin></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>html,body,#r{margin:0;height:100%;background:#0e1420;font-family:Inter,sans-serif}*{box-sizing:border-box}</style>
+</head><body><div id="r" style="width:1480px;height:920px"></div>
+<script type="text/babel" src="design/relay-data.jsx"></script>
+<script type="text/babel" src="design/direction-a-base.jsx"></script>
+<script type="text/babel" src="design/direction-a-sidebar.jsx"></script>
+<script type="text/babel" src="design/direction-a-header.jsx"></script>
+<script type="text/babel" src="design/direction-a-chat.jsx"></script>
+<script type="text/babel" src="design/direction-a-right.jsx"></script>
+<script type="text/babel" src="design/direction-a-app.jsx"></script>
+<script type="text/babel" src="design/direction-c-repos.jsx"></script>
+<script type="text/babel" src="design/direction-c-tidewater.jsx"></script>
+<script type="text/babel">ReactDOM.createRoot(document.getElementById('r')).render(<DirectionC tweaks={{avatarStyle:'glyph',density:'medium'}}/>);</script>
+</body></html>
+```
+
+---
+
+## 4. What's new (critical — read this before implementing)
+
+Tidewater introduces several concepts that don't exist in the current Relay CLI and will need backend support. **This is the part most likely to cause confusion — read all of it.**
+
+### 4.1 Repos are channel-scoped, not global
+
+The earlier iteration had a global "Repos" section in the sidebar. That's gone.
+- Workspaces registered via `rly up` live in a **global pool** — see `AVAILABLE_WORKSPACES` in `relay-data.jsx`.
+- A workspace only becomes a pingable `@alias` agent **after it's attached to a channel**.
+- Each channel has an array `repos: string[]` (aliases) and a single `primaryRepo: string`.
+- The **primary repo** hosts the channel's main agent — the one that receives the channel's first message and does classification / ticket planning.
+
+> **Backend contract:** the daemon needs an API to (a) list registered workspaces, (b) attach/detach a workspace to a channel, (c) promote a non-primary attached repo to primary. A repo may be attached to many channels simultaneously. Each (channel, repo) pair spawns its own agent instance with its own working directory state — attaching `@relay` to two channels gives you two independent agents.
+
+### 4.2 `@alias` mentions as a first-class pingable
+
+In Tidewater, typing `@` in the composer opens a Slack-style popover (see `MentionPopover` in `direction-c-repos.jsx`) listing **the channel's attached repos + channel members**. Picking one inserts `@alias` as a styled chip.
+
+- Primary repo mentions render in **coral** (the accent color)
+- Non-primary attached repos render in **slate-blue**
+- Human mentions (`@jcast`, `@channel`) render in **mint green**
+- The `renderWithMentions(text, channel)` helper is the single tokenizer — it handles `@alias`, `**bold**`, and `` `code` ``. Messages from your chat store should flow through it.
+
+> **Backend contract:** messages in channels carry a `mentions: Array<{kind: 'repo'|'human', alias: string}>`. When the daemon receives a message, the primary agent is always addressed by default; non-primary repo mentions trigger a cross-agent ping (the other repo's agent gets the message + a crosslink reference). Crosslinks from other channels/DMs arrive as a `crosslink` message kind.
+
+### 4.3 Channel header is **interactive for repo management**
+
+Open `direction-c-tidewater.jsx` → `ChannelHeader` and `direction-c-repos.jsx` → `RepoChipRow`. The header has:
+- **Row 1:** `#` + channel name + tier badge + star + topic (truncates) | agent stack | right-rail toggle
+- **Row 2 (tabs):** `Chat | Board | Decisions` tabs | **RepoChipRow** (right-aligned)
+
+The RepoChipRow is where inline repo management lives:
+- Each chip is clickable — opens a popover with "Set as primary", "Detach", etc.
+- Hovering a non-primary chip reveals an `×` shortcut to detach.
+- The primary chip cannot be directly detached; the user must promote another repo first.
+- A trailing `+` chip opens `AddRepoPopover`, which lists un-attached workspaces from `AVAILABLE_WORKSPACES`.
+- The gear icon next to the chips opens `ChannelSettingsDrawer` (see below).
+
+### 4.4 Channel settings drawer
+
+Gear icon → right-side slide-over (`ChannelSettingsDrawer` in `direction-c-repos.jsx`). Tabs: **Repos | Members | About**. The Repos tab is the full-fidelity version of the header chip controls — useful for managing many repos at once. Members and About are scaffolded but deliberately thin (members are inferred from who's posted; About shows topic + tier).
+
+### 4.5 New-channel modal (3-step)
+
+`NewChannelModal` in `direction-c-repos.jsx`. Three steps:
+1. **Basics** — channel name + optional topic. Name is auto-slugged.
+2. **Repos** — multi-select from `AVAILABLE_WORKSPACES`. Radio for primary. Shows last-active + open-PR count per workspace. First-selected repo becomes primary by default.
+3. **Kick off** — free-text first message. This goes straight to the primary agent; classifier decides tier + ticket plan.
+
+Entry points:
+- `+` button next to "CHANNELS" in the sidebar
+- A DM can be **promoted** to a channel (`DmView.onPromote` → opens the same modal, prefilled with the DM's agent's repo as primary). This is the "DM as kickoff surface" pattern — users often start informally in a DM, then promote once the work is real.
+
+> **Backend contract:** channel creation is a single atomic operation that (a) creates the channel record, (b) attaches each selected workspace, (c) sets primary, (d) posts the first message and triggers classification. If classification resolves to a `feature_large` or similar, the planner then fans out tickets across attached repos — this already exists in the CLI path, just needs a GUI-facing API.
+
+### 4.6 DMs
+DMs are direct-to-agent (not direct-to-human). A yellow banner at the top of a DM explains they're "kickoff surfaces" — you talk 1:1 with an agent; if the conversation becomes real work, promote it to a channel. The composer placeholder hints at `/new` as the slash-command path to promote.
+
+### 4.7 Messaging — markdown + mentions
+`renderWithMentions(text, channel)` is the single render path for message body text in channels, DMs, and decisions. It recognises:
+- `**bold**` → `<strong>`
+- `` `code` `` → inline code chip with paper-alt background
+- `@alias` → repo-or-human chip
+
+No other markdown. No links are auto-linkified in bodies (they appear raw) — if you need that, add it to `renderWithMentions` in one place.
+
+---
+
+## 5. Screens and layout
+
+Sizes below are the absolute values in the designs. They're designed against a **1480×920** frame; if the Tauri window can resize, treat the sidebar / rails as fixed-width and let the center pane flex.
+
+### 5.1 Global shell
+
+```
+[ 58 Workspace rail ] [ 230 Sidebar ] [ flex Center pane ] [ 360 Right rail (collapsible) ]
+```
+Min pane height fills viewport. `overflow: auto` only inside the three scroll regions: sidebar channel list, message list, right-rail panes.
+
+### 5.2 Sidebar (left) — `direction-a-sidebar.jsx`
+- Workspace header (big R avatar + "Relay" + user subtitle)
+- Activity row, Threads row, Running row (badges on the right)
+- **Starred** section (collapsible)
+- **Channels** section with `+` → new-channel modal
+- **Direct messages** section
+- **No Repos section** — pass `repos={[]}` to `Sidebar` to hide it
+
+### 5.3 Channel center pane — `direction-c-tidewater.jsx`
+- `ChannelHeader` (see §4.3)
+- Pane selector tabs inside the header (Chat | Board | Decisions)
+- `MessageListC` + `ComposerC` when pane is `chat`
+- `BoardView` (dense list: ID, Status pill, Title, Agent, PR link) when `board`
+- `DecisionsView` when `decisions`
+- `ChannelSettingsDrawer` mounted as an overlay when `settingsOpen`
+
+### 5.4 Right rail — `RightRail`
+Tabs: **Threads | Decisions | PRs**. Each tab shows a list; clicking an item opens a detail view reusing A's `PrThread` / `DecisionDrawer` bodies. Auto-switches to "PRs" when the channel has a failing CI.
+
+### 5.5 Composer — `ComposerC`
+- Leading `→ @primaryRepo` chip (fixed; indicates where the message routes by default)
+- `Auto-approve` toggle
+- Hint text (truncates first at narrow widths)
+- `⌘⏎` affordance + Send button
+- **Mention autocomplete**: type `@` anywhere; popover mounts above the composer, ↑↓ to navigate, Enter/Tab to accept
+
+### 5.6 Modals and drawers
+- **NewChannelModal** — centered, 640px wide, 3 steps
+- **ChannelSettingsDrawer** — right-side, 460px wide, dimmed backdrop
+- **AddRepoPopover**, **MentionPopover**, **RepoChipRow popovers** — anchored floating popovers, dismiss on outside click or Escape
+
+---
+
+## 6. Data shapes (UI-facing contracts)
+
+These are the only contracts the UI cares about. The daemon can have richer internal representations; these are the projections it needs to serve to the GUI.
+
+```ts
+type Workspace = {
+  workspaceId: string;      // stable id
+  path: string;             // human-readable, e.g. "~/code/relay"
+  defaultAlias: string;     // basename(path) unless user overrode
+  lastActive: string;       // humanized, e.g. "2m", "3d"
+  openPrs: number;
+};
+
+type Channel = {
+  id: string;
+  name: string;             // e.g. "oauth-api-users" (no leading #)
+  topic: string;
+  tier: 'feature_large' | 'feature' | 'bugfix' | 'chore' | 'question';
+  starred: boolean;
+  repos: string[];          // aliases — each an attached workspace
+  primaryRepo: string;      // must be in repos[]
+  agents: string[];         // agent ids sourced from AGENTS
+  messages: Message[];
+  tickets: Ticket[];
+  decisions: Decision[];
+  prs: Pr[];
+  activeAt: string;         // humanized
+};
+
+type Message = {
+  id: string;
+  kind: 'user' | 'assistant' | 'system' | 'tool' | 'crosslink';
+  author: string;           // user id or agent id
+  text: string;             // rendered via renderWithMentions()
+  time: string;             // humanized or HH:MM
+  // Optional: mentions: Array<{ kind: 'repo'|'human', alias: string }>
+  //   — the UI can re-derive these from text + channel, but having them
+  //     server-side simplifies notification routing.
+};
+
+type Ticket = {
+  id: string;               // e.g. "T-1"
+  title: string;
+  status: 'pending'|'ready'|'executing'|'verifying'|'completed'|'failed'|'blocked'|'retry';
+  agent: string;            // agent id
+  pr?: number;
+  specialty?: string;       // for the Board group-by-specialty view
+};
+
+type Pr = {
+  number: number;
+  title: string;
+  branch: string;
+  repo: string;              // alias
+  agent: string;             // agent id
+  ci: 'passing'|'failing'|'pending';
+  review: 'approved'|'pending'|'changes_requested';
+};
+
+type Decision = {
+  id: string;
+  title: string;
+  summary: string;
+  madeBy: string;            // agent or 'you'
+  time: string;
+};
+
+type Dm = {
+  id: string;
+  agentId: string;
+  messages: Message[];
+};
+
+type Agent = {
+  id: string;
+  name: string;              // e.g. "Saturn"
+  glyph: string;             // short, e.g. "♄"
+  provider: string;          // e.g. "claude"
+  status: 'idle' | 'working';
+  repoAlias?: string;        // which repo alias this agent is attached to
+  specialty?: string;
+};
+```
+
+### 6.1 Backend-facing actions the UI dispatches
+
+| UI action | Backend call (suggested) |
+|---|---|
+| Sidebar `+` → create channel | `POST /channels { name, topic, repos, primary, firstMessage }` |
+| Attach repo from header `+` popover | `POST /channels/:id/repos { alias }` |
+| Detach repo from chip popover | `DELETE /channels/:id/repos/:alias` |
+| Promote to primary | `PATCH /channels/:id { primaryRepo: alias }` |
+| DM → promote to channel | same as create, with DM messages as context |
+| Send message (composer) | `POST /channels/:id/messages { text, targetRepo, autoApprove }` |
+| Toggle auto-approve | channel-scoped setting; persists to `PATCH /channels/:id` |
+
+None of these are implemented — see §8.
+
+---
+
+## 7. Design tokens
+
+See `tokens.json` for the complete palette + scale. Key bindings:
+
+### Colors
+| Token | Hex | Use |
+|---|---|---|
+| `ink.deepest` | `#0e1420` | Workspace rail, app frame |
+| `ink.deep` | `#141b2a` | Sidebar background |
+| `ink.panel` | `#1a2232` | Raised panels on the rail |
+| `paper.base` | `#fbf9f4` | Center pane, drawers, modals |
+| `paper.alt` | `#f3f0e7` | Inputs, chip bg, muted zones |
+| `paper.line` | `#e5e1d5` | Borders on paper |
+| `text.primary` | `#1b1f2a` | Body text on paper |
+| `text.muted` | `#5b6579` | Secondary text |
+| `text.dim` | `#8a93a5` | Tertiary / placeholder |
+| **`accent.coral`** | `#e65a4f` | **Primary accent** — active tab, primary repo, CTA, selected channel |
+| `accent.coralSoft` | `#fbe1dd` | Coral backgrounds, selected-row bg |
+| `accent.amber` | `#e89a2b` | Executing status, working indicator pulse |
+| `accent.mint` | `#3fb984` | Idle/online presence, success |
+| `accent.sky` | `#4a7fd0` | Info / links |
+| `accent.magenta` | `#c44d8a` | Agent color hash entry |
+
+### Type
+- **UI:** Inter — 400/500/600/700
+- **Mono:** JetBrains Mono for code, aliases, paths
+- Sizes: sidebar items 13px, message body 14.5px, header 16px, section headers 10.5px uppercase
+
+### Spacing + radius
+- 2 / 4 / 6 / 8 / 10 / 12 / 14 / 16 / 20 / 24 / 32 px base scale
+- Radius: chips 3px, pills 14px, cards 6px, popovers 6–8px, modals 12px
+
+### Shadows
+- Popover: `0 6px 18px rgba(0,0,0,0.08)`
+- Modal: `0 24px 80px rgba(0,0,0,0.2)`
+- Drawer: `-16px 0 48px rgba(0,0,0,0.15)`
+
+---
+
+## 8. Not yet built (open TODOs)
+
+These were scoped but not implemented in the design. The patterns are sketched in the files — finish them in the Tauri app.
+
+1. **`/new` slash command inside DMs** — typing `/new` at the start of a DM composer should surface an inline action to promote the DM to a channel. Currently the user has to click "Promote" or trigger from the DM header. The wire is stubbed (`DmView.onPromote` already opens `NewChannelModal`); just add the slash-command parser to `ComposerC`.
+2. **Crosslink DM→channel promote pre-fill** — when promoting, carry over the DM's agent's repo alias as the primary and inject the DM messages into the new channel's history as a crosslink thread. Modal supports an `initial` prop scaffolded for this.
+3. **Visual tweaks panel** — the `tweaks` prop on `DirectionC` accepts `{ avatarStyle, density }` but there's no UI to flip them. Add a Tweaks drawer if desired (standard dev-tool pattern) — the design skill has a helper for this but it's not wired in.
+4. **Attach-on-command** — when a user types `@foo` and `foo` is a registered workspace but **not attached** to the channel, offer a "Attach @foo to this channel?" inline action instead of falling through to plain text. `MentionPopover` currently only lists already-attached repos; extending the data model is trivial.
+5. **Mention notifications for absent repos** — if `@saturn` is pinged in `#release-3-0` but `saturn` isn't attached, the UI currently renders it as a plain text chip. Product decision needed.
+6. **Decisions view polish** — the tab exists and renders `DecisionDrawer` bodies but hasn't been stress-tested with long lists.
+7. **Board view filters** — sort / group is implemented; adding a search box + status multi-select would help at scale.
+
+---
+
+## 9. Notes for the developer
+
+- **Framework:** if the Tauri shell is already React + TypeScript, split the files roughly the same way — `base` (tokens + primitives), `sidebar`, `header`, `chat`, `right-rail`, `repos` (modal + settings + mentions + chip row), `app`. The design uses inline `style={}` objects — convert to CSS modules or your styling library of choice; the colors and measurements are the important part.
+- **Do not copy the IIFE + `window.RELAY_*` pattern.** That's a browser-only thing for loading JSX files without a bundler. Use normal ES imports.
+- **Tauri IPC:** all the backend contracts in §6.1 map cleanly to Tauri `invoke()` commands. Keep them typed.
+- **Persistence:** channel list, selection, and right-rail open state should survive window restart. The designs have no persistence; add it via Tauri's state manager or a light wrapper around `localStorage`.
+- **Accessibility:** the designs are keyboard-friendly for the popovers (arrow keys, Enter, Escape) but not all chips are reachable with Tab. Treat the tab order as a thing to fix during implementation.
+- **Fonts:** the designs load Inter + JetBrains Mono from Google Fonts. In Tauri, bundle the fonts locally — offline is a requirement.
+- **Window size:** design frame is 1480×920 but the shell should be resizable. Fixed widths: workspace rail 58px, sidebar 230px, right rail 360px. Everything else flexes.
+
+---
+
+## 10. Quick orientation checklist
+
+Open `design/direction-c-tidewater.jsx` and search for:
+- `function DirectionC(` — top-level component (§5)
+- `function ChannelHeader(` — header layout (§4.3, §5.3)
+- `function BoardView(` — list-view alternative to chat pane
+- `function MessageListC(` / `function MessageC(` — message rendering
+- `function ComposerC(` — composer with mention autocomplete (§5.5)
+- `function RightRail(` — tabbed right pane (§5.4)
+- `function DmView(` — DM surface (§4.6)
+
+Then open `design/direction-c-repos.jsx`:
+- `RepoChipRow` — header chip row (§4.3)
+- `AddRepoPopover` — `+` chip popover
+- `ChannelSettingsDrawer` — gear icon drawer (§4.4)
+- `NewChannelModal` — 3-step modal (§4.5)
+- `MentionPopover` — composer `@` autocomplete (§4.2)
+- `renderWithMentions` — the single text→React renderer for all message bodies (§4.7)
+
+That's it. Everything else is composition of these primitives.

--- a/agent_docs/tidewater_handoff/design/design-canvas.jsx
+++ b/agent_docs/tidewater_handoff/design/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/agent_docs/tidewater_handoff/design/direction-a-app.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-a-app.jsx
@@ -1,0 +1,261 @@
+/* Direction A — Main app: activity view, DM view, channel view, orchestration */
+
+const { A, I, Avatar, WorkspaceRail } = window.RELAY_A;
+const { Sidebar } = window.RELAY_A_SIDEBAR;
+const { ChannelHeader, PinnedCanvas } = window.RELAY_A_HEADER;
+const { MessageList, Composer } = window.RELAY_A_CHAT;
+const { DecisionsDrawer, PrThread, ApprovalThread, TicketDetail } = window.RELAY_A_RIGHT;
+// ─────────────────────────────────────────────────────────────
+// Activity view — center when "Activity" is selected
+// ─────────────────────────────────────────────────────────────
+function ActivityView({ onGoTo }) {
+  const grouped = {
+    approvals: ACTIVITY.filter((a) => a.kind === 'approval'),
+    ci:        ACTIVITY.filter((a) => a.kind === 'ci_fail' || a.kind === 'ticket_fail'),
+    reviews:   ACTIVITY.filter((a) => a.kind === 'pr_review'),
+    mentions:  ACTIVITY.filter((a) => a.kind === 'mention'),
+  };
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', background: A.paper }}>
+      <div style={{ padding: '18px 28px 8px' }}>
+        <div style={{ fontSize: 20, fontWeight: 700, color: A.text, display: 'flex', alignItems: 'center', gap: 10 }}>
+          <I.bell style={{ color: A.coral }} /> Activity
+        </div>
+        <div style={{ fontSize: 13, color: A.textMuted, marginTop: 2 }}>
+          Plan approvals, CI failures, PR reviews, and @mentions — across every channel
+        </div>
+      </div>
+      <ActivityGroup title="Needs approval" items={grouped.approvals} accent={A.coral} onGoTo={onGoTo} />
+      <ActivityGroup title="CI failing · ticket failed" items={grouped.ci} accent={A.coral} onGoTo={onGoTo} />
+      <ActivityGroup title="Reviews" items={grouped.reviews} accent={A.amber} onGoTo={onGoTo} />
+      <ActivityGroup title="Mentions" items={grouped.mentions} accent={A.sky} onGoTo={onGoTo} />
+    </div>
+  );
+}
+
+function ActivityGroup({ title, items, accent, onGoTo }) {
+  if (!items.length) return null;
+  return (
+    <div style={{ padding: '12px 28px' }}>
+      <div style={{
+        fontSize: 11, fontWeight: 700, color: A.textMuted,
+        letterSpacing: '0.04em', marginBottom: 8, display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: accent }} />
+        {title.toUpperCase()} · {items.length}
+      </div>
+      {items.map((a) => {
+        const agent = AGENTS.find((x) => x.id === a.agent);
+        return (
+          <div key={a.id} onClick={() => onGoTo(a)} style={{
+            display: 'flex', gap: 12, alignItems: 'flex-start',
+            padding: '12px 14px', marginBottom: 6,
+            background: A.paper, border: `1px solid ${A.paperLine}`,
+            borderRadius: 8, cursor: 'pointer', transition: 'all 0.12s',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.borderColor = accent; e.currentTarget.style.background = A.paperAlt; }}
+          onMouseLeave={(e) => { e.currentTarget.style.borderColor = A.paperLine; e.currentTarget.style.background = A.paper; }}
+          >
+            {agent && <Avatar agent={agent} size={32} />}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13.5, fontWeight: 600, color: A.text }}>{a.title}</div>
+              <div style={{ fontSize: 12.5, color: A.textMuted, marginTop: 2 }}>{a.detail}</div>
+              <div style={{ fontSize: 11, color: A.textDim, marginTop: 4, display: 'flex', gap: 8 }}>
+                <span>#{a.channel}</span><span>·</span><span>{a.time} ago</span>
+              </div>
+            </div>
+            <button style={{
+              padding: '5px 10px', borderRadius: 5, fontSize: 11.5, fontWeight: 600,
+              background: accent, color: '#fff', border: 'none', cursor: 'pointer',
+              flexShrink: 0,
+            }}>Go to</button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DM view
+// ─────────────────────────────────────────────────────────────
+function DmView({ dm, agent, avatarStyle, onPromote }) {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: A.paper }}>
+      <div style={{
+        padding: '12px 20px', borderBottom: `1px solid ${A.paperLine}`,
+        display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0,
+      }}>
+        <Avatar agent={agent} size={36} style={avatarStyle} showStatus />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 700, color: A.text }}>{agent.name}</div>
+          <div style={{ fontSize: 12, color: A.textMuted }}>
+            {agent.provider} · {agent.status === 'working' ? (
+              <span style={{ color: A.amber }}>⚙ {agent.activity || 'working'}</span>
+            ) : (
+              <span>{agent.status}</span>
+            )}
+          </div>
+        </div>
+        <button onClick={onPromote} style={{
+          padding: '7px 12px', borderRadius: 6,
+          background: A.coral, color: '#fff', border: 'none',
+          fontSize: 12.5, fontWeight: 600, cursor: 'pointer',
+          display: 'flex', alignItems: 'center', gap: 6,
+        }}><I.hash /> Promote to channel</button>
+      </div>
+
+      <div style={{
+        padding: '8px 20px', background: A.paperAlt,
+        borderBottom: `1px solid ${A.paperLine}`,
+        fontSize: 12, color: A.textMuted, display: 'flex', gap: 10, alignItems: 'center',
+      }}>
+        <I.spark style={{ color: A.coral }} />
+        <span>
+          DMs are <strong style={{ color: A.text }}>kickoff surfaces</strong> — your first request here can promote into a channel with attached repos. Crosslink messages from {agent.name} show up here.
+        </span>
+      </div>
+
+      <MessageList messages={dm.messages} avatarStyle={avatarStyle} />
+      <Composer placeholder={`Message ${agent.name}... (paste an issue URL or /new to spin up a channel)`} />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Channel view
+// ─────────────────────────────────────────────────────────────
+function ChannelView({
+  channel, avatarStyle, onOpenDecisions, decisionsOpen,
+  onOpenTicket, onOpenPr, rightOpen,
+}) {
+  const [canvasCollapsed, setCanvasCollapsed] = useState(false);
+  const agents = channel.agents.map((id) => AGENTS.find((a) => a.id === id)).filter(Boolean);
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: A.paper }}>
+      <ChannelHeader channel={channel} agents={agents}
+                    onOpenDecisions={onOpenDecisions} decisionsOpen={decisionsOpen} />
+      <PinnedCanvas channel={channel}
+                    collapsed={canvasCollapsed}
+                    onToggle={() => setCanvasCollapsed(!canvasCollapsed)}
+                    onOpenTicket={onOpenTicket}
+                    onOpenPr={onOpenPr} />
+      <MessageList messages={channel.messages} avatarStyle={avatarStyle} />
+      <Composer channel={channel} />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Empty state
+// ─────────────────────────────────────────────────────────────
+function EmptyState({ title, subtitle, icon }) {
+  return (
+    <div style={{
+      flex: 1, background: A.paper, display: 'flex',
+      alignItems: 'center', justifyContent: 'center',
+    }}>
+      <div style={{ textAlign: 'center', maxWidth: 400, padding: 40 }}>
+        <div style={{
+          width: 60, height: 60, margin: '0 auto 18px',
+          borderRadius: 14, background: A.coralSoft, color: A.coral,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 28,
+        }}>{icon}</div>
+        <div style={{ fontSize: 18, fontWeight: 700, color: A.text, marginBottom: 6 }}>{title}</div>
+        <div style={{ fontSize: 13.5, color: A.textMuted, lineHeight: 1.55 }}>{subtitle}</div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Main App
+// ─────────────────────────────────────────────────────────────
+function DirectionA({ tweaks }) {
+  const [selection, setSelection] = useState({ type: 'channel', id: 'oauth-api-users' });
+  const [right, setRight] = useState(null); // { kind, payload }
+  const avatarStyle = tweaks?.avatarStyle || 'glyph';
+
+  const channel = selection.type === 'channel'
+    ? CHANNELS.find((c) => c.id === selection.id)
+    : null;
+  const dm = selection.type === 'dm'
+    ? DMS.find((d) => d.id === selection.id)
+    : null;
+  const dmAgent = dm ? AGENTS.find((a) => a.id === dm.agentId) : null;
+
+  // Reset right pane when selection changes
+  useEffect(() => { setRight(null); }, [selection.type, selection.id]);
+
+  const handleGoTo = (activityItem) => {
+    setSelection({ type: 'channel', id: activityItem.channel });
+    if (activityItem.kind === 'approval') setRight({ kind: 'approval' });
+    else if (activityItem.kind === 'ci_fail' || activityItem.kind === 'pr_review') {
+      const ch = CHANNELS.find((c) => c.id === activityItem.channel);
+      const pr = ch?.prs?.[activityItem.kind === 'ci_fail' ? 1 : 0];
+      if (pr) setRight({ kind: 'pr', payload: pr });
+    }
+  };
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', display: 'flex',
+      background: A.inkDeepest, color: A.text,
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif',
+      fontSize: 14,
+    }}>
+      <WorkspaceRail current="relay" />
+      <Sidebar
+        channels={CHANNELS} dms={DMS} activity={ACTIVITY} repos={REPOS}
+        selection={selection} onSelect={setSelection}
+        onNewChannel={() => alert('Open new channel modal')}
+        onOpenActivity={() => setSelection({ type: 'activity' })}
+        avatarStyle={avatarStyle}
+      />
+
+      {/* Main area */}
+      {selection.type === 'channel' && channel && (
+        <ChannelView
+          channel={channel} avatarStyle={avatarStyle}
+          onOpenDecisions={() => setRight(right?.kind === 'decisions' ? null : { kind: 'decisions' })}
+          decisionsOpen={right?.kind === 'decisions'}
+          onOpenTicket={(t) => setRight({ kind: 'ticket', payload: t })}
+          onOpenPr={(pr) => setRight({ kind: 'pr', payload: pr })}
+        />
+      )}
+      {selection.type === 'dm' && dm && dmAgent && (
+        <DmView dm={dm} agent={dmAgent} avatarStyle={avatarStyle}
+               onPromote={() => alert(`Promote DM with ${dmAgent.name} to a new channel`)} />
+      )}
+      {selection.type === 'activity' && <ActivityView onGoTo={handleGoTo} />}
+      {selection.type === 'threads' && (
+        <EmptyState icon="🧵" title="Threads"
+                    subtitle="Your recent right-pane threads — PR reviews, approvals, ticket discussions — will live here." />
+      )}
+      {selection.type === 'running' && (
+        <EmptyState icon="⚙" title="Running tasks"
+                    subtitle="Every active agent across every workspace. Same data as `rly running`." />
+      )}
+
+      {/* Right pane */}
+      {right?.kind === 'decisions' && channel && (
+        <DecisionsDrawer channel={channel} onClose={() => setRight(null)} />
+      )}
+      {right?.kind === 'pr' && (
+        <PrThread pr={right.payload} channel={channel} onClose={() => setRight(null)} />
+      )}
+      {right?.kind === 'approval' && channel && (
+        <ApprovalThread channel={channel} onClose={() => setRight(null)}
+                       onApprove={() => { alert('Plan approved — 6 tickets dispatched'); setRight(null); }}
+                       onReject={() => { alert('Plan rejected'); setRight(null); }} />
+      )}
+      {right?.kind === 'ticket' && channel && (
+        <TicketDetail ticket={right.payload} channel={channel} onClose={() => setRight(null)} />
+      )}
+    </div>
+  );
+}
+
+window.DirectionA = DirectionA;

--- a/agent_docs/tidewater_handoff/design/direction-a-base.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-a-base.jsx
@@ -1,0 +1,177 @@
+/* Direction A — "Tide"
+   Fresh modern palette, Slack's 3-pane layout.
+   - Deep ink sidebar, soft paper center, cream right rail
+   - Coral/salmon accent, fresh mint success
+   - Board lives as a pinned Canvas at the top of channel (collapsible)
+   - Decisions live in a sidebar drawer (right-pane)
+   - PRs/approvals open as right-pane threads
+   - Agent presence shown as inline tool-use text (not dots)
+   - DM-first: any DM can be "promoted" to a channel
+*/
+
+window.__RELAY_R = window.__RELAY_R || {};
+window.__RELAY_R.useState = window.__RELAY_R.useState || React.useState;
+window.__RELAY_R.useEffect = window.__RELAY_R.useEffect || React.useEffect;
+window.__RELAY_R.useRef = window.__RELAY_R.useRef || React.useRef;
+window.__RELAY_R.useMemo = window.__RELAY_R.useMemo || React.useMemo;
+const useState = window.__RELAY_R.useState;
+const useEffect = window.__RELAY_R.useEffect;
+const useRef = window.__RELAY_R.useRef;
+const useMemo = window.__RELAY_R.useMemo;
+const { AGENTS, REPOS, CHANNELS, DMS, ACTIVITY } = window.RELAY_DATA;
+
+const A = {
+  // Tide palette
+  inkDeepest: '#0e1420',
+  inkDeep:    '#141b2a',
+  inkPanel:   '#1a2232',
+  inkRaised:  '#232c40',
+  inkLine:    '#2b3550',
+
+  paper:      '#fbf9f4',
+  paperAlt:   '#f3f0e7',
+  paperLine:  '#e5e1d5',
+
+  text:       '#1b1f2a',
+  textMuted:  '#5b6579',
+  textDim:    '#8a93a5',
+  textOnDark: '#e8ecf4',
+  textOnDarkMuted: '#8a93a5',
+
+  coral:      '#e65a4f',   // primary accent
+  coralSoft:  '#fbe1dd',
+  amber:      '#e89a2b',
+  mint:       '#3fb984',
+  mintSoft:   '#d9f1e6',
+  sky:        '#4a7fd0',
+  magenta:    '#c44d8a',
+
+  // status for tickets
+  statusFill: {
+    pending:   '#d0d4de',
+    ready:     '#86a6d9',
+    executing: '#e89a2b',
+    verifying: '#7a6fd0',
+    completed: '#3fb984',
+    failed:    '#e65a4f',
+    blocked:   '#9ba3b6',
+    retry:     '#d88a3b',
+  },
+};
+
+// ─────────────────────────────────────────────────────────────
+// Icons (minimal inline SVG)
+// ─────────────────────────────────────────────────────────────
+const I = {
+  hash:     (p) => <svg {...p} width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M3 5h9M2.5 9h9M6 2L5 12M9 2L8 12" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>,
+  star:     (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 1l1.5 3.3 3.5.4-2.6 2.4.7 3.5L6 9l-3.1 1.6.7-3.5L1 5.1l3.5-.4L6 1z" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round"/></svg>,
+  starFill: (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M6 1l1.5 3.3 3.5.4-2.6 2.4.7 3.5L6 9l-3.1 1.6.7-3.5L1 5.1l3.5-.4L6 1z"/></svg>,
+  lock:     (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="2.5" y="5.5" width="7" height="5" rx="1" stroke="currentColor" strokeWidth="1.1"/><path d="M4 5.5V4a2 2 0 1 1 4 0v1.5" stroke="currentColor" strokeWidth="1.1"/></svg>,
+  at:       (p) => <svg {...p} width="14" height="14" viewBox="0 0 14 14" fill="none"><circle cx="7" cy="7" r="2.2" stroke="currentColor" strokeWidth="1.2"/><path d="M9.2 7v1a1.5 1.5 0 0 0 3 0V7a5.2 5.2 0 1 0-2.1 4.2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/></svg>,
+  bell:     (p) => <svg {...p} width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M3 10h8l-1.2-1.8V6a2.8 2.8 0 0 0-5.6 0v2.2L3 10zM6 11.5a1 1 0 0 0 2 0" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"/></svg>,
+  plus:     (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 2v8M2 6h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>,
+  chevR:    (p) => <svg {...p} width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M4 2l3 3-3 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  chevD:    (p) => <svg {...p} width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M2 4l3 3 3-3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  send:     (p) => <svg {...p} width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M2 7l10-5-4 10-1.5-4L2 7z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>,
+  folder:   (p) => <svg {...p} width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M2 4a1 1 0 0 1 1-1h3l1 1h4a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4z" stroke="currentColor" strokeWidth="1.2"/></svg>,
+  close:    (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>,
+  check:    (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2.5 6.5l2.5 2.5 4.5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  spark:    (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 1l1.2 3.3 3.3 1.2-3.3 1.2L6 10l-1.2-3.3L1.5 5.5l3.3-1.2L6 1z" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round"/></svg>,
+  flask:    (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M5 1v3L2.5 9a1.5 1.5 0 0 0 1.3 2.2h4.4A1.5 1.5 0 0 0 9.5 9L7 4V1M4 1h4" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round"/></svg>,
+  gear:     (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><circle cx="6" cy="6" r="1.8" stroke="currentColor" strokeWidth="1.1"/><path d="M6 1.5v1.3M6 9.2v1.3M1.5 6h1.3M9.2 6h1.3M2.8 2.8l.9.9M8.3 8.3l.9.9M2.8 9.2l.9-.9M8.3 3.7l.9-.9" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/></svg>,
+  repo:     (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 2v8M3 2h6a1 1 0 0 1 1 1v6M3 10h7M5 4v2l1-.7L7 6V4" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round"/></svg>,
+  pr:       (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><circle cx="3" cy="3" r="1.2" stroke="currentColor" strokeWidth="1.1"/><circle cx="3" cy="9" r="1.2" stroke="currentColor" strokeWidth="1.1"/><circle cx="9" cy="9" r="1.2" stroke="currentColor" strokeWidth="1.1"/><path d="M3 4.2v3.6M9 7.8V5.5a1.5 1.5 0 0 0-1.5-1.5H6" stroke="currentColor" strokeWidth="1.1"/><path d="M7.3 2.8L6 4l1.3 1.2" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  book:     (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2.5 2.5h3a1.5 1.5 0 0 1 1.5 1.5v6a1.5 1.5 0 0 0-1.5-1.5h-3v-6zM9.5 2.5h-3A1.5 1.5 0 0 0 5 4v6a1.5 1.5 0 0 1 1.5-1.5h3v-6z" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round"/></svg>,
+  canvas:   (p) => <svg {...p} width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="1.5" y="2.5" width="9" height="7" rx="1" stroke="currentColor" strokeWidth="1.1"/><path d="M3.5 5h2M3.5 7h5M6.5 5h2" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/></svg>,
+  search:   (p) => <svg {...p} width="13" height="13" viewBox="0 0 13 13" fill="none"><circle cx="5.5" cy="5.5" r="3.5" stroke="currentColor" strokeWidth="1.3"/><path d="M8.5 8.5l3 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>,
+};
+
+// ─────────────────────────────────────────────────────────────
+// Avatar — shows agent glyph or initials, with tool-use halo when working
+// ─────────────────────────────────────────────────────────────
+function Avatar({ agent, size = 28, style = 'glyph', showStatus = false }) {
+  if (!agent) return null;
+  const content = style === 'glyph'
+    ? agent.glyph
+    : agent.name.slice(0, 2).toUpperCase();
+  const bg = agentColor(agent.id);
+  return (
+    <div style={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
+      <div style={{
+        width: size, height: size, borderRadius: size * 0.22,
+        background: bg, color: '#fff',
+        fontSize: size * 0.42, fontWeight: 600,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontFamily: style === 'glyph' ? 'ui-monospace, "SF Mono", Menlo, monospace' : 'inherit',
+        letterSpacing: style === 'glyph' ? 0 : '-0.02em',
+      }}>
+        {content}
+      </div>
+      {showStatus && agent.status === 'working' && (
+        <div style={{
+          position: 'absolute', bottom: -1, right: -1,
+          width: size * 0.32, height: size * 0.32, borderRadius: '50%',
+          background: A.amber, border: `2px solid ${A.paper}`,
+          animation: 'relay-pulse 1.6s ease-in-out infinite',
+        }} />
+      )}
+      {showStatus && agent.status === 'idle' && (
+        <div style={{
+          position: 'absolute', bottom: -1, right: -1,
+          width: size * 0.28, height: size * 0.28, borderRadius: '50%',
+          background: A.mint, border: `2px solid ${A.paper}`,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function agentColor(id) {
+  const palette = ['#3e5886', '#9c5a7c', '#2f7a6a', '#b26a3a', '#5b5fb0', '#c8654a', '#5a7a4a', '#7a5290', '#3a7590'];
+  let h = 0; for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return palette[Math.abs(h) % palette.length];
+}
+
+// ─────────────────────────────────────────────────────────────
+// LEFT SIDEBAR (Workspace rail + nav)
+// ─────────────────────────────────────────────────────────────
+function WorkspaceRail({ current, onPick }) {
+  const workspaces = [
+    { id: 'relay', name: 'Relay', glyph: 'R', tint: A.coral },
+    { id: 'venture-os', name: 'venture-os', glyph: 'V', tint: A.sky },
+    { id: 'lci', name: 'LCI', glyph: 'L', tint: A.mint },
+  ];
+  return (
+    <div style={{
+      width: 58, background: A.inkDeepest,
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      padding: '10px 0 14px', gap: 6, borderRight: `1px solid ${A.inkLine}`,
+    }}>
+      {workspaces.map((w) => (
+        <button key={w.id} onClick={() => onPick?.(w.id)} title={w.name} style={{
+          width: 38, height: 38, borderRadius: 9,
+          background: w.id === current ? w.tint : A.inkPanel,
+          color: w.id === current ? '#fff' : A.textOnDarkMuted,
+          border: 'none', cursor: 'pointer',
+          fontSize: 14, fontWeight: 700, letterSpacing: '-0.02em',
+          boxShadow: w.id === current ? `0 0 0 2px ${A.inkDeepest}, 0 0 0 3.5px ${w.tint}` : 'none',
+          transition: 'all 0.15s',
+        }}>{w.glyph}</button>
+      ))}
+      <div style={{ height: 1, background: A.inkLine, width: 28, margin: '4px 0' }} />
+      <button title="Add workspace" style={{
+        width: 38, height: 38, borderRadius: 9,
+        background: 'transparent', border: `1.5px dashed ${A.inkLine}`,
+        color: A.textOnDarkMuted, cursor: 'pointer',
+      }}><I.plus /></button>
+      <div style={{ flex: 1 }} />
+      <button title="Settings" style={{
+        width: 38, height: 38, borderRadius: 9, background: 'transparent',
+        border: 'none', color: A.textOnDarkMuted, cursor: 'pointer',
+      }}><I.gear /></button>
+    </div>
+  );
+}
+
+// Expose to window for modular loading
+window.RELAY_A = { A, I, Avatar, agentColor, WorkspaceRail };

--- a/agent_docs/tidewater_handoff/design/direction-a-chat.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-a-chat.jsx
@@ -1,0 +1,267 @@
+/* Direction A — Chat feed, composer, right-pane threads */
+
+const { A, I, Avatar, agentColor } = window.RELAY_A;
+// ─────────────────────────────────────────────────────────────
+// Message list — Slack style, but denser when author repeats
+// ─────────────────────────────────────────────────────────────
+function MessageList({ messages, avatarStyle, onOpenThread }) {
+  if (!messages || messages.length === 0) {
+    return (
+      <div style={{
+        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: A.textDim, fontSize: 13,
+      }}>No messages yet — say something to kick off.</div>
+    );
+  }
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: '16px 0 8px' }}>
+      {messages.map((m, i) => {
+        const prev = messages[i - 1];
+        const samePrev = prev && prev.author === m.author && prev.kind === m.kind;
+        return <Message key={m.id} m={m} compact={samePrev} avatarStyle={avatarStyle} onOpenThread={onOpenThread} />;
+      })}
+    </div>
+  );
+}
+
+function Message({ m, compact, avatarStyle, onOpenThread }) {
+  const agent = m.kind === 'assistant' || m.kind === 'crosslink'
+    ? AGENTS.find((a) => a.id === m.author) : null;
+  const isSystem = m.kind === 'system';
+  const isUser = m.kind === 'user';
+
+  if (isSystem) {
+    return (
+      <div style={{
+        padding: '6px 24px', fontSize: 12.5, color: A.textMuted,
+        display: 'flex', alignItems: 'center', gap: 10,
+      }}>
+        <div style={{ flex: 1, height: 1, background: A.paperLine }} />
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <I.spark style={{ color: A.coral }} />
+          <span dangerouslySetInnerHTML={{ __html: markdownMini(m.text) }} />
+          <span style={{ color: A.textDim }}>· {m.time}</span>
+        </span>
+        <div style={{ flex: 1, height: 1, background: A.paperLine }} />
+      </div>
+    );
+  }
+
+  // Activity-only message (no text) — show inline tool-use preview card
+  if (m.activity && !m.text) {
+    const steps = m.activity.split(' · ');
+    return (
+      <div style={{ padding: compact ? '2px 24px 2px 70px' : '6px 24px 6px 24px', display: 'flex', gap: 12 }}>
+        {!compact && agent && <Avatar agent={agent} size={34} style={avatarStyle} />}
+        {compact && <div style={{ width: 34 }} />}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {!compact && agent && (
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 3 }}>
+              <span style={{ fontWeight: 700, fontSize: 14, color: A.text }}>{agent.name}</span>
+              <span style={{ fontSize: 11, color: A.textDim }}>{m.time}</span>
+            </div>
+          )}
+          <div style={{
+            background: A.paperAlt, border: `1px solid ${A.paperLine}`,
+            borderRadius: 8, padding: '8px 12px',
+            display: 'flex', flexDirection: 'column', gap: 4,
+            borderLeft: `3px solid ${A.amber}`,
+          }}>
+            <div style={{
+              fontSize: 11, fontWeight: 600, color: A.amber,
+              letterSpacing: '0.04em', textTransform: 'uppercase',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}>
+              <span style={{
+                width: 6, height: 6, borderRadius: '50%', background: A.amber,
+                animation: 'relay-pulse 1.4s ease-in-out infinite',
+              }} />
+              working · {steps.length} action{steps.length === 1 ? '' : 's'}
+            </div>
+            {steps.slice(-3).map((s, i) => (
+              <div key={i} style={{
+                fontSize: 12.5, color: i === steps.slice(-3).length - 1 ? A.text : A.textMuted,
+                fontFamily: 'ui-monospace, Menlo, monospace',
+                display: 'flex', gap: 8,
+              }}>
+                <span style={{ color: A.textDim }}>⚙</span>
+                <span>{s}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      padding: compact ? '2px 24px 2px 24px' : '6px 24px 6px 24px',
+      display: 'flex', gap: 12,
+      transition: 'background 0.1s',
+    }}
+    onMouseEnter={(e) => e.currentTarget.style.background = A.paperAlt}
+    onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+    >
+      {!compact ? (
+        isUser ? <UserAvatar /> : <Avatar agent={agent} size={34} style={avatarStyle} />
+      ) : (
+        <div style={{ width: 34, fontSize: 10, color: A.textDim, textAlign: 'right', paddingTop: 4 }}>
+          {m.time}
+        </div>
+      )}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {!compact && (
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 2 }}>
+            <span style={{ fontWeight: 700, fontSize: 14.5, color: A.text }}>
+              {isUser ? 'jcast' : (agent?.name || m.author)}
+            </span>
+            {m.kind === 'crosslink' && (
+              <span style={{
+                fontSize: 10, fontWeight: 600, padding: '1px 5px', borderRadius: 3,
+                background: A.coralSoft, color: A.coral, letterSpacing: '0.03em',
+              }}>CROSSLINK</span>
+            )}
+            {agent && !isUser && (
+              <span style={{
+                fontSize: 10, padding: '1px 5px', borderRadius: 3,
+                background: agent.provider === 'claude' ? '#e9deff' : '#d8e9d4',
+                color: agent.provider === 'claude' ? '#624caa' : '#3a6a2e',
+                fontWeight: 600, letterSpacing: '0.02em',
+              }}>{agent.provider}</span>
+            )}
+            <span style={{ fontSize: 11, color: A.textDim }}>{m.time}</span>
+          </div>
+        )}
+        <div style={{ fontSize: 14.5, color: A.text, lineHeight: 1.5 }}
+             dangerouslySetInnerHTML={{ __html: markdownMini(m.text) }} />
+      </div>
+    </div>
+  );
+}
+
+function UserAvatar() {
+  return (
+    <div style={{
+      width: 34, height: 34, borderRadius: 7,
+      background: `linear-gradient(135deg, ${A.inkRaised}, ${A.inkDeep})`,
+      color: '#fff', fontWeight: 600, fontSize: 13,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      flexShrink: 0,
+    }}>jc</div>
+  );
+}
+
+// very light markdown: **bold**, `code`, @mentions, URLs
+function markdownMini(s) {
+  if (!s) return '';
+  return s
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/`([^`]+)`/g, `<code style="background:${A.paperAlt};padding:1px 5px;border-radius:3px;font-size:0.9em;font-family:ui-monospace,Menlo,monospace;color:${A.text}">$1</code>`)
+    .replace(/\*\*([^*]+)\*\*/g, '<strong style="font-weight:700">$1</strong>')
+    .replace(/@([a-zA-Z0-9_-]+)/g, `<span style="color:${A.coral};background:${A.coralSoft};padding:1px 4px;border-radius:3px;font-weight:600">@$1</span>`)
+    .replace(/(https?:\/\/[^\s]+)/g, `<a href="$1" style="color:${A.sky};text-decoration:underline">$1</a>`);
+}
+
+// ─────────────────────────────────────────────────────────────
+// Composer
+// ─────────────────────────────────────────────────────────────
+function Composer({ channel, onSend, placeholder }) {
+  const [text, setText] = useState('');
+  const [autoApprove, setAutoApprove] = useState(true);
+  const [targetRepo, setTargetRepo] = useState(channel?.primaryRepo || channel?.repos?.[0]);
+  const aliases = channel?.repos || [];
+
+  const submit = () => {
+    if (!text.trim()) return;
+    onSend?.({ text, targetRepo, autoApprove });
+    setText('');
+  };
+
+  return (
+    <div style={{
+      padding: '0 18px 16px 20px', flexShrink: 0,
+      background: A.paper,
+    }}>
+      <div style={{
+        border: `1.5px solid ${A.paperLine}`, borderRadius: 10,
+        background: '#fff', transition: 'border-color 0.15s',
+      }}
+      onFocus={(e) => e.currentTarget.style.borderColor = A.coral}
+      onBlur={(e) => e.currentTarget.style.borderColor = A.paperLine}
+      >
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); submit(); }
+          }}
+          placeholder={placeholder || `Message #${channel?.name || 'channel'}`}
+          rows={2}
+          style={{
+            width: '100%', border: 'none', outline: 'none',
+            background: 'transparent', resize: 'none',
+            padding: '12px 14px 6px', fontSize: 14,
+            fontFamily: 'inherit', color: A.text, lineHeight: 1.5,
+          }}
+        />
+        <div style={{
+          padding: '6px 10px 8px', display: 'flex', alignItems: 'center', gap: 6,
+          borderTop: `1px solid ${A.paperLine}`,
+        }}>
+          {aliases.length > 0 && (
+            <ComposerChip label={`@${targetRepo}`} icon={<I.at />}>
+              <select value={targetRepo} onChange={(e) => setTargetRepo(e.target.value)} style={selectStyle}>
+                {aliases.map((a) => <option key={a} value={a}>{`@${a}`}</option>)}
+              </select>
+            </ComposerChip>
+          )}
+          <ComposerChip icon={<I.spark />}
+            label={autoApprove ? 'Auto-approve on' : 'Auto-approve off'}
+            tone={autoApprove ? 'coral' : 'muted'}
+            onClick={() => setAutoApprove(!autoApprove)}
+          />
+          <div style={{ fontSize: 11.5, color: A.textDim, marginLeft: 6 }}>
+            Tip: paste a GitHub issue or Linear URL — Relay classifies it automatically
+          </div>
+          <div style={{ flex: 1 }} />
+          <span style={{ fontSize: 11, color: A.textDim }}>⌘⏎ to send</span>
+          <button onClick={submit} disabled={!text.trim()} style={{
+            padding: '6px 12px', borderRadius: 6, border: 'none',
+            background: text.trim() ? A.coral : A.paperLine,
+            color: text.trim() ? '#fff' : A.textMuted,
+            fontSize: 13, fontWeight: 600,
+            cursor: text.trim() ? 'pointer' : 'not-allowed',
+            display: 'flex', alignItems: 'center', gap: 6,
+          }}><I.send /> Send</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const selectStyle = {
+  border: 'none', background: 'transparent', fontSize: 12,
+  fontWeight: 600, color: A.text, cursor: 'pointer', outline: 'none',
+  fontFamily: 'inherit',
+};
+
+function ComposerChip({ children, label, icon, tone, onClick }) {
+  const bg = tone === 'coral' ? A.coralSoft : A.paperAlt;
+  const fg = tone === 'coral' ? A.coral : A.textMuted;
+  return (
+    <div onClick={onClick} style={{
+      display: 'flex', alignItems: 'center', gap: 5,
+      padding: '3px 9px', borderRadius: 14,
+      background: bg, color: fg, fontSize: 12, fontWeight: 500,
+      cursor: onClick ? 'pointer' : 'default',
+      border: `1px solid ${tone === 'coral' ? A.coralSoft : A.paperLine}`,
+    }}>
+      {icon}
+      <span>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+window.RELAY_A_CHAT = { MessageList, Composer, markdownMini };

--- a/agent_docs/tidewater_handoff/design/direction-a-header.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-a-header.jsx
@@ -1,0 +1,306 @@
+/* Direction A — Channel center pane: header, pinned Board canvas,
+   message feed, composer. */
+
+const { A, I, Avatar, agentColor } = window.RELAY_A;
+// ─────────────────────────────────────────────────────────────
+// Channel header bar
+// ─────────────────────────────────────────────────────────────
+function ChannelHeader({ channel, agents, onOpenDecisions, decisionsOpen }) {
+  return (
+    <div style={{
+      padding: '11px 18px 11px 20px',
+      borderBottom: `1px solid ${A.paperLine}`,
+      display: 'flex', alignItems: 'center', gap: 14,
+      background: A.paper, flexShrink: 0,
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <I.hash style={{ color: A.textMuted }} />
+          <span style={{ fontSize: 16, fontWeight: 600, color: A.text }}>{channel.name}</span>
+          <span style={{
+            fontSize: 10, fontWeight: 600, letterSpacing: '0.04em',
+            textTransform: 'uppercase', padding: '2px 7px', borderRadius: 4,
+            background: tierColor(channel.tier).bg, color: tierColor(channel.tier).fg,
+          }}>{channel.tier.replace('_', ' ')}</span>
+          <button style={{
+            border: 'none', background: 'none', padding: 4, cursor: 'pointer',
+            color: channel.starred ? A.amber : A.textDim,
+          }}>{channel.starred ? <I.starFill /> : <I.star />}</button>
+        </div>
+        <div style={{
+          fontSize: 12.5, color: A.textMuted, marginTop: 2,
+          display: 'flex', alignItems: 'center', gap: 10,
+        }}>
+          <span>{channel.topic}</span>
+        </div>
+      </div>
+
+      {/* Agent stack */}
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        {agents.slice(0, 4).map((a, i) => (
+          <div key={a.id} style={{ marginLeft: i === 0 ? 0 : -8 }}>
+            <Avatar agent={a} size={26} showStatus />
+          </div>
+        ))}
+        {agents.length > 4 && (
+          <div style={{
+            marginLeft: -8, width: 26, height: 26, borderRadius: 6,
+            background: A.paperAlt, color: A.textMuted,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 11, fontWeight: 600, border: `2px solid ${A.paper}`,
+          }}>+{agents.length - 4}</div>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', gap: 4 }}>
+        <HeaderButton onClick={onOpenDecisions} active={decisionsOpen}>
+          <I.book /> Decisions <span style={{
+            fontSize: 11, padding: '0 5px', borderRadius: 3,
+            background: decisionsOpen ? 'rgba(255,255,255,0.25)' : A.paperAlt,
+            color: decisionsOpen ? '#fff' : A.textMuted, marginLeft: 4,
+          }}>2</span>
+        </HeaderButton>
+        <HeaderButton><I.search /></HeaderButton>
+      </div>
+    </div>
+  );
+}
+
+function HeaderButton({ children, onClick, active }) {
+  return (
+    <button onClick={onClick} style={{
+      padding: '6px 10px', borderRadius: 6,
+      background: active ? A.coral : 'transparent',
+      color: active ? '#fff' : A.textMuted,
+      border: active ? 'none' : `1px solid ${A.paperLine}`,
+      fontSize: 12.5, fontWeight: 500, cursor: 'pointer',
+      display: 'flex', alignItems: 'center', gap: 6,
+    }}>{children}</button>
+  );
+}
+
+function tierColor(tier) {
+  switch (tier) {
+    case 'feature_large':   return { bg: '#fce7c7', fg: '#8a4e0e' };
+    case 'feature_small':   return { bg: '#d6ead7', fg: '#2e5c33' };
+    case 'architectural':   return { bg: '#e1dcf2', fg: '#4a3d8c' };
+    case 'bugfix':          return { bg: '#fcd9d4', fg: '#933b30' };
+    case 'trivial':         return { bg: '#e5e1d5', fg: '#5b6579' };
+    case 'multi_repo':      return { bg: '#d1e5e9', fg: '#26545b' };
+    default:                return { bg: '#e5e1d5', fg: '#5b6579' };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Pinned Board Canvas — collapsible strip at the top of the channel
+// showing ticket board + active PRs + repo assignments at a glance
+// ─────────────────────────────────────────────────────────────
+function PinnedCanvas({ channel, collapsed, onToggle, onOpenTicket, onOpenPr }) {
+  const statusGroups = {
+    executing: channel.tickets.filter((t) => t.status === 'executing' || t.status === 'verifying' || t.status === 'retry'),
+    ready:     channel.tickets.filter((t) => t.status === 'ready'),
+    blocked:   channel.tickets.filter((t) => t.status === 'blocked' || t.status === 'pending'),
+    done:      channel.tickets.filter((t) => t.status === 'completed'),
+    failed:    channel.tickets.filter((t) => t.status === 'failed'),
+  };
+
+  return (
+    <div style={{
+      background: A.paperAlt,
+      borderBottom: `1px solid ${A.paperLine}`,
+      flexShrink: 0,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: '8px 18px 8px 20px',
+        cursor: 'pointer',
+      }} onClick={onToggle}>
+        <I.canvas style={{ color: A.coral }} />
+        <span style={{ fontSize: 12, fontWeight: 600, color: A.text, letterSpacing: '0.02em' }}>
+          BOARD · CANVAS
+        </span>
+        <span style={{ fontSize: 11, color: A.textMuted }}>
+          {channel.tickets.length} tickets · {channel.prs.length} PRs · {channel.repos.length} repos
+        </span>
+        <div style={{ flex: 1 }} />
+        <ProgressBar tickets={channel.tickets} />
+        <button style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: A.textMuted, padding: 4, display: 'flex',
+        }}>{collapsed ? <I.chevR /> : <I.chevD />}</button>
+      </div>
+
+      {!collapsed && (
+        <div style={{
+          padding: '4px 18px 14px 20px',
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 2.2fr) minmax(0, 1fr)',
+          gap: 16,
+        }}>
+          {/* Tickets */}
+          <div>
+            <MiniColumn title="In flight" tickets={statusGroups.executing} onOpen={onOpenTicket} tone="amber" />
+            <MiniColumn title="Ready" tickets={statusGroups.ready} onOpen={onOpenTicket} tone="sky" />
+            {statusGroups.failed.length > 0 && (
+              <MiniColumn title="Failed" tickets={statusGroups.failed} onOpen={onOpenTicket} tone="coral" />
+            )}
+            <MiniColumn title="Blocked / pending" tickets={statusGroups.blocked} onOpen={onOpenTicket} tone="neutral" />
+            <MiniColumn title="Done" tickets={statusGroups.done} onOpen={onOpenTicket} tone="mint" muted />
+          </div>
+
+          {/* PRs + repos */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{
+              background: A.paper, borderRadius: 8,
+              border: `1px solid ${A.paperLine}`,
+              padding: '10px 12px',
+            }}>
+              <div style={{ fontSize: 11, fontWeight: 600, color: A.textMuted, marginBottom: 6, letterSpacing: '0.02em' }}>
+                TRACKED PRS
+              </div>
+              {channel.prs.length === 0 && (
+                <div style={{ fontSize: 12, color: A.textDim }}>None yet</div>
+              )}
+              {channel.prs.map((pr) => (
+                <PrMini key={pr.number} pr={pr} onOpen={() => onOpenPr(pr)} />
+              ))}
+            </div>
+            <div style={{
+              background: A.paper, borderRadius: 8,
+              border: `1px solid ${A.paperLine}`,
+              padding: '10px 12px',
+            }}>
+              <div style={{ fontSize: 11, fontWeight: 600, color: A.textMuted, marginBottom: 6, letterSpacing: '0.02em' }}>
+                REPOS
+              </div>
+              {channel.repos.map((alias) => {
+                const r = REPOS.find((x) => x.alias === alias);
+                const isPrimary = channel.primaryRepo === alias;
+                return (
+                  <div key={alias} style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    padding: '3px 0', fontSize: 12.5, color: A.text,
+                  }}>
+                    <I.repo style={{ color: A.textMuted }} />
+                    <span style={{ fontWeight: 500 }}>@{alias}</span>
+                    {isPrimary && <span style={{
+                      fontSize: 10, fontWeight: 700, letterSpacing: '0.04em',
+                      padding: '1px 5px', borderRadius: 3,
+                      background: A.coralSoft, color: A.coral,
+                    }}>PRIMARY</span>}
+                    <span style={{ marginLeft: 'auto', fontSize: 11, color: A.textDim, fontFamily: 'ui-monospace, Menlo, monospace' }}>
+                      {r?.path || ''}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProgressBar({ tickets }) {
+  const total = tickets.length || 1;
+  const done = tickets.filter((t) => t.status === 'completed').length;
+  const active = tickets.filter((t) => ['executing', 'verifying', 'retry'].includes(t.status)).length;
+  const failed = tickets.filter((t) => t.status === 'failed').length;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{
+        width: 120, height: 6, borderRadius: 3, background: A.paperLine,
+        display: 'flex', overflow: 'hidden',
+      }}>
+        <div style={{ width: `${(done/total)*100}%`, background: A.mint }} />
+        <div style={{ width: `${(active/total)*100}%`, background: A.amber }} />
+        <div style={{ width: `${(failed/total)*100}%`, background: A.coral }} />
+      </div>
+      <span style={{ fontSize: 11.5, color: A.textMuted, fontVariantNumeric: 'tabular-nums' }}>
+        {done}/{total}
+      </span>
+    </div>
+  );
+}
+
+function MiniColumn({ title, tickets, onOpen, tone, muted }) {
+  if (tickets.length === 0) return null;
+  const toneMap = {
+    amber: A.amber, sky: A.sky, coral: A.coral, mint: A.mint, neutral: A.textDim,
+  };
+  const c = toneMap[tone];
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{
+        fontSize: 11, fontWeight: 600, color: A.textMuted,
+        letterSpacing: '0.02em', marginBottom: 6,
+        display: 'flex', alignItems: 'center', gap: 6,
+      }}>
+        <span style={{ width: 6, height: 6, borderRadius: '50%', background: c }} />
+        {title.toUpperCase()}
+        <span style={{ color: A.textDim, fontWeight: 500 }}>· {tickets.length}</span>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {tickets.map((t) => <TicketChip key={t.id} ticket={t} onOpen={() => onOpen(t)} muted={muted} />)}
+      </div>
+    </div>
+  );
+}
+
+function TicketChip({ ticket, onOpen, muted }) {
+  const agent = AGENTS.find((a) => a.id === ticket.agent);
+  const statusColor = A.statusFill[ticket.status] || A.textDim;
+  return (
+    <div onClick={onOpen} style={{
+      background: A.paper, border: `1px solid ${A.paperLine}`,
+      borderRadius: 6, padding: '6px 9px', cursor: 'pointer',
+      display: 'flex', alignItems: 'center', gap: 8,
+      opacity: muted ? 0.65 : 1,
+      minWidth: 200, maxWidth: 360,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.02)',
+    }}>
+      <span style={{ width: 3, height: 20, borderRadius: 2, background: statusColor, flexShrink: 0 }} />
+      <span style={{
+        fontFamily: 'ui-monospace, Menlo, monospace',
+        fontSize: 11, color: A.textMuted, fontWeight: 500,
+      }}>{ticket.id}</span>
+      <span style={{
+        fontSize: 12.5, color: A.text, flex: 1,
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>{ticket.title}</span>
+      {agent && <Avatar agent={agent} size={18} />}
+    </div>
+  );
+}
+
+function PrMini({ pr, onOpen }) {
+  const ciColor = pr.ci === 'passing' ? A.mint : pr.ci === 'failing' ? A.coral : A.textDim;
+  const reviewColor = pr.review === 'approved' ? A.mint : pr.review === 'changes_requested' ? A.coral : A.amber;
+  return (
+    <div onClick={onOpen} style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: '5px 0', cursor: 'pointer',
+      fontSize: 12.5, borderTop: `1px solid ${A.paperLine}`,
+    }}>
+      <I.pr style={{ color: A.textMuted, flexShrink: 0 }} />
+      <span style={{ fontFamily: 'ui-monospace, Menlo, monospace', color: A.coral, fontWeight: 600 }}>
+        #{pr.number}
+      </span>
+      <span style={{
+        flex: 1, overflow: 'hidden', textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap', color: A.text,
+      }}>{pr.title}</span>
+      <span style={{
+        fontSize: 10, padding: '1px 5px', borderRadius: 3,
+        background: `${ciColor}22`, color: ciColor, fontWeight: 600,
+      }}>{pr.ci}</span>
+      <span style={{
+        fontSize: 10, padding: '1px 5px', borderRadius: 3,
+        background: `${reviewColor}22`, color: reviewColor, fontWeight: 600,
+      }}>{pr.review === 'changes_requested' ? 'changes' : pr.review}</span>
+    </div>
+  );
+}
+
+window.RELAY_A_HEADER = { ChannelHeader, PinnedCanvas };

--- a/agent_docs/tidewater_handoff/design/direction-a-right.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-a-right.jsx
@@ -1,0 +1,405 @@
+/* Direction A — Right-pane threads: Decisions drawer, PR thread, Approval thread, Ticket detail */
+
+const { A, I, Avatar } = window.RELAY_A;
+const { markdownMini } = window.RELAY_A_CHAT;
+// ─────────────────────────────────────────────────────────────
+// Right-pane container: header + close
+// ─────────────────────────────────────────────────────────────
+function RightPane({ title, subtitle, icon, onClose, children, width = 380 }) {
+  return (
+    <div style={{
+      width, flexShrink: 0,
+      borderLeft: `1px solid ${A.paperLine}`,
+      background: A.paper, display: 'flex', flexDirection: 'column',
+      boxShadow: '-8px 0 24px rgba(0,0,0,0.04)',
+    }}>
+      <div style={{
+        padding: '12px 16px', borderBottom: `1px solid ${A.paperLine}`,
+        display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0,
+      }}>
+        {icon && <span style={{ color: A.coral }}>{icon}</span>}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: A.text }}>{title}</div>
+          {subtitle && <div style={{ fontSize: 12, color: A.textMuted, marginTop: 1 }}>{subtitle}</div>}
+        </div>
+        <button onClick={onClose} style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: A.textMuted, padding: 6, borderRadius: 5,
+          display: 'flex',
+        }}><I.close /></button>
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto' }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Decisions drawer
+// ─────────────────────────────────────────────────────────────
+function DecisionsDrawer({ channel, onClose }) {
+  return (
+    <RightPane
+      title="Decisions" icon={<I.book />}
+      subtitle={`${channel.decisions.length} recorded · #${channel.name}`}
+      onClose={onClose}
+    >
+      {channel.decisions.length === 0 && (
+        <div style={{ padding: 20, color: A.textDim, fontSize: 13 }}>
+          No decisions recorded yet. Agents record decisions via{' '}
+          <code style={inlineCode}>channel_record_decision</code>.
+        </div>
+      )}
+      {channel.decisions.map((d) => (
+        <div key={d.id} style={{
+          padding: '14px 16px', borderBottom: `1px solid ${A.paperLine}`,
+        }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6,
+          }}>
+            <span style={{
+              fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 11,
+              color: A.textMuted, fontWeight: 500,
+            }}>{d.id}</span>
+            <span style={{ fontSize: 11, color: A.textDim }}>·</span>
+            <span style={{ fontSize: 12, color: A.textMuted }}>by {d.by} · {d.at}</span>
+          </div>
+          <div style={{ fontSize: 14.5, fontWeight: 600, color: A.text, marginBottom: 6, lineHeight: 1.35 }}>
+            {d.title}
+          </div>
+          <div style={{ fontSize: 13, color: A.text, lineHeight: 1.55, marginBottom: 10 }}>
+            {d.description}
+          </div>
+          <div style={{
+            padding: '8px 10px', background: A.paperAlt, borderRadius: 6,
+            borderLeft: `3px solid ${A.mint}`, marginBottom: 8,
+          }}>
+            <div style={{ fontSize: 11, fontWeight: 600, color: A.mint, letterSpacing: '0.04em', marginBottom: 3 }}>
+              RATIONALE
+            </div>
+            <div style={{ fontSize: 13, color: A.text, lineHeight: 1.5 }}>{d.rationale}</div>
+          </div>
+          {d.alternatives.length > 0 && (
+            <div>
+              <div style={{
+                fontSize: 11, fontWeight: 600, color: A.textMuted,
+                letterSpacing: '0.04em', marginBottom: 4,
+              }}>ALTERNATIVES CONSIDERED</div>
+              {d.alternatives.map((a, i) => (
+                <div key={i} style={{
+                  fontSize: 12.5, color: A.textMuted, paddingLeft: 12, marginBottom: 2,
+                  position: 'relative',
+                }}>
+                  <span style={{ position: 'absolute', left: 0, color: A.textDim }}>·</span>
+                  {a}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </RightPane>
+  );
+}
+
+const inlineCode = {
+  background: A.paperAlt, padding: '1px 5px', borderRadius: 3,
+  fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12,
+};
+
+// ─────────────────────────────────────────────────────────────
+// PR Thread
+// ─────────────────────────────────────────────────────────────
+function PrThread({ pr, channel, onClose }) {
+  const author = AGENTS.find((a) => a.name === pr.author);
+  const ciColor = pr.ci === 'passing' ? A.mint : pr.ci === 'failing' ? A.coral : A.textDim;
+  const reviewColor = pr.review === 'approved' ? A.mint : pr.review === 'changes_requested' ? A.coral : A.amber;
+
+  const events = pr.ci === 'failing' ? [
+    { at: '18m', kind: 'ci_fail', text: 'CI failed — **2 tests** in `test/auth/providers.test.ts`' },
+    { at: '24m', kind: 'commit', text: 'Titan pushed `fix: handle 429 from github`' },
+    { at: '1h',  kind: 'open', text: 'PR opened by Titan' },
+  ] : [
+    { at: '12m', kind: 'approve', text: 'Approved by jcast' },
+    { at: '45m', kind: 'review', text: 'Saturn requested self-review · all comments resolved' },
+    { at: '1h',  kind: 'open',   text: 'PR opened by Saturn' },
+  ];
+
+  return (
+    <RightPane
+      title={`#${pr.number}`} icon={<I.pr />}
+      subtitle={pr.title}
+      onClose={onClose} width={420}
+    >
+      {/* Status pills */}
+      <div style={{ padding: '12px 16px 8px', display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        <StatusPill color={A.mint} label={`open · ${pr.branch}`} />
+        <StatusPill color={ciColor} label={`ci: ${pr.ci}`} />
+        <StatusPill color={reviewColor} label={`review: ${pr.review === 'changes_requested' ? 'changes' : pr.review}`} />
+      </div>
+
+      <div style={{ padding: '0 16px 12px', color: A.textMuted, fontSize: 12.5 }}>
+        Tracked by the PR watcher every 30s · on CI fail, a follow-up ticket is enqueued automatically
+      </div>
+
+      {/* Actions */}
+      <div style={{ padding: '0 16px 14px', display: 'flex', gap: 6 }}>
+        <ActionBtn primary>Open on GitHub</ActionBtn>
+        <ActionBtn>View diff</ActionBtn>
+        <ActionBtn>Unwatch</ActionBtn>
+      </div>
+
+      <div style={{ padding: '12px 16px', background: A.paperAlt, borderTop: `1px solid ${A.paperLine}`, borderBottom: `1px solid ${A.paperLine}` }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: A.textMuted, letterSpacing: '0.04em', marginBottom: 8 }}>
+          TIMELINE
+        </div>
+        {events.map((e, i) => (
+          <div key={i} style={{
+            display: 'flex', gap: 10, padding: '6px 0',
+            fontSize: 13, color: A.text,
+          }}>
+            <span style={{
+              width: 22, height: 22, borderRadius: '50%',
+              background: e.kind === 'ci_fail' || e.kind === 'changes_requested' ? A.coralSoft :
+                         e.kind === 'approve' ? '#dceed7' :
+                         A.paperLine,
+              color: e.kind === 'ci_fail' ? A.coral : e.kind === 'approve' ? A.mint : A.textMuted,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flexShrink: 0,
+            }}>
+              {e.kind === 'ci_fail' ? <I.close /> : e.kind === 'approve' ? <I.check /> : e.kind === 'commit' ? <I.spark /> : <I.pr />}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div dangerouslySetInnerHTML={{ __html: markdownMini(e.text) }} />
+              <div style={{ fontSize: 11, color: A.textDim, marginTop: 1 }}>{e.at} ago</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Discussion */}
+      <div style={{ padding: '14px 16px' }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: A.textMuted, letterSpacing: '0.04em', marginBottom: 10 }}>
+          DISCUSSION
+        </div>
+
+        {author && (
+          <ThreadMessage agent={author} time={`${pr.ci === 'failing' ? '1h' : '1h'} ago`}
+                        text={`Opened **#${pr.number}**. Branch \`${pr.branch}\`. Summary in the PR description.`} />
+        )}
+        {pr.ci === 'failing' && (
+          <>
+            <ThreadMessage system text={`CI failing on \`pnpm test\` — 2 tests in \`test/auth/providers.test.ts\`. A follow-up ticket was enqueued automatically.`} />
+            {AGENTS.find((a) => a.id === 'titan') && (
+              <ThreadMessage agent={AGENTS.find((a) => a.id === 'titan')} time="18m ago"
+                            text="Fetched error — github adapter isn't handling 429 from `/user/emails`. Adding backoff + retry." />
+            )}
+          </>
+        )}
+      </div>
+
+      <ThreadComposer placeholder={`Reply to #${pr.number}...`} />
+    </RightPane>
+  );
+}
+
+function ActionBtn({ children, primary, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      padding: '6px 12px', borderRadius: 6, cursor: 'pointer',
+      background: primary ? A.coral : A.paper,
+      color: primary ? '#fff' : A.text,
+      border: primary ? 'none' : `1px solid ${A.paperLine}`,
+      fontSize: 12.5, fontWeight: 600,
+    }}>{children}</button>
+  );
+}
+
+function StatusPill({ color, label }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: '3px 8px', borderRadius: 10,
+      background: `${color}1c`, color,
+      fontSize: 11.5, fontWeight: 600,
+    }}>
+      <span style={{ width: 6, height: 6, borderRadius: '50%', background: color }} />
+      {label}
+    </span>
+  );
+}
+
+function ThreadMessage({ agent, system, text, time }) {
+  if (system) {
+    return (
+      <div style={{
+        padding: '8px 10px', margin: '0 0 12px',
+        background: A.paperAlt, borderLeft: `3px solid ${A.coral}`,
+        borderRadius: 6, fontSize: 13, color: A.text, lineHeight: 1.5,
+      }} dangerouslySetInnerHTML={{ __html: markdownMini(text) }} />
+    );
+  }
+  return (
+    <div style={{ display: 'flex', gap: 10, marginBottom: 14 }}>
+      <Avatar agent={agent} size={28} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 2 }}>
+          <span style={{ fontSize: 13.5, fontWeight: 700, color: A.text }}>{agent.name}</span>
+          <span style={{ fontSize: 11, color: A.textDim }}>{time}</span>
+        </div>
+        <div style={{ fontSize: 13.5, color: A.text, lineHeight: 1.5 }}
+             dangerouslySetInnerHTML={{ __html: markdownMini(text) }} />
+      </div>
+    </div>
+  );
+}
+
+function ThreadComposer({ placeholder }) {
+  const [t, setT] = useState('');
+  return (
+    <div style={{
+      padding: 12, borderTop: `1px solid ${A.paperLine}`, background: A.paper,
+      position: 'sticky', bottom: 0,
+    }}>
+      <textarea value={t} onChange={(e) => setT(e.target.value)}
+                placeholder={placeholder} rows={2} style={{
+        width: '100%', border: `1px solid ${A.paperLine}`, borderRadius: 8,
+        padding: '8px 10px', fontSize: 13, fontFamily: 'inherit',
+        resize: 'none', outline: 'none',
+      }} />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Approval Thread
+// ─────────────────────────────────────────────────────────────
+function ApprovalThread({ channel, onClose, onApprove, onReject }) {
+  return (
+    <RightPane
+      title="Plan awaiting approval" icon={<I.spark />}
+      subtitle={`#${channel.name} · feature_large`}
+      onClose={onClose} width={420}
+    >
+      <div style={{ padding: 16 }}>
+        <div style={{
+          background: A.coralSoft, borderRadius: 8, padding: '12px 14px',
+          border: `1px solid ${A.coral}33`, marginBottom: 14,
+        }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: A.coral, marginBottom: 4 }}>
+            Saturn drafted a plan — your approval blocks execution
+          </div>
+          <div style={{ fontSize: 12.5, color: A.text, lineHeight: 1.5 }}>
+            6 tickets · 2 repos · estimated 4–7 hours of agent time · opens 2 PRs
+          </div>
+        </div>
+
+        <div style={{
+          fontSize: 11, fontWeight: 600, color: A.textMuted,
+          letterSpacing: '0.04em', marginBottom: 8,
+        }}>PROPOSED TICKETS</div>
+
+        {channel.tickets.map((t) => {
+          const a = AGENTS.find((x) => x.id === t.agent);
+          return (
+            <div key={t.id} style={{
+              padding: '10px 0', borderBottom: `1px solid ${A.paperLine}`,
+              display: 'flex', gap: 10, alignItems: 'flex-start',
+            }}>
+              <span style={{
+                fontFamily: 'ui-monospace, Menlo, monospace',
+                fontSize: 11, color: A.textMuted, fontWeight: 600,
+                background: A.paperAlt, padding: '2px 6px', borderRadius: 4,
+                flexShrink: 0,
+              }}>{t.id}</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13.5, color: A.text, fontWeight: 500, marginBottom: 3 }}>{t.title}</div>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', fontSize: 11 }}>
+                  <span style={{ color: A.textMuted }}>· {t.specialty.replace('_', ' ')}</span>
+                  {t.deps.length > 0 && <span style={{ color: A.textMuted }}>· blocks on {t.deps.join(', ')}</span>}
+                  {a && <span style={{ color: A.textMuted }}>· → {a.name}</span>}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+
+        <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+          <button onClick={onApprove} style={{
+            flex: 1, padding: '10px 14px', borderRadius: 8,
+            background: A.mint, color: '#fff', border: 'none',
+            fontSize: 14, fontWeight: 600, cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+          }}><I.check /> Approve & dispatch</button>
+          <button onClick={onReject} style={{
+            padding: '10px 14px', borderRadius: 8,
+            background: A.paper, color: A.text,
+            border: `1px solid ${A.paperLine}`,
+            fontSize: 14, fontWeight: 600, cursor: 'pointer',
+          }}>Request changes</button>
+        </div>
+      </div>
+    </RightPane>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Ticket detail thread
+// ─────────────────────────────────────────────────────────────
+function TicketDetail({ ticket, channel, onClose }) {
+  const agent = AGENTS.find((a) => a.id === ticket.agent);
+  const statusColor = A.statusFill[ticket.status] || A.textDim;
+  const deps = (ticket.deps || []).map((d) => channel.tickets.find((t) => t.id === d)).filter(Boolean);
+  return (
+    <RightPane
+      title={ticket.id}
+      subtitle={ticket.title}
+      onClose={onClose} width={400}
+    >
+      <div style={{ padding: 16 }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 12 }}>
+          <StatusPill color={statusColor} label={ticket.status} />
+          <StatusPill color={A.textMuted} label={ticket.specialty.replace('_', ' ')} />
+          {agent && <StatusPill color={agentColorHex(agent.id)} label={`→ ${agent.name}`} />}
+        </div>
+        <div style={{ fontSize: 13.5, color: A.text, lineHeight: 1.5, marginBottom: 16 }}>
+          {ticket.title}
+        </div>
+
+        {deps.length > 0 && (
+          <>
+            <div style={{ fontSize: 11, fontWeight: 600, color: A.textMuted, letterSpacing: '0.04em', marginBottom: 6 }}>
+              DEPENDS ON
+            </div>
+            {deps.map((d) => (
+              <div key={d.id} style={{
+                display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0',
+                fontSize: 12.5, color: A.text,
+              }}>
+                <span style={{ width: 3, height: 16, borderRadius: 2, background: A.statusFill[d.status] || A.textDim }} />
+                <span style={{ fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 11, color: A.textMuted, fontWeight: 600 }}>{d.id}</span>
+                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.title}</span>
+                <span style={{ fontSize: 11, color: A.textDim }}>{d.status}</span>
+              </div>
+            ))}
+          </>
+        )}
+
+        <div style={{
+          marginTop: 16, padding: '10px 12px', background: A.paperAlt,
+          borderRadius: 6, fontSize: 12, color: A.textMuted, lineHeight: 1.6,
+        }}>
+          <strong style={{ color: A.text }}>Verification</strong><br />
+          <code style={inlineCode}>pnpm test test/auth</code>
+        </div>
+      </div>
+    </RightPane>
+  );
+}
+
+function agentColorHex(id) {
+  const palette = ['#3e5886', '#9c5a7c', '#2f7a6a', '#b26a3a', '#5b5fb0', '#c8654a', '#5a7a4a', '#7a5290', '#3a7590'];
+  let h = 0; for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return palette[Math.abs(h) % palette.length];
+}
+
+window.RELAY_A_RIGHT = { DecisionsDrawer, PrThread, ApprovalThread, TicketDetail };

--- a/agent_docs/tidewater_handoff/design/direction-a-sidebar.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-a-sidebar.jsx
@@ -1,0 +1,316 @@
+/* Direction A — Sidebar (channels, DMs, starred, activity, repos) */
+
+const { A, I, Avatar, agentColor, WorkspaceRail } = window.RELAY_A;
+function SidebarSection({ title, count, collapsed, onToggle, action, children }) {
+  return (
+    <div style={{ marginBottom: 6 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 4,
+        padding: '4px 12px 4px 10px', color: A.textOnDarkMuted,
+        fontSize: 11, fontWeight: 600, letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+      }}>
+        <button onClick={onToggle} style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: A.textOnDarkMuted, padding: '2px 4px', marginLeft: -4,
+          display: 'flex', alignItems: 'center',
+        }}>
+          {collapsed ? <I.chevR /> : <I.chevD />}
+        </button>
+        <span style={{ flex: 1 }}>{title}{count !== undefined && ` · ${count}`}</span>
+        {action && (
+          <button onClick={action.onClick} title={action.title} style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: A.textOnDarkMuted, padding: '2px 4px',
+            display: 'flex', alignItems: 'center', borderRadius: 4,
+          }}>
+            <I.plus />
+          </button>
+        )}
+      </div>
+      {!collapsed && children}
+    </div>
+  );
+}
+
+function SidebarRow({ active, unread, mentions, onClick, children, indent = 22, dense = false }) {
+  return (
+    <div onClick={onClick} style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: dense ? `3px ${indent}px` : `5px ${indent}px`,
+      cursor: 'pointer',
+      background: active ? A.coral : 'transparent',
+      color: active ? '#fff' : (unread ? A.textOnDark : A.textOnDarkMuted),
+      fontWeight: unread && !active ? 600 : 400,
+      fontSize: 13.5, lineHeight: 1.3,
+      position: 'relative',
+    }}
+    onMouseEnter={(e) => { if (!active) e.currentTarget.style.background = A.inkRaised; }}
+    onMouseLeave={(e) => { if (!active) e.currentTarget.style.background = 'transparent'; }}
+    >
+      {children}
+      {mentions > 0 && (
+        <span style={{
+          background: A.coral, color: '#fff',
+          fontSize: 10, fontWeight: 700,
+          padding: '1px 6px', borderRadius: 10,
+          marginLeft: 'auto',
+          border: active ? '1.5px solid #fff' : 'none',
+        }}>{mentions}</span>
+      )}
+      {unread > 0 && !mentions && !active && (
+        <span style={{
+          width: 6, height: 6, borderRadius: '50%',
+          background: A.coral, marginLeft: 'auto',
+        }} />
+      )}
+    </div>
+  );
+}
+
+function ChannelRow({ channel, active, onClick }) {
+  return (
+    <SidebarRow active={active} unread={channel.unread} mentions={channel.mentions} onClick={onClick}>
+      <I.hash style={{ flexShrink: 0, opacity: 0.8 }} />
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {channel.name}
+      </span>
+    </SidebarRow>
+  );
+}
+
+function DmRow({ dm, agent, active, onClick, avatarStyle }) {
+  if (!agent) return null;
+  return (
+    <SidebarRow active={active} unread={dm.unread} onClick={onClick} indent={12}>
+      <Avatar agent={agent} size={20} style={avatarStyle} showStatus />
+      <span style={{
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        flex: 1,
+      }}>
+        {agent.name}
+        {agent.activity && (
+          <span style={{
+            display: 'block', fontSize: 11, color: active ? 'rgba(255,255,255,0.85)' : A.amber,
+            fontWeight: 400, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            marginTop: 1,
+          }}>
+            ⚙ {agent.activity}
+          </span>
+        )}
+      </span>
+    </SidebarRow>
+  );
+}
+
+function ActivityRow({ item, onClick, active }) {
+  const iconMap = {
+    approval:    { icon: <I.spark />, color: A.coral,   label: 'Approval' },
+    ci_fail:     { icon: <I.flask />, color: A.coral,   label: 'CI' },
+    pr_review:   { icon: <I.pr />,    color: A.amber,   label: 'Review' },
+    mention:     { icon: <I.at />,    color: A.sky,     label: 'Mention' },
+    ticket_fail: { icon: <I.close />, color: A.coral,   label: 'Failed' },
+  };
+  const m = iconMap[item.kind];
+  return (
+    <SidebarRow active={active} unread={true} onClick={onClick} indent={12}>
+      <span style={{
+        width: 18, height: 18, borderRadius: 4,
+        background: active ? 'rgba(255,255,255,0.18)' : `${m.color}22`,
+        color: active ? '#fff' : m.color,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        flexShrink: 0,
+      }}>{m.icon}</span>
+      <span style={{
+        flex: 1, overflow: 'hidden', textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap', fontSize: 13,
+      }}>
+        {item.title}
+      </span>
+      <span style={{
+        fontSize: 11, color: active ? 'rgba(255,255,255,0.75)' : A.textOnDarkMuted,
+      }}>{item.time}</span>
+    </SidebarRow>
+  );
+}
+
+function RepoRow({ repo, active, onClick, attachedChannels }) {
+  return (
+    <SidebarRow active={active} onClick={onClick} indent={12} dense>
+      <I.repo style={{ opacity: 0.8, flexShrink: 0 }} />
+      <span style={{
+        overflow: 'hidden', textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap', flex: 1,
+      }}>
+        {repo.alias}
+        {repo.primary && (
+          <span style={{
+            marginLeft: 6, fontSize: 10, opacity: 0.7,
+            padding: '0 5px', borderRadius: 3,
+            background: active ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.06)',
+          }}>primary</span>
+        )}
+      </span>
+      <span style={{
+        fontSize: 11, color: active ? 'rgba(255,255,255,0.75)' : A.textOnDarkMuted,
+      }}>{attachedChannels}</span>
+    </SidebarRow>
+  );
+}
+
+function Sidebar({
+  channels, dms, activity, repos,
+  selection, onSelect, onNewChannel, onOpenActivity,
+  avatarStyle,
+}) {
+  const [collapsed, setCollapsed] = useState({ starred: false, channels: false, dms: false, activity: false, repos: false });
+  const toggle = (k) => setCollapsed((c) => ({ ...c, [k]: !c[k] }));
+  const starred = channels.filter((c) => c.starred);
+  const unstarred = channels.filter((c) => !c.starred && c.activeAt !== undefined);
+  const totalUnread = [...channels, ...dms].reduce((n, x) => n + (x.unread || 0), 0);
+
+  return (
+    <div style={{
+      width: 260, background: A.inkDeep, color: A.textOnDark,
+      display: 'flex', flexDirection: 'column',
+      borderRight: `1px solid ${A.inkLine}`,
+      flexShrink: 0, overflow: 'hidden',
+    }}>
+      {/* Workspace header */}
+      <div style={{
+        padding: '14px 14px 12px',
+        borderBottom: `1px solid ${A.inkLine}`,
+        display: 'flex', alignItems: 'center', gap: 10,
+      }}>
+        <div style={{
+          width: 30, height: 30, borderRadius: 8,
+          background: `linear-gradient(135deg, ${A.coral}, ${A.amber})`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#fff', fontWeight: 700, fontSize: 15,
+        }}>R</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontWeight: 600, fontSize: 14, color: '#fff' }}>Relay</div>
+          <div style={{ fontSize: 11.5, color: A.textOnDarkMuted }}>
+            jcast · 3 repos · {AGENTS.filter(a=>a.status==='working').length} working
+          </div>
+        </div>
+      </div>
+
+      {/* Quick actions */}
+      <div style={{ padding: '10px 10px 4px', display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <button onClick={onOpenActivity} style={quickBtnStyle(selection.type === 'activity')}>
+          <I.bell style={{ opacity: 0.85 }} /> Activity
+          {ACTIVITY.length > 0 && <span style={{
+            marginLeft: 'auto', background: A.coral, color: '#fff',
+            fontSize: 10, fontWeight: 700, padding: '1px 6px', borderRadius: 10,
+          }}>{ACTIVITY.length}</span>}
+        </button>
+        <button onClick={() => onSelect({ type: 'threads' })} style={quickBtnStyle(selection.type === 'threads')}>
+          <I.book style={{ opacity: 0.85 }} /> Threads
+        </button>
+        <button onClick={() => onSelect({ type: 'running' })} style={quickBtnStyle(selection.type === 'running')}>
+          <I.spark style={{ opacity: 0.85 }} /> Running
+          <span style={{
+            marginLeft: 'auto', fontSize: 11, color: A.textOnDarkMuted,
+          }}>{AGENTS.filter(a=>a.status==='working').length}</span>
+        </button>
+      </div>
+
+      <div style={{ height: 1, background: A.inkLine, margin: '6px 12px' }} />
+
+      <div style={{ flex: 1, overflowY: 'auto', paddingBottom: 12 }}>
+        {/* Starred */}
+        {starred.length > 0 && (
+          <SidebarSection title="Starred" collapsed={collapsed.starred} onToggle={() => toggle('starred')}>
+            {starred.map((c) => (
+              <SidebarRow key={c.id} active={selection.type === 'channel' && selection.id === c.id}
+                          unread={c.unread} mentions={c.mentions}
+                          onClick={() => onSelect({ type: 'channel', id: c.id })}>
+                <I.starFill style={{ opacity: 0.85, color: A.amber, flexShrink: 0 }} />
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {c.name}
+                </span>
+              </SidebarRow>
+            ))}
+          </SidebarSection>
+        )}
+
+        {/* Channels */}
+        <SidebarSection
+          title="Channels" count={unstarred.length}
+          collapsed={collapsed.channels} onToggle={() => toggle('channels')}
+          action={{ onClick: onNewChannel, title: 'New channel' }}
+        >
+          {unstarred.map((c) => (
+            <ChannelRow key={c.id} channel={c}
+                        active={selection.type === 'channel' && selection.id === c.id}
+                        onClick={() => onSelect({ type: 'channel', id: c.id })} />
+          ))}
+        </SidebarSection>
+
+        {/* DMs */}
+        <SidebarSection
+          title="Direct Messages" count={dms.length}
+          collapsed={collapsed.dms} onToggle={() => toggle('dms')}
+          action={{ onClick: () => {}, title: 'New DM' }}
+        >
+          {dms.map((dm) => {
+            const agent = AGENTS.find((a) => a.id === dm.agentId);
+            return (
+              <DmRow key={dm.id} dm={dm} agent={agent}
+                     active={selection.type === 'dm' && selection.id === dm.id}
+                     onClick={() => onSelect({ type: 'dm', id: dm.id })}
+                     avatarStyle={avatarStyle} />
+            );
+          })}
+        </SidebarSection>
+
+        {/* Repos — only rendered if explicitly passed (A still passes them
+             as a "before" reference; C passes [] since repos are channel-scoped) */}
+        {repos.length > 0 && (
+          <SidebarSection title="Repos" count={repos.length}
+                          collapsed={collapsed.repos} onToggle={() => toggle('repos')}>
+            {repos.map((r) => {
+              const attached = channels.filter((c) => c.repos.includes(r.alias)).length;
+              return <RepoRow key={r.alias} repo={r} attachedChannels={attached} onClick={() => {}} />;
+            })}
+          </SidebarSection>
+        )}
+      </div>
+
+      {/* Footer: your presence */}
+      <div style={{
+        padding: '10px 14px', borderTop: `1px solid ${A.inkLine}`,
+        display: 'flex', alignItems: 'center', gap: 10,
+      }}>
+        <div style={{
+          width: 28, height: 28, borderRadius: 7,
+          background: A.inkRaised,
+          color: A.textOnDark, fontSize: 12, fontWeight: 600,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>jc</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 12.5, color: A.textOnDark }}>jcast</div>
+          <div style={{ fontSize: 11, color: A.mint, display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: A.mint }} /> active
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function quickBtnStyle(active) {
+  return {
+    display: 'flex', alignItems: 'center', gap: 10,
+    padding: '6px 10px', borderRadius: 6,
+    background: active ? A.coral : 'transparent',
+    color: active ? '#fff' : A.textOnDark,
+    border: 'none', cursor: 'pointer',
+    fontSize: 13, fontWeight: 500,
+    textAlign: 'left', width: '100%',
+    transition: 'background 0.12s',
+  };
+}
+
+window.RELAY_A_SIDEBAR = { Sidebar };

--- a/agent_docs/tidewater_handoff/design/direction-c-repos.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-c-repos.jsx
@@ -1,0 +1,897 @@
+/* Direction C — Repos, mentions, channel settings, new-channel modal.
+   Shared helpers used by direction-c-tidewater.jsx and the "New channel"
+   artboard. Exposes window.RELAY_C_REPOS = { ... }.
+*/
+
+(() => {
+  const { useState, useEffect, useRef, useMemo } = React;
+  const { A, I } = window.RELAY_A;
+  const { AVAILABLE_WORKSPACES, AGENTS } = window.RELAY_DATA;
+
+  // ─────────────────────────────────────────────────────────────
+  // Mentions + inline markdown (bold, code) → React elements
+  // Handles @alias (channel repos), @human, **bold**, `code`.
+  // Tokenizes in a single pass so order-of-operations is correct.
+  // ─────────────────────────────────────────────────────────────
+  const TOKEN_RE = /(@[a-z0-9][a-z0-9_-]*)|(\*\*[^*]+\*\*)|(`[^`]+`)/gi;
+
+  function renderWithMentions(text, channel) {
+    if (!text) return null;
+    const aliasSet = new Set((channel?.repos || []));
+    const out = [];
+    let lastIdx = 0;
+    let m;
+    let key = 0;
+    TOKEN_RE.lastIndex = 0;
+    while ((m = TOKEN_RE.exec(text)) !== null) {
+      if (m.index > lastIdx) {
+        out.push(<span key={key++}>{text.slice(lastIdx, m.index)}</span>);
+      }
+      const tok = m[0];
+      if (tok.startsWith('**')) {
+        out.push(<strong key={key++} style={{ fontWeight: 700 }}>{tok.slice(2, -2)}</strong>);
+      } else if (tok.startsWith('`')) {
+        out.push(
+          <code key={key++} style={{
+            background: A.paperAlt, padding: '1px 5px', borderRadius: 3,
+            fontSize: '0.9em', fontFamily: 'ui-monospace, Menlo, monospace', color: A.text,
+          }}>{tok.slice(1, -1)}</code>
+        );
+      } else if (tok.startsWith('@')) {
+        const handle = tok.slice(1).toLowerCase();
+        const isRepo = aliasSet.has(handle);
+        const isPrimary = isRepo && channel.primaryRepo === handle;
+        if (isRepo) {
+          out.push(
+            <span key={key++} style={{
+              display: 'inline-flex', alignItems: 'center', gap: 3,
+              padding: '1px 6px 1px 4px', borderRadius: 3,
+              background: isPrimary ? A.coralSoft : '#dce6f5',
+              color:      isPrimary ? A.coral    : '#3a5fa0',
+              border: `1px solid ${isPrimary ? A.coral + '55' : '#b3c5e0'}`,
+              fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+              fontSize: '0.88em', fontWeight: 600,
+              lineHeight: 1.3, verticalAlign: 'baseline',
+            }}>
+              <svg width="9" height="9" viewBox="0 0 12 12" fill="none" aria-hidden>
+                <rect x="1.5" y="2" width="9" height="8" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+                <path d="M4 5h4M4 7h2.5" stroke="currentColor" strokeWidth="1.2"/>
+              </svg>
+              {tok}
+            </span>
+          );
+        } else {
+          out.push(
+            <span key={key++} style={{
+              display: 'inline-flex', alignItems: 'center',
+              padding: '0 4px', borderRadius: 3,
+              background: A.mintSoft, color: '#2a7a5a',
+              fontWeight: 600, fontSize: '0.94em',
+            }}>{tok}</span>
+          );
+        }
+      }
+      lastIdx = m.index + tok.length;
+    }
+    if (lastIdx < text.length) {
+      out.push(<span key={key++}>{text.slice(lastIdx)}</span>);
+    }
+    return out;
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Floating mention popover (Slack-style, above composer)
+  // Renders above its anchor when triggered. Pure-presentational.
+  // ─────────────────────────────────────────────────────────────
+  function MentionPopover({ channel, query, onPick, onClose, position = 'top' }) {
+    const q = query.toLowerCase();
+    const repos = (channel?.repos || []).map((alias) => {
+      const ws = AVAILABLE_WORKSPACES.find((w) => w.defaultAlias === alias) || { path: `~/code/${alias}` };
+      return {
+        kind: 'repo', alias, path: ws.path,
+        isPrimary: channel.primaryRepo === alias,
+      };
+    });
+    const humans = [
+      { kind: 'human', alias: 'jcast',   name: 'You',         avatar: '◉' },
+      { kind: 'human', alias: 'channel', name: 'Everyone here', avatar: '#' },
+    ];
+    const all = [...repos, ...humans].filter((m) => m.alias.toLowerCase().includes(q));
+    const [sel, setSel] = useState(0);
+
+    useEffect(() => { setSel(0); }, [query]);
+    useEffect(() => {
+      const h = (e) => {
+        if (e.key === 'Escape') { onClose(); return; }
+        if (e.key === 'ArrowDown') { e.preventDefault(); setSel((s) => (s + 1) % all.length); }
+        if (e.key === 'ArrowUp')   { e.preventDefault(); setSel((s) => (s - 1 + all.length) % all.length); }
+        if (e.key === 'Enter' || e.key === 'Tab') {
+          e.preventDefault(); if (all[sel]) onPick(all[sel]);
+        }
+      };
+      window.addEventListener('keydown', h);
+      return () => window.removeEventListener('keydown', h);
+    }, [all, sel, onPick, onClose]);
+
+    if (!all.length) return null;
+
+    return (
+      <div style={{
+        position: 'absolute',
+        [position === 'top' ? 'bottom' : 'top']: 'calc(100% + 6px)',
+        left: 14, width: 340, maxHeight: 260, overflow: 'auto',
+        background: A.paper,
+        border: `1px solid ${A.paperLine}`,
+        borderRadius: 8,
+        boxShadow: '0 -8px 24px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04)',
+        zIndex: 100,
+      }}>
+        <div style={{
+          padding: '8px 12px 4px', fontSize: 10.5, fontWeight: 700,
+          color: A.textMuted, letterSpacing: '0.04em', textTransform: 'uppercase',
+          display: 'flex', justifyContent: 'space-between',
+        }}>
+          <span>{repos.filter((r) => r.alias.includes(q)).length > 0 ? 'Repos in channel' : 'Members'}</span>
+          <span style={{ fontWeight: 500, color: A.textDim, textTransform: 'none', letterSpacing: 0 }}>↑↓ Enter</span>
+        </div>
+        {all.map((m, i) => (
+          <div key={m.alias} onClick={() => onPick(m)} onMouseEnter={() => setSel(i)} style={{
+            padding: '7px 12px', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', gap: 10,
+            background: i === sel ? A.coralSoft : 'transparent',
+            color: A.text,
+          }}>
+            {m.kind === 'repo' ? (
+              <>
+                <div style={{
+                  width: 22, height: 22, borderRadius: 4,
+                  background: m.isPrimary ? A.coralSoft : A.paperAlt,
+                  color:      m.isPrimary ? A.coral    : A.textMuted,
+                  border: `1px solid ${m.isPrimary ? A.coral + '55' : A.paperLine}`,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                }}>
+                  <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+                    <rect x="1.5" y="2" width="9" height="8" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+                    <path d="M4 5h4M4 7h2.5" stroke="currentColor" strokeWidth="1.2"/>
+                  </svg>
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, fontFamily: 'ui-monospace, Menlo, monospace', display: 'flex', alignItems: 'center', gap: 6 }}>
+                    @{m.alias}
+                    {m.isPrimary && (
+                      <span style={{
+                        fontSize: 9, fontWeight: 700, padding: '1px 4px',
+                        background: A.coral, color: '#fff', borderRadius: 2,
+                        letterSpacing: '0.04em',
+                      }}>PRIMARY</span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 11, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace' }}>{m.path}</div>
+                </div>
+                <div style={{ fontSize: 10.5, color: A.textDim, fontWeight: 500 }}>
+                  agent in repo
+                </div>
+              </>
+            ) : (
+              <>
+                <div style={{
+                  width: 22, height: 22, borderRadius: 4,
+                  background: A.mintSoft, color: '#2a7a5a',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 12, fontWeight: 700, flexShrink: 0,
+                }}>{m.avatar}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600 }}>@{m.alias}</div>
+                  <div style={{ fontSize: 11, color: A.textMuted }}>{m.name}</div>
+                </div>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Header repo-chip row with inline add / remove / primary swap
+  // ─────────────────────────────────────────────────────────────
+  function RepoChipRow({ channel, onOpenSettings, onChange, compact }) {
+    const [popAnchor, setPopAnchor] = useState(null); // 'add' | alias
+    const [hoverAlias, setHoverAlias] = useState(null);
+    const rowRef = useRef(null);
+
+    const attached = channel.repos || [];
+    const available = AVAILABLE_WORKSPACES.filter((w) => !attached.includes(w.defaultAlias));
+
+    const removeRepo = (alias) => {
+      if (alias === channel.primaryRepo) return; // can't remove primary directly
+      onChange?.({
+        ...channel,
+        repos: attached.filter((a) => a !== alias),
+      });
+      setPopAnchor(null);
+    };
+    const makePrimary = (alias) => {
+      onChange?.({ ...channel, primaryRepo: alias });
+      setPopAnchor(null);
+    };
+    const addRepo = (alias) => {
+      if (attached.includes(alias)) return;
+      onChange?.({ ...channel, repos: [...attached, alias] });
+      setPopAnchor(null);
+    };
+
+    return (
+      <div ref={rowRef} style={{ position: 'relative', display: 'flex', gap: 4, alignItems: 'center' }}>
+        {attached.map((alias) => {
+          const isPrimary = alias === channel.primaryRepo;
+          const ws = AVAILABLE_WORKSPACES.find((w) => w.defaultAlias === alias);
+          const hovered = hoverAlias === alias;
+          const popOpen = popAnchor === alias;
+          return (
+            <div key={alias} style={{ position: 'relative' }}
+                 onMouseEnter={() => setHoverAlias(alias)}
+                 onMouseLeave={() => setHoverAlias(null)}>
+              <button onClick={() => setPopAnchor(popOpen ? null : alias)} style={{
+                fontSize: 10.5, fontWeight: 500,
+                padding: '2px 6px', borderRadius: 3,
+                background: isPrimary ? A.coralSoft : (popOpen || hovered ? A.paperAlt : A.paperAlt),
+                color:      isPrimary ? A.coral     : A.textMuted,
+                border: `1px solid ${isPrimary ? A.coral + '55' : (hovered || popOpen ? A.textDim : A.paperLine)}`,
+                fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+                display: 'flex', alignItems: 'center', gap: 4,
+                cursor: 'pointer',
+              }}>
+                {isPrimary && <span style={{ width: 4, height: 4, borderRadius: '50%', background: A.coral }} />}
+                {alias}
+                {hovered && !isPrimary && (
+                  <span onClick={(e) => { e.stopPropagation(); removeRepo(alias); }} title="Detach repo" style={{
+                    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                    width: 12, height: 12, borderRadius: 2, marginLeft: 1,
+                    color: A.coral, background: 'transparent',
+                    fontSize: 12, lineHeight: 1,
+                  }}>×</span>
+                )}
+              </button>
+              {popOpen && (
+                <div style={{
+                  position: 'absolute', top: 'calc(100% + 4px)', left: 0,
+                  width: 260, background: A.paper,
+                  border: `1px solid ${A.paperLine}`, borderRadius: 6,
+                  boxShadow: '0 6px 18px rgba(0,0,0,0.08)',
+                  zIndex: 50,
+                }}>
+                  <div style={{ padding: '10px 12px 8px', borderBottom: `1px solid ${A.paperLine}` }}>
+                    <div style={{ fontSize: 13, fontWeight: 700, color: A.text, fontFamily: 'ui-monospace, Menlo, monospace', display: 'flex', alignItems: 'center', gap: 6 }}>
+                      @{alias}
+                      {isPrimary && <span style={{
+                        fontSize: 9, fontWeight: 700, padding: '1px 4px',
+                        background: A.coral, color: '#fff', borderRadius: 2, letterSpacing: '0.04em',
+                      }}>PRIMARY</span>}
+                    </div>
+                    <div style={{ fontSize: 11.5, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace', marginTop: 2 }}>
+                      {ws?.path || `~/code/${alias}`}
+                    </div>
+                  </div>
+                  <div style={{ padding: 6 }}>
+                    {!isPrimary && (
+                      <PopItem onClick={() => makePrimary(alias)} icon="✓">Set as primary</PopItem>
+                    )}
+                    <PopItem onClick={() => {}} icon="⇱">Open agent terminal</PopItem>
+                    <PopItem onClick={() => {}} icon="⎈">View in repo settings</PopItem>
+                    <div style={{ height: 1, background: A.paperLine, margin: '4px 0' }} />
+                    {isPrimary ? (
+                      <PopItem disabled hint="Promote another repo first" icon="—">Detach</PopItem>
+                    ) : (
+                      <PopItem onClick={() => removeRepo(alias)} icon="×" danger>Detach from channel</PopItem>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Add chip */}
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setPopAnchor(popAnchor === 'add' ? null : 'add')} title="Attach repo" style={{
+            fontSize: 11, fontWeight: 600,
+            width: 20, height: 20, borderRadius: 3,
+            background: popAnchor === 'add' ? A.coralSoft : 'transparent',
+            color:      popAnchor === 'add' ? A.coral    : A.textMuted,
+            border: `1px dashed ${popAnchor === 'add' ? A.coral : A.paperLine}`,
+            cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 0,
+          }}>+</button>
+          {popAnchor === 'add' && (
+            <AddRepoPopover available={available} attachedCount={attached.length}
+                            onPick={addRepo} onClose={() => setPopAnchor(null)} />
+          )}
+        </div>
+
+        {/* Gear → settings drawer */}
+        <button onClick={onOpenSettings} title="Channel settings" style={{
+          marginLeft: 2,
+          width: 22, height: 22, borderRadius: 3,
+          background: 'transparent', color: A.textDim,
+          border: 'none', cursor: 'pointer',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+            <path d="M7 4.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5z" stroke="currentColor" strokeWidth="1.1"/>
+            <path d="M11.5 7c0-.3-.04-.6-.1-.88l1.1-.86-1-1.72-1.3.5a4.2 4.2 0 00-1.52-.88l-.2-1.38H6.52l-.2 1.38a4.2 4.2 0 00-1.52.88l-1.3-.5-1 1.72 1.1.86A4.3 4.3 0 002.5 7c0 .3.04.6.1.88l-1.1.86 1 1.72 1.3-.5c.45.36.97.67 1.52.88l.2 1.38h1.96l.2-1.38a4.2 4.2 0 001.52-.88l1.3.5 1-1.72-1.1-.86c.06-.28.1-.58.1-.88z" stroke="currentColor" strokeWidth="1.1"/>
+          </svg>
+        </button>
+      </div>
+    );
+  }
+
+  function PopItem({ children, icon, onClick, danger, disabled, hint }) {
+    return (
+      <button onClick={disabled ? undefined : onClick} disabled={disabled} style={{
+        width: '100%', textAlign: 'left',
+        padding: '6px 10px', borderRadius: 4,
+        background: 'transparent', border: 'none',
+        color: disabled ? A.textDim : (danger ? '#a43c32' : A.text),
+        fontSize: 12.5, fontFamily: 'inherit',
+        display: 'flex', alignItems: 'center', gap: 8,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.65 : 1,
+      }}
+      onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = A.paperAlt; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+      >
+        <span style={{ width: 14, textAlign: 'center', color: danger ? '#a43c32' : A.textMuted, fontWeight: 600 }}>{icon}</span>
+        <span style={{ flex: 1 }}>{children}</span>
+        {hint && <span style={{ fontSize: 10.5, color: A.textDim }}>{hint}</span>}
+      </button>
+    );
+  }
+
+  function AddRepoPopover({ available, attachedCount, onPick, onClose }) {
+    const [query, setQuery] = useState('');
+    const filtered = available.filter((w) =>
+      w.defaultAlias.includes(query.toLowerCase()) ||
+      w.path.includes(query.toLowerCase())
+    );
+    return (
+      <div style={{
+        position: 'absolute', top: 'calc(100% + 4px)', right: 0,
+        width: 300, background: A.paper,
+        border: `1px solid ${A.paperLine}`, borderRadius: 6,
+        boxShadow: '0 6px 18px rgba(0,0,0,0.08)',
+        zIndex: 50,
+      }}>
+        <div style={{ padding: '10px 12px 8px', borderBottom: `1px solid ${A.paperLine}` }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: A.textMuted, letterSpacing: '0.04em', textTransform: 'uppercase', marginBottom: 4 }}>
+            Attach a workspace · {attachedCount} already attached
+          </div>
+          <input autoFocus value={query} onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search registered workspaces..."
+            style={{
+              width: '100%', padding: '5px 8px', borderRadius: 4,
+              border: `1px solid ${A.paperLine}`, background: A.paperAlt,
+              fontSize: 12.5, color: A.text, outline: 'none', fontFamily: 'inherit',
+            }} />
+        </div>
+        <div style={{ maxHeight: 220, overflow: 'auto', padding: 4 }}>
+          {filtered.length === 0 ? (
+            <div style={{ padding: '16px 12px', fontSize: 12, color: A.textMuted, textAlign: 'center' }}>
+              {available.length === 0 ? 'All registered workspaces are attached.' : 'No matches.'}
+            </div>
+          ) : (
+            filtered.map((w) => (
+              <button key={w.workspaceId} onClick={() => onPick(w.defaultAlias)} style={{
+                width: '100%', textAlign: 'left',
+                padding: '7px 10px', borderRadius: 4,
+                background: 'transparent', border: 'none', cursor: 'pointer',
+                display: 'flex', alignItems: 'center', gap: 10,
+                fontFamily: 'inherit',
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = A.paperAlt; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+              >
+                <div style={{
+                  width: 22, height: 22, borderRadius: 4,
+                  background: A.paperAlt, color: A.textMuted,
+                  border: `1px solid ${A.paperLine}`,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                }}>
+                  <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+                    <rect x="1.5" y="2" width="9" height="8" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+                    <path d="M4 5h4M4 7h2.5" stroke="currentColor" strokeWidth="1.2"/>
+                  </svg>
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, fontWeight: 600, color: A.text, fontFamily: 'ui-monospace, Menlo, monospace' }}>@{w.defaultAlias}</div>
+                  <div style={{ fontSize: 11, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace',
+                                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{w.path}</div>
+                </div>
+                <div style={{ fontSize: 10.5, color: A.textDim, textAlign: 'right' }}>
+                  <div>{w.lastActive}</div>
+                  {w.openPrs > 0 && <div>{w.openPrs} PR</div>}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Channel settings drawer (right-side slide-over)
+  // ─────────────────────────────────────────────────────────────
+  function ChannelSettingsDrawer({ channel, onClose, onChange }) {
+    const [tab, setTab] = useState('repos');
+    const attached = channel.repos || [];
+    const available = AVAILABLE_WORKSPACES.filter((w) => !attached.includes(w.defaultAlias));
+
+    return (
+      <>
+        <div onClick={onClose} style={{
+          position: 'absolute', inset: 0,
+          background: 'rgba(20,22,26,0.32)', zIndex: 200,
+        }} />
+        <aside style={{
+          position: 'absolute', top: 0, right: 0, bottom: 0, width: 460,
+          background: A.paper, boxShadow: '-16px 0 48px rgba(0,0,0,0.15)',
+          zIndex: 201, display: 'flex', flexDirection: 'column',
+          minHeight: 0,
+        }}>
+          <div style={{
+            padding: '14px 18px', borderBottom: `1px solid ${A.paperLine}`,
+            display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0,
+          }}>
+            <I.hash style={{ color: A.textMuted }} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 15, fontWeight: 700, color: A.text }}>{channel.name}</div>
+              <div style={{ fontSize: 12, color: A.textMuted }}>Channel settings</div>
+            </div>
+            <button onClick={onClose} style={{
+              width: 28, height: 28, borderRadius: 5,
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: A.textMuted,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}><I.close /></button>
+          </div>
+          <div style={{ display: 'flex', gap: 2, padding: '0 18px', borderBottom: `1px solid ${A.paperLine}`, flexShrink: 0 }}>
+            {['repos', 'members', 'about'].map((t) => (
+              <button key={t} onClick={() => setTab(t)} style={{
+                padding: '9px 10px', background: 'transparent', border: 'none',
+                color: tab === t ? A.text : A.textMuted,
+                fontSize: 12.5, fontWeight: tab === t ? 600 : 500,
+                borderBottom: `2px solid ${tab === t ? A.coral : 'transparent'}`,
+                cursor: 'pointer', marginBottom: -1,
+                fontFamily: 'inherit', textTransform: 'capitalize',
+              }}>{t}</button>
+            ))}
+          </div>
+          <div style={{ flex: 1, overflow: 'auto', padding: '18px 20px' }}>
+            {tab === 'repos' && (
+              <>
+                <SectionHeader title="Attached repos" count={attached.length}
+                               hint="Each attached repo becomes a pingable @alias. The primary repo hosts the main channel agent." />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
+                  {attached.map((alias) => {
+                    const ws = AVAILABLE_WORKSPACES.find((w) => w.defaultAlias === alias);
+                    const isPrimary = alias === channel.primaryRepo;
+                    return (
+                      <div key={alias} style={{
+                        border: `1px solid ${isPrimary ? A.coral + '66' : A.paperLine}`,
+                        borderRadius: 6, padding: 10, background: isPrimary ? A.coralSoft + '55' : A.paper,
+                        display: 'flex', alignItems: 'center', gap: 10,
+                      }}>
+                        <div style={{
+                          width: 30, height: 30, borderRadius: 5,
+                          background: isPrimary ? A.coral : A.paperAlt,
+                          color: isPrimary ? '#fff' : A.textMuted,
+                          border: isPrimary ? 'none' : `1px solid ${A.paperLine}`,
+                          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                        }}>
+                          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                            <rect x="2" y="2.5" width="10" height="9" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+                            <path d="M4.5 5.5h5M4.5 8h3" stroke="currentColor" strokeWidth="1.3"/>
+                          </svg>
+                        </div>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 13.5, fontWeight: 600, fontFamily: 'ui-monospace, Menlo, monospace', display: 'flex', alignItems: 'center', gap: 6 }}>
+                            @{alias}
+                            {isPrimary && <span style={{
+                              fontSize: 9, fontWeight: 700, padding: '1px 5px',
+                              background: A.coral, color: '#fff', borderRadius: 2, letterSpacing: '0.04em',
+                            }}>PRIMARY</span>}
+                          </div>
+                          <div style={{ fontSize: 11.5, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace' }}>
+                            {ws?.path || `~/code/${alias}`}
+                          </div>
+                        </div>
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          {!isPrimary && (
+                            <button onClick={() => onChange?.({ ...channel, primaryRepo: alias })} style={chipBtn(false)}>
+                              Make primary
+                            </button>
+                          )}
+                          {!isPrimary && (
+                            <button onClick={() => onChange?.({ ...channel, repos: attached.filter((a) => a !== alias) })}
+                              style={chipBtn(true)}>Detach</button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                <SectionHeader title="Available workspaces" count={available.length}
+                               hint="Registered via `rly up`. Attach to make pingable in this channel." />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {available.map((w) => (
+                    <div key={w.workspaceId} style={{
+                      border: `1px solid ${A.paperLine}`, borderRadius: 6, padding: 9,
+                      display: 'flex', alignItems: 'center', gap: 10,
+                    }}>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 12.5, fontWeight: 600, fontFamily: 'ui-monospace, Menlo, monospace', color: A.text }}>@{w.defaultAlias}</div>
+                        <div style={{ fontSize: 11, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace' }}>{w.path}</div>
+                      </div>
+                      <button onClick={() => onChange?.({ ...channel, repos: [...attached, w.defaultAlias] })}
+                        style={{
+                          padding: '4px 10px', borderRadius: 4,
+                          background: A.coral, color: '#fff', border: 'none',
+                          fontSize: 11.5, fontWeight: 600, cursor: 'pointer',
+                          fontFamily: 'inherit',
+                        }}>Attach</button>
+                    </div>
+                  ))}
+                  {available.length === 0 && (
+                    <div style={{ fontSize: 12, color: A.textMuted, textAlign: 'center', padding: 20 }}>
+                      All registered workspaces are already attached. Run <code style={{ fontFamily: 'ui-monospace, Menlo, monospace', background: A.paperAlt, padding: '1px 5px', borderRadius: 3 }}>rly up</code> in a new repo to register more.
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+            {tab === 'members' && (
+              <div style={{ fontSize: 13, color: A.textMuted, lineHeight: 1.6 }}>
+                Human members are inferred from who's pinged or posted. The channel's agent roster is derived from attached repos — see the <strong style={{ color: A.text }}>Repos</strong> tab.
+              </div>
+            )}
+            {tab === 'about' && (
+              <div>
+                <SectionHeader title="Topic" />
+                <div style={{ fontSize: 13, color: A.text, padding: '8px 0 16px', lineHeight: 1.55 }}>{channel.topic}</div>
+                <SectionHeader title="Classification" />
+                <div style={{ fontSize: 13, color: A.text, padding: '8px 0 16px' }}>{channel.tier.replace('_',' ')}</div>
+                <SectionHeader title="Created" />
+                <div style={{ fontSize: 13, color: A.text, padding: '8px 0' }}>Inferred from first message · {channel.activeAt} ago</div>
+              </div>
+            )}
+          </div>
+        </aside>
+      </>
+    );
+  }
+
+  function chipBtn(danger) {
+    return {
+      padding: '3px 8px', borderRadius: 4,
+      background: 'transparent', color: danger ? '#a43c32' : A.text,
+      border: `1px solid ${danger ? '#a43c3255' : A.paperLine}`,
+      fontSize: 11, fontWeight: 500, cursor: 'pointer',
+      fontFamily: 'inherit',
+    };
+  }
+
+  function SectionHeader({ title, count, hint }) {
+    return (
+      <div style={{ marginBottom: 8 }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          fontSize: 10.5, fontWeight: 700, color: A.textMuted,
+          letterSpacing: '0.05em', textTransform: 'uppercase',
+        }}>
+          <span>{title}</span>
+          {count != null && <span style={{ color: A.textDim, fontWeight: 500 }}>· {count}</span>}
+        </div>
+        {hint && <div style={{ fontSize: 11.5, color: A.textMuted, marginTop: 3, lineHeight: 1.5 }}>{hint}</div>}
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // NEW CHANNEL MODAL (multi-step)
+  // Steps: 1. Name + topic  2. Repos + primary  3. First message
+  // ─────────────────────────────────────────────────────────────
+  function NewChannelModal({ initial = {}, onClose, onCreate, step: stepProp }) {
+    const [step, setStep] = useState(stepProp || 1);
+    const [name, setName] = useState(initial.name || '');
+    const [topic, setTopic] = useState(initial.topic || '');
+    const [selected, setSelected] = useState(new Map(
+      (initial.repos || []).map((a) => [a, { alias: a, spawn: false }])
+    )); // workspaceId -> { alias, spawn }
+    const [primary, setPrimary] = useState(initial.primary || null);
+    const [firstMsg, setFirstMsg] = useState(initial.firstMsg || '');
+    const [filter, setFilter] = useState('');
+
+    // Infer default channel name from topic if blank
+    const slug = name.trim() || (topic ? topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g,'').slice(0, 28) : '');
+
+    const toggle = (w) => {
+      setSelected((prev) => {
+        const next = new Map(prev);
+        if (next.has(w.workspaceId)) {
+          next.delete(w.workspaceId);
+          if (primary === w.workspaceId) {
+            const first = [...next.keys()][0] || null;
+            setPrimary(first);
+          }
+        } else {
+          next.set(w.workspaceId, { alias: w.defaultAlias, spawn: false });
+          if (!primary) setPrimary(w.workspaceId);
+        }
+        return next;
+      });
+    };
+
+    const filteredWorkspaces = AVAILABLE_WORKSPACES.filter((w) =>
+      !filter || w.defaultAlias.includes(filter.toLowerCase()) || w.path.includes(filter.toLowerCase())
+    );
+
+    const canNext = step === 1 ? slug.length > 0 : step === 2 ? selected.size > 0 && primary : true;
+    const canCreate = slug && selected.size > 0 && primary;
+
+    return (
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: 'rgba(20,22,26,0.5)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 300, padding: 40,
+      }} onClick={onClose}>
+        <div onClick={(e) => e.stopPropagation()} style={{
+          width: 640, maxHeight: '85%',
+          background: A.paper, borderRadius: 12,
+          boxShadow: '0 24px 80px rgba(0,0,0,0.2)',
+          display: 'flex', flexDirection: 'column',
+          overflow: 'hidden',
+        }}>
+          {/* Header */}
+          <div style={{
+            padding: '16px 22px 12px', borderBottom: `1px solid ${A.paperLine}`,
+            display: 'flex', alignItems: 'center', gap: 12,
+          }}>
+            <div style={{
+              width: 34, height: 34, borderRadius: 8,
+              background: A.coral, color: '#fff',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 18, fontWeight: 700,
+            }}>#</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 16, fontWeight: 700, color: A.text }}>New channel</div>
+              <div style={{ fontSize: 12, color: A.textMuted }}>Attach repos, set a primary, kick off with a first message.</div>
+            </div>
+            <button onClick={onClose} style={{
+              width: 28, height: 28, borderRadius: 5,
+              background: 'none', border: 'none', cursor: 'pointer', color: A.textMuted,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}><I.close /></button>
+          </div>
+
+          {/* Stepper */}
+          <div style={{
+            padding: '10px 22px', display: 'flex', gap: 6, alignItems: 'center',
+            borderBottom: `1px solid ${A.paperLine}`,
+            fontSize: 12,
+          }}>
+            {[
+              { n: 1, label: 'Basics' },
+              { n: 2, label: 'Repos' },
+              { n: 3, label: 'Kick off' },
+            ].map((s, i, arr) => (
+              <React.Fragment key={s.n}>
+                <div onClick={() => setStep(s.n)} style={{
+                  display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer',
+                  color: step === s.n ? A.text : A.textMuted,
+                  fontWeight: step === s.n ? 600 : 500,
+                }}>
+                  <span style={{
+                    width: 18, height: 18, borderRadius: '50%',
+                    background: step >= s.n ? A.coral : A.paperAlt,
+                    color:      step >= s.n ? '#fff'  : A.textMuted,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: 10.5, fontWeight: 700,
+                    border: step === s.n ? `2px solid ${A.coral}55` : 'none',
+                    boxSizing: step === s.n ? 'content-box' : 'border-box',
+                  }}>{step > s.n ? '✓' : s.n}</span>
+                  {s.label}
+                </div>
+                {i < arr.length - 1 && (
+                  <div style={{ flex: 1, height: 1, background: step > s.n ? A.coral : A.paperLine }} />
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+
+          {/* Body */}
+          <div style={{ flex: 1, overflow: 'auto', padding: '20px 22px' }}>
+            {step === 1 && (
+              <div>
+                <Field label="Channel name">
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{
+                      width: 24, height: 32, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      color: A.textMuted, fontSize: 16,
+                    }}>#</span>
+                    <input autoFocus value={name} onChange={(e) => setName(e.target.value.replace(/\s+/g, '-').toLowerCase())}
+                      placeholder="e.g. oauth-api-users" style={inputStyle()} />
+                  </div>
+                  <FieldHint>Lowercase, dashes for spaces. Shown in the sidebar as <code style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>#{slug || 'your-channel'}</code>.</FieldHint>
+                </Field>
+                <Field label="Topic (optional)">
+                  <input value={topic} onChange={(e) => setTopic(e.target.value)}
+                    placeholder="What's this channel for?" style={inputStyle()} />
+                </Field>
+                <Field label="Tier">
+                  <div style={{ fontSize: 12.5, color: A.textMuted, lineHeight: 1.55 }}>
+                    Classified automatically from your first message. You can override later.
+                  </div>
+                </Field>
+              </div>
+            )}
+            {step === 2 && (
+              <div>
+                <div style={{ fontSize: 12, color: A.textMuted, marginBottom: 8, lineHeight: 1.55 }}>
+                  Pick the repos this channel spans. Each attached repo becomes a pingable <code style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>@alias</code>. The <strong style={{ color: A.coral }}>primary</strong> repo hosts the main channel agent.
+                </div>
+                <input value={filter} onChange={(e) => setFilter(e.target.value)}
+                  placeholder="Filter by path or alias..."
+                  style={{ ...inputStyle(), marginBottom: 10 }} />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 340, overflow: 'auto' }}>
+                  {filteredWorkspaces.map((w) => {
+                    const isSel = selected.has(w.workspaceId);
+                    const isPrimary = primary === w.workspaceId;
+                    return (
+                      <div key={w.workspaceId} onClick={() => toggle(w)} style={{
+                        padding: 10, borderRadius: 6,
+                        background: isSel ? A.coralSoft + '88' : A.paperAlt,
+                        border: `1px solid ${isPrimary ? A.coral : (isSel ? A.coral + '55' : A.paperLine)}`,
+                        display: 'flex', alignItems: 'center', gap: 12, cursor: 'pointer',
+                      }}>
+                        <input type="checkbox" checked={isSel} readOnly style={{ accentColor: A.coral }} />
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 13, fontWeight: 600, fontFamily: 'ui-monospace, Menlo, monospace', color: A.text, display: 'flex', alignItems: 'center', gap: 6 }}>
+                            @{w.defaultAlias}
+                            {isPrimary && <span style={{
+                              fontSize: 9, fontWeight: 700, padding: '1px 5px',
+                              background: A.coral, color: '#fff', borderRadius: 2, letterSpacing: '0.04em',
+                            }}>PRIMARY</span>}
+                          </div>
+                          <div style={{ fontSize: 11, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace' }}>{w.path}</div>
+                        </div>
+                        {isSel && (
+                          <label onClick={(e) => e.stopPropagation()} style={{
+                            display: 'flex', alignItems: 'center', gap: 4,
+                            fontSize: 11.5, color: isPrimary ? A.coral : A.textMuted,
+                            cursor: 'pointer', fontWeight: 500,
+                          }}>
+                            <input type="radio" name="primary" checked={isPrimary}
+                              onChange={() => setPrimary(w.workspaceId)}
+                              style={{ accentColor: A.coral }} />
+                            primary
+                          </label>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                <div style={{ fontSize: 11.5, color: A.textDim, marginTop: 10, padding: '8px 10px', background: A.paperAlt, borderRadius: 5, lineHeight: 1.55 }}>
+                  <strong style={{ color: A.textMuted }}>Don't see your repo?</strong> Run <code style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>rly up</code> in its directory to register it, then come back.
+                </div>
+              </div>
+            )}
+            {step === 3 && (
+              <div>
+                <div style={{ fontSize: 12, color: A.textMuted, marginBottom: 12, lineHeight: 1.55 }}>
+                  First message goes straight to the primary agent <strong style={{ color: A.coral, fontFamily: 'ui-monospace, Menlo, monospace' }}>@{selected.get(primary)?.alias}</strong>. Paste an issue URL, describe a feature, or ask a question — Relay classifies and either plans tickets or answers directly.
+                </div>
+                <Field label="First message">
+                  <textarea autoFocus value={firstMsg} onChange={(e) => setFirstMsg(e.target.value)}
+                    placeholder={`e.g. "Add OAuth2 to /api/users — github and google to start." or paste an issue URL...`}
+                    rows={6} style={{
+                      ...inputStyle(), resize: 'vertical', padding: 10,
+                      fontFamily: 'inherit', lineHeight: 1.5,
+                    }} />
+                  <FieldHint>
+                    You can also type <code style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>@</code> to ping another attached repo in the same turn.
+                  </FieldHint>
+                </Field>
+                <div style={{
+                  padding: 10, background: A.paperAlt, borderRadius: 6,
+                  fontSize: 12, color: A.textMuted, lineHeight: 1.55, marginTop: 10,
+                }}>
+                  <div style={{ fontSize: 10.5, fontWeight: 700, color: A.textMuted, letterSpacing: '0.04em', textTransform: 'uppercase', marginBottom: 6 }}>Summary</div>
+                  <div>Channel: <code style={{ fontFamily: 'ui-monospace, Menlo, monospace', color: A.text }}>#{slug}</code></div>
+                  <div>Repos: {[...selected.values()].map((r, i) =>
+                    <React.Fragment key={r.alias}>{i > 0 && ', '}<code style={{ fontFamily: 'ui-monospace, Menlo, monospace', color: primary && selected.get(primary)?.alias === r.alias ? A.coral : A.text }}>@{r.alias}</code></React.Fragment>
+                  )}</div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div style={{
+            padding: '12px 22px', borderTop: `1px solid ${A.paperLine}`,
+            display: 'flex', gap: 8, alignItems: 'center',
+            background: A.paperAlt,
+          }}>
+            {step > 1 ? (
+              <button onClick={() => setStep(step - 1)} style={{
+                padding: '8px 14px', borderRadius: 5,
+                background: 'transparent', color: A.textMuted,
+                border: `1px solid ${A.paperLine}`,
+                fontSize: 12.5, fontWeight: 500, cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}>← Back</button>
+            ) : <div />}
+            <div style={{ flex: 1 }} />
+            <div style={{ fontSize: 11.5, color: A.textDim }}>
+              You can also: <code style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>/new #{slug || 'name'} {[...selected.values()].map((r) => r.alias).join(',') || 'repo1,repo2'}</code>
+            </div>
+            {step < 3 ? (
+              <button onClick={() => canNext && setStep(step + 1)} disabled={!canNext} style={{
+                padding: '8px 16px', borderRadius: 5,
+                background: canNext ? A.coral : A.paperAlt,
+                color: canNext ? '#fff' : A.textDim,
+                border: 'none', fontSize: 12.5, fontWeight: 600,
+                cursor: canNext ? 'pointer' : 'not-allowed',
+                fontFamily: 'inherit',
+              }}>Next →</button>
+            ) : (
+              <button onClick={() => canCreate && onCreate({ name: slug, topic, primary, selected, firstMsg })}
+                disabled={!canCreate} style={{
+                padding: '8px 16px', borderRadius: 5,
+                background: canCreate ? A.coral : A.paperAlt,
+                color: canCreate ? '#fff' : A.textDim,
+                border: 'none', fontSize: 12.5, fontWeight: 600,
+                cursor: canCreate ? 'pointer' : 'not-allowed',
+                fontFamily: 'inherit',
+              }}>Create & post</button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function Field({ label, children }) {
+    return (
+      <div style={{ marginBottom: 16 }}>
+        <div style={{
+          fontSize: 10.5, fontWeight: 700, color: A.textMuted,
+          letterSpacing: '0.05em', textTransform: 'uppercase',
+          marginBottom: 5,
+        }}>{label}</div>
+        {children}
+      </div>
+    );
+  }
+  function FieldHint({ children }) {
+    return <div style={{ fontSize: 11.5, color: A.textDim, marginTop: 5, lineHeight: 1.5 }}>{children}</div>;
+  }
+  function inputStyle() {
+    return {
+      width: '100%', padding: '7px 10px', borderRadius: 5,
+      border: `1px solid ${A.paperLine}`, background: A.paper,
+      fontSize: 13, color: A.text, outline: 'none',
+      fontFamily: 'inherit',
+    };
+  }
+
+  window.RELAY_C_REPOS = {
+    RepoChipRow,
+    ChannelSettingsDrawer,
+    NewChannelModal,
+    MentionPopover,
+    renderWithMentions,
+  };
+})();

--- a/agent_docs/tidewater_handoff/design/direction-c-tidewater.jsx
+++ b/agent_docs/tidewater_handoff/design/direction-c-tidewater.jsx
@@ -1,0 +1,1272 @@
+/* Direction C — "Tidewater" (synthesis of A + B)
+   Base: Direction A's 3-pane layout, Tide palette, tool-use presence,
+         full-fidelity bubbles, DM-promote affordance.
+   Adds from B: tabbed right rail (Threads / Decisions / PRs).
+   New: channel header tabs (Chat | Board | Decisions) — the pane switches,
+        not a pinned canvas. Board is a dense list view w/ columns
+        (ID, Status, Title, Agent, PR).
+*/
+
+(() => {
+  const { useState, useMemo, useEffect, useRef } = React;
+  const { AGENTS, REPOS, CHANNELS, DMS, ACTIVITY } = window.RELAY_DATA;
+  const { A, I, Avatar, agentColor, WorkspaceRail } = window.RELAY_A;
+  const { Sidebar } = window.RELAY_A_SIDEBAR;
+  const { MessageList, Composer, markdownMini } = window.RELAY_A_CHAT;
+  const { RepoChipRow, ChannelSettingsDrawer, NewChannelModal, MentionPopover, renderWithMentions } = window.RELAY_C_REPOS;
+  // We'll reuse A's right-pane bodies (Decisions, PR thread) for individual
+  // thread detail — but the rail itself is new (tabbed, medium-density).
+
+  const agentById = (id) => AGENTS.find((a) => a.id === id);
+
+  function tierColor(tier) {
+    return {
+      architectural: { bg: '#e9dff5', fg: '#6a4ea0' },
+      feature_large: { bg: A.coralSoft, fg: A.coral },
+      feature_small: { bg: A.mintSoft,  fg: A.mint },
+      bugfix:        { bg: '#fae8d8',   fg: '#b26a3a' },
+    }[tier] || { bg: A.paperAlt, fg: A.textMuted };
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Channel header — NEW: tabbed pane switcher
+  // ─────────────────────────────────────────────────────────────
+  function ChannelHeader({ channel, agents, pane, onPane, rightOpen, onToggleRight, counts, onChannelChange, onOpenSettings }) {
+    const tabs = [
+      { id: 'chat',      label: 'Chat',      count: null },
+      { id: 'board',     label: 'Board',     count: counts.tickets },
+      { id: 'decisions', label: 'Decisions', count: counts.decisions },
+    ];
+    const tc = tierColor(channel.tier);
+    return (
+      <div style={{
+        borderBottom: `1px solid ${A.paperLine}`,
+        background: A.paper, flexShrink: 0,
+      }}>
+        {/* Top row: name, tier, topic, agents, right-rail toggle */}
+        <div style={{
+          padding: '10px 18px 8px 20px',
+          display: 'flex', alignItems: 'center', gap: 12,
+        }}>
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
+            <I.hash style={{ color: A.textMuted, flexShrink: 0 }} />
+            <span style={{
+              fontSize: 16, fontWeight: 600, color: A.text, letterSpacing: '-0.005em',
+              whiteSpace: 'nowrap', flexShrink: 0,
+            }}>{channel.name}</span>
+            <span style={{
+              fontSize: 10, fontWeight: 600, letterSpacing: '0.04em',
+              textTransform: 'uppercase', padding: '2px 7px', borderRadius: 4,
+              background: tc.bg, color: tc.fg, flexShrink: 0, whiteSpace: 'nowrap',
+            }}>{channel.tier.replace('_', ' ')}</span>
+            <button style={{
+              border: 'none', background: 'none', padding: 4, cursor: 'pointer',
+              color: channel.starred ? A.amber : A.textDim, flexShrink: 0,
+            }}>{channel.starred ? <I.starFill /> : <I.star />}</button>
+            <span style={{ width: 1, height: 12, background: A.paperLine, flexShrink: 0 }} />
+            <span style={{
+              fontSize: 12, color: A.textDim,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}>{channel.topic}</span>
+          </div>
+
+          {/* Agent stack */}
+          <div style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+            {agents.slice(0, 4).map((a, i) => (
+              <div key={a.id} style={{ marginLeft: i === 0 ? 0 : -8 }}>
+                <Avatar agent={a} size={26} showStatus />
+              </div>
+            ))}
+            {agents.length > 4 && (
+              <div style={{
+                marginLeft: -8, width: 26, height: 26, borderRadius: 6,
+                background: A.paperAlt, color: A.textMuted,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 11, fontWeight: 600, border: `2px solid ${A.paper}`,
+              }}>+{agents.length - 4}</div>
+            )}
+          </div>
+
+          <button onClick={onToggleRight} title="Toggle right rail" style={{
+            width: 30, height: 28, borderRadius: 5,
+            background: rightOpen ? A.coralSoft : 'transparent',
+            color:      rightOpen ? A.coral    : A.textMuted,
+            border: `1px solid ${rightOpen ? A.coral + '55' : A.paperLine}`,
+            cursor: 'pointer', flexShrink: 0,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}>
+            <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+              <rect x="2" y="3" width="10" height="8" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+              <path d="M9 3v8" stroke="currentColor" strokeWidth="1.2"/>
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs row — with interactive repo chips on the right */}
+        <div style={{ padding: '0 18px 0 20px', display: 'flex', gap: 2, alignItems: 'flex-end' }}>
+          {tabs.map((t) => (
+            <button key={t.id} onClick={() => onPane(t.id)} style={{
+              padding: '7px 12px 8px',
+              background: 'transparent', border: 'none', cursor: 'pointer',
+              color: pane === t.id ? A.text : A.textMuted,
+              fontSize: 13, fontWeight: pane === t.id ? 600 : 500,
+              borderBottom: `2px solid ${pane === t.id ? A.coral : 'transparent'}`,
+              marginBottom: -1, fontFamily: 'inherit',
+              display: 'flex', alignItems: 'center', gap: 6,
+              letterSpacing: '-0.005em',
+            }}>
+              {t.label}
+              {t.count != null && (
+                <span style={{
+                  fontSize: 10.5, fontWeight: 600, fontVariantNumeric: 'tabular-nums',
+                  color: pane === t.id ? A.coral : A.textDim,
+                  background: pane === t.id ? A.coralSoft : A.paperAlt,
+                  padding: '1px 6px', borderRadius: 8,
+                }}>{t.count}</span>
+              )}
+            </button>
+          ))}
+          <div style={{ flex: 1 }} />
+          <div style={{ paddingBottom: 6, display: 'flex', alignItems: 'center' }}>
+            <RepoChipRow channel={channel} onChange={onChannelChange} onOpenSettings={onOpenSettings} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // BOARD LIST VIEW (new)
+  // Columns: ID · Status · Title · Agent · PR
+  // ─────────────────────────────────────────────────────────────
+  function BoardView({ channel, onOpenTicket, onOpenPr }) {
+    const [sort, setSort] = useState('order'); // order | status | agent
+    const [group, setGroup] = useState('status'); // none | status | specialty
+
+    const statusOrder = ['executing', 'verifying', 'ready', 'blocked', 'pending', 'failed', 'completed'];
+    const statusLabel = {
+      pending:   'Pending',
+      ready:     'Ready',
+      executing: 'Running',
+      verifying: 'Verifying',
+      completed: 'Done',
+      failed:    'Failed',
+      blocked:   'Blocked',
+      retry:     'Retrying',
+    };
+
+    // Sort tickets
+    const sorted = useMemo(() => {
+      const copy = [...channel.tickets];
+      if (sort === 'status') {
+        copy.sort((a, b) => statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status));
+      } else if (sort === 'agent') {
+        copy.sort((a, b) => (a.agent || 'zzz').localeCompare(b.agent || 'zzz'));
+      }
+      return copy;
+    }, [channel.tickets, sort]);
+
+    // Group
+    const groups = useMemo(() => {
+      if (group === 'none') return [['', sorted]];
+      const key = group === 'status' ? 'status' : 'specialty';
+      const map = new Map();
+      for (const t of sorted) {
+        const k = t[key] || 'other';
+        if (!map.has(k)) map.set(k, []);
+        map.get(k).push(t);
+      }
+      if (group === 'status') {
+        return statusOrder.filter((s) => map.has(s)).map((s) => [s, map.get(s)]);
+      }
+      return [...map.entries()];
+    }, [sorted, group]);
+
+    const totalPrs = (channel.prs || []).length;
+
+    return (
+      <div style={{
+        flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0,
+        background: A.paper,
+      }}>
+        {/* Toolbar */}
+        <div style={{
+          flexShrink: 0, padding: '12px 20px 10px',
+          borderBottom: `1px solid ${A.paperLine}`,
+          display: 'flex', alignItems: 'center', gap: 10,
+          background: A.paper,
+        }}>
+          <div style={{ fontSize: 13, color: A.textMuted }}>
+            <span style={{ color: A.text, fontWeight: 600 }}>{channel.tickets.length}</span> tickets ·{' '}
+            <span style={{ color: A.text, fontWeight: 600 }}>{totalPrs}</span> PRs ·{' '}
+            across <span style={{ color: A.text, fontWeight: 600 }}>{channel.repos.length}</span> repos
+          </div>
+          <div style={{ flex: 1 }} />
+          <Toggle label="Group" value={group} options={[
+            { v: 'status',    l: 'by status' },
+            { v: 'specialty', l: 'by specialty' },
+            { v: 'none',      l: 'none' },
+          ]} onChange={setGroup} />
+          <Toggle label="Sort" value={sort} options={[
+            { v: 'order',  l: 'original' },
+            { v: 'status', l: 'by status' },
+            { v: 'agent',  l: 'by agent' },
+          ]} onChange={setSort} />
+          <button style={{
+            padding: '5px 10px', borderRadius: 5, fontSize: 12, fontWeight: 600,
+            background: A.coral, color: '#fff', border: 'none', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', gap: 5,
+          }}><I.plus /> Add ticket</button>
+        </div>
+
+        {/* Table */}
+        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{
+                background: A.paperAlt,
+                position: 'sticky', top: 0, zIndex: 1,
+                borderBottom: `1px solid ${A.paperLine}`,
+              }}>
+                <th style={thStyle()}>ID</th>
+                <th style={thStyle()}>Status</th>
+                <th style={thStyle({ width: '100%' })}>Title</th>
+                <th style={thStyle()}>Agent</th>
+                <th style={thStyle()}>PR</th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map(([gk, gtickets], gi) => (
+                <React.Fragment key={gk || 'all'}>
+                  {gk && (
+                    <tr>
+                      <td colSpan={5} style={{
+                        padding: '12px 20px 4px', fontSize: 11, fontWeight: 700,
+                        color: A.textMuted, letterSpacing: '0.04em',
+                        background: A.paper,
+                      }}>
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                          {group === 'status' && <StatusDot status={gk} />}
+                          <span style={{ textTransform: 'uppercase' }}>{group === 'status' ? statusLabel[gk] : gk.replace('_', ' ')}</span>
+                          <span style={{ color: A.textDim, fontWeight: 500 }}>· {gtickets.length}</span>
+                        </span>
+                      </td>
+                    </tr>
+                  )}
+                  {gtickets.map((t) => (
+                    <BoardRow key={t.id} t={t} channel={channel}
+                              onOpenTicket={onOpenTicket}
+                              onOpenPr={onOpenPr}
+                              statusLabel={statusLabel} />
+                  ))}
+                </React.Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
+  function thStyle(extra) {
+    return {
+      padding: '8px 16px',
+      textAlign: 'left',
+      fontSize: 10.5, fontWeight: 700, letterSpacing: '0.05em',
+      textTransform: 'uppercase',
+      color: A.textMuted,
+      whiteSpace: 'nowrap',
+      ...extra,
+    };
+  }
+
+  function BoardRow({ t, channel, onOpenTicket, onOpenPr, statusLabel }) {
+    const agent = t.agent ? agentById(t.agent) : null;
+    // Rough heuristic: first PR matches first "executing/completed" ticket w/ feat- branch
+    const pr = (channel.prs || []).find((p) =>
+      p.author.toLowerCase() === (t.agent || '').toLowerCase()
+    );
+    return (
+      <tr onClick={() => onOpenTicket(t)} style={{
+        borderBottom: `1px solid ${A.paperLine}`,
+        cursor: 'pointer',
+      }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = A.paperAlt; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+      >
+        <td style={tdStyle({ fontFamily: 'ui-monospace, Menlo, monospace', color: A.textMuted, fontSize: 12 })}>{t.id}</td>
+        <td style={tdStyle()}>
+          <StatusPill status={t.status} label={statusLabel[t.status]} />
+        </td>
+        <td style={tdStyle({ color: A.text, fontWeight: 500 })}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span>{t.title}</span>
+            {t.deps?.length > 0 && (
+              <span style={{
+                fontSize: 10.5, color: A.textDim,
+                fontFamily: 'ui-monospace, Menlo, monospace',
+              }}>← {t.deps.join(', ')}</span>
+            )}
+            <span style={{
+              fontSize: 10, color: A.textDim,
+              padding: '1px 5px', borderRadius: 3,
+              background: A.paperAlt,
+              fontFamily: 'ui-monospace, Menlo, monospace',
+            }}>{t.specialty.replace('_', ' ')}</span>
+          </div>
+        </td>
+        <td style={tdStyle()}>
+          {agent ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+              <Avatar agent={agent} size={20} />
+              <span style={{ color: A.text, fontSize: 12.5, fontWeight: 500 }}>{agent.name}</span>
+            </div>
+          ) : (
+            <span style={{ color: A.textDim, fontSize: 12 }}>unassigned</span>
+          )}
+        </td>
+        <td style={tdStyle()}>
+          {pr ? (
+            <button onClick={(e) => { e.stopPropagation(); onOpenPr(pr); }} style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: 'transparent', border: `1px solid ${A.paperLine}`,
+              color: A.text, padding: '3px 8px', borderRadius: 4,
+              cursor: 'pointer', fontFamily: 'inherit', fontSize: 12,
+            }}>
+              <I.pr />
+              <span style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>#{pr.number}</span>
+              <span style={{ width: 5, height: 5, borderRadius: '50%', background:
+                pr.ci === 'passing' ? A.mint : pr.ci === 'failing' ? A.coral : A.textDim }} />
+            </button>
+          ) : (
+            <span style={{ color: A.textDim, fontSize: 12 }}>—</span>
+          )}
+        </td>
+      </tr>
+    );
+  }
+
+  function tdStyle(extra) {
+    return {
+      padding: '10px 16px',
+      verticalAlign: 'middle',
+      fontSize: 13,
+      ...extra,
+    };
+  }
+
+  function StatusDot({ status }) {
+    const c = A.statusFill[status] || A.textDim;
+    if (status === 'executing') {
+      return <span style={{
+        width: 7, height: 7, borderRadius: '50%', background: c,
+        boxShadow: `0 0 0 3px ${c}22`,
+        animation: 'c-pulse 1.6s ease-in-out infinite',
+        display: 'inline-block',
+      }} />;
+    }
+    if (status === 'blocked') {
+      return <span style={{ width: 7, height: 2, background: c, display: 'inline-block' }} />;
+    }
+    if (status === 'ready' || status === 'pending') {
+      return <span style={{
+        width: 7, height: 7, borderRadius: '50%', background: 'transparent',
+        border: `1.5px ${status === 'pending' ? 'dashed' : 'solid'} ${c}`,
+        display: 'inline-block', boxSizing: 'border-box',
+      }} />;
+    }
+    return <span style={{ width: 7, height: 7, borderRadius: '50%', background: c, display: 'inline-block' }} />;
+  }
+
+  function StatusPill({ status, label }) {
+    const c = A.statusFill[status] || A.textDim;
+    const bg = {
+      executing: A.coralSoft,
+      verifying: '#e9dff5',
+      completed: A.mintSoft,
+      failed:    A.coralSoft,
+      ready:     '#dce6f5',
+      blocked:   A.paperAlt,
+      pending:   A.paperAlt,
+    }[status] || A.paperAlt;
+    const fg = {
+      executing: '#b8761f',
+      verifying: '#6a4ea0',
+      completed: '#2a7a5a',
+      failed:    '#a43c32',
+      ready:     '#3a5fa0',
+      blocked:   A.textMuted,
+      pending:   A.textDim,
+    }[status] || A.textMuted;
+    return (
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 5,
+        padding: '2px 8px', borderRadius: 10,
+        background: bg, color: fg,
+        fontSize: 11, fontWeight: 600,
+        whiteSpace: 'nowrap',
+      }}>
+        <StatusDot status={status} />
+        {label}
+      </span>
+    );
+  }
+
+  function Toggle({ label, value, options, onChange }) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11.5 }}>
+        <span style={{ color: A.textDim, fontWeight: 500 }}>{label}:</span>
+        <div style={{ display: 'flex', background: A.paperAlt, borderRadius: 5, padding: 2, border: `1px solid ${A.paperLine}` }}>
+          {options.map((o) => (
+            <button key={o.v} onClick={() => onChange(o.v)} style={{
+              padding: '2px 8px', borderRadius: 3,
+              background: value === o.v ? A.paper : 'transparent',
+              color:      value === o.v ? A.text  : A.textMuted,
+              border: 'none', cursor: 'pointer',
+              fontSize: 11.5, fontWeight: value === o.v ? 600 : 500,
+              boxShadow: value === o.v ? `0 1px 2px rgba(0,0,0,0.05)` : 'none',
+              fontFamily: 'inherit',
+            }}>{o.l}</button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // DECISIONS VIEW (center pane, when tab=decisions)
+  // Similar to A's decisions drawer but more breathing room
+  // ─────────────────────────────────────────────────────────────
+  function DecisionsView({ channel, onOpenThread }) {
+    if (!channel.decisions?.length) {
+      return (
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: A.paper }}>
+          <div style={{ textAlign: 'center', maxWidth: 440, padding: 40 }}>
+            <div style={{
+              width: 60, height: 60, margin: '0 auto 18px', borderRadius: 14,
+              background: A.coralSoft, color: A.coral,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 26,
+            }}>⎉</div>
+            <div style={{ fontSize: 18, fontWeight: 700, color: A.text, marginBottom: 6 }}>No decisions yet</div>
+            <div style={{ fontSize: 13.5, color: A.textMuted, lineHeight: 1.55 }}>
+              When agents make a call worth preserving — architecture, approach, trade-off — it shows up here as an ADR. They're searchable across channels.
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div style={{ flex: 1, overflow: 'auto', background: A.paper, minHeight: 0 }}>
+        <div style={{ maxWidth: 820, margin: '0 auto', padding: '28px 40px 60px' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: A.textMuted, letterSpacing: '0.05em', marginBottom: 4 }}>
+            DECISION LOG · {channel.decisions.length}
+          </div>
+          <div style={{ fontSize: 22, fontWeight: 700, color: A.text, marginBottom: 24, letterSpacing: '-0.01em' }}>
+            #{channel.name}
+          </div>
+          {channel.decisions.map((d, i) => (
+            <article key={d.id} style={{
+              padding: '20px 0 24px',
+              borderTop: i === 0 ? 'none' : `1px solid ${A.paperLine}`,
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+                <span style={{
+                  fontSize: 10.5, fontWeight: 700, letterSpacing: '0.05em',
+                  color: A.coral, background: A.coralSoft,
+                  padding: '2px 7px', borderRadius: 3,
+                  fontFamily: 'ui-monospace, Menlo, monospace',
+                }}>{d.id}</span>
+                <span style={{ fontSize: 12, color: A.textDim }}>by {d.by} · {d.at}</span>
+              </div>
+              <h3 style={{
+                fontSize: 18, fontWeight: 700, color: A.text,
+                margin: '0 0 10px', letterSpacing: '-0.01em', lineHeight: 1.3,
+              }}>{d.title}</h3>
+              <p style={{ fontSize: 14, lineHeight: 1.6, color: A.text, margin: '0 0 12px' }}
+                 dangerouslySetInnerHTML={{ __html: markdownMini(d.description) }} />
+              <div style={{
+                padding: '10px 14px', background: A.paperAlt, borderRadius: 6,
+                borderLeft: `3px solid ${A.coral}`, marginBottom: 10,
+              }}>
+                <div style={{ fontSize: 10.5, fontWeight: 700, color: A.coral, letterSpacing: '0.05em', marginBottom: 4 }}>RATIONALE</div>
+                <div style={{ fontSize: 13, lineHeight: 1.55, color: A.text }}
+                     dangerouslySetInnerHTML={{ __html: markdownMini(d.rationale) }} />
+              </div>
+              <details style={{ fontSize: 12.5, color: A.textMuted, marginTop: 6 }}>
+                <summary style={{ cursor: 'pointer', color: A.textMuted, fontWeight: 500 }}>
+                  Alternatives considered ({d.alternatives.length})
+                </summary>
+                <ul style={{ margin: '6px 0 0 0', paddingLeft: 18, lineHeight: 1.6 }}>
+                  {d.alternatives.map((alt, j) => <li key={j}>{alt}</li>)}
+                </ul>
+              </details>
+            </article>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // RIGHT RAIL — tabbed (Threads / Decisions / PRs)
+  // ─────────────────────────────────────────────────────────────
+  function RightRail({ channel, right, setRight, tab, setTab, onClose }) {
+    const tabs = [
+      { id: 'threads',   label: 'Threads',   count: 2 /* synthesized */ },
+      { id: 'decisions', label: 'Decisions', count: channel.decisions?.length || 0 },
+      { id: 'prs',       label: 'PRs',       count: channel.prs?.length || 0 },
+    ];
+    return (
+      <div style={{
+        width: 380, flexShrink: 0,
+        borderLeft: `1px solid ${A.paperLine}`,
+        background: A.paper, display: 'flex', flexDirection: 'column',
+        boxShadow: '-8px 0 24px rgba(0,0,0,0.04)',
+        minHeight: 0,
+      }}>
+        <div style={{
+          flexShrink: 0, borderBottom: `1px solid ${A.paperLine}`,
+          padding: '0 6px 0 10px', display: 'flex', alignItems: 'center',
+          background: A.paper,
+        }}>
+          {tabs.map((t) => (
+            <button key={t.id} onClick={() => { setTab(t.id); setRight(null); }} style={{
+              padding: '12px 10px',
+              background: 'transparent', border: 'none', cursor: 'pointer',
+              color: tab === t.id ? A.text : A.textMuted,
+              fontSize: 12.5, fontWeight: tab === t.id ? 600 : 500,
+              borderBottom: `2px solid ${tab === t.id ? A.coral : 'transparent'}`,
+              marginBottom: -1, fontFamily: 'inherit',
+              display: 'flex', alignItems: 'center', gap: 5,
+            }}>
+              {t.label}
+              <span style={{
+                fontSize: 10.5, fontWeight: 600, fontVariantNumeric: 'tabular-nums',
+                color: tab === t.id ? A.coral : A.textDim,
+                background: tab === t.id ? A.coralSoft : A.paperAlt,
+                padding: '1px 5px', borderRadius: 8,
+              }}>{t.count}</span>
+            </button>
+          ))}
+          <div style={{ flex: 1 }} />
+          <button onClick={onClose} style={{
+            width: 28, height: 28, borderRadius: 5,
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: A.textMuted,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}><I.close /></button>
+        </div>
+
+        {/* Body — if `right` is set (detail view), render thread detail; else list */}
+        <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+          {right ? (
+            <ThreadDetail right={right} channel={channel} onBack={() => setRight(null)} />
+          ) : (
+            <>
+              {tab === 'threads'   && <ThreadsList channel={channel} onOpen={setRight} />}
+              {tab === 'decisions' && <DecisionsList channel={channel} onOpen={setRight} />}
+              {tab === 'prs'       && <PrsList channel={channel} onOpen={setRight} />}
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Threads are synthesized (PR #482 discussion, plan approval)
+  function synthesizeThreads(channel) {
+    const out = [];
+    if (channel.tickets.some((t) => t.status === 'pending' || t.status === 'ready')) {
+      out.push({
+        id: 'th-approval', kind: 'approval',
+        title: 'Plan awaiting approval',
+        by: 'Relay', time: '8m ago',
+        preview: `${channel.tickets.length} tickets · ${channel.tier.replace('_',' ')}`,
+        replies: 1,
+      });
+    }
+    (channel.prs || []).forEach((pr) => {
+      if (pr.ci === 'failing') {
+        out.push({
+          id: `th-pr-${pr.number}`, kind: 'pr', pr,
+          title: `PR #${pr.number} · CI failing`,
+          by: pr.author, time: '12m ago',
+          preview: pr.title,
+          replies: 3,
+        });
+      }
+    });
+    return out;
+  }
+
+  function ThreadsList({ channel, onOpen }) {
+    const threads = synthesizeThreads(channel);
+    if (!threads.length) {
+      return <EmptyRail icon="🧵" title="No open threads"
+                        hint="Replies to messages and auto-opened approval / CI threads appear here." />;
+    }
+    return (
+      <div style={{ padding: '6px 0' }}>
+        {threads.map((t) => (
+          <div key={t.id} onClick={() => onOpen({ kind: t.kind, payload: t })} style={{
+            padding: '12px 16px', borderBottom: `1px solid ${A.paperLine}`,
+            cursor: 'pointer', display: 'flex', gap: 10, alignItems: 'flex-start',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = A.paperAlt; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+          >
+            <div style={{
+              width: 6, height: 6, borderRadius: '50%',
+              background: t.kind === 'approval' ? A.coral : A.amber,
+              marginTop: 6, flexShrink: 0,
+            }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: A.text, marginBottom: 2 }}>{t.title}</div>
+              <div style={{ fontSize: 12, color: A.textMuted, lineHeight: 1.4,
+                            overflow: 'hidden', textOverflow: 'ellipsis',
+                            display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                {t.preview}
+              </div>
+              <div style={{ fontSize: 11, color: A.textDim, marginTop: 4, display: 'flex', gap: 8 }}>
+                <span>{t.by}</span>
+                <span>·</span>
+                <span>{t.time}</span>
+                <span>·</span>
+                <span>{t.replies} repl{t.replies === 1 ? 'y' : 'ies'}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  function DecisionsList({ channel, onOpen }) {
+    if (!channel.decisions?.length) {
+      return <EmptyRail icon="⎉" title="No decisions"
+                        hint="ADRs recorded by agents show up here. Same list as the Decisions tab in the channel header." />;
+    }
+    return (
+      <div>
+        {channel.decisions.map((d) => (
+          <div key={d.id} onClick={() => onOpen({ kind: 'decision', payload: d })} style={{
+            padding: '12px 16px', borderBottom: `1px solid ${A.paperLine}`, cursor: 'pointer',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = A.paperAlt; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+              <span style={{
+                fontSize: 10.5, fontWeight: 700, color: A.coral,
+                fontFamily: 'ui-monospace, Menlo, monospace',
+              }}>{d.id}</span>
+              <span style={{ fontSize: 11, color: A.textDim }}>· {d.by} · {d.at}</span>
+            </div>
+            <div style={{ fontSize: 13, fontWeight: 600, color: A.text, lineHeight: 1.35, marginBottom: 4 }}>{d.title}</div>
+            <div style={{ fontSize: 12, color: A.textMuted, lineHeight: 1.45,
+                          overflow: 'hidden', textOverflow: 'ellipsis',
+                          display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+              {d.description}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  function PrsList({ channel, onOpen }) {
+    if (!channel.prs?.length) {
+      return <EmptyRail icon="⧖" title="No open PRs"
+                        hint="Agent PRs with live CI + review status land here." />;
+    }
+    return (
+      <div style={{ padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {channel.prs.map((pr) => {
+          const ciColor = pr.ci === 'passing' ? A.mint : pr.ci === 'failing' ? A.coral : A.textDim;
+          const rvColor = pr.review === 'approved' ? A.mint : pr.review === 'pending' ? A.amber : A.textDim;
+          return (
+            <div key={pr.number} onClick={() => onOpen({ kind: 'pr', payload: pr })} style={{
+              padding: 12, background: A.paper, border: `1px solid ${A.paperLine}`,
+              borderRadius: 6, cursor: 'pointer', transition: 'all 0.12s',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.borderColor = A.coral; }}
+            onMouseLeave={(e) => { e.currentTarget.style.borderColor = A.paperLine; }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: 11, color: A.textDim, marginBottom: 4 }}>
+                <span style={{ display: 'flex', color: A.textMuted }}><I.pr /></span>
+                <span style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>#{pr.number}</span>
+                <span>·</span>
+                <span style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>{pr.branch}</span>
+                <div style={{ flex: 1 }} />
+                <span style={{ color: agentColor(pr.author.toLowerCase()), fontWeight: 600 }}>{pr.author}</span>
+              </div>
+              <div style={{ fontSize: 13, fontWeight: 500, color: A.text, lineHeight: 1.35, marginBottom: 8 }}>{pr.title}</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 11.5 }}>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: ciColor, fontWeight: 500 }}>
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: ciColor }} />CI {pr.ci}
+                </span>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: rvColor, fontWeight: 500 }}>
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: rvColor }} />review {pr.review}
+                </span>
+                <div style={{ flex: 1 }} />
+                <span style={{ color: A.coral, fontWeight: 500, fontSize: 11.5 }}>Open thread →</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  function EmptyRail({ icon, title, hint }) {
+    return (
+      <div style={{ padding: '40px 24px', textAlign: 'center' }}>
+        <div style={{
+          width: 44, height: 44, margin: '0 auto 12px', borderRadius: 10,
+          background: A.paperAlt, color: A.textMuted,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 20,
+        }}>{icon}</div>
+        <div style={{ fontSize: 13, fontWeight: 600, color: A.text, marginBottom: 4 }}>{title}</div>
+        <div style={{ fontSize: 12, color: A.textMuted, lineHeight: 1.55 }}>{hint}</div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // THREAD DETAIL (right-rail body when a thread is opened)
+  // ─────────────────────────────────────────────────────────────
+  function ThreadDetail({ right, channel, onBack }) {
+    return (
+      <div style={{ padding: 0 }}>
+        <div style={{
+          padding: '10px 14px', borderBottom: `1px solid ${A.paperLine}`,
+          display: 'flex', alignItems: 'center', gap: 8,
+          background: A.paperAlt, position: 'sticky', top: 0, zIndex: 1,
+        }}>
+          <button onClick={onBack} style={{
+            background: 'transparent', border: `1px solid ${A.paperLine}`,
+            color: A.textMuted, padding: '3px 8px', borderRadius: 4,
+            cursor: 'pointer', fontSize: 11.5, fontFamily: 'inherit',
+            display: 'flex', alignItems: 'center', gap: 4,
+          }}>← Back</button>
+          <span style={{ fontSize: 11, color: A.textDim, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600 }}>
+            {right.kind === 'approval' ? 'Approval' : right.kind === 'pr' ? 'PR thread' : right.kind === 'decision' ? 'Decision' : 'Thread'}
+          </span>
+        </div>
+        <div style={{ padding: '14px 16px' }}>
+          {right.kind === 'approval' && <ApprovalBody channel={channel} />}
+          {right.kind === 'pr'        && <PrBody pr={right.payload?.pr || right.payload} channel={channel} />}
+          {right.kind === 'decision'  && <DecisionBody d={right.payload} />}
+        </div>
+      </div>
+    );
+  }
+
+  function ApprovalBody({ channel }) {
+    return (
+      <div>
+        <div style={{
+          padding: 12, background: A.coralSoft,
+          borderRadius: 6, fontSize: 12.5, color: '#8e3b32', marginBottom: 12,
+          display: 'flex', gap: 10, alignItems: 'flex-start',
+        }}>
+          <I.spark style={{ color: A.coral, marginTop: 2, flexShrink: 0 }} />
+          <div>
+            <div style={{ fontWeight: 600, marginBottom: 2 }}>Plan generated — awaiting your approval</div>
+            <div>{channel.tickets.length} tickets across {channel.repos.length} repos · {channel.tier.replace('_', ' ')}</div>
+          </div>
+        </div>
+        <div style={{ fontSize: 13, color: A.text, lineHeight: 1.55, marginBottom: 14 }}>
+          Classified this issue as <strong>{channel.tier.replace('_', ' ')}</strong>. Planner decomposed it into {channel.tickets.length} tickets,{' '}
+          dispatched the first ready ones after approval. You can edit tickets before approving.
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button style={{
+            flex: 1, padding: '9px 12px', borderRadius: 5,
+            background: A.coral, color: '#fff', border: 'none',
+            fontSize: 13, fontWeight: 600, cursor: 'pointer',
+          }}>Approve & dispatch</button>
+          <button style={{
+            padding: '9px 12px', borderRadius: 5,
+            background: 'transparent', color: A.textMuted,
+            border: `1px solid ${A.paperLine}`,
+            fontSize: 13, fontWeight: 500, cursor: 'pointer',
+          }}>Edit plan</button>
+          <button style={{
+            padding: '9px 12px', borderRadius: 5,
+            background: 'transparent', color: A.textMuted,
+            border: `1px solid ${A.paperLine}`,
+            fontSize: 13, fontWeight: 500, cursor: 'pointer',
+          }}>Reject</button>
+        </div>
+      </div>
+    );
+  }
+
+  function PrBody({ pr, channel }) {
+    if (!pr) return null;
+    const ciColor = pr.ci === 'passing' ? A.mint : pr.ci === 'failing' ? A.coral : A.textDim;
+    const rvColor = pr.review === 'approved' ? A.mint : pr.review === 'pending' ? A.amber : A.textDim;
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: 11.5, color: A.textDim, marginBottom: 6 }}>
+          <span style={{ display: 'flex', color: A.textMuted }}><I.pr /></span>
+          <span style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>#{pr.number}</span>
+          <span>·</span>
+          <span style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>{pr.branch}</span>
+          <span>·</span>
+          <span style={{ color: agentColor(pr.author.toLowerCase()), fontWeight: 600 }}>{pr.author}</span>
+        </div>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: A.text, margin: '0 0 10px', lineHeight: 1.35 }}>{pr.title}</h3>
+        <div style={{ display: 'flex', gap: 10, marginBottom: 14, fontSize: 12 }}>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: ciColor, fontWeight: 500 }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: ciColor }} />CI {pr.ci}
+          </span>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: rvColor, fontWeight: 500 }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: rvColor }} />review {pr.review}
+          </span>
+          <span style={{ color: A.textMuted }}>· state {pr.state}</span>
+        </div>
+        {pr.ci === 'failing' && (
+          <div style={{
+            padding: 12, background: '#fdeeed', border: `1px solid ${A.coral}55`,
+            borderRadius: 6, fontSize: 12.5, marginBottom: 12,
+          }}>
+            <div style={{ fontWeight: 600, color: '#8e3b32', marginBottom: 4 }}>2 tests failing</div>
+            <div style={{ fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 11.5, color: A.textMuted, lineHeight: 1.6 }}>
+              oauth-github.test.ts  · expected 200, got 401<br/>
+              oauth-google.test.ts  · timeout after 5000ms
+            </div>
+          </div>
+        )}
+        <div style={{ fontSize: 12, color: A.textDim, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 700, marginBottom: 6 }}>
+          Activity · {pr.author.toLowerCase()} is on it
+        </div>
+        <div style={{ fontSize: 12, color: A.textMuted, fontFamily: 'ui-monospace, Menlo, monospace', lineHeight: 1.7, background: A.paperAlt, padding: 10, borderRadius: 5 }}>
+          <div><span style={{ color: A.amber }}>⚙</span> reading src/auth/providers/github.ts</div>
+          <div><span style={{ color: A.amber }}>⚙</span> running pnpm test oauth-github</div>
+          <div><span style={{ color: A.amber }}>⚙</span> editing src/auth/providers/github.ts</div>
+        </div>
+        <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+          <button style={{
+            flex: 1, padding: '8px 12px', borderRadius: 5,
+            background: A.coral, color: '#fff', border: 'none',
+            fontSize: 12.5, fontWeight: 600, cursor: 'pointer',
+          }}>Review in GitHub ↗</button>
+          <button style={{
+            padding: '8px 12px', borderRadius: 5,
+            background: 'transparent', color: A.textMuted,
+            border: `1px solid ${A.paperLine}`,
+            fontSize: 12.5, fontWeight: 500, cursor: 'pointer',
+          }}>Request changes</button>
+        </div>
+      </div>
+    );
+  }
+
+  function DecisionBody({ d }) {
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+          <span style={{
+            fontSize: 10.5, fontWeight: 700, letterSpacing: '0.05em',
+            color: A.coral, background: A.coralSoft,
+            padding: '2px 7px', borderRadius: 3,
+            fontFamily: 'ui-monospace, Menlo, monospace',
+          }}>{d.id}</span>
+          <span style={{ fontSize: 11.5, color: A.textDim }}>by {d.by} · {d.at}</span>
+        </div>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: A.text, margin: '0 0 10px', lineHeight: 1.35 }}>{d.title}</h3>
+        <p style={{ fontSize: 13, lineHeight: 1.6, color: A.text, margin: '0 0 12px' }}
+           dangerouslySetInnerHTML={{ __html: markdownMini(d.description) }} />
+        <div style={{
+          padding: '10px 12px', background: A.paperAlt, borderRadius: 5,
+          borderLeft: `3px solid ${A.coral}`, marginBottom: 12,
+        }}>
+          <div style={{ fontSize: 10.5, fontWeight: 700, color: A.coral, letterSpacing: '0.05em', marginBottom: 4 }}>RATIONALE</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: A.text }}
+               dangerouslySetInnerHTML={{ __html: markdownMini(d.rationale) }} />
+        </div>
+        <div style={{ fontSize: 10.5, fontWeight: 700, color: A.textMuted, letterSpacing: '0.05em', marginBottom: 5 }}>
+          ALTERNATIVES
+        </div>
+        <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12.5, color: A.textMuted, lineHeight: 1.6 }}>
+          {d.alternatives.map((alt, i) => <li key={i}>{alt}</li>)}
+        </ul>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // DM view (A-style, inlined)
+  // ─────────────────────────────────────────────────────────────
+  function DmView({ dm, agent, avatarStyle, onPromote }) {
+    return (
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: A.paper }}>
+        <div style={{
+          padding: '12px 20px', borderBottom: `1px solid ${A.paperLine}`,
+          display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0,
+        }}>
+          <Avatar agent={agent} size={36} style={avatarStyle} showStatus />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 15, fontWeight: 700, color: A.text }}>{agent.name}</div>
+            <div style={{ fontSize: 12, color: A.textMuted }}>
+              {agent.provider} · {agent.status === 'working'
+                ? <span style={{ color: A.amber }}>⚙ {agent.activity || 'working'}</span>
+                : <span>{agent.status}</span>}
+            </div>
+          </div>
+          <button onClick={onPromote} style={{
+            padding: '7px 12px', borderRadius: 6,
+            background: A.coral, color: '#fff', border: 'none',
+            fontSize: 12.5, fontWeight: 600, cursor: 'pointer',
+            display: 'flex', alignItems: 'center', gap: 6,
+          }}><I.hash /> Promote to channel</button>
+        </div>
+        <div style={{
+          padding: '8px 20px', background: A.paperAlt,
+          borderBottom: `1px solid ${A.paperLine}`,
+          fontSize: 12, color: A.textMuted, display: 'flex', gap: 10, alignItems: 'center',
+        }}>
+          <I.spark style={{ color: A.coral }} />
+          <span>
+            DMs are <strong style={{ color: A.text }}>kickoff surfaces</strong> — your first request here can promote into a channel with attached repos. Crosslinks from {agent.name} arrive here.
+          </span>
+        </div>
+        <MessageList messages={dm.messages} avatarStyle={avatarStyle} />
+        <Composer placeholder={`Message ${agent.name}... (paste an issue URL or /new to spin up a channel)`} />
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // C's MessageList — renders mentions as React chips
+  // ─────────────────────────────────────────────────────────────
+  function MessageListC({ messages, avatarStyle, channel }) {
+    if (!messages?.length) {
+      return <div style={{ flex: 1, background: A.paper }} />;
+    }
+    return (
+      <div style={{ flex: 1, overflow: 'auto', padding: '12px 0', background: A.paper, minHeight: 0 }}>
+        {messages.map((m, i) => {
+          const prev = messages[i - 1];
+          const compact = prev && prev.author === m.author && prev.kind === m.kind;
+          return <MessageC key={m.id} m={m} compact={compact} avatarStyle={avatarStyle} channel={channel} />;
+        })}
+      </div>
+    );
+  }
+
+  function MessageC({ m, compact, avatarStyle, channel }) {
+    const agent = m.kind === 'assistant' || m.kind === 'crosslink'
+      ? AGENTS.find((a) => a.id === m.author) : null;
+
+    // System lines
+    if (m.kind === 'system') {
+      return (
+        <div style={{
+          padding: '4px 20px 4px 60px',
+          fontSize: 12, color: A.textMuted,
+          display: 'flex', alignItems: 'center', gap: 8,
+        }}>
+          <I.spark style={{ color: A.coral }} />
+          <span>{renderWithMentions(m.text, channel)}</span>
+          <span style={{ color: A.textDim }}>· {m.time}</span>
+        </div>
+      );
+    }
+
+    // Tool-use line
+    if (m.kind === 'tool') {
+      return (
+        <div style={{
+          padding: '2px 20px 2px 60px',
+          fontSize: 12, color: A.textDim,
+          fontFamily: 'ui-monospace, Menlo, monospace',
+          display: 'flex', alignItems: 'center', gap: 6,
+        }}>
+          <span style={{ color: A.amber }}>⚙</span>
+          <span>{m.text}</span>
+          <span>· {m.time}</span>
+        </div>
+      );
+    }
+
+    const authorName = agent?.name || (m.author === 'you' ? 'You' : m.author);
+    const authorColor = agent ? agentColor(agent.id) : A.text;
+
+    return (
+      <div style={{
+        padding: compact ? '2px 20px 2px 20px' : '10px 20px 2px 20px',
+        display: 'flex', gap: 10, alignItems: 'flex-start',
+        position: 'relative',
+      }}>
+        <div style={{ width: 32, flexShrink: 0, paddingTop: 2 }}>
+          {!compact && (agent
+            ? <Avatar agent={agent} size={32} showStatus style={avatarStyle} />
+            : (
+              <div style={{
+                width: 32, height: 32, borderRadius: 6,
+                background: A.mintSoft, color: '#2a7a5a',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 14, fontWeight: 700,
+              }}>◉</div>
+            )
+          )}
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {!compact && (
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 2 }}>
+              <span style={{ fontWeight: 700, fontSize: 14, color: authorColor }}>{authorName}</span>
+              {agent && (
+                <span style={{ fontSize: 10.5, color: A.textDim, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600 }}>{agent.provider}</span>
+              )}
+              <span style={{ fontSize: 11.5, color: A.textDim }}>{m.time}</span>
+            </div>
+          )}
+          <div style={{ fontSize: 14.5, color: A.text, lineHeight: 1.5 }}>
+            {renderWithMentions(m.text, channel)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // C's Composer — with @ mention popover
+  // ─────────────────────────────────────────────────────────────
+  function ComposerC({ channel, placeholder }) {
+    const [text, setText] = useState('');
+    const [autoApprove, setAutoApprove] = useState(true);
+    const [mentionState, setMentionState] = useState(null); // { start, query } | null
+    const taRef = useRef(null);
+
+    const aliases = channel?.repos || [];
+    const targetRepo = channel?.primaryRepo || aliases[0];
+
+    // Detect @mention trigger as user types
+    const onChange = (e) => {
+      const v = e.target.value;
+      setText(v);
+      const caret = e.target.selectionStart;
+      const before = v.slice(0, caret);
+      const m = before.match(/(?:^|\s)@([a-z0-9_-]*)$/i);
+      if (m) {
+        setMentionState({ start: caret - m[1].length - 1, query: m[1] });
+      } else {
+        setMentionState(null);
+      }
+    };
+
+    const acceptMention = (pick) => {
+      if (!mentionState) return;
+      const { start } = mentionState;
+      const before = text.slice(0, start);
+      const after  = text.slice(taRef.current?.selectionStart ?? text.length);
+      const next = `${before}@${pick.alias} ${after}`;
+      setText(next);
+      setMentionState(null);
+      requestAnimationFrame(() => {
+        taRef.current?.focus();
+        const pos = (before + `@${pick.alias} `).length;
+        taRef.current?.setSelectionRange(pos, pos);
+      });
+    };
+
+    return (
+      <div style={{ padding: '0 18px 16px 20px', flexShrink: 0, background: A.paper, position: 'relative' }}>
+        {mentionState && (
+          <MentionPopover channel={channel} query={mentionState.query}
+                          onPick={acceptMention}
+                          onClose={() => setMentionState(null)} />
+        )}
+        <div style={{
+          border: `1.5px solid ${A.paperLine}`, borderRadius: 10,
+          background: '#fff', transition: 'border-color 0.15s',
+        }}>
+          <textarea ref={taRef} value={text} onChange={onChange}
+            onKeyDown={(e) => {
+              // Let MentionPopover handle Enter/Tab/Arrows when active
+              if (mentionState && ['Enter','Tab','ArrowUp','ArrowDown','Escape'].includes(e.key)) return;
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                setText('');
+              }
+            }}
+            placeholder={placeholder || `Message #${channel?.name || 'channel'}  ·  type @ to ping a repo`}
+            rows={2}
+            style={{
+              width: '100%', border: 'none', outline: 'none',
+              background: 'transparent', resize: 'none',
+              padding: '12px 14px 6px', fontSize: 14,
+              fontFamily: 'inherit', color: A.text, lineHeight: 1.5,
+            }}
+          />
+          <div style={{
+            padding: '6px 10px 8px', display: 'flex', alignItems: 'center', gap: 6,
+            borderTop: `1px solid ${A.paperLine}`,
+          }}>
+            {aliases.length > 0 && (
+              <div style={{
+                display: 'flex', alignItems: 'center', gap: 5,
+                padding: '3px 9px', borderRadius: 14,
+                background: A.coralSoft, color: A.coral,
+                fontSize: 12, fontWeight: 600,
+                border: `1px solid ${A.coral}33`,
+                fontFamily: 'ui-monospace, Menlo, monospace',
+                flexShrink: 0, whiteSpace: 'nowrap',
+              }}>
+                → @{targetRepo}
+              </div>
+            )}
+            <div onClick={() => setAutoApprove(!autoApprove)} style={{
+              display: 'flex', alignItems: 'center', gap: 5,
+              padding: '3px 9px', borderRadius: 14,
+              background: autoApprove ? A.mintSoft : A.paperAlt,
+              color:      autoApprove ? '#2a7a5a' : A.textMuted,
+              fontSize: 12, fontWeight: 500, cursor: 'pointer',
+              border: `1px solid ${autoApprove ? '#2a7a5a33' : A.paperLine}`,
+              flexShrink: 0, whiteSpace: 'nowrap',
+            }}>
+              <I.spark />
+              <span>{autoApprove ? 'Auto-approve' : 'Auto-approve off'}</span>
+            </div>
+            <div style={{
+              fontSize: 11.5, color: A.textDim, marginLeft: 6,
+              flex: 1, minWidth: 0,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>
+              Type <code style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>@</code> to ping a repo · paste an issue URL to classify
+            </div>
+            <span style={{ fontSize: 11, color: A.textDim, flexShrink: 0 }}>⌘⏎</span>
+            <button disabled={!text.trim()} style={{
+              padding: '6px 12px', borderRadius: 6, border: 'none',
+              background: text.trim() ? A.coral : A.paperLine,
+              color: text.trim() ? '#fff' : A.textMuted,
+              fontSize: 13, fontWeight: 600,
+              cursor: text.trim() ? 'pointer' : 'not-allowed',
+              display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0,
+            }}><I.send /> Send</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // MAIN APP
+  // ─────────────────────────────────────────────────────────────
+  function DirectionC({ tweaks, initialNewChannelOpen, initialSettingsOpen, initialStep }) {
+    const [selection, setSelection] = useState({ type: 'channel', id: 'oauth-api-users' });
+    const [pane, setPane] = useState('chat'); // chat | board | decisions
+    const [rightOpen, setRightOpen] = useState(true);
+    const [rightTab, setRightTab] = useState('threads');
+    const [right, setRight] = useState(null); // opened thread detail in rail
+    const [settingsOpen, setSettingsOpen] = useState(!!initialSettingsOpen);
+    const [newChanOpen, setNewChanOpen] = useState(!!initialNewChannelOpen);
+    // Local channel overrides — let users edit repos/primary in-place.
+    // Keyed by channel.id → { repos, primaryRepo }.
+    const [channelOverrides, setChannelOverrides] = useState({});
+    const avatarStyle = tweaks?.avatarStyle || 'glyph';
+    const density = tweaks?.density || 'medium';
+
+    const baseChannel = selection.type === 'channel' ? CHANNELS.find((c) => c.id === selection.id) : null;
+    const channel = baseChannel ? { ...baseChannel, ...(channelOverrides[baseChannel.id] || {}) } : null;
+    const dm = selection.type === 'dm' ? DMS.find((d) => d.id === selection.id) : null;
+    const dmAgent = dm ? agentById(dm.agentId) : null;
+
+    const onChannelChange = (next) => {
+      setChannelOverrides((prev) => ({
+        ...prev,
+        [next.id]: { repos: next.repos, primaryRepo: next.primaryRepo },
+      }));
+    };
+
+    useEffect(() => { setRight(null); setPane('chat'); }, [selection.type, selection.id]);
+
+    // Auto-open: if channel has a failing PR, default right tab to PRs
+    useEffect(() => {
+      if (!channel) return;
+      const failing = (channel.prs || []).some((p) => p.ci === 'failing');
+      const pending = channel.tickets.some((t) => t.status === 'pending' || t.status === 'ready');
+      if (failing) setRightTab('prs');
+      else if (pending) setRightTab('threads');
+    }, [channel?.id]);
+
+    const agents = channel ? channel.agents.map(agentById).filter(Boolean) : [];
+
+    return (
+      <div style={{
+        width: '100%', height: '100%', display: 'flex',
+        background: A.inkDeepest, color: A.text,
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif',
+        fontSize: density === 'dense' ? 13 : 14,
+      }}>
+        <style>{`
+          @keyframes c-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.45 } }
+        `}</style>
+        <WorkspaceRail current="relay" />
+        <Sidebar
+          channels={CHANNELS} dms={DMS} activity={ACTIVITY} repos={[]}
+          selection={selection} onSelect={setSelection}
+          onNewChannel={() => setNewChanOpen(true)}
+          onOpenActivity={() => setSelection({ type: 'activity' })}
+          avatarStyle={avatarStyle}
+        />
+
+        {/* Center pane */}
+        {selection.type === 'channel' && channel && (
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0, background: A.paper, position: 'relative' }}>
+            <ChannelHeader
+              channel={channel} agents={agents}
+              pane={pane} onPane={setPane}
+              rightOpen={rightOpen} onToggleRight={() => setRightOpen(!rightOpen)}
+              counts={{ tickets: channel.tickets.length, decisions: channel.decisions.length }}
+              onChannelChange={onChannelChange}
+              onOpenSettings={() => setSettingsOpen(true)}
+            />
+            {pane === 'chat' && (
+              <>
+                <MessageListC messages={channel.messages} avatarStyle={avatarStyle} channel={channel} />
+                <ComposerC channel={channel} />
+              </>
+            )}
+            {pane === 'board' && (
+              <BoardView channel={channel}
+                        onOpenTicket={(t) => { setRightOpen(true); setRightTab('threads'); setRight({ kind: 'ticket', payload: t }); }}
+                        onOpenPr={(pr) => { setRightOpen(true); setRightTab('prs'); setRight({ kind: 'pr', payload: pr }); }} />
+            )}
+            {pane === 'decisions' && <DecisionsView channel={channel} />}
+            {settingsOpen && (
+              <ChannelSettingsDrawer channel={channel}
+                onClose={() => setSettingsOpen(false)}
+                onChange={onChannelChange} />
+            )}
+          </div>
+        )}
+        {selection.type === 'dm' && dm && dmAgent && (
+          <DmView dm={dm} agent={dmAgent} avatarStyle={avatarStyle}
+                  onPromote={() => setNewChanOpen(true)} />
+        )}
+
+        {/* Right rail */}
+        {rightOpen && channel && (
+          <RightRail channel={channel}
+                     right={right} setRight={setRight}
+                     tab={rightTab} setTab={setRightTab}
+                     onClose={() => setRightOpen(false)} />
+        )}
+
+        {/* New channel modal */}
+        {newChanOpen && (
+          <NewChannelModal step={initialStep}
+            onClose={() => setNewChanOpen(false)}
+            onCreate={() => setNewChanOpen(false)} />
+        )}
+      </div>
+    );
+  }
+
+  window.DirectionC = DirectionC;
+})();

--- a/agent_docs/tidewater_handoff/design/relay-data.jsx
+++ b/agent_docs/tidewater_handoff/design/relay-data.jsx
@@ -1,0 +1,238 @@
+// Shared mock data for both Relay Slack-style directions.
+// Exposes RELAY_DATA on window.
+
+const AGENTS = [
+  { id: 'saturn',   name: 'Saturn',   glyph: '◆', provider: 'claude', activity: 'editing src/orchestrator/planner.ts', status: 'working' },
+  { id: 'titan',    name: 'Titan',    glyph: '▲', provider: 'claude', activity: 'running pnpm test', status: 'working' },
+  { id: 'rhea',     name: 'Rhea',     glyph: '●', provider: 'codex',  activity: null, status: 'idle' },
+  { id: 'oberon',   name: 'Oberon',   glyph: '■', provider: 'claude', activity: 'reading AGENTS.md', status: 'working' },
+  { id: 'miranda',  name: 'Miranda',  glyph: '◈', provider: 'claude', activity: null, status: 'idle' },
+  { id: 'phoebe',   name: 'Phoebe',   glyph: '▼', provider: 'codex',  activity: 'opening PR #482', status: 'working' },
+  { id: 'janus',    name: 'Janus',    glyph: '◆', provider: 'claude', activity: null, status: 'offline' },
+  { id: 'europa',   name: 'Europa',   glyph: '◉', provider: 'claude', activity: 'grepping handlers', status: 'working' },
+  { id: 'callisto', name: 'Callisto', glyph: '◇', provider: 'codex',  activity: null, status: 'idle' },
+];
+
+// Global pool of repos registered via `rly up`. These are NOT channel-scoped
+// on their own — they become pingable agents only when attached to a channel.
+// (A's sidebar still renders them in a "Repos" section as a before-state.)
+const REPOS = [
+  { alias: 'relay',      path: '~/code/relay',         primary: true  },
+  { alias: 'flowtide',   path: '~/code/flowtide',      primary: false },
+  { alias: 'venture-os', path: '~/code/venture-os',    primary: false },
+  { alias: 'bdrift',     path: '~/code/bdrift',        primary: false },
+];
+
+// Workspaces the user has registered (via `rly up`). Superset — more than
+// what's currently attached to any channel. Used by the new-channel modal
+// and the repo-add popover. Each entry carries a friendly path + a default
+// alias suggestion (it's just `basename(path)` unless user overrides).
+const AVAILABLE_WORKSPACES = [
+  { workspaceId: 'ws-relay',     path: '~/code/relay',      defaultAlias: 'relay',      lastActive: '2m',  openPrs: 3 },
+  { workspaceId: 'ws-flowtide',  path: '~/code/flowtide',   defaultAlias: 'flowtide',   lastActive: '14m', openPrs: 1 },
+  { workspaceId: 'ws-venture',   path: '~/code/venture-os', defaultAlias: 'venture-os', lastActive: '2h',  openPrs: 0 },
+  { workspaceId: 'ws-bdrift',    path: '~/code/bdrift',     defaultAlias: 'bdrift',     lastActive: '3d',  openPrs: 0 },
+  { workspaceId: 'ws-harmonia',  path: '~/code/harmonia',   defaultAlias: 'harmonia',   lastActive: '1w',  openPrs: 0 },
+  { workspaceId: 'ws-gridlab',   path: '~/code/gridlab',    defaultAlias: 'gridlab',    lastActive: '3w',  openPrs: 0 },
+];
+
+const CHANNELS = [
+  {
+    id: 'oauth-api-users',
+    name: 'oauth-api-users',
+    topic: 'Add OAuth2 flow to /api/users',
+    starred: true,
+    unread: 3,
+    mentions: 1,
+    agents: ['saturn', 'titan', 'oberon'],
+    repos: ['relay', 'flowtide'],
+    primaryRepo: 'relay',
+    tier: 'feature_large',
+    activeAt: '2m',
+    tickets: [
+      { id: 'T-1', title: 'Scaffold /auth/oauth endpoint', specialty: 'api_crud', status: 'completed', deps: [], agent: 'saturn' },
+      { id: 'T-2', title: 'Add provider adapters (github, google)', specialty: 'business_logic', status: 'executing', deps: ['T-1'], agent: 'titan' },
+      { id: 'T-3', title: 'Migration: users.auth_provider column', specialty: 'devops', status: 'verifying', deps: ['T-1'], agent: 'oberon' },
+      { id: 'T-4', title: 'Token refresh middleware', specialty: 'business_logic', status: 'ready', deps: ['T-2'], agent: null },
+      { id: 'T-5', title: 'Integration tests for /auth/oauth/*', specialty: 'testing', status: 'blocked', deps: ['T-2', 'T-3'], agent: null },
+      { id: 'T-6', title: 'Update AGENTS.md with auth patterns', specialty: 'general', status: 'pending', deps: [], agent: null },
+    ],
+    decisions: [
+      {
+        id: 'D-1',
+        title: 'Store refresh tokens server-side, not in JWTs',
+        description: 'Refresh tokens are kept in the `oauth_tokens` table and rotated on each use. JWT access tokens are 15m-lived, stateless, and do not contain refresh material.',
+        rationale: 'Revocation becomes possible without a distributed blocklist, and a leaked JWT is only dangerous for 15 minutes. Aligns with the existing session model.',
+        alternatives: ['Encode refresh in JWT (rejected — no revocation)', 'Session cookies only (rejected — mobile clients)'],
+        by: 'Saturn',
+        at: '1h ago',
+      },
+      {
+        id: 'D-2',
+        title: 'Use `openid-client` over hand-rolled OAuth',
+        description: 'Adopt `openid-client@5` for all provider integrations rather than writing per-provider HTTP glue.',
+        rationale: 'Certified OIDC library; discovery + PKCE + ID token verification handled correctly. ~1.2kloc we do not have to maintain.',
+        alternatives: ['Hand-roll per provider', 'Use Passport.js (rejected — maintenance concerns)'],
+        by: 'Titan',
+        at: '47m ago',
+      },
+    ],
+    prs: [
+      { number: 482, title: 'feat(auth): scaffold OAuth2 endpoint', branch: 'saturn/oauth-scaffold', ci: 'passing', review: 'approved', state: 'open', url: '#', author: 'Saturn' },
+      { number: 483, title: 'feat(auth): github + google adapters', branch: 'titan/oauth-adapters', ci: 'failing', review: 'pending', state: 'open', url: '#', author: 'Titan' },
+    ],
+    messages: [
+      { id: 1, author: 'you',    kind: 'user',      time: '10:12', text: 'Add OAuth2 to /api/users — github and google to start, linear/figma later. Here\'s the issue: https://github.com/jcast90/relay/issues/142' },
+      { id: 2, author: 'system', kind: 'system',    time: '10:12', text: 'Classified as **feature_large** · tracker issue resolved · 6 tickets planned across 2 repos' },
+      { id: 3, author: 'saturn', kind: 'assistant', time: '10:13', text: 'Looked through `src/auth/`. Current session handling is cookie-based; I\'ll keep that surface and add OAuth as a parallel entry. Planning to put refresh tokens in a new `oauth_tokens` table — want to keep JWTs short-lived and revocable.', activity: null },
+      { id: 4, author: 'you',    kind: 'user',      time: '10:14', text: 'Sounds right. Go ahead.' },
+      { id: 5, author: 'saturn', kind: 'assistant', time: '10:14', text: '**T-1 complete** — `POST /auth/oauth/:provider` scaffolded with PKCE-ready redirect handler. Tests pass. PR #482 opened.', activity: null },
+      { id: 6, author: 'titan',  kind: 'assistant', time: '10:22', text: '@saturn — when you wire token refresh, can you use the same `oauth_tokens` row and not a sibling table? Saves a join on every middleware pass.', activity: null },
+      { id: 7, author: 'saturn', kind: 'assistant', time: '10:23', text: '@titan yep, will do. Adding `refresh_token_hash` to the same migration.', activity: null },
+      { id: 8, author: 'titan',  kind: 'assistant', time: '10:31', text: null, activity: 'editing src/auth/providers/github.ts · running tsc --noEmit · opening PR #483' },
+    ],
+  },
+  {
+    id: 'metrics-dashboard',
+    name: 'metrics-dashboard',
+    topic: 'Surface p95/p99 in the TUI',
+    starred: true,
+    unread: 0,
+    mentions: 0,
+    agents: ['europa', 'miranda'],
+    repos: ['relay'],
+    primaryRepo: 'relay',
+    tier: 'feature_small',
+    activeAt: '14m',
+    tickets: [
+      { id: 'M-1', title: 'Add histogram recorder to scheduler', specialty: 'business_logic', status: 'executing', deps: [], agent: 'europa' },
+      { id: 'M-2', title: 'TUI: percentile sparkline widget', specialty: 'ui', status: 'ready', deps: ['M-1'], agent: null },
+      { id: 'M-3', title: 'Expose metrics via `rly status --json`', specialty: 'api_crud', status: 'pending', deps: ['M-1'], agent: null },
+    ],
+    decisions: [],
+    prs: [],
+    messages: [
+      { id: 1, author: 'you',    kind: 'user',      time: '9:40',  text: 'Add p95/p99 latency to `rly status` and a sparkline in the TUI.' },
+      { id: 2, author: 'europa', kind: 'assistant', time: '9:41',  text: 'On it. Starting with the histogram recorder — planning to use HDR histogram in the scheduler loop so we don\'t allocate on every sample.', activity: null },
+    ],
+  },
+  {
+    id: 'pod-executor',
+    name: 'pod-executor',
+    topic: 'Wire Kubernetes pod executor end-to-end',
+    starred: false,
+    unread: 0,
+    mentions: 0,
+    agents: ['oberon', 'phoebe'],
+    repos: ['relay', 'venture-os'],
+    primaryRepo: 'relay',
+    tier: 'architectural',
+    activeAt: '2h',
+    tickets: [
+      { id: 'P-1', title: 'Design doc: pod lifecycle + failure modes', specialty: 'general', status: 'completed', deps: [], agent: 'oberon' },
+      { id: 'P-2', title: 'PodExecutor implements Executor', specialty: 'business_logic', status: 'failed', deps: ['P-1'], agent: 'phoebe' },
+      { id: 'P-3', title: 'Sidecar for artifact upload to S3', specialty: 'devops', status: 'blocked', deps: ['P-2'], agent: null },
+    ],
+    decisions: [
+      {
+        id: 'D-3',
+        title: 'One pod per ticket, not per run',
+        description: 'Each ticket gets its own pod. Pods are ephemeral — artifacts stream to S3, logs to the host.',
+        rationale: 'Ticket-level isolation makes retry + parallelism trivial, and pod startup is <2s with a warm node pool.',
+        alternatives: ['One pod per run (rejected — serializes tickets)', 'Shared pod with workspaces (rejected — noisy neighbor)'],
+        by: 'Oberon',
+        at: 'yesterday',
+      },
+    ],
+    prs: [],
+    messages: [],
+  },
+  {
+    id: 'release-3-0',
+    name: 'release-3-0',
+    topic: 'v3.0 release prep',
+    starred: false,
+    unread: 0,
+    mentions: 0,
+    agents: ['rhea'],
+    repos: ['relay'],
+    primaryRepo: 'relay',
+    tier: 'feature_small',
+    activeAt: '1d',
+    tickets: [],
+    decisions: [],
+    prs: [],
+    messages: [],
+  },
+  {
+    id: 'crosslink-bugfix',
+    name: 'crosslink-bugfix',
+    topic: 'Fix heartbeat deadlock on Linux',
+    starred: false,
+    unread: 0,
+    mentions: 0,
+    agents: ['callisto'],
+    repos: ['relay'],
+    primaryRepo: 'relay',
+    tier: 'bugfix',
+    activeAt: '3d',
+    tickets: [],
+    decisions: [],
+    prs: [],
+    messages: [],
+  },
+];
+
+// DMs — each DM is a direct 1:1 with an agent. Promoting a DM to a channel
+// is a core affordance of this design.
+const DMS = [
+  {
+    id: 'dm-saturn',
+    agentId: 'saturn',
+    unread: 1,
+    activeAt: '4m',
+    messages: [
+      { id: 1, author: 'you',    kind: 'user',      time: '10:40', text: 'Quick one — is the `oauth_tokens` table indexed on `user_id`?' },
+      { id: 2, author: 'saturn', kind: 'assistant', time: '10:41', text: 'Yes, composite `(user_id, provider)` unique index. I added it in the T-3 migration.' },
+      { id: 3, author: 'saturn', kind: 'crosslink', time: '10:42', text: 'Heads up from `flowtide` — `@phoebe` saw a 429 pattern from github\'s user endpoint. Might want to add backoff before we scale.' },
+    ],
+  },
+  {
+    id: 'dm-titan',
+    agentId: 'titan',
+    unread: 0,
+    activeAt: '22m',
+    messages: [
+      { id: 1, author: 'you',    kind: 'user',      time: '10:18', text: 'What\'s the story on provider-specific scopes?' },
+      { id: 2, author: 'titan',  kind: 'assistant', time: '10:18', text: 'Per-provider config in `src/auth/providers/<name>.ts`. github uses `read:user user:email`, google uses `openid email profile`. Drop-in to add more.' },
+    ],
+  },
+  {
+    id: 'dm-rhea',
+    agentId: 'rhea',
+    unread: 0,
+    activeAt: '2d',
+    messages: [
+      { id: 1, author: 'you',   kind: 'user',      time: 'Mon',  text: 'Can you take a look at the v3.0 changelog draft?' },
+      { id: 2, author: 'rhea',  kind: 'assistant', time: 'Mon',  text: 'Pulled it. Three nits: "MCP" isn\'t defined on first use, the pod-executor bullet is misleading (still stubbed), and I\'d flip the order of "crosslink" and "channels" — channels is the user-facing term.' },
+    ],
+  },
+  {
+    id: 'dm-europa',
+    agentId: 'europa',
+    unread: 0,
+    activeAt: '1h',
+    messages: [],
+  },
+];
+
+// Activity inbox — unified feed of things-that-want-you.
+const ACTIVITY = [
+  { id: 'a1', kind: 'approval',  channel: 'oauth-api-users', agent: 'saturn', time: '8m',   title: 'Plan awaiting approval', detail: '6 tickets · 2 repos · feature_large' },
+  { id: 'a2', kind: 'ci_fail',   channel: 'oauth-api-users', agent: 'titan',  time: '18m',  title: 'CI failing on PR #483', detail: 'feat(auth): github + google adapters · 2 tests failing' },
+  { id: 'a3', kind: 'pr_review', channel: 'oauth-api-users', agent: 'saturn', time: '1h',   title: 'Review requested on PR #482', detail: 'feat(auth): scaffold OAuth2 endpoint' },
+  { id: 'a4', kind: 'mention',   channel: 'oauth-api-users', agent: 'titan',  time: '1h',   title: '@you in #oauth-api-users', detail: 'Titan: "@you — worth keeping the same row, not a sibling table"' },
+  { id: 'a5', kind: 'ticket_fail', channel: 'pod-executor',  agent: 'phoebe', time: '2h',   title: 'Ticket P-2 failed after retry budget', detail: 'PodExecutor implements Executor · 3/3 attempts' },
+];
+
+window.RELAY_DATA = { AGENTS, REPOS, AVAILABLE_WORKSPACES, CHANNELS, DMS, ACTIVITY };

--- a/agent_docs/tidewater_handoff/tokens.json
+++ b/agent_docs/tidewater_handoff/tokens.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "./tokens.schema.json",
+  "_meta": {
+    "palette": "Tidewater (fork of Tide)",
+    "source": "design/direction-a-base.jsx — window.RELAY_A.A",
+    "notes": "Two-surface system: deep 'ink' rail (sidebar/workspace rail) + warm 'paper' content. Coral is the only strong accent; reserve it for primary CTAs, active tabs, the primary repo, and selection."
+  },
+
+  "color": {
+    "ink": {
+      "deepest": "#0e1420",
+      "deep":    "#141b2a",
+      "panel":   "#1a2232",
+      "raised":  "#232c40",
+      "line":    "#2b3550"
+    },
+    "paper": {
+      "base":    "#fbf9f4",
+      "alt":     "#f3f0e7",
+      "line":    "#e5e1d5"
+    },
+    "text": {
+      "primary":     "#1b1f2a",
+      "muted":       "#5b6579",
+      "dim":         "#8a93a5",
+      "onDark":      "#e8ecf4",
+      "onDarkMuted": "#8a93a5"
+    },
+    "accent": {
+      "coral":      "#e65a4f",
+      "coralSoft":  "#fbe1dd",
+      "amber":      "#e89a2b",
+      "mint":       "#3fb984",
+      "mintSoft":   "#d9f1e6",
+      "sky":        "#4a7fd0",
+      "magenta":    "#c44d8a"
+    },
+    "status": {
+      "pending":   "#d0d4de",
+      "ready":     "#86a6d9",
+      "executing": "#e89a2b",
+      "verifying": "#7a6fd0",
+      "completed": "#3fb984",
+      "failed":    "#e65a4f",
+      "blocked":   "#9ba3b6",
+      "retry":     "#d88a3b"
+    },
+    "mention": {
+      "repoPrimaryBg":   "#fbe1dd",
+      "repoPrimaryFg":   "#e65a4f",
+      "repoPrimaryLine": "rgba(230, 90, 79, 0.33)",
+      "repoAttachedBg":  "#dce6f5",
+      "repoAttachedFg":  "#3a5fa0",
+      "repoAttachedLine":"#b3c5e0",
+      "humanBg":         "#d9f1e6",
+      "humanFg":         "#2a7a5a"
+    }
+  },
+
+  "typography": {
+    "fontFamily": {
+      "ui":   "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+      "mono": "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace"
+    },
+    "size": {
+      "xs":   10.5,
+      "sm":   11.5,
+      "base": 13,
+      "body": 14,
+      "md":   14.5,
+      "lg":   16,
+      "xl":   18
+    },
+    "weight": { "regular": 400, "medium": 500, "semibold": 600, "bold": 700 },
+    "letterSpacing": {
+      "tight":     "-0.01em",
+      "normal":    "0",
+      "uppercase": "0.04em"
+    },
+    "lineHeight": { "tight": 1.3, "normal": 1.5, "relaxed": 1.55 }
+  },
+
+  "radius": { "xs": 2, "sm": 3, "md": 4, "base": 5, "card": 6, "pill": 14, "lg": 8, "xl": 10, "modal": 12 },
+
+  "shadow": {
+    "card":    "0 2px 8px rgba(0,0,0,0.04)",
+    "popover": "0 6px 18px rgba(0,0,0,0.08)",
+    "modal":   "0 24px 80px rgba(0,0,0,0.2)",
+    "drawer":  "-16px 0 48px rgba(0,0,0,0.15)",
+    "frame":   "0 24px 60px rgba(0,0,0,0.25)"
+  },
+
+  "spacing": {
+    "1": 2, "2": 4, "3": 6, "4": 8, "5": 10, "6": 12, "7": 14, "8": 16, "10": 20, "12": 24, "16": 32
+  },
+
+  "layout": {
+    "workspaceRail":  58,
+    "sidebar":        230,
+    "rightRail":      360,
+    "channelHeader":  82,
+    "messageAvatar":  32,
+    "chipHeight":     20
+  },
+
+  "animation": {
+    "pulse":      "relay-pulse 1.6s ease-in-out infinite",
+    "hoverFast":  "all 0.15s ease"
+  }
+}

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -90,6 +90,16 @@ pub struct RepoAssignment {
     pub repo_path: String,    // absolute path to repo
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelTier {
+    FeatureLarge,
+    Feature,
+    Bugfix,
+    Chore,
+    Question,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Channel {
@@ -113,6 +123,13 @@ pub struct Channel {
     /// Absence means no Linear mirror is configured.
     #[serde(default)]
     pub linear_project_id: Option<String>,
+    /// Classifier-assigned tier surfaced as a pill in the channel header.
+    /// Back-compat via serde default; older channel files deserialize with None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<ChannelTier>,
+    /// Channel is pinned to the Starred section of the sidebar.
+    #[serde(default)]
+    pub starred: bool,
     /// ISO 8601 timestamps. Optional for back-compat with channel files
     /// written before these fields were tracked.
     #[serde(default)]
@@ -261,6 +278,53 @@ pub fn load_config() -> HarnessConfig {
     })
 }
 
+// --- GUI Settings ---
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GuiSettings {
+    #[serde(default = "default_ticket_provider")]
+    pub ticket_provider: String,
+    #[serde(default)]
+    pub linear_api_token: String,
+    #[serde(default)]
+    pub linear_workspace: String,
+    #[serde(default = "default_poll_interval")]
+    pub linear_poll_seconds: u32,
+    #[serde(default = "default_right_rail_open")]
+    pub right_rail_open: bool,
+}
+
+fn default_ticket_provider() -> String { "relay".to_string() }
+fn default_poll_interval() -> u32 { 30 }
+fn default_right_rail_open() -> bool { true }
+
+pub fn gui_settings_path() -> PathBuf {
+    harness_root().join("gui-settings.json")
+}
+
+pub fn load_gui_settings() -> GuiSettings {
+    load_json::<GuiSettings>(&gui_settings_path()).unwrap_or_else(|| GuiSettings {
+        ticket_provider: default_ticket_provider(),
+        linear_api_token: String::new(),
+        linear_workspace: String::new(),
+        linear_poll_seconds: default_poll_interval(),
+        right_rail_open: default_right_rail_open(),
+    })
+}
+
+pub fn save_gui_settings(s: &GuiSettings) -> Result<(), String> {
+    let path = gui_settings_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let content = serde_json::to_string_pretty(s).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, &content).map_err(|e| e.to_string())?;
+    fs::rename(&tmp, &path).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 /// Scan a directory for immediate child directories that contain a .git folder
 fn discover_repos_in(dir: &Path) -> Vec<WorkspaceEntry> {
     let mut repos = Vec::new();
@@ -326,6 +390,32 @@ pub fn load_agent_names() -> Vec<AgentNameEntry> {
 
 pub fn load_channels() -> Vec<Channel> {
     load_channels_with_status(false)
+}
+
+fn channel_json_path(channel_id: &str) -> PathBuf {
+    harness_root()
+        .join("channels")
+        .join(format!("{}.json", channel_id))
+}
+
+pub fn load_channel(channel_id: &str) -> Option<Channel> {
+    load_json::<Channel>(&channel_json_path(channel_id))
+}
+
+/// Atomic write of a Channel record. Stamps `updated_at` to now before
+/// persisting so every mutator doesn't have to remember to bump it.
+pub fn save_channel(channel: &Channel) -> Result<(), String> {
+    let mut ch = channel.clone();
+    ch.updated_at = Some(chrono::Utc::now().to_rfc3339());
+    let path = channel_json_path(&ch.channel_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let content = serde_json::to_string_pretty(&ch).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, &content).map_err(|e| e.to_string())?;
+    fs::rename(&tmp, &path).map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 pub fn load_channels_with_status(include_archived: bool) -> Vec<Channel> {

--- a/gui/package.json
+++ b/gui/package.json
@@ -14,9 +14,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.1.0",

--- a/gui/pnpm-lock.yaml
+++ b/gui/pnpm-lock.yaml
@@ -17,12 +17,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-markdown:
-        specifier: ^10.1.0
-        version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
-      remark-gfm:
-        specifier: ^4.0.1
-        version: 4.0.1
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2.1.0
@@ -496,23 +490,8 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/debug@4.1.13':
-    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
-
-  '@types/estree-jsx@1.0.5':
-    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/mdast@4.0.4':
-    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -525,23 +504,11 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
-  '@types/unist@2.0.11':
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
-
-  '@types/unist@3.0.3':
-    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-
-  bail@2.0.2:
-    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
@@ -555,24 +522,6 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
-
-  ccount@2.0.1:
-    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
-
-  character-entities-html4@2.1.0:
-    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
-
-  character-entities-legacy@3.0.0:
-    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
-
-  character-entities@2.0.2:
-    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
-
-  character-reference-invalid@2.0.1:
-    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
-
-  comma-separated-tokens@2.0.3:
-    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -589,16 +538,6 @@ packages:
       supports-color:
         optional: true
 
-  decode-named-character-reference@1.3.0:
-    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
-
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
-  devlop@1.1.0:
-    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
@@ -611,16 +550,6 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
-
-  estree-util-is-identifier-name@3.0.0:
-    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
-
-  extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -629,34 +558,6 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  hast-util-to-jsx-runtime@2.3.6:
-    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
-
-  hast-util-whitespace@3.0.0:
-    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  html-url-attributes@3.0.1:
-    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
-
-  inline-style-parser@0.2.7:
-    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  is-alphabetical@2.0.1:
-    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
-
-  is-alphanumerical@2.0.1:
-    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
-
-  is-decimal@2.0.1:
-    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
-
-  is-hexadecimal@2.0.1:
-    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
-
-  is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -671,147 +572,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  longest-streak@3.1.0:
-    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  markdown-table@3.0.4:
-    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  mdast-util-find-and-replace@3.0.2:
-    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
-
-  mdast-util-from-markdown@2.0.3:
-    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
-
-  mdast-util-gfm-autolink-literal@2.0.1:
-    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
-
-  mdast-util-gfm-footnote@2.1.0:
-    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
-
-  mdast-util-gfm-strikethrough@2.0.0:
-    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
-
-  mdast-util-gfm-table@2.0.0:
-    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
-
-  mdast-util-gfm-task-list-item@2.0.0:
-    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
-
-  mdast-util-gfm@3.1.0:
-    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
-
-  mdast-util-mdx-expression@2.0.1:
-    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
-
-  mdast-util-mdx-jsx@3.2.0:
-    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
-
-  mdast-util-mdxjs-esm@2.0.1:
-    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
-
-  mdast-util-phrasing@4.1.0:
-    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
-
-  mdast-util-to-hast@13.2.1:
-    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
-
-  mdast-util-to-markdown@2.1.2:
-    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
-
-  mdast-util-to-string@4.0.0:
-    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  micromark-core-commonmark@2.0.3:
-    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
-
-  micromark-extension-gfm-autolink-literal@2.1.0:
-    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
-
-  micromark-extension-gfm-footnote@2.1.0:
-    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
-
-  micromark-extension-gfm-strikethrough@2.1.0:
-    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
-
-  micromark-extension-gfm-table@2.1.1:
-    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
-
-  micromark-extension-gfm-tagfilter@2.0.0:
-    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
-
-  micromark-extension-gfm-task-list-item@2.1.0:
-    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
-
-  micromark-extension-gfm@3.0.0:
-    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
-
-  micromark-factory-destination@2.0.1:
-    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
-
-  micromark-factory-label@2.0.1:
-    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
-
-  micromark-factory-space@2.0.1:
-    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
-
-  micromark-factory-title@2.0.1:
-    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
-
-  micromark-factory-whitespace@2.0.1:
-    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
-
-  micromark-util-character@2.1.1:
-    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
-
-  micromark-util-chunked@2.0.1:
-    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
-
-  micromark-util-classify-character@2.0.1:
-    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
-
-  micromark-util-combine-extensions@2.0.1:
-    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
-
-  micromark-util-decode-numeric-character-reference@2.0.2:
-    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
-
-  micromark-util-decode-string@2.0.1:
-    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
-
-  micromark-util-encode@2.0.1:
-    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
-
-  micromark-util-html-tag-name@2.0.1:
-    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
-
-  micromark-util-normalize-identifier@2.0.1:
-    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
-
-  micromark-util-resolve-all@2.0.1:
-    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
-
-  micromark-util-sanitize-uri@2.0.1:
-    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
-
-  micromark-util-subtokenize@2.1.0:
-    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
-
-  micromark-util-symbol@2.0.1:
-    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
-
-  micromark-util-types@2.0.2:
-    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
-
-  micromark@4.0.2:
-    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -824,9 +590,6 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
-  parse-entities@4.0.2:
-    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -834,19 +597,10 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  property-information@7.1.0:
-    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
-
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
-
-  react-markdown@10.1.0:
-    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
-    peerDependencies:
-      '@types/react': '>=18'
-      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -855,18 +609,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
-
-  remark-gfm@4.0.1:
-    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
-
-  remark-parse@11.0.0:
-    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
-
-  remark-rehype@11.1.2:
-    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
-
-  remark-stringify@11.0.0:
-    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -884,58 +626,16 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  space-separated-tokens@2.0.2:
-    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
-
-  stringify-entities@4.0.4:
-    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
-
-  style-to-js@1.1.21:
-    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
-
-  style-to-object@1.0.14:
-    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
-
-  trim-lines@3.0.1:
-    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
-
-  trough@2.2.0:
-    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  unified@11.0.5:
-    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unist-util-is@6.0.1:
-    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
-
-  unist-util-position@5.0.0:
-    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
-
-  unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
-
-  unist-util-visit-parents@6.0.2:
-    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
-
-  unist-util-visit@5.1.0:
-    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  vfile-message@4.0.3:
-    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
-
-  vfile@6.0.3:
-    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -970,9 +670,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1323,25 +1020,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@types/debug@4.1.13':
-    dependencies:
-      '@types/ms': 2.1.0
-
-  '@types/estree-jsx@1.0.5':
-    dependencies:
-      '@types/estree': 1.0.8
-
   '@types/estree@1.0.8': {}
-
-  '@types/hast@3.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
-
-  '@types/mdast@4.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
-
-  '@types/ms@2.1.0': {}
 
   '@types/prop-types@15.7.15': {}
 
@@ -1353,12 +1032,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
-
-  '@types/unist@2.0.11': {}
-
-  '@types/unist@3.0.3': {}
-
-  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
     dependencies:
@@ -1372,8 +1045,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bail@2.0.2: {}
-
   baseline-browser-mapping@2.10.20: {}
 
   browserslist@4.28.2:
@@ -1386,18 +1057,6 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
-  ccount@2.0.1: {}
-
-  character-entities-html4@2.1.0: {}
-
-  character-entities-legacy@3.0.0: {}
-
-  character-entities@2.0.2: {}
-
-  character-reference-invalid@2.0.1: {}
-
-  comma-separated-tokens@2.0.3: {}
-
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
@@ -1405,16 +1064,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decode-named-character-reference@1.3.0:
-    dependencies:
-      character-entities: 2.0.2
-
-  dequal@2.0.3: {}
-
-  devlop@1.1.0:
-    dependencies:
-      dequal: 2.0.3
 
   electron-to-chromium@1.5.340: {}
 
@@ -1446,65 +1095,16 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@5.0.0: {}
-
-  estree-util-is-identifier-name@3.0.0: {}
-
-  extend@3.0.2: {}
-
   fsevents@2.3.3:
     optional: true
 
   gensync@1.0.0-beta.2: {}
-
-  hast-util-to-jsx-runtime@2.3.6:
-    dependencies:
-      '@types/estree': 1.0.8
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      estree-util-is-identifier-name: 3.0.0
-      hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
-      style-to-js: 1.1.21
-      unist-util-position: 5.0.0
-      vfile-message: 4.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  hast-util-whitespace@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
-  html-url-attributes@3.0.1: {}
-
-  inline-style-parser@0.2.7: {}
-
-  is-alphabetical@2.0.1: {}
-
-  is-alphanumerical@2.0.1:
-    dependencies:
-      is-alphabetical: 2.0.1
-      is-decimal: 2.0.1
-
-  is-decimal@2.0.1: {}
-
-  is-hexadecimal@2.0.1: {}
-
-  is-plain-obj@4.1.0: {}
 
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
-
-  longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -1514,367 +1114,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  markdown-table@3.0.4: {}
-
-  mdast-util-find-and-replace@3.0.2:
-    dependencies:
-      '@types/mdast': 4.0.4
-      escape-string-regexp: 5.0.0
-      unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.2
-
-  mdast-util-from-markdown@2.0.3:
-    dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      decode-named-character-reference: 1.3.0
-      devlop: 1.1.0
-      mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-decode-string: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-      unist-util-stringify-position: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm-autolink-literal@2.0.1:
-    dependencies:
-      '@types/mdast': 4.0.4
-      ccount: 2.0.1
-      devlop: 1.1.0
-      mdast-util-find-and-replace: 3.0.2
-      micromark-util-character: 2.1.1
-
-  mdast-util-gfm-footnote@2.1.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-      micromark-util-normalize-identifier: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm-strikethrough@2.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm-table@2.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm-task-list-item@2.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm@3.1.0:
-    dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdx-expression@2.0.1:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdx-jsx@3.2.0:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      ccount: 2.0.1
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-      parse-entities: 4.0.2
-      stringify-entities: 4.0.4
-      unist-util-stringify-position: 4.0.0
-      vfile-message: 4.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdxjs-esm@2.0.1:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-phrasing@4.1.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      unist-util-is: 6.0.1
-
-  mdast-util-to-hast@13.2.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
-      devlop: 1.1.0
-      micromark-util-sanitize-uri: 2.0.1
-      trim-lines: 3.0.1
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-
-  mdast-util-to-markdown@2.1.2:
-    dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      longest-streak: 3.1.0
-      mdast-util-phrasing: 4.1.0
-      mdast-util-to-string: 4.0.0
-      micromark-util-classify-character: 2.0.1
-      micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.1.0
-      zwitch: 2.0.4
-
-  mdast-util-to-string@4.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-
-  micromark-core-commonmark@2.0.3:
-    dependencies:
-      decode-named-character-reference: 1.3.0
-      devlop: 1.1.0
-      micromark-factory-destination: 2.0.1
-      micromark-factory-label: 2.0.1
-      micromark-factory-space: 2.0.1
-      micromark-factory-title: 2.0.1
-      micromark-factory-whitespace: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-chunked: 2.0.1
-      micromark-util-classify-character: 2.0.1
-      micromark-util-html-tag-name: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-subtokenize: 2.1.0
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm-autolink-literal@2.1.0:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-sanitize-uri: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm-footnote@2.1.0:
-    dependencies:
-      devlop: 1.1.0
-      micromark-core-commonmark: 2.0.3
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-sanitize-uri: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm-strikethrough@2.1.0:
-    dependencies:
-      devlop: 1.1.0
-      micromark-util-chunked: 2.0.1
-      micromark-util-classify-character: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm-table@2.1.1:
-    dependencies:
-      devlop: 1.1.0
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm-tagfilter@2.0.0:
-    dependencies:
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm-task-list-item@2.1.0:
-    dependencies:
-      devlop: 1.1.0
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-gfm@3.0.0:
-    dependencies:
-      micromark-extension-gfm-autolink-literal: 2.1.0
-      micromark-extension-gfm-footnote: 2.1.0
-      micromark-extension-gfm-strikethrough: 2.1.0
-      micromark-extension-gfm-table: 2.1.1
-      micromark-extension-gfm-tagfilter: 2.0.0
-      micromark-extension-gfm-task-list-item: 2.1.0
-      micromark-util-combine-extensions: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-factory-destination@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-factory-label@2.0.1:
-    dependencies:
-      devlop: 1.1.0
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-factory-space@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-types: 2.0.2
-
-  micromark-factory-title@2.0.1:
-    dependencies:
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-factory-whitespace@2.0.1:
-    dependencies:
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-character@2.1.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-chunked@2.0.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-classify-character@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-combine-extensions@2.0.1:
-    dependencies:
-      micromark-util-chunked: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-decode-numeric-character-reference@2.0.2:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-decode-string@2.0.1:
-    dependencies:
-      decode-named-character-reference: 1.3.0
-      micromark-util-character: 2.1.1
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-encode@2.0.1: {}
-
-  micromark-util-html-tag-name@2.0.1: {}
-
-  micromark-util-normalize-identifier@2.0.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-resolve-all@2.0.1:
-    dependencies:
-      micromark-util-types: 2.0.2
-
-  micromark-util-sanitize-uri@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-encode: 2.0.1
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-subtokenize@2.1.0:
-    dependencies:
-      devlop: 1.1.0
-      micromark-util-chunked: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-symbol@2.0.1: {}
-
-  micromark-util-types@2.0.2: {}
-
-  micromark@4.0.2:
-    dependencies:
-      '@types/debug': 4.1.13
-      debug: 4.4.3
-      decode-named-character-reference: 1.3.0
-      devlop: 1.1.0
-      micromark-core-commonmark: 2.0.3
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-chunked: 2.0.1
-      micromark-util-combine-extensions: 2.0.1
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-encode: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-sanitize-uri: 2.0.1
-      micromark-util-subtokenize: 2.1.0
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   node-releases@2.0.37: {}
-
-  parse-entities@4.0.2:
-    dependencies:
-      '@types/unist': 2.0.11
-      character-entities-legacy: 3.0.0
-      character-reference-invalid: 2.0.1
-      decode-named-character-reference: 1.3.0
-      is-alphanumerical: 2.0.1
-      is-decimal: 2.0.1
-      is-hexadecimal: 2.0.1
 
   picocolors@1.1.1: {}
 
@@ -1884,71 +1128,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  property-information@7.1.0: {}
-
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 18.3.28
-      devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
-      html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.1
-      react: 18.3.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  remark-gfm@4.0.1:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
-      micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-parse@11.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
-      micromark-util-types: 2.0.2
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-rehype@11.1.2:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.1
-      unified: 11.0.5
-      vfile: 6.0.3
-
-  remark-stringify@11.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-to-markdown: 2.1.2
-      unified: 11.0.5
 
   rollup@4.60.2:
     dependencies:
@@ -1989,75 +1179,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  space-separated-tokens@2.0.2: {}
-
-  stringify-entities@4.0.4:
-    dependencies:
-      character-entities-html4: 2.1.0
-      character-entities-legacy: 3.0.0
-
-  style-to-js@1.1.21:
-    dependencies:
-      style-to-object: 1.0.14
-
-  style-to-object@1.0.14:
-    dependencies:
-      inline-style-parser: 0.2.7
-
-  trim-lines@3.0.1: {}
-
-  trough@2.2.0: {}
-
   typescript@5.9.3: {}
-
-  unified@11.0.5:
-    dependencies:
-      '@types/unist': 3.0.3
-      bail: 2.0.2
-      devlop: 1.1.0
-      extend: 3.0.2
-      is-plain-obj: 4.1.0
-      trough: 2.2.0
-      vfile: 6.0.3
-
-  unist-util-is@6.0.1:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-position@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-stringify-position@4.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-visit-parents@6.0.2:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-
-  unist-util-visit@5.1.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  vfile-message@4.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-stringify-position: 4.0.0
-
-  vfile@6.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile-message: 4.0.3
 
   vite@5.4.21:
     dependencies:
@@ -2068,5 +1196,3 @@ snapshots:
       fsevents: 2.3.3
 
   yallist@3.1.1: {}
-
-  zwitch@2.0.4: {}

--- a/gui/public/fonts/README.md
+++ b/gui/public/fonts/README.md
@@ -1,0 +1,9 @@
+# Fonts
+
+Tidewater uses Inter (UI) and JetBrains Mono (code). The CSS in
+`src/styles/tokens.css` currently falls back to OS-installed copies via
+`src: local(...)`. To ship fully offline, drop the variable .woff2 files
+here and extend the `@font-face` src lists to reference them first:
+
+- `Inter.woff2` — https://rsms.me/inter/inter.html (variable)
+- `JetBrainsMono.woff2` — https://www.jetbrains.com/lp/mono/ (variable)

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -375,6 +375,59 @@ fn update_channel_repos(
 }
 
 #[tauri::command]
+fn set_channel_starred(channel_id: String, starred: bool) -> Result<(), String> {
+    validate_id_segment(&channel_id, "channelId")?;
+    let mut ch = data::load_channel(&channel_id)
+        .ok_or_else(|| format!("channel {} not found", channel_id))?;
+    ch.starred = starred;
+    data::save_channel(&ch)
+}
+
+#[tauri::command]
+fn set_channel_tier(channel_id: String, tier: Option<String>) -> Result<(), String> {
+    validate_id_segment(&channel_id, "channelId")?;
+    let parsed = match tier.as_deref() {
+        None | Some("") => None,
+        Some("feature_large") => Some(data::ChannelTier::FeatureLarge),
+        Some("feature") => Some(data::ChannelTier::Feature),
+        Some("bugfix") => Some(data::ChannelTier::Bugfix),
+        Some("chore") => Some(data::ChannelTier::Chore),
+        Some("question") => Some(data::ChannelTier::Question),
+        Some(other) => return Err(format!("unknown tier: {}", other)),
+    };
+    let mut ch = data::load_channel(&channel_id)
+        .ok_or_else(|| format!("channel {} not found", channel_id))?;
+    ch.tier = parsed;
+    data::save_channel(&ch)
+}
+
+#[tauri::command]
+fn get_settings() -> data::GuiSettings {
+    data::load_gui_settings()
+}
+
+#[tauri::command]
+fn update_settings(settings: data::GuiSettings) -> Result<(), String> {
+    data::save_gui_settings(&settings)
+}
+
+#[tauri::command]
+fn set_primary_repo(channel_id: String, workspace_id: String) -> Result<(), String> {
+    validate_id_segment(&channel_id, "channelId")?;
+    validate_id_segment(&workspace_id, "workspaceId")?;
+    let mut ch = data::load_channel(&channel_id)
+        .ok_or_else(|| format!("channel {} not found", channel_id))?;
+    if !ch.repo_assignments.iter().any(|r| r.workspace_id == workspace_id) {
+        return Err(format!(
+            "workspace {} is not attached to channel {}",
+            workspace_id, channel_id
+        ));
+    }
+    ch.primary_workspace_id = Some(workspace_id);
+    data::save_channel(&ch)
+}
+
+#[tauri::command]
 fn post_to_channel(
     channel_id: String,
     content: String,
@@ -1879,6 +1932,11 @@ pub fn run() {
             archive_channel,
             unarchive_channel,
             update_channel_repos,
+            set_channel_starred,
+            set_channel_tier,
+            set_primary_repo,
+            get_settings,
+            update_settings,
             post_to_channel,
             create_session,
             delete_session,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -238,11 +238,11 @@ fn cli_json(args: &[&str]) -> Result<serde_json::Value, String> {
 
 /// Subcommands the renderer is allowed to invoke through `run_cli`.
 ///
-/// As of this commit, no call site in `gui/src/` uses `run_cli` — the
-/// frontend reaches the CLI through the typed wrappers (`create_channel`,
-/// `post_to_channel`, etc.). `run_cli` stays for escape-hatch diagnostics
-/// but is locked down to a short read-only list so a compromised renderer
-/// can't trigger destructive operations. Add entries here as the renderer
+/// The frontend reaches the CLI through the typed wrappers
+/// (`create_channel`, `post_to_channel`, etc.). `run_cli` stays for
+/// escape-hatch diagnostics but is locked down to a short read-only list
+/// so a compromised renderer can't trigger destructive operations. Add
+/// entries here as the renderer
 /// grows legitimate needs.
 const RUN_CLI_ALLOWED_SUBCOMMANDS: &[&[&str]] = &[
     &["channel", "list"],
@@ -938,7 +938,7 @@ fn cancel_chat_stream(stream_id: u64) -> Result<(), String> {
     Ok(())
 }
 
-// --- Terminal spawn/kill lifecycle (Task #24, OSS-10) ---
+// --- Terminal spawn/kill lifecycle ---
 //
 // Each channel tracks an associated-repo agent spawn in
 // `~/.relay/channels/<channelId>/spawns.json`.

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "./api";
 import type { Channel, GuiSettings } from "./types";
 import { CenterPane } from "./components/CenterPane";
@@ -27,7 +27,11 @@ export function App() {
     }
   });
 
-  const refresh = () => setRefreshTick((n) => n + 1);
+  // Stable identity so effects that depend on it (CenterPane's chat-event
+  // subscription) don't tear down on every parent render — we also run a
+  // 5s setInterval that bumps refreshTick, which would otherwise churn
+  // listeners once per tick.
+  const refresh = useCallback(() => setRefreshTick((n) => n + 1), []);
 
   useEffect(() => {
     try {

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react";
 import { api } from "./api";
-import type { Channel } from "./types";
-import { Sidebar } from "./components/Sidebar";
+import type { Channel, GuiSettings } from "./types";
 import { CenterPane } from "./components/CenterPane";
-import { RightPane } from "./components/RightPane";
 import { NewChannelModal } from "./components/NewChannelModal";
+import { RightPane } from "./components/RightPane";
+import { SettingsPage } from "./components/SettingsPage";
+import { Sidebar } from "./components/Sidebar";
+import { WorkspaceRail } from "./components/WorkspaceRail";
+
+const RAIL_OPEN_KEY = "relay.rightRailOpen";
 
 export function App() {
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -13,15 +17,35 @@ export function App() {
   const [refreshTick, setRefreshTick] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
   const [includeArchived, setIncludeArchived] = useState(false);
+  const [settings, setSettings] = useState<GuiSettings | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [rightRailOpen, setRightRailOpen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(RAIL_OPEN_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
 
   const refresh = () => setRefreshTick((n) => n + 1);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(RAIL_OPEN_KEY, rightRailOpen ? "true" : "false");
+    } catch {
+      /* storage blocked — best-effort */
+    }
+  }, [rightRailOpen]);
 
   useEffect(() => {
     let cancelled = false;
     api.listChannels(includeArchived).then((cs) => {
       if (cancelled) return;
       setChannels(cs);
-      if (!selectedId && cs.length > 0) setSelectedId(cs[0].channelId);
+      if (!selectedId && cs.length > 0) {
+        const firstActive = cs.find((c) => c.status === "active") ?? cs[0];
+        setSelectedId(firstActive.channelId);
+      }
     });
     return () => {
       cancelled = true;
@@ -29,11 +53,22 @@ export function App() {
   }, [refreshTick, includeArchived]);
 
   useEffect(() => {
+    api.getSettings().then(setSettings).catch(() => {
+      setSettings({
+        ticketProvider: "relay",
+        linearApiToken: "",
+        linearWorkspace: "",
+        linearPollSeconds: 30,
+        rightRailOpen: true,
+      });
+    });
+  }, []);
+
+  useEffect(() => {
     const id = setInterval(refresh, 5000);
     return () => clearInterval(id);
   }, []);
 
-  // Reset session when switching channels
   useEffect(() => {
     setSessionId(null);
   }, [selectedId]);
@@ -41,34 +76,53 @@ export function App() {
   const selected = channels.find((c) => c.channelId === selectedId) ?? null;
 
   return (
-    <div className="app">
-      <Sidebar
-        channels={channels}
-        selectedId={selectedId}
-        includeArchived={includeArchived}
-        onSelect={setSelectedId}
-        onNewChannel={() => setModalOpen(true)}
-        onToggleIncludeArchived={setIncludeArchived}
-        onArchived={(id) => {
-          // If the archived channel was selected, drop the selection so the
-          // center pane doesn't keep rendering a stale channel.
-          if (selectedId === id) setSelectedId(null);
-        }}
-        onRefresh={refresh}
-      />
-      <CenterPane
-        channel={selected}
-        sessionId={sessionId}
-        refreshTick={refreshTick}
-        onRefresh={refresh}
-        onSessionCreated={setSessionId}
-      />
-      <RightPane
-        channel={selected}
-        sessionId={sessionId}
-        onSelectSession={setSessionId}
-        refreshTick={refreshTick}
-      />
+    <div className={`app ${rightRailOpen ? "" : "rail-collapsed"}`}>
+      <WorkspaceRail onOpenSettings={() => setSettingsOpen(true)} />
+      {settingsOpen && settings ? (
+        <div style={{ gridColumn: "2 / -1", display: "flex", minHeight: 0 }}>
+          <SettingsPage
+            settings={settings}
+            onSaved={setSettings}
+            onClose={() => setSettingsOpen(false)}
+          />
+        </div>
+      ) : (
+        <>
+          <Sidebar
+            channels={channels}
+            selectedId={selectedId}
+            includeArchived={includeArchived}
+            onSelect={setSelectedId}
+            onNewChannel={() => setModalOpen(true)}
+            onToggleIncludeArchived={setIncludeArchived}
+            onRefresh={refresh}
+          />
+          <CenterPane
+            channel={selected}
+            sessionId={sessionId}
+            refreshTick={refreshTick}
+            rightRailOpen={rightRailOpen}
+            settings={settings}
+            onToggleRail={() => setRightRailOpen((v) => !v)}
+            onRefresh={refresh}
+            onSessionCreated={setSessionId}
+            onChannelRemoved={(id) => {
+              if (selectedId === id) setSelectedId(null);
+              refresh();
+            }}
+          />
+          {rightRailOpen && selected && (
+            <RightPane
+              channel={selected}
+              sessionId={sessionId}
+              onSelectSession={setSessionId}
+              refreshTick={refreshTick}
+              onRefresh={refresh}
+            />
+          )}
+          {!rightRailOpen && <div />}
+        </>
+      )}
       <NewChannelModal
         open={modalOpen}
         onClose={() => setModalOpen(false)}

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -6,6 +6,7 @@ import type {
   ChannelRunLink,
   ChatSession,
   Decision,
+  GuiSettings,
   PendingPlan,
   PersistedChatMessage,
   RewindResult,
@@ -65,6 +66,15 @@ export const api = {
     channelId: string,
     repos: { alias: string; workspaceId: string; repoPath: string }[]
   ) => invoke<unknown>("update_channel_repos", { channelId, repos }),
+  setChannelStarred: (channelId: string, starred: boolean) =>
+    invoke<void>("set_channel_starred", { channelId, starred }),
+  setChannelTier: (channelId: string, tier: string | null) =>
+    invoke<void>("set_channel_tier", { channelId, tier }),
+  setPrimaryRepo: (channelId: string, workspaceId: string) =>
+    invoke<void>("set_primary_repo", { channelId, workspaceId }),
+  getSettings: () => invoke<GuiSettings>("get_settings"),
+  updateSettings: (settings: GuiSettings) =>
+    invoke<void>("update_settings", { settings }),
   postToChannel: (channelId: string, content: string, from?: string, entryType?: string) =>
     invoke<unknown>("post_to_channel", {
       channelId,

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -130,21 +130,15 @@ export const api = {
   // append a stale assistant turn afterwards.
   cancelChatStream: (streamId: number) => invoke<void>("cancel_chat_stream", { streamId }),
 
-  // Task #24 contract. These invoke wrappers are thin passthroughs that
-  // assume the Rust side registers `spawn_agent`, `list_spawns`, and
-  // `kill_spawned_agent` commands that accept / return camelCase via
-  // serde rename_all. Until that lands, calls here will reject at runtime
-  // with a "command not found"-style error — which surfaces inline in the
-  // spawn UI rather than crashing the app.
   spawnAgent: (channelId: string, alias: string, repoPath: string) =>
     invoke<Spawn>("spawn_agent", { channelId, alias, repoPath }),
   listSpawns: (channelId: string) => invoke<Spawn[]>("list_spawns", { channelId }),
   killSpawnedAgent: (channelId: string, alias: string) =>
     invoke<void>("kill_spawned_agent", { channelId, alias }),
 
-  // OSS-05: Parity commands — tracked-PR mirror + plan approval. These
-  // shell out to the same `rly approve` / `rly reject` commands the CLI
-  // uses, so there's exactly one code path that writes approval records.
+  // Tracked-PR mirror + plan approval. `approve` / `reject` shell out to
+  // the same `rly approve` / `rly reject` paths the CLI uses so approval
+  // records are written through a single code path.
   listTrackedPrs: (channelId: string) => invoke<TrackedPrRow[]>("list_tracked_prs", { channelId }),
   listPendingPlans: () => invoke<PendingPlan[]>("list_pending_plans"),
   approvePlan: (runId: string) => invoke<unknown>("approve_plan", { runId }),

--- a/gui/src/components/BoardView.tsx
+++ b/gui/src/components/BoardView.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState } from "react";
+import type { GuiSettings, TicketLedgerEntry } from "../types";
+
+type Props = {
+  tickets: TicketLedgerEntry[];
+  settings: GuiSettings | null;
+};
+
+type View = "list" | "kanban";
+
+const STATUS_ORDER = [
+  "pending",
+  "ready",
+  "executing",
+  "verifying",
+  "retry",
+  "blocked",
+  "completed",
+  "failed",
+];
+
+export function BoardView({ tickets, settings }: Props) {
+  const [view, setView] = useState<View>("list");
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<TicketLedgerEntry | null>(null);
+
+  const showLinearBadge = settings?.ticketProvider === "linear";
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return tickets.filter((t) => {
+      if (q && !t.title.toLowerCase().includes(q) && !t.ticketId.toLowerCase().includes(q)) {
+        return false;
+      }
+      if (statusFilter.size > 0 && !statusFilter.has(t.status)) return false;
+      return true;
+    });
+  }, [tickets, query, statusFilter]);
+
+  const toggleStatus = (s: string) => {
+    setStatusFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+  };
+
+  if (tickets.length === 0) {
+    return <div className="chat-empty">No tickets in this channel</div>;
+  }
+
+  return (
+    <div className="chat-scroll board" style={{ display: "flex", flexDirection: "column" }}>
+      <div className="board-toolbar">
+        <input
+          placeholder="Search tickets…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {STATUS_ORDER.map((s) => (
+            <button
+              key={s}
+              onClick={() => toggleStatus(s)}
+              style={{
+                fontSize: "var(--font-size-xs)",
+                padding: "2px 8px",
+                textTransform: "capitalize",
+                ...(statusFilter.has(s)
+                  ? {
+                      background: "var(--color-accent-coral)",
+                      borderColor: "var(--color-accent-coral)",
+                      color: "#fff",
+                    }
+                  : {}),
+              }}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+        <div className="board-view-toggle">
+          <button className={view === "list" ? "active" : ""} onClick={() => setView("list")}>
+            List
+          </button>
+          <button className={view === "kanban" ? "active" : ""} onClick={() => setView("kanban")}>
+            Kanban
+          </button>
+        </div>
+      </div>
+
+      {view === "list" ? (
+        <div className="board-list">
+          {filtered.map((t) => (
+            <div key={t.ticketId} className="board-list-row" onClick={() => setSelected(t)}>
+              <span className="ticket-id">{t.ticketId}</span>
+              <span className={`status-pill status-${statusKey(t.status)}`}>{t.status}</span>
+              <span className="ticket-title">
+                {t.title}
+                {showLinearBadge && t.source === "linear" && t.linearIdentifier && (
+                  <span className="linear-tag">Linear · {t.linearIdentifier}</span>
+                )}
+              </span>
+              <span className="agent-chip">
+                {t.assignedAlias ? `@${t.assignedAlias}` : t.assignedAgentName ?? "—"}
+              </span>
+              <span className="agent-chip">
+                {t.linearIdentifier ? t.linearIdentifier : `#${t.attempt}`}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <KanbanView tickets={filtered} onSelect={setSelected} showLinearBadge={showLinearBadge} />
+      )}
+
+      {selected && <TicketDetailModal ticket={selected} tickets={tickets} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}
+
+function KanbanView({
+  tickets,
+  onSelect,
+  showLinearBadge,
+}: {
+  tickets: TicketLedgerEntry[];
+  onSelect: (t: TicketLedgerEntry) => void;
+  showLinearBadge: boolean;
+}) {
+  const grouped: Record<string, TicketLedgerEntry[]> = {};
+  for (const t of tickets) {
+    const key = STATUS_ORDER.includes(t.status) ? t.status : "pending";
+    (grouped[key] ||= []).push(t);
+  }
+  const visible = STATUS_ORDER.filter((s) => (grouped[s]?.length ?? 0) > 0);
+  return (
+    <div className="board-columns">
+      {visible.map((s) => (
+        <div key={s} className="board-column">
+          <h4>
+            {s} ({grouped[s].length})
+          </h4>
+          <div className="board-column-body">
+            {grouped[s].map((t) => (
+              <div key={t.ticketId} className="ticket-card" onClick={() => onSelect(t)}>
+                {showLinearBadge && t.source === "linear" && t.linearIdentifier && (
+                  <div className="linear-tag" style={{ marginBottom: 4 }}>
+                    Linear · {t.linearIdentifier}
+                  </div>
+                )}
+                <div className="title">{t.title}</div>
+                <div className="meta">
+                  {t.specialty}
+                  {t.assignedAlias ? ` · @${t.assignedAlias}` : ""}
+                  {t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TicketDetailModal({
+  ticket,
+  tickets,
+  onClose,
+}: {
+  ticket: TicketLedgerEntry;
+  tickets: TicketLedgerEntry[];
+  onClose: () => void;
+}) {
+  const deps = ticket.dependsOn.map((depId) => {
+    const found = tickets.find((x) => x.ticketId === depId);
+    return {
+      id: depId,
+      title: found?.title ?? "(not in this channel's ledger)",
+      status: found?.status ?? "?",
+    };
+  });
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal modal-sm" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          {ticket.title}
+          <button className="close-btn" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-body">
+          <DetailRow label="ID">
+            <code>{ticket.ticketId}</code>
+          </DetailRow>
+          <DetailRow label="Status">
+            <span className={`status-pill status-${statusKey(ticket.status)}`}>{ticket.status}</span>
+          </DetailRow>
+          <DetailRow label="Specialty">{ticket.specialty}</DetailRow>
+          <DetailRow label="Verification">{ticket.verification}</DetailRow>
+          <DetailRow label="Attempt">{ticket.attempt}</DetailRow>
+          {ticket.assignedAgentName && <DetailRow label="Assigned">{ticket.assignedAgentName}</DetailRow>}
+          {ticket.assignedAlias && <DetailRow label="Routed to">@{ticket.assignedAlias}</DetailRow>}
+          {ticket.source === "linear" && ticket.linearUrl && (
+            <DetailRow label="Linear">
+              <a
+                href={ticket.linearUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="tracked-pr-link"
+              >
+                {ticket.linearIdentifier ?? "Open"}
+              </a>
+            </DetailRow>
+          )}
+          {deps.length > 0 && (
+            <div>
+              <div style={{ fontSize: 10, textTransform: "uppercase", color: "var(--color-text-dim)", marginBottom: 6 }}>
+                Depends on ({deps.length})
+              </div>
+              <ul style={{ padding: 0, margin: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 6 }}>
+                {deps.map((d) => (
+                  <li
+                    key={d.id}
+                    style={{
+                      padding: 8,
+                      background: "var(--color-paper-alt)",
+                      borderRadius: 4,
+                      fontSize: 12,
+                    }}
+                  >
+                    <code>{d.id}</code>
+                    <span style={{ marginLeft: 8, color: "var(--color-text-muted)" }}>{d.status}</span>
+                    <div style={{ marginTop: 2 }}>{d.title}</div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <div className="modal-footer" style={{ justifyContent: "flex-end" }}>
+          <button type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "120px 1fr", gap: 8, fontSize: 13 }}>
+      <span style={{ fontSize: 10, textTransform: "uppercase", color: "var(--color-text-dim)" }}>
+        {label}
+      </span>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function statusKey(s: string): string {
+  return STATUS_ORDER.includes(s) ? s : "pending";
+}

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -1,71 +1,52 @@
-import { useEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { useEffect, useState } from "react";
 import { api, subscribeChatEvents, type ChatEvent } from "../api";
 import type {
   Channel,
   ChannelEntry,
   ChatSession,
   Decision,
-  PendingPlan,
+  GuiSettings,
   PersistedChatMessage,
   TicketLedgerEntry,
 } from "../types";
-
-type Tab = "chat" | "board" | "decisions";
+import { BoardView } from "./BoardView";
+import { ChannelHeader, type ChannelTab } from "./ChannelHeader";
+import { ChannelSettingsDrawer } from "./ChannelSettingsDrawer";
+import { Composer, reduceStream, type ActiveStream } from "./Composer";
+import { DecisionsView } from "./DecisionsView";
+import { MessageList } from "./MessageList";
 
 type Props = {
   channel: Channel | null;
   sessionId: string | null;
   refreshTick: number;
+  rightRailOpen: boolean;
+  settings: GuiSettings | null;
+  onToggleRail: () => void;
   onRefresh: () => void;
   onSessionCreated: (sessionId: string) => void;
+  onChannelRemoved: (id: string) => void;
 };
-
-type ActivityEntry = { text: string; ts: number };
-
-type ActiveStream = {
-  streamId: number;
-  alias: string | null;
-  accum: string;
-  activity: ActivityEntry[];
-  expanded: boolean;
-};
-
-const ACTIVITY_STACK_MAX = 20;
-const ACTIVITY_TOP_N = 3;
-
-// Renders message text as Github-flavored markdown. Links open in a new tab so
-// they don't navigate the Tauri webview away from the app shell.
-function MessageMarkdown({ text }: { text: string }) {
-  return (
-    <div className="md">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          a: (props) => <a {...props} target="_blank" rel="noreferrer noopener" />,
-        }}
-      >
-        {text}
-      </ReactMarkdown>
-    </div>
-  );
-}
 
 export function CenterPane({
   channel,
   sessionId,
   refreshTick,
+  rightRailOpen,
+  settings,
+  onToggleRail,
   onRefresh,
   onSessionCreated,
+  onChannelRemoved,
 }: Props) {
-  const [tab, setTab] = useState<Tab>("chat");
+  const [tab, setTab] = useState<ChannelTab>("chat");
   const [feed, setFeed] = useState<ChannelEntry[]>([]);
   const [tickets, setTickets] = useState<TicketLedgerEntry[]>([]);
   const [decisions, setDecisions] = useState<Decision[]>([]);
   const [sessionMessages, setSessionMessages] = useState<PersistedChatMessage[]>([]);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [stream, setStream] = useState<ActiveStream | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {
     if (!channel) return;
@@ -95,16 +76,14 @@ export function CenterPane({
     api.loadSession(channel.channelId, sessionId, 500).then(setSessionMessages);
   }, [channel?.channelId, sessionId, refreshTick]);
 
-  // Subscribe once to chat-event stream and route by streamId.
   useEffect(() => {
     let unlisten: (() => void) | undefined;
-    subscribeChatEvents((event) => {
+    subscribeChatEvents((event: ChatEvent) => {
       setStream((current) => {
         if (!current || event.streamId !== current.streamId) return current;
         return reduceStream(current, event);
       });
       if (event.kind === "done" || event.kind === "error") {
-        // Refresh persisted messages so the stored assistant text shows up.
         onRefresh();
         setStream((current) => (current && current.streamId === event.streamId ? null : current));
       }
@@ -118,952 +97,60 @@ export function CenterPane({
 
   if (!channel) {
     return (
-      <div className="panel">
-        <div className="empty">Select or create a channel</div>
+      <div className="center-pane">
+        <div className="center-empty">Select or create a channel</div>
       </div>
     );
   }
 
   return (
-    <div className="panel">
-      <PendingPlanCta channel={channel} refreshTick={refreshTick} onChanged={onRefresh} />
-      <div className="tabs">
-        <div className={`tab ${tab === "chat" ? "active" : ""}`} onClick={() => setTab("chat")}>
-          Chat
-        </div>
-        <div className={`tab ${tab === "board" ? "active" : ""}`} onClick={() => setTab("board")}>
-          Board ({tickets.length})
-        </div>
-        <div
-          className={`tab ${tab === "decisions" ? "active" : ""}`}
-          onClick={() => setTab("decisions")}
-        >
-          Decisions ({decisions.length})
-        </div>
-      </div>
+    <div className="center-pane">
+      <ChannelHeader
+        channel={channel}
+        tab={tab}
+        onTabChange={setTab}
+        rightRailOpen={rightRailOpen}
+        onToggleRail={onToggleRail}
+        onOpenSettings={() => setSettingsOpen(true)}
+        onRefresh={onRefresh}
+      />
       {tab === "chat" && (
-        <ChatView
-          channel={channel}
-          sessionId={sessionId}
-          activeSession={activeSession}
-          sessionMessages={sessionMessages}
-          feed={feed}
-          stream={stream}
-          onStartStream={setStream}
-          onSessionCreated={onSessionCreated}
-          onRefresh={onRefresh}
-        />
-      )}
-      {tab === "board" && (
-        <div className="content board-content">
-          <BoardView tickets={tickets} />
-        </div>
-      )}
-      {tab === "decisions" && (
-        <div className="content">
-          <DecisionsView decisions={decisions} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-function reduceStream(current: ActiveStream, event: ChatEvent): ActiveStream {
-  switch (event.kind) {
-    case "chunk":
-      return { ...current, accum: current.accum + event.text };
-    case "activity": {
-      // Cap BEFORE pushing so a runaway tool-use burst can't transiently
-      // queue thousands of entries before the slice kicks in.
-      const keep = current.activity.slice(-(ACTIVITY_STACK_MAX - 1));
-      return {
-        ...current,
-        activity: [...keep, { text: event.text, ts: Date.now() }],
-      };
-    }
-    default:
-      return current;
-  }
-}
-
-function ChatView({
-  channel,
-  sessionId,
-  activeSession,
-  sessionMessages,
-  feed,
-  stream,
-  onStartStream,
-  onSessionCreated,
-  onRefresh,
-}: {
-  channel: Channel;
-  sessionId: string | null;
-  activeSession: ChatSession | null;
-  sessionMessages: PersistedChatMessage[];
-  feed: ChannelEntry[];
-  stream: ActiveStream | null;
-  onStartStream: (s: ActiveStream | null) => void;
-  onSessionCreated: (sessionId: string) => void;
-  onRefresh: () => void;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [sessionMessages.length, feed.length, sessionId, stream?.accum.length]);
-
-  return (
-    <>
-      <div className="content" ref={scrollRef}>
-        {sessionId ? (
-          <SessionMessages
+        <>
+          <MessageList
             channel={channel}
             sessionId={sessionId}
-            messages={sessionMessages}
-            streaming={!!stream}
+            feed={feed}
+            sessionMessages={sessionMessages}
+            stream={stream}
             streamId={stream?.streamId ?? null}
+            onToggleStreamExpanded={() =>
+              setStream((s) => (s ? { ...s, expanded: !s.expanded } : s))
+            }
             onRewound={() => {
-              onStartStream(null);
+              setStream(null);
               onRefresh();
             }}
           />
-        ) : (
-          <FeedView entries={feed} />
-        )}
-        {stream && (
-          <ActivityStreamCard
-            stream={stream}
-            onToggleExpanded={() => onStartStream({ ...stream, expanded: !stream.expanded })}
-          />
-        )}
-      </div>
-      <Composer
-        channel={channel}
-        sessionId={sessionId}
-        activeSession={activeSession}
-        streaming={!!stream}
-        onStartStream={onStartStream}
-        onSessionCreated={onSessionCreated}
-      />
-    </>
-  );
-}
-
-function ActivityStreamCard({
-  stream,
-  onToggleExpanded,
-}: {
-  stream: ActiveStream;
-  onToggleExpanded: () => void;
-}) {
-  const total = stream.activity.length;
-  const visibleCount = stream.expanded ? total : Math.min(ACTIVITY_TOP_N, total);
-  const visible = total === 0 ? [] : stream.activity.slice(total - visibleCount);
-  const hiddenCount = total - visibleCount;
-  const agentBadge = stream.alias ? `@${stream.alias}` : "agent";
-  const latestTs = total > 0 ? stream.activity[total - 1].ts : null;
-
-  return (
-    <div className="feed-entry role-assistant streaming">
-      <div className="feed-header">
-        <span className="feed-author">{stream.alias ? `@${stream.alias}` : "assistant"}</span>
-        <span className="stream-status">
-          <span className="stream-dot" />
-          {stream.accum ? "writing response" : "thinking"}
-          {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
-        </span>
-      </div>
-      <div className={`stream-activity ${stream.expanded ? "expanded" : ""}`}>
-        {total === 0 ? (
-          <div className="stream-activity-empty">
-            <span className="activity-badge">{agentBadge}</span>
-            <span className="activity-icon">⚙</span>
-            <span className="activity-ellipsis">
-              {stream.accum ? "writing response…" : "thinking…"}
-            </span>
-          </div>
-        ) : (
-          <>
-            {visible.map((entry, i) => {
-              const isNewest = i === visible.length - 1;
-              return (
-                <div
-                  key={`${entry.ts}-${i}`}
-                  className={`stream-activity-line ${isNewest ? "newest" : ""}`}
-                  title={new Date(entry.ts).toLocaleTimeString()}
-                >
-                  {isNewest && <span className="activity-badge">{agentBadge}</span>}
-                  <span className="activity-icon">⚙</span>
-                  <span className="activity-text">{entry.text}</span>
-                </div>
-              );
-            })}
-            {hiddenCount > 0 && (
-              <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
-                +{hiddenCount} more
-              </button>
-            )}
-            {stream.expanded && total > ACTIVITY_TOP_N && (
-              <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
-                collapse
-              </button>
-            )}
-          </>
-        )}
-        {latestTs && (
-          <div className="stream-activity-meta">
-            last update {new Date(latestTs).toLocaleTimeString()}
-          </div>
-        )}
-      </div>
-      {stream.accum && (
-        <div className="feed-content">
-          <MessageMarkdown text={stream.accum} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SessionMessages({
-  channel,
-  sessionId,
-  messages,
-  streaming,
-  streamId,
-  onRewound,
-}: {
-  channel: Channel;
-  sessionId: string;
-  messages: PersistedChatMessage[];
-  streaming: boolean;
-  streamId: number | null;
-  onRewound: () => void;
-}) {
-  const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(null);
-
-  if (messages.length === 0) return <div className="empty">No messages in this session yet</div>;
-  return (
-    <>
-      {messages.map((m, i) => {
-        const rewindKey = m.metadata?.rewindKey;
-        const canRewind = m.role === "user" && !!rewindKey && !streaming;
-        return (
-          <div key={i} className={`feed-entry role-${m.role}`}>
-            <div className="feed-header">
-              <span className="feed-author">{m.agentAlias ? `@${m.agentAlias}` : m.role}</span>
-              <span className="feed-header-right">
-                {formatTime(m.timestamp)}
-                {m.role === "user" && rewindKey && (
-                  <button
-                    type="button"
-                    className="rewind-btn"
-                    disabled={!canRewind}
-                    title={
-                      streaming
-                        ? "Finish the current stream before rewinding"
-                        : "Rewind repos + chat to this turn"
-                    }
-                    onClick={() => setRewindTarget(m)}
-                  >
-                    ⟲ Rewind
-                  </button>
-                )}
-              </span>
-            </div>
-            <div className="feed-content">
-              <MessageMarkdown text={m.content} />
-            </div>
-          </div>
-        );
-      })}
-      {rewindTarget && (
-        <RewindConfirmModal
-          channel={channel}
-          sessionId={sessionId}
-          target={rewindTarget}
-          streamId={streamId}
-          onClose={() => setRewindTarget(null)}
-          onDone={() => {
-            setRewindTarget(null);
-            onRewound();
-          }}
-        />
-      )}
-    </>
-  );
-}
-
-function RewindConfirmModal({
-  channel,
-  sessionId,
-  target,
-  streamId,
-  onClose,
-  onDone,
-}: {
-  channel: Channel;
-  sessionId: string;
-  target: PersistedChatMessage;
-  streamId: number | null;
-  onClose: () => void;
-  onDone: () => void;
-}) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const rewindKey = target.metadata?.rewindKey;
-
-  const apply = async () => {
-    if (!rewindKey) {
-      setError("Message has no rewindKey metadata — cannot rewind.");
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    try {
-      // Gap #8: abort any in-flight stream BEFORE truncating the session
-      // log. Otherwise the Rust streaming thread can append a stale
-      // assistant turn after `rewind-apply` has already truncated + reset.
-      if (streamId !== null) {
-        try {
-          await api.cancelChatStream(streamId);
-        } catch (e) {
-          console.warn("[rewind] cancelChatStream failed:", e);
-        }
-      }
-      await api.rewindApply(channel.channelId, sessionId, rewindKey, target.timestamp);
-      onDone();
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">Rewind to this turn?</div>
-        <div className="modal-body">
-          <p>
-            Each repo in this channel will be reset to the commit captured before this message. All
-            messages at or after this turn will be removed from the session, and Claude session IDs
-            will be cleared so the next message starts a fresh conversation.
-          </p>
-          <div className="rewind-repo-list">
-            {channel.repoAssignments.map((r) => (
-              <div key={r.alias} className="rewind-repo-row">
-                <code>@{r.alias}</code>
-                <span className="rewind-repo-path">{r.repoPath}</span>
-              </div>
-            ))}
-          </div>
-          <p className="rewind-warning">
-            <strong>Warning:</strong> this runs <code>git reset --hard</code>. Any uncommitted
-            changes in these repos will be lost. Shell side effects (API calls, spawned processes,
-            database writes) are <strong>not</strong> undone.
-          </p>
-          {error && <div className="composer-error">{error}</div>}
-        </div>
-        <div className="modal-footer">
-          <button type="button" onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
-          <button type="button" className="primary" onClick={apply} disabled={busy || !rewindKey}>
-            {busy ? "Rewinding…" : "Rewind"}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function FeedView({ entries }: { entries: ChannelEntry[] }) {
-  if (entries.length === 0) return <div className="empty">No activity yet</div>;
-  return (
-    <>
-      {entries.map((e) => (
-        <div key={e.entryId} className={`feed-entry role-${e.type}`}>
-          <div className="feed-header">
-            <span className="feed-author">{e.fromDisplayName ?? e.type}</span>
-            <span>{formatTime(e.createdAt)}</span>
-          </div>
-          <div className="feed-content">
-            <MessageMarkdown text={e.content} />
-          </div>
-        </div>
-      ))}
-    </>
-  );
-}
-
-function Composer({
-  channel,
-  sessionId,
-  activeSession,
-  streaming,
-  onStartStream,
-  onSessionCreated,
-}: {
-  channel: Channel;
-  sessionId: string | null;
-  activeSession: ChatSession | null;
-  streaming: boolean;
-  onStartStream: (s: ActiveStream | null) => void;
-  onSessionCreated: (sessionId: string) => void;
-}) {
-  const [text, setText] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [autoApprove, setAutoApprove] = useState(true);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [mention, setMention] = useState<{ start: number; query: string; index: number } | null>(
-    null
-  );
-
-  const aliases = channel.repoAssignments.map((r) => r.alias);
-  // Token being typed is a mention when it starts with `@` and sits at the
-  // beginning of the text or is preceded by whitespace — matches how the
-  // backend parses routing prefixes.
-  const detectMention = (value: string, caret: number) => {
-    const before = value.slice(0, caret);
-    const match = before.match(/(?:^|\s)@([a-zA-Z0-9_-]*)$/);
-    if (!match) return null;
-    const start = caret - match[1].length - 1;
-    return { start, query: match[1] };
-  };
-  const filteredAliases = mention
-    ? aliases.filter((a) => a.toLowerCase().startsWith(mention.query.toLowerCase()))
-    : [];
-
-  const applyMention = (alias: string) => {
-    if (!mention) return;
-    const ta = textareaRef.current;
-    const caret = ta?.selectionStart ?? text.length;
-    const before = text.slice(0, mention.start);
-    const after = text.slice(caret);
-    const insertion = `@${alias} `;
-    const next = before + insertion + after;
-    setText(next);
-    setMention(null);
-    const nextCaret = before.length + insertion.length;
-    requestAnimationFrame(() => {
-      const el = textareaRef.current;
-      if (!el) return;
-      el.focus();
-      el.setSelectionRange(nextCaret, nextCaret);
-    });
-  };
-
-  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
-    setText(value);
-    const next = detectMention(value, e.target.selectionStart ?? value.length);
-    setMention(next ? { ...next, index: 0 } : null);
-  };
-
-  const handleSelect = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
-    const el = e.currentTarget;
-    const next = detectMention(el.value, el.selectionStart ?? el.value.length);
-    setMention((prev) =>
-      next ? { ...next, index: prev && prev.start === next.start ? prev.index : 0 } : null
-    );
-  };
-
-  const send = async () => {
-    const raw = text.trim();
-    if (!raw) return;
-    setBusy(true);
-    setError(null);
-    try {
-      // Parse @alias prefix to route to a repo.
-      const { alias, body } = parseAliasPrefix(raw, aliases);
-      const repo = alias ? channel.repoAssignments.find((r) => r.alias === alias) : null;
-      const cwd = repo?.repoPath;
-      const aliasKey = alias ?? "general";
-      const claudeSessionId = activeSession?.claudeSessionIds?.[aliasKey] ?? undefined;
-
-      let activeId = sessionId;
-      if (!activeId) {
-        const session = await api.createSession(channel.channelId, raw.slice(0, 60));
-        activeId = session.sessionId;
-        onSessionCreated(activeId);
-      }
-
-      // Snapshot every repo in the channel *before* the turn runs so the
-      // user can later click Rewind on this message to restore state.
-      // Snapshot is best-effort — if a repo lacks commits or git errors,
-      // surface it but still let the user send; rewind just won't be
-      // offered for this turn.
-      let rewindKey: string | undefined;
-      if (channel.repoAssignments.length > 0) {
-        try {
-          const snap = await api.rewindSnapshot(channel.channelId, activeId);
-          rewindKey = snap.key;
-        } catch (err) {
-          console.warn("[rewind] snapshot failed:", err);
-        }
-      }
-
-      const streamId = await api.startChat({
-        channelId: channel.channelId,
-        sessionId: activeId,
-        message: body,
-        alias: alias ?? undefined,
-        cwd,
-        claudeSessionId,
-        autoApprove,
-        rewindKey,
-      });
-      onStartStream({
-        streamId,
-        alias,
-        accum: "",
-        activity: [],
-        expanded: false,
-      });
-      setText("");
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (mention && filteredAliases.length > 0) {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setMention({ ...mention, index: (mention.index + 1) % filteredAliases.length });
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setMention({
-          ...mention,
-          index: (mention.index - 1 + filteredAliases.length) % filteredAliases.length,
-        });
-        return;
-      }
-      if (e.key === "Enter" || e.key === "Tab") {
-        e.preventDefault();
-        applyMention(filteredAliases[mention.index]);
-        return;
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setMention(null);
-        return;
-      }
-    }
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      send();
-    }
-  };
-
-  const disabled = busy || streaming;
-  const showMentions = !!mention && filteredAliases.length > 0;
-
-  return (
-    <div className="composer">
-      {error && <div className="composer-error">{error}</div>}
-      <div className="composer-input-wrap">
-        {showMentions && (
-          <MentionPopover
+          <Composer
             channel={channel}
-            aliases={filteredAliases}
-            index={mention!.index}
-            onPick={applyMention}
+            sessionId={sessionId}
+            activeSession={activeSession}
+            streaming={!!stream}
+            onStartStream={setStream}
+            onSessionCreated={onSessionCreated}
           />
-        )}
-        <textarea
-          ref={textareaRef}
-          value={text}
-          onChange={handleTextChange}
-          onKeyDown={onKeyDown}
-          onSelect={handleSelect}
-          onBlur={() => setTimeout(() => setMention(null), 120)}
-          placeholder={
-            channel.repoAssignments.length > 0
-              ? "Use @alias to target a repo · Enter to send · Shift+Enter newline"
-              : "Type a message · Enter to send · Shift+Enter newline"
-          }
-          rows={2}
-          disabled={disabled}
-        />
-      </div>
-      <div className="composer-controls">
-        <label className="auto-approve" title="Pass --dangerously-skip-permissions to claude">
-          <input
-            type="checkbox"
-            checked={autoApprove}
-            onChange={(e) => setAutoApprove(e.target.checked)}
-          />
-          auto-approve
-        </label>
-        <button className="primary" onClick={send} disabled={disabled || !text.trim()}>
-          {streaming ? "…" : "Send"}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function MentionPopover({
-  channel,
-  aliases,
-  index,
-  onPick,
-}: {
-  channel: Channel;
-  aliases: string[];
-  index: number;
-  onPick: (alias: string) => void;
-}) {
-  return (
-    <div className="mention-popover" role="listbox">
-      {aliases.map((a, i) => {
-        const repo = channel.repoAssignments.find((r) => r.alias === a);
-        return (
-          <button
-            key={a}
-            type="button"
-            role="option"
-            aria-selected={i === index}
-            className={`mention-option ${i === index ? "active" : ""}`}
-            // Use onMouseDown so the pick fires before textarea blur clears it.
-            onMouseDown={(e) => {
-              e.preventDefault();
-              onPick(a);
-            }}
-          >
-            <span className="mention-alias">@{a}</span>
-            {repo?.repoPath && <span className="mention-path">{repo.repoPath}</span>}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function parseAliasPrefix(
-  message: string,
-  aliases: string[]
-): { alias: string | null; body: string } {
-  const match = message.match(/^@([a-zA-Z0-9_-]+)\s+([\s\S]*)$/);
-  if (!match) return { alias: null, body: message };
-  const candidate = match[1];
-  if (!aliases.includes(candidate)) return { alias: null, body: message };
-  return { alias: candidate, body: match[2] };
-}
-
-// Canonical ticket statuses + display labels. "pending" shows as "Backlog"
-// because that's what a kanban board reader expects.
-const BOARD_COLUMNS: Array<{ status: string; label: string }> = [
-  { status: "pending", label: "Backlog" },
-  { status: "ready", label: "Ready" },
-  { status: "executing", label: "Executing" },
-  { status: "verifying", label: "Verifying" },
-  { status: "retry", label: "Retry" },
-  { status: "blocked", label: "Blocked" },
-  { status: "completed", label: "Completed" },
-  { status: "failed", label: "Failed" },
-];
-
-function BoardView({ tickets }: { tickets: TicketLedgerEntry[] }) {
-  const [selected, setSelected] = useState<TicketLedgerEntry | null>(null);
-
-  if (tickets.length === 0) return <div className="empty">No tickets in this channel</div>;
-
-  const grouped: Record<string, TicketLedgerEntry[]> = {};
-  for (const t of tickets) {
-    const key = BOARD_COLUMNS.some((c) => c.status === t.status) ? t.status : "pending";
-    (grouped[key] ||= []).push(t);
-  }
-  const visible = BOARD_COLUMNS.filter((c) => (grouped[c.status]?.length ?? 0) > 0);
-
-  return (
-    <>
-      <div className="board-columns">
-        {visible.map(({ status, label }) => (
-          <div key={status} className="board-column">
-            <h4>
-              {label} ({grouped[status].length})
-            </h4>
-            <div className="board-column-body">
-              {grouped[status].map((t) => {
-                const isLinear = t.source === "linear";
-                return (
-                  <div
-                    key={t.ticketId}
-                    className={`ticket clickable${isLinear ? " ticket-linear" : ""}`}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => setSelected(t)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        setSelected(t);
-                      }
-                    }}
-                  >
-                    {isLinear && t.linearIdentifier && (
-                      <div className="ticket-linear-chip">Linear · {t.linearIdentifier}</div>
-                    )}
-                    <div>{t.title}</div>
-                    {t.assignedAlias && <div className="ticket-alias-chip">@{t.assignedAlias}</div>}
-                    <div className="ticket-meta">
-                      {isLinear
-                        ? (t.linearState ?? "linear mirror")
-                        : `${t.specialty} · attempt ${t.attempt}${
-                            t.assignedAgentName ? ` · ${t.assignedAgentName}` : ""
-                          }`}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        ))}
-      </div>
-      {selected && (
-        <TicketDetailModal ticket={selected} tickets={tickets} onClose={() => setSelected(null)} />
+        </>
       )}
-    </>
-  );
-}
-
-function TicketDetailModal({
-  ticket,
-  tickets,
-  onClose,
-}: {
-  ticket: TicketLedgerEntry;
-  tickets: TicketLedgerEntry[];
-  onClose: () => void;
-}) {
-  const deps = ticket.dependsOn.map((depId) => {
-    const found = tickets.find((x) => x.ticketId === depId);
-    return {
-      id: depId,
-      title: found?.title ?? "(not in this channel's ledger)",
-      status: found?.status ?? "?",
-    };
-  });
-  return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal ticket-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">{ticket.title}</div>
-        <div className="modal-body">
-          <div className="detail-row">
-            <span className="detail-label">ID</span>
-            <code>{ticket.ticketId}</code>
-          </div>
-          <div className="detail-row">
-            <span className="detail-label">Status</span>
-            <span>{ticket.status}</span>
-          </div>
-          <div className="detail-row">
-            <span className="detail-label">Specialty</span>
-            <span>{ticket.specialty}</span>
-          </div>
-          <div className="detail-row">
-            <span className="detail-label">Verification</span>
-            <span>{ticket.verification}</span>
-          </div>
-          <div className="detail-row">
-            <span className="detail-label">Attempt</span>
-            <span>{ticket.attempt}</span>
-          </div>
-          {ticket.assignedAgentName && (
-            <div className="detail-row">
-              <span className="detail-label">Assigned</span>
-              <span>{ticket.assignedAgentName}</span>
-            </div>
-          )}
-          {ticket.assignedAlias && (
-            <div className="detail-row">
-              <span className="detail-label">Assigned to</span>
-              <span>@{ticket.assignedAlias}</span>
-            </div>
-          )}
-          {ticket.source === "linear" && (
-            <>
-              {ticket.linearIdentifier && (
-                <div className="detail-row">
-                  <span className="detail-label">Linear</span>
-                  <span>{ticket.linearIdentifier}</span>
-                </div>
-              )}
-              {ticket.linearState && (
-                <div className="detail-row">
-                  <span className="detail-label">Linear state</span>
-                  <span>{ticket.linearState}</span>
-                </div>
-              )}
-              {ticket.linearUrl && (
-                <div className="detail-row">
-                  <span className="detail-label">Link</span>
-                  <a
-                    href={ticket.linearUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="tracked-pr-link"
-                  >
-                    Open in Linear
-                  </a>
-                </div>
-              )}
-            </>
-          )}
-          {deps.length > 0 && (
-            <div className="detail-row detail-row-block">
-              <span className="detail-label">Depends on ({deps.length})</span>
-              <ul className="dep-list">
-                {deps.map((d) => (
-                  <li key={d.id}>
-                    <code>{d.id}</code> <span className="dep-status">{d.status}</span>
-                    <div className="dep-title">{d.title}</div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-        <div className="modal-footer">
-          <button type="button" onClick={onClose}>
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function DecisionsView({ decisions }: { decisions: Decision[] }) {
-  if (decisions.length === 0) return <div className="empty">No decisions recorded</div>;
-  return (
-    <>
-      {decisions.map((d) => (
-        <div key={d.decisionId} className="decision">
-          <h4>{d.title}</h4>
-          <div className="meta">
-            {d.decidedByName} · {formatTime(d.createdAt)}
-          </div>
-          <p>{d.description}</p>
-          {d.rationale && (
-            <p>
-              <strong>Why:</strong> {d.rationale}
-            </p>
-          )}
-          {d.alternatives.length > 0 && (
-            <p>
-              <strong>Alternatives:</strong> {d.alternatives.join(", ")}
-            </p>
-          )}
-        </div>
-      ))}
-    </>
-  );
-}
-
-function formatTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
-}
-
-/**
- * Approval CTA shown above the tabs whenever a run tied to the current
- * channel is `AWAITING_APPROVAL`. Clicking Approve/Reject shells out to
- * `rly approve` / `rly reject` via the Tauri bridge — the same code path
- * the TUI and CLI hit, so there's only one surface that writes approval
- * records.
- */
-function PendingPlanCta({
-  channel,
-  refreshTick,
-  onChanged,
-}: {
-  channel: Channel | null;
-  refreshTick: number;
-  onChanged: () => void;
-}) {
-  const [plans, setPlans] = useState<PendingPlan[]>([]);
-  const [busyRunId, setBusyRunId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .listPendingPlans()
-      .then((p) => {
-        if (!cancelled) setPlans(p);
-      })
-      .catch(() => {
-        if (!cancelled) setPlans([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [refreshTick]);
-
-  const relevant = plans.filter((p) =>
-    channel ? !p.channelId || p.channelId === channel.channelId : true
-  );
-  if (relevant.length === 0) return null;
-
-  const act = async (plan: PendingPlan, decision: "approve" | "reject") => {
-    setBusyRunId(plan.runId);
-    setError(null);
-    try {
-      if (decision === "approve") {
-        await api.approvePlan(plan.runId);
-      } else {
-        await api.rejectPlan(plan.runId);
-      }
-      // Nudge the app-wide refresh so the banner disappears once the
-      // approval record lands.
-      onChanged();
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setBusyRunId(null);
-    }
-  };
-
-  return (
-    <div className="plan-cta" role="status" aria-live="polite">
-      {relevant.map((p) => (
-        <div key={p.runId} className="plan-cta-row">
-          <div className="plan-cta-body">
-            <strong>Plan awaiting approval</strong>
-            <span className="plan-cta-feature">{p.featureRequest.slice(0, 80)}</span>
-            <span className="plan-cta-meta">
-              run {p.runId.slice(0, 12)}… · workspace {p.workspaceId}
-            </span>
-          </div>
-          <div className="plan-cta-buttons">
-            <button
-              type="button"
-              className="primary"
-              disabled={busyRunId === p.runId}
-              onClick={() => act(p, "approve")}
-            >
-              {busyRunId === p.runId ? "…" : "Approve"}
-            </button>
-            <button type="button" disabled={busyRunId === p.runId} onClick={() => act(p, "reject")}>
-              Reject
-            </button>
-          </div>
-        </div>
-      ))}
-      {error && <div className="composer-error">{error}</div>}
+      {tab === "board" && <BoardView tickets={tickets} settings={settings} />}
+      {tab === "decisions" && <DecisionsView decisions={decisions} channel={channel} />}
+      {settingsOpen && (
+        <ChannelSettingsDrawer
+          channel={channel}
+          onClose={() => setSettingsOpen(false)}
+          onRefresh={onRefresh}
+          onArchived={() => onChannelRemoved(channel.channelId)}
+        />
+      )}
     </div>
   );
 }

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -56,13 +56,18 @@ export function CenterPane({
       api.listChannelTickets(channel.channelId),
       api.listChannelDecisions(channel.channelId),
       api.listSessions(channel.channelId),
-    ]).then(([f, t, d, s]) => {
-      if (cancelled) return;
-      setFeed(f);
-      setTickets(t);
-      setDecisions(d);
-      setSessions(s);
-    });
+    ])
+      .then(([f, t, d, s]) => {
+        if (cancelled) return;
+        setFeed(f);
+        setTickets(t);
+        setDecisions(d);
+        setSessions(s);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("[center] batch fetch failed", err);
+      });
     return () => {
       cancelled = true;
     };
@@ -73,10 +78,28 @@ export function CenterPane({
       setSessionMessages([]);
       return;
     }
-    api.loadSession(channel.channelId, sessionId, 500).then(setSessionMessages);
+    let cancelled = false;
+    api
+      .loadSession(channel.channelId, sessionId, 500)
+      .then((ms) => {
+        if (!cancelled) setSessionMessages(ms);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("[center] loadSession failed", err);
+        setSessionMessages([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [channel?.channelId, sessionId, refreshTick]);
 
+  // Tauri's `subscribeChatEvents` returns an UnlistenFn asynchronously.
+  // If the effect unmounts before the promise resolves, we must still call
+  // the unlisten that arrives late — otherwise the channel listener leaks
+  // for the rest of the process lifetime.
   useEffect(() => {
+    let cancelled = false;
     let unlisten: (() => void) | undefined;
     subscribeChatEvents((event: ChatEvent) => {
       setStream((current) => {
@@ -87,8 +110,12 @@ export function CenterPane({
         onRefresh();
         setStream((current) => (current && current.streamId === event.streamId ? null : current));
       }
-    }).then((u) => (unlisten = u));
+    }).then((u) => {
+      if (cancelled) u();
+      else unlisten = u;
+    });
     return () => {
+      cancelled = true;
       if (unlisten) unlisten();
     };
   }, [onRefresh]);

--- a/gui/src/components/ChannelHeader.tsx
+++ b/gui/src/components/ChannelHeader.tsx
@@ -1,0 +1,101 @@
+import { api } from "../api";
+import type { Channel, ChannelTier } from "../types";
+import { RepoChipRow } from "./RepoChipRow";
+
+export type ChannelTab = "chat" | "board" | "decisions";
+
+type Props = {
+  channel: Channel;
+  tab: ChannelTab;
+  onTabChange: (t: ChannelTab) => void;
+  rightRailOpen: boolean;
+  onToggleRail: () => void;
+  onOpenSettings: () => void;
+  onRefresh: () => void;
+};
+
+const TIER_LABELS: Record<ChannelTier, string> = {
+  feature_large: "feature+",
+  feature: "feature",
+  bugfix: "bugfix",
+  chore: "chore",
+  question: "question",
+};
+
+export function ChannelHeader({
+  channel,
+  tab,
+  onTabChange,
+  rightRailOpen,
+  onToggleRail,
+  onOpenSettings,
+  onRefresh,
+}: Props) {
+  const toggleStar = async () => {
+    try {
+      await api.setChannelStarred(channel.channelId, !channel.starred);
+      onRefresh();
+    } catch (err) {
+      console.warn("[star] failed:", err);
+    }
+  };
+
+  return (
+    <div className="channel-header">
+      <div className="channel-header-row1">
+        <div className="channel-header-name">
+          <span className="sigil">#</span>
+          <span>{channel.name}</span>
+          {channel.tier && (
+            <span className={`channel-header-tier tier-${channel.tier}`}>
+              {TIER_LABELS[channel.tier]}
+            </span>
+          )}
+        </div>
+        <button
+          className={`channel-header-star ${channel.starred ? "starred" : ""}`}
+          onClick={toggleStar}
+          title={channel.starred ? "Unstar" : "Star"}
+        >
+          {channel.starred ? "★" : "☆"}
+        </button>
+        {channel.description && (
+          <div className="channel-header-topic">{channel.description}</div>
+        )}
+        <div className="agent-stack">
+          {channel.members.slice(0, 4).map((m) => (
+            <span
+              key={m.agentId}
+              className="agent-avatar"
+              title={`${m.displayName} · ${m.provider}`}
+            >
+              {m.displayName.slice(0, 1).toUpperCase()}
+            </span>
+          ))}
+        </div>
+        <button className="rail-toggle" onClick={onToggleRail} title="Toggle right rail">
+          {rightRailOpen ? "⋮›" : "‹⋮"}
+        </button>
+      </div>
+      <div className="channel-header-row2">
+        <div className="channel-tabs">
+          {(["chat", "board", "decisions"] as ChannelTab[]).map((t) => (
+            <div
+              key={t}
+              className={`channel-tab ${tab === t ? "active" : ""}`}
+              onClick={() => onTabChange(t)}
+            >
+              {t === "chat" ? "Chat" : t === "board" ? "Board" : "Decisions"}
+            </div>
+          ))}
+        </div>
+        <div className="row2-right">
+          <RepoChipRow channel={channel} onChanged={onRefresh} />
+          <button className="gear-btn" onClick={onOpenSettings} title="Channel settings">
+            ⚙
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/ChannelSettingsDrawer.tsx
+++ b/gui/src/components/ChannelSettingsDrawer.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from "react";
+import { api } from "../api";
+import type { Channel, Spawn } from "../types";
+
+type Tab = "repos" | "members" | "about";
+
+type Props = {
+  channel: Channel;
+  onClose: () => void;
+  onRefresh: () => void;
+  onArchived: () => void;
+};
+
+export function ChannelSettingsDrawer({ channel, onClose, onRefresh, onArchived }: Props) {
+  const [tab, setTab] = useState<Tab>("repos");
+
+  return (
+    <>
+      <div className="drawer-backdrop" onClick={onClose} />
+      <div className="drawer" role="dialog" aria-label="Channel settings">
+        <div className="drawer-header">
+          <h3># {channel.name}</h3>
+          <button className="rail-toggle" onClick={onClose} title="Close">
+            ✕
+          </button>
+        </div>
+        <div className="drawer-tabs">
+          {(["repos", "members", "about"] as Tab[]).map((t) => (
+            <div
+              key={t}
+              className={`drawer-tab ${tab === t ? "active" : ""}`}
+              onClick={() => setTab(t)}
+            >
+              {t[0].toUpperCase() + t.slice(1)}
+            </div>
+          ))}
+        </div>
+        <div className="drawer-body">
+          {tab === "repos" && <ReposTab channel={channel} onRefresh={onRefresh} />}
+          {tab === "members" && <MembersTab channel={channel} />}
+          {tab === "about" && (
+            <AboutTab channel={channel} onArchived={onArchived} onRefresh={onRefresh} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ReposTab({ channel, onRefresh }: { channel: Channel; onRefresh: () => void }) {
+  const [spawns, setSpawns] = useState<Spawn[]>([]);
+  const primaryId = channel.primaryWorkspaceId ?? channel.repoAssignments[0]?.workspaceId;
+
+  useEffect(() => {
+    api.listSpawns(channel.channelId).then(setSpawns).catch(() => setSpawns([]));
+  }, [channel.channelId]);
+
+  const setPrimary = async (workspaceId: string) => {
+    try {
+      await api.setPrimaryRepo(channel.channelId, workspaceId);
+      onRefresh();
+    } catch (err) {
+      alert(`Promote failed: ${err}`);
+    }
+  };
+
+  const detach = async (workspaceId: string) => {
+    if (!confirm("Detach this repo from the channel?")) return;
+    const remaining = channel.repoAssignments
+      .filter((r) => r.workspaceId !== workspaceId)
+      .map((r) => ({ alias: r.alias, workspaceId: r.workspaceId, repoPath: r.repoPath }));
+    try {
+      await api.updateChannelRepos(channel.channelId, remaining);
+      onRefresh();
+    } catch (err) {
+      alert(`Detach failed: ${err}`);
+    }
+  };
+
+  const spawn = async (alias: string, repoPath: string) => {
+    try {
+      const s = await api.spawnAgent(channel.channelId, alias, repoPath);
+      setSpawns((prev) => [...prev, s]);
+    } catch (err) {
+      alert(`Spawn failed: ${err}`);
+    }
+  };
+
+  const killSpawn = async (alias: string) => {
+    setSpawns((prev) => prev.filter((s) => s.alias !== alias));
+    try {
+      await api.killSpawnedAgent(channel.channelId, alias);
+    } catch (err) {
+      alert(`Kill failed: ${err}`);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div className="drawer-section">
+        <h4>Attached repos ({channel.repoAssignments.length})</h4>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {channel.repoAssignments.map((r) => {
+            const isPrimary = r.workspaceId === primaryId;
+            const spawnRow = spawns.find((s) => s.alias === r.alias);
+            return (
+              <div
+                key={r.workspaceId}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr auto auto auto",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: 8,
+                  background: "var(--color-paper-alt)",
+                  borderRadius: 4,
+                }}
+              >
+                <div>
+                  <div style={{ fontFamily: "var(--font-mono)", fontWeight: 600 }}>
+                    @{r.alias}
+                    {isPrimary && (
+                      <span
+                        className="primary-badge"
+                        style={{
+                          marginLeft: 6,
+                          padding: "1px 6px",
+                          fontSize: 10,
+                          background: "var(--color-accent-coral)",
+                          color: "#fff",
+                          borderRadius: 10,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.04em",
+                        }}
+                      >
+                        primary
+                      </span>
+                    )}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: "var(--font-size-xs)",
+                      color: "var(--color-text-dim)",
+                    }}
+                  >
+                    {r.repoPath}
+                  </div>
+                </div>
+                {!isPrimary && (
+                  <button onClick={() => setPrimary(r.workspaceId)}>Promote</button>
+                )}
+                {spawnRow ? (
+                  <button onClick={() => killSpawn(r.alias)}>Kill</button>
+                ) : (
+                  <button onClick={() => spawn(r.alias, r.repoPath)}>Spawn</button>
+                )}
+                {!isPrimary && (
+                  <button
+                    onClick={() => detach(r.workspaceId)}
+                    style={{
+                      color: "var(--color-accent-coral)",
+                      borderColor: "var(--color-accent-coral)",
+                    }}
+                  >
+                    Detach
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MembersTab({ channel }: { channel: Channel }) {
+  return (
+    <div className="drawer-section">
+      <h4>Members ({channel.members.length})</h4>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {channel.members.map((m) => (
+          <div
+            key={m.agentId}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr auto",
+              gap: 8,
+              padding: 8,
+              background: "var(--color-paper-alt)",
+              borderRadius: 4,
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 600 }}>{m.displayName}</div>
+              <div
+                style={{
+                  fontSize: "var(--font-size-xs)",
+                  color: "var(--color-text-dim)",
+                }}
+              >
+                {m.provider} · {m.role}
+              </div>
+            </div>
+            <span
+              style={{
+                fontSize: "var(--font-size-xs)",
+                color: m.status === "working"
+                  ? "var(--color-accent-amber)"
+                  : "var(--color-accent-mint)",
+              }}
+            >
+              {m.status}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AboutTab({
+  channel,
+  onArchived,
+  onRefresh,
+}: {
+  channel: Channel;
+  onArchived: () => void;
+  onRefresh: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [tier, setTier] = useState<string>(channel.tier ?? "");
+
+  const saveTier = async (next: string) => {
+    setTier(next);
+    try {
+      await api.setChannelTier(channel.channelId, next || null);
+      onRefresh();
+    } catch (err) {
+      alert(`Tier update failed: ${err}`);
+    }
+  };
+
+  const handleArchive = async () => {
+    const archived = channel.status === "archived";
+    if (!confirm(`${archived ? "Unarchive" : "Archive"} #${channel.name}?`)) return;
+    setBusy(true);
+    try {
+      if (archived) {
+        await api.unarchiveChannel(channel.channelId);
+      } else {
+        await api.archiveChannel(channel.channelId);
+        onArchived();
+      }
+      onRefresh();
+    } catch (err) {
+      alert(`Failed: ${err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="drawer-section">
+        <h4>Topic</h4>
+        <div>{channel.description || <em>No topic set</em>}</div>
+      </div>
+      <div className="drawer-section">
+        <h4>Tier</h4>
+        <select
+          value={tier}
+          onChange={(e) => saveTier(e.target.value)}
+          style={{
+            padding: "6px 10px",
+            border: "1px solid var(--color-paper-line)",
+            borderRadius: 4,
+            background: "var(--color-paper-base)",
+            fontFamily: "var(--font-ui)",
+            fontSize: "var(--font-size-base)",
+          }}
+        >
+          <option value="">(unset)</option>
+          <option value="feature_large">Feature (large)</option>
+          <option value="feature">Feature</option>
+          <option value="bugfix">Bugfix</option>
+          <option value="chore">Chore</option>
+          <option value="question">Question</option>
+        </select>
+      </div>
+      <div className="drawer-section">
+        <h4>Status</h4>
+        <div>{channel.status}</div>
+        <button
+          style={{ marginTop: 8 }}
+          disabled={busy}
+          onClick={handleArchive}
+        >
+          {channel.status === "archived" ? "Unarchive" : "Archive"}
+        </button>
+      </div>
+      <div className="drawer-section">
+        <h4>Created</h4>
+        <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-dim)" }}>
+          {channel.createdAt ?? "—"}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/gui/src/components/Composer.tsx
+++ b/gui/src/components/Composer.tsx
@@ -1,0 +1,299 @@
+import { useRef, useState } from "react";
+import { api, type ChatEvent } from "../api";
+import type { Channel, ChatSession } from "../types";
+
+type ActivityEntry = { text: string; ts: number };
+
+export type ActiveStream = {
+  streamId: number;
+  alias: string | null;
+  accum: string;
+  activity: ActivityEntry[];
+  expanded: boolean;
+};
+
+export type StreamDispatch = (s: ActiveStream | null) => void;
+
+type Props = {
+  channel: Channel;
+  sessionId: string | null;
+  activeSession: ChatSession | null;
+  streaming: boolean;
+  onStartStream: StreamDispatch;
+  onSessionCreated: (sessionId: string) => void;
+};
+
+export function Composer({
+  channel,
+  sessionId,
+  activeSession,
+  streaming,
+  onStartStream,
+  onSessionCreated,
+}: Props) {
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [autoApprove, setAutoApprove] = useState(true);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [mention, setMention] = useState<{ start: number; query: string; index: number } | null>(
+    null
+  );
+
+  const aliases = channel.repoAssignments.map((r) => r.alias);
+  const primaryId = channel.primaryWorkspaceId ?? channel.repoAssignments[0]?.workspaceId;
+  const primaryAlias =
+    channel.repoAssignments.find((r) => r.workspaceId === primaryId)?.alias ?? "";
+
+  const detectMention = (value: string, caret: number) => {
+    const before = value.slice(0, caret);
+    const match = before.match(/(?:^|\s)@([a-zA-Z0-9_-]*)$/);
+    if (!match) return null;
+    const start = caret - match[1].length - 1;
+    return { start, query: match[1] };
+  };
+  const filteredAliases = mention
+    ? aliases.filter((a) => a.toLowerCase().startsWith(mention.query.toLowerCase()))
+    : [];
+
+  const applyMention = (alias: string) => {
+    if (!mention) return;
+    const ta = textareaRef.current;
+    const caret = ta?.selectionStart ?? text.length;
+    const before = text.slice(0, mention.start);
+    const after = text.slice(caret);
+    const insertion = `@${alias} `;
+    const next = before + insertion + after;
+    setText(next);
+    setMention(null);
+    const nextCaret = before.length + insertion.length;
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(nextCaret, nextCaret);
+    });
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setText(value);
+    const next = detectMention(value, e.target.selectionStart ?? value.length);
+    setMention(next ? { ...next, index: 0 } : null);
+  };
+
+  const handleSelect = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    const el = e.currentTarget;
+    const next = detectMention(el.value, el.selectionStart ?? el.value.length);
+    setMention((prev) =>
+      next ? { ...next, index: prev && prev.start === next.start ? prev.index : 0 } : null
+    );
+  };
+
+  const send = async () => {
+    const raw = text.trim();
+    if (!raw) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { alias, body } = parseAliasPrefix(raw, aliases);
+      const target = alias ?? primaryAlias;
+      const repo = target ? channel.repoAssignments.find((r) => r.alias === target) : null;
+      const cwd = repo?.repoPath;
+      const aliasKey = target || "general";
+      const claudeSessionId = activeSession?.claudeSessionIds?.[aliasKey] ?? undefined;
+
+      let activeId = sessionId;
+      if (!activeId) {
+        const session = await api.createSession(channel.channelId, raw.slice(0, 60));
+        activeId = session.sessionId;
+        onSessionCreated(activeId);
+      }
+
+      let rewindKey: string | undefined;
+      if (channel.repoAssignments.length > 0) {
+        try {
+          const snap = await api.rewindSnapshot(channel.channelId, activeId);
+          rewindKey = snap.key;
+        } catch (err) {
+          console.warn("[rewind] snapshot failed:", err);
+        }
+      }
+
+      const streamId = await api.startChat({
+        channelId: channel.channelId,
+        sessionId: activeId,
+        message: body,
+        alias: target || undefined,
+        cwd,
+        claudeSessionId,
+        autoApprove,
+        rewindKey,
+      });
+      onStartStream({
+        streamId,
+        alias: target || null,
+        accum: "",
+        activity: [],
+        expanded: false,
+      });
+      setText("");
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mention && filteredAliases.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setMention({ ...mention, index: (mention.index + 1) % filteredAliases.length });
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setMention({
+          ...mention,
+          index: (mention.index - 1 + filteredAliases.length) % filteredAliases.length,
+        });
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        applyMention(filteredAliases[mention.index]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMention(null);
+        return;
+      }
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      send();
+      return;
+    }
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  const disabled = busy || streaming;
+  const showMentions = !!mention && filteredAliases.length > 0;
+
+  return (
+    <div className="composer">
+      {error && <div className="composer-error">{error}</div>}
+      {primaryAlias && (
+        <div className="composer-routing">
+          <span>→</span>
+          <span className="route-chip">@{primaryAlias}</span>
+          <span>primary · override with @alias</span>
+        </div>
+      )}
+      <div className="composer-body">
+        {showMentions && (
+          <MentionPopover
+            channel={channel}
+            aliases={filteredAliases}
+            index={mention!.index}
+            onPick={applyMention}
+          />
+        )}
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={handleTextChange}
+          onKeyDown={onKeyDown}
+          onSelect={handleSelect}
+          onBlur={() => setTimeout(() => setMention(null), 120)}
+          placeholder={`Message #${channel.name}…  Enter to send · Shift+Enter newline`}
+          rows={2}
+          disabled={disabled}
+        />
+      </div>
+      <div className="composer-controls">
+        <label className="auto-approve" title="Pass --dangerously-skip-permissions to claude">
+          <input
+            type="checkbox"
+            checked={autoApprove}
+            onChange={(e) => setAutoApprove(e.target.checked)}
+          />
+          Auto-approve
+        </label>
+        <span className="composer-hint">⌘⏎ to send</span>
+        <button className="primary" onClick={send} disabled={disabled || !text.trim()}>
+          {streaming ? "…" : "Send"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MentionPopover({
+  channel,
+  aliases,
+  index,
+  onPick,
+}: {
+  channel: Channel;
+  aliases: string[];
+  index: number;
+  onPick: (alias: string) => void;
+}) {
+  return (
+    <div className="mention-popover" role="listbox">
+      {aliases.map((a, i) => {
+        const repo = channel.repoAssignments.find((r) => r.alias === a);
+        return (
+          <button
+            key={a}
+            type="button"
+            role="option"
+            aria-selected={i === index}
+            className={`mention-option ${i === index ? "active" : ""}`}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onPick(a);
+            }}
+          >
+            <span className="mention-alias">@{a}</span>
+            {repo?.repoPath && <span className="mention-path">{repo.repoPath}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function parseAliasPrefix(
+  message: string,
+  aliases: string[]
+): { alias: string | null; body: string } {
+  const match = message.match(/^@([a-zA-Z0-9_-]+)\s+([\s\S]*)$/);
+  if (!match) return { alias: null, body: message };
+  const candidate = match[1];
+  if (!aliases.includes(candidate)) return { alias: null, body: message };
+  return { alias: candidate, body: match[2] };
+}
+
+export function reduceStream(current: ActiveStream, event: ChatEvent): ActiveStream {
+  const ACTIVITY_STACK_MAX = 20;
+  switch (event.kind) {
+    case "chunk":
+      return { ...current, accum: current.accum + event.text };
+    case "activity": {
+      const keep = current.activity.slice(-(ACTIVITY_STACK_MAX - 1));
+      return {
+        ...current,
+        activity: [...keep, { text: event.text, ts: Date.now() }],
+      };
+    }
+    default:
+      return current;
+  }
+}

--- a/gui/src/components/DecisionsView.tsx
+++ b/gui/src/components/DecisionsView.tsx
@@ -1,0 +1,46 @@
+import type { Channel, Decision } from "../types";
+import { toUiChannel } from "../lib/channel";
+import { renderWithMentions } from "../lib/mentions";
+
+type Props = {
+  decisions: Decision[];
+  channel: Channel;
+};
+
+export function DecisionsView({ decisions, channel }: Props) {
+  const ui = toUiChannel(channel);
+  if (decisions.length === 0) {
+    return <div className="chat-empty">No decisions recorded</div>;
+  }
+  return (
+    <div className="chat-scroll decisions">
+      {decisions.map((d) => (
+        <div key={d.decisionId} className="decision-card">
+          <h4>{d.title}</h4>
+          <div className="meta">
+            {d.decidedByName} · {formatTime(d.createdAt)}
+          </div>
+          <p>{renderWithMentions(d.description, ui)}</p>
+          {d.rationale && (
+            <p>
+              <strong>Why:</strong> {renderWithMentions(d.rationale, ui)}
+            </p>
+          )}
+          {d.alternatives.length > 0 && (
+            <p>
+              <strong>Alternatives:</strong> {d.alternatives.join(", ")}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import type { Channel, ChannelEntry, PersistedChatMessage } from "../types";
+import { renderWithMentions } from "../lib/mentions";
+import { toUiChannel } from "../lib/channel";
+import type { ActiveStream } from "./Composer";
+
+const ACTIVITY_TOP_N = 3;
+
+type Props = {
+  channel: Channel;
+  sessionId: string | null;
+  feed: ChannelEntry[];
+  sessionMessages: PersistedChatMessage[];
+  stream: ActiveStream | null;
+  streamId: number | null;
+  onToggleStreamExpanded: () => void;
+  onRewound: () => void;
+};
+
+export function MessageList({
+  channel,
+  sessionId,
+  feed,
+  sessionMessages,
+  stream,
+  streamId,
+  onToggleStreamExpanded,
+  onRewound,
+}: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const ui = toUiChannel(channel);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [sessionMessages.length, feed.length, sessionId, stream?.accum.length]);
+
+  return (
+    <div className="chat-scroll" ref={scrollRef}>
+      {sessionId ? (
+        <SessionMessages
+          channel={channel}
+          sessionId={sessionId}
+          messages={sessionMessages}
+          streaming={!!stream}
+          streamId={streamId}
+          onRewound={onRewound}
+        />
+      ) : (
+        <FeedView entries={feed} channel={ui} />
+      )}
+      {stream && <StreamCard stream={stream} channel={ui} onToggleExpanded={onToggleStreamExpanded} />}
+    </div>
+  );
+}
+
+function FeedView({ entries, channel }: { entries: ChannelEntry[]; channel: ReturnType<typeof toUiChannel> }) {
+  if (entries.length === 0) return <div className="chat-empty">No activity yet</div>;
+  return (
+    <>
+      {entries.map((e) => (
+        <div key={e.entryId} className={`message role-${e.type}`}>
+          <div className="msg-avatar">
+            {(e.fromDisplayName ?? e.type).slice(0, 1).toUpperCase()}
+          </div>
+          <div>
+            <div className="msg-head">
+              <span className="msg-author">{e.fromDisplayName ?? e.type}</span>
+              <span className="msg-time">{formatTime(e.createdAt)}</span>
+            </div>
+            <div className="msg-body">{renderWithMentions(e.content, channel)}</div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function SessionMessages({
+  channel,
+  sessionId,
+  messages,
+  streaming,
+  streamId,
+  onRewound,
+}: {
+  channel: Channel;
+  sessionId: string;
+  messages: PersistedChatMessage[];
+  streaming: boolean;
+  streamId: number | null;
+  onRewound: () => void;
+}) {
+  const ui = toUiChannel(channel);
+  const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(null);
+
+  if (messages.length === 0) return <div className="chat-empty">No messages in this session yet</div>;
+  return (
+    <>
+      {messages.map((m, i) => {
+        const rewindKey = m.metadata?.rewindKey;
+        const canRewind = m.role === "user" && !!rewindKey && !streaming;
+        return (
+          <div key={i} className={`message role-${m.role}`}>
+            <div className="msg-avatar">
+              {m.agentAlias ? m.agentAlias.slice(0, 1).toUpperCase() : m.role.slice(0, 1).toUpperCase()}
+            </div>
+            <div>
+              <div className="msg-head">
+                <span className="msg-author">
+                  {m.agentAlias ? `@${m.agentAlias}` : m.role}
+                </span>
+                <span className="msg-time">{formatTime(m.timestamp)}</span>
+                <span className="msg-actions">
+                  {m.role === "user" && rewindKey && (
+                    <button
+                      className="msg-action-btn"
+                      disabled={!canRewind}
+                      title={
+                        streaming
+                          ? "Finish the current stream before rewinding"
+                          : "Rewind repos + chat to this turn"
+                      }
+                      onClick={() => setRewindTarget(m)}
+                    >
+                      ⟲ Rewind
+                    </button>
+                  )}
+                </span>
+              </div>
+              <div className="msg-body">{renderWithMentions(m.content, ui)}</div>
+            </div>
+          </div>
+        );
+      })}
+      {rewindTarget && (
+        <RewindConfirmModal
+          channel={channel}
+          sessionId={sessionId}
+          target={rewindTarget}
+          streamId={streamId}
+          onClose={() => setRewindTarget(null)}
+          onDone={() => {
+            setRewindTarget(null);
+            onRewound();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function RewindConfirmModal({
+  channel,
+  sessionId,
+  target,
+  streamId,
+  onClose,
+  onDone,
+}: {
+  channel: Channel;
+  sessionId: string;
+  target: PersistedChatMessage;
+  streamId: number | null;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const rewindKey = target.metadata?.rewindKey;
+
+  const apply = async () => {
+    if (!rewindKey) {
+      setError("Message has no rewindKey metadata — cannot rewind.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      if (streamId !== null) {
+        try {
+          await api.cancelChatStream(streamId);
+        } catch (err) {
+          console.warn("[rewind] cancelChatStream failed:", err);
+        }
+      }
+      await api.rewindApply(channel.channelId, sessionId, rewindKey, target.timestamp);
+      onDone();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal modal-sm" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          Rewind to this turn?
+          <button className="close-btn" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-body">
+          <p style={{ margin: 0 }}>
+            Each repo in this channel will be reset to the commit captured before this message.
+            Messages at or after this turn will be removed from the session.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              padding: 10,
+              background: "var(--color-paper-alt)",
+              borderRadius: 4,
+            }}
+          >
+            {channel.repoAssignments.map((r) => (
+              <div
+                key={r.alias}
+                style={{ display: "flex", gap: 8, fontFamily: "var(--font-mono)", fontSize: 12 }}
+              >
+                <code>@{r.alias}</code>
+                <span style={{ color: "var(--color-text-dim)" }}>{r.repoPath}</span>
+              </div>
+            ))}
+          </div>
+          <div
+            style={{
+              color: "var(--color-accent-coral)",
+              background: "var(--color-accent-coral-soft)",
+              padding: 8,
+              borderRadius: 4,
+              fontSize: 12,
+            }}
+          >
+            <strong>Warning:</strong> this runs <code>git reset --hard</code>. Uncommitted changes
+            will be lost. Shell side effects are not undone.
+          </div>
+          {error && <div className="error">{error}</div>}
+        </div>
+        <div className="modal-footer" style={{ justifyContent: "flex-end" }}>
+          <button type="button" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="primary" onClick={apply} disabled={busy || !rewindKey}>
+            {busy ? "Rewinding…" : "Rewind"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StreamCard({
+  stream,
+  channel,
+  onToggleExpanded,
+}: {
+  stream: ActiveStream;
+  channel: ReturnType<typeof toUiChannel>;
+  onToggleExpanded: () => void;
+}) {
+  const total = stream.activity.length;
+  const visibleCount = stream.expanded ? total : Math.min(ACTIVITY_TOP_N, total);
+  const visible = total === 0 ? [] : stream.activity.slice(total - visibleCount);
+  const hiddenCount = total - visibleCount;
+
+  return (
+    <div className="stream-card">
+      <div className="stream-card-head">
+        <span className="dot" />
+        <span className="author">{stream.alias ? `@${stream.alias}` : "assistant"}</span>
+        <span>
+          {stream.accum ? "writing response" : "thinking"}
+          {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
+        </span>
+      </div>
+      <div className={`stream-activity ${stream.expanded ? "expanded" : ""}`}>
+        {visible.map((entry, i) => {
+          const isNewest = i === visible.length - 1;
+          return (
+            <div
+              key={`${entry.ts}-${i}`}
+              className={`stream-activity-line ${isNewest ? "newest" : ""}`}
+              title={new Date(entry.ts).toLocaleTimeString()}
+            >
+              <span>⚙</span>
+              <span>{entry.text}</span>
+            </div>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
+            +{hiddenCount} more
+          </button>
+        )}
+        {stream.expanded && total > ACTIVITY_TOP_N && (
+          <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
+            collapse
+          </button>
+        )}
+      </div>
+      {stream.accum && (
+        <div className="stream-body">{renderWithMentions(stream.accum, channel)}</div>
+      )}
+    </div>
+  );
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -110,60 +110,66 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
     setError(null);
     setSpawnWarning(null);
     try {
+      // Normalize aliases once; everything downstream (create, spawn, kickoff
+      // routing) reads from `sel` so the persisted channel and the kickoff
+      // address agree on the alias string.
       const sel = selectedRows.map((r) => ({
         alias: r.alias.trim() || defaultAlias(r.workspace.repoPath),
         workspaceId: r.workspace.workspaceId,
         repoPath: r.workspace.repoPath,
+        spawn: r.spawn,
       }));
       const result = await api.createChannel(
         slug,
         topic.trim(),
-        sel,
+        sel.map(({ alias, workspaceId, repoPath }) => ({ alias, workspaceId, repoPath })),
         primaryWorkspaceId ?? undefined
       );
 
-      const toSpawn = selectedRows.filter(
-        (r) => r.spawn && r.workspace.workspaceId !== primaryWorkspaceId
-      );
+      const warnings: string[] = [];
+
+      const toSpawn = sel.filter((r) => r.spawn && r.workspaceId !== primaryWorkspaceId);
       if (toSpawn.length > 0) {
         const results = await Promise.all(
           toSpawn.map(async (r) => {
-            const alias = r.alias.trim() || defaultAlias(r.workspace.repoPath);
             try {
-              await api.spawnAgent(result.channelId, alias, r.workspace.repoPath);
+              await api.spawnAgent(result.channelId, r.alias, r.repoPath);
               return { ok: true as const };
             } catch {
-              return { ok: false as const, alias };
+              return { ok: false as const, alias: r.alias };
             }
           })
         );
         const failed = results.filter((x) => !x.ok);
         if (failed.length > 0) {
-          setSpawnWarning(`${failed.length}/${results.length} spawn(s) failed`);
+          warnings.push(`${failed.length}/${results.length} spawn(s) failed`);
         }
       }
 
       const kickoff = firstMessage.trim();
       if (kickoff) {
+        const primary = sel.find((r) => r.workspaceId === primaryWorkspaceId);
         try {
-          const primaryAlias =
-            selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.alias ??
-            undefined;
-          const primaryPath =
-            selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.workspace
-              .repoPath ?? undefined;
           const session = await api.createSession(result.channelId, kickoff.slice(0, 60));
           await api.startChat({
             channelId: result.channelId,
             sessionId: session.sessionId,
             message: kickoff,
-            alias: primaryAlias,
-            cwd: primaryPath,
+            alias: primary?.alias,
+            cwd: primary?.repoPath,
             autoApprove: true,
           });
         } catch (err) {
-          console.warn("[kickoff] startChat failed:", err);
+          warnings.push(`Channel created but kickoff failed: ${err}. Send your message manually.`);
         }
+      }
+
+      if (warnings.length > 0) {
+        setSpawnWarning(warnings.join(" · "));
+        // Keep the modal open so the user can see the warning; they can close
+        // manually via the × after reading it.
+        onCreated(result.channelId);
+        return;
       }
 
       onCreated(result.channelId);

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
 import type { WorkspaceEntry } from "../types";
 
@@ -12,36 +12,30 @@ type RepoRow = {
   workspace: WorkspaceEntry;
   selected: boolean;
   alias: string;
-  // Only one row can be primary at a time. We track it at the workspace-id
-  // level (see `primaryWorkspaceId` below) rather than on the row so the
-  // invariant "at most one primary" is centrally enforced.
   spawn: boolean;
 };
 
+type Step = 1 | 2 | 3;
+
 export function NewChannelModal({ open, onClose, onCreated }: Props) {
+  const [step, setStep] = useState<Step>(1);
   const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
+  const [topic, setTopic] = useState("");
   const [repos, setRepos] = useState<RepoRow[]>([]);
+  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
-  const [highlightIdx, setHighlightIdx] = useState(0);
+  const [firstMessage, setFirstMessage] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Non-fatal warning shown after createChannel succeeds but one or more
-  // spawnAgent calls failed. We still navigate to the channel regardless.
   const [spawnWarning, setSpawnWarning] = useState<string | null>(null);
-  // Which workspace is flagged primary. Null until the user checks the
-  // first row, at which point we auto-set to that row. If the current
-  // primary is later unchecked, we reassign to the earliest still-
-  // selected row (by master-array order, not visible order).
-  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(null);
-  const filterRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
+    setStep(1);
     setName("");
-    setDescription("");
+    setTopic("");
     setFilter("");
-    setHighlightIdx(0);
+    setFirstMessage("");
     setError(null);
     setSpawnWarning(null);
     setPrimaryWorkspaceId(null);
@@ -57,9 +51,6 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
     });
   }, [open]);
 
-  // Visible rows after filter. `origIndex` keeps a pointer back to the master
-  // `repos` array so toggles / alias edits never corrupt non-visible
-  // selections when the filter changes.
   const visible = useMemo(() => {
     const tokens = filter.trim().toLowerCase().split(/\s+/).filter(Boolean);
     return repos
@@ -73,128 +64,66 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
       });
   }, [repos, filter]);
 
-  useEffect(() => {
-    if (highlightIdx >= visible.length) {
-      setHighlightIdx(Math.max(0, visible.length - 1));
-    }
-  }, [visible.length, highlightIdx]);
-
   if (!open) return null;
 
+  const selectedRows = repos.filter((r) => r.selected);
+  const slug = slugify(name);
+  const canNextFromStep1 = slug.length > 0;
+  const canNextFromStep2 = selectedRows.length > 0 && !!primaryWorkspaceId;
+
   const toggleSelected = (origIndex: number) => {
-    // Compute next state based on current master array, then fold in the
-    // primary-assignment rule in a single pass so we don't race with React
-    // batching two setState calls.
     setRepos((prev) => {
-      const next = prev.map((row, j) => {
-        if (j !== origIndex) return row;
-        const nowSelected = !row.selected;
-        // Deselecting also clears spawn so we don't carry a stale opt-in
-        // forward if the user re-selects later.
-        return {
-          ...row,
-          selected: nowSelected,
-          spawn: nowSelected ? row.spawn : false,
-        };
-      });
-      // Auto-assign / reassign primary:
-      //   - If nothing is currently primary and we just selected a row,
-      //     that row becomes primary.
-      //   - If the current primary just got unchecked, hand primary to the
-      //     earliest still-selected row (master-array order).
-      //   - If no selected rows remain, clear primary.
+      const next = prev.map((row, j) =>
+        j === origIndex
+          ? {
+              ...row,
+              selected: !row.selected,
+              spawn: !row.selected ? row.spawn : false,
+            }
+          : row
+      );
       setPrimaryWorkspaceId((currentPrimary) => {
-        const selectedRows = next.filter((r) => r.selected);
-        if (selectedRows.length === 0) return null;
-        if (
-          currentPrimary &&
-          selectedRows.some((r) => r.workspace.workspaceId === currentPrimary)
-        ) {
+        const sel = next.filter((r) => r.selected);
+        if (sel.length === 0) return null;
+        if (currentPrimary && sel.some((r) => r.workspace.workspaceId === currentPrimary)) {
           return currentPrimary;
         }
-        return selectedRows[0].workspace.workspaceId;
+        return sel[0].workspace.workspaceId;
       });
       return next;
     });
   };
 
   const setPrimary = (workspaceId: string) => {
-    // Radio-click: assumes the row is already selected (the radio is only
-    // rendered on selected rows). Defensive: verify and no-op otherwise.
-    setRepos((prev) => {
-      const match = prev.find((r) => r.workspace.workspaceId === workspaceId && r.selected);
-      if (!match) return prev;
-      setPrimaryWorkspaceId(workspaceId);
-      return prev;
-    });
+    if (!repos.find((r) => r.workspace.workspaceId === workspaceId && r.selected)) return;
+    setPrimaryWorkspaceId(workspaceId);
   };
-
   const toggleSpawn = (origIndex: number) => {
-    setRepos((prev) =>
-      prev.map((row, j) => (j === origIndex ? { ...row, spawn: !row.spawn } : row))
-    );
+    setRepos((prev) => prev.map((r, j) => (j === origIndex ? { ...r, spawn: !r.spawn } : r)));
   };
-
   const updateAlias = (origIndex: number, alias: string) => {
-    setRepos((prev) => prev.map((row, j) => (j === origIndex ? { ...row, alias } : row)));
+    setRepos((prev) => prev.map((r, j) => (j === origIndex ? { ...r, alias } : r)));
   };
-
-  const onFilterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setHighlightIdx((i) => Math.min(visible.length - 1, i + 1));
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setHighlightIdx((i) => Math.max(0, i - 1));
-    } else if (e.key === " ") {
-      // Space toggles the currently highlighted row when the filter field has
-      // focus. Avoids the built-in "space in a text input" conflict by only
-      // intercepting when there's a highlighted visible row.
-      const target = visible[highlightIdx];
-      if (target) {
-        e.preventDefault();
-        toggleSelected(target.origIndex);
-      }
-    } else if (e.key === "Escape") {
-      if (filter.length > 0) {
-        e.preventDefault();
-        setFilter("");
-      }
-    }
-  };
-
-  const selectedCount = repos.filter((r) => r.selected).length;
 
   const submit = async () => {
-    if (!name.trim()) {
-      setError("Name is required");
-      return;
-    }
     setBusy(true);
     setError(null);
     setSpawnWarning(null);
     try {
-      const selectedRows = repos.filter((r) => r.selected);
-      const selected = selectedRows.map((r) => ({
+      const sel = selectedRows.map((r) => ({
         alias: r.alias.trim() || defaultAlias(r.workspace.repoPath),
         workspaceId: r.workspace.workspaceId,
         repoPath: r.workspace.repoPath,
       }));
-      const effectivePrimary =
-        primaryWorkspaceId ?? selectedRows[0]?.workspace.workspaceId ?? undefined;
       const result = await api.createChannel(
-        name.trim(),
-        description.trim(),
-        selected,
-        effectivePrimary
+        slug,
+        topic.trim(),
+        sel,
+        primaryWorkspaceId ?? undefined
       );
 
-      // Spawn all non-primary rows that were opted-in. Run in parallel; a
-      // spawn failure surfaces as a warning but doesn't block navigation —
-      // the channel was created successfully, and the user can still
-      // launch agents later from the right pane.
       const toSpawn = selectedRows.filter(
-        (r) => r.spawn && r.workspace.workspaceId !== effectivePrimary
+        (r) => r.spawn && r.workspace.workspaceId !== primaryWorkspaceId
       );
       if (toSpawn.length > 0) {
         const results = await Promise.all(
@@ -202,25 +131,45 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
             const alias = r.alias.trim() || defaultAlias(r.workspace.repoPath);
             try {
               await api.spawnAgent(result.channelId, alias, r.workspace.repoPath);
-              return { alias, ok: true as const };
-            } catch (e) {
-              return { alias, ok: false as const, error: String(e) };
+              return { ok: true as const };
+            } catch {
+              return { ok: false as const, alias };
             }
           })
         );
-        const failures = results.filter((x) => !x.ok);
-        if (failures.length > 0) {
-          setSpawnWarning(
-            `Channel created, but ${failures.length}/${results.length} spawn(s) failed: ` +
-              failures.map((f) => `@${f.alias}`).join(", ")
-          );
+        const failed = results.filter((x) => !x.ok);
+        if (failed.length > 0) {
+          setSpawnWarning(`${failed.length}/${results.length} spawn(s) failed`);
+        }
+      }
+
+      const kickoff = firstMessage.trim();
+      if (kickoff) {
+        try {
+          const primaryAlias =
+            selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.alias ??
+            undefined;
+          const primaryPath =
+            selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.workspace
+              .repoPath ?? undefined;
+          const session = await api.createSession(result.channelId, kickoff.slice(0, 60));
+          await api.startChat({
+            channelId: result.channelId,
+            sessionId: session.sessionId,
+            message: kickoff,
+            alias: primaryAlias,
+            cwd: primaryPath,
+            autoApprove: true,
+          });
+        } catch (err) {
+          console.warn("[kickoff] startChat failed:", err);
         }
       }
 
       onCreated(result.channelId);
       onClose();
-    } catch (e) {
-      setError(String(e));
+    } catch (err) {
+      setError(String(err));
     } finally {
       setBusy(false);
     }
@@ -229,66 +178,75 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">New channel</div>
+        <div className="modal-header">
+          New channel
+          <button className="close-btn" onClick={onClose}>×</button>
+        </div>
         <div className="modal-body">
-          <label>
-            Name
-            <input
-              autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. my-project"
-            />
-          </label>
-          <label>
-            Description
-            <input
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional"
-            />
-          </label>
-          <div className="repo-list">
-            <div className="repo-list-head">
-              <span className="modal-subhead">
-                Repos ({visible.length}/{repos.length}
-                {selectedCount > 0 ? ` · ${selectedCount} selected` : ""})
-              </span>
-            </div>
-            {repos.length === 0 ? (
-              <div className="empty">No registered workspaces. Run `rly up` in a repo first.</div>
-            ) : (
-              <>
+          {step === 1 && (
+            <div className="wizard-step">
+              <h3>Basics</h3>
+              <p className="help">Give this channel a short name. Topic is optional.</p>
+              <label>
+                Channel name
                 <input
-                  ref={filterRef}
+                  autoFocus
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="oauth-api-users"
+                />
+                {name && slug !== name && (
+                  <small style={{ color: "var(--color-text-dim)" }}>
+                    will be #{slug}
+                  </small>
+                )}
+              </label>
+              <label>
+                Topic
+                <input
+                  value={topic}
+                  onChange={(e) => setTopic(e.target.value)}
+                  placeholder="What is this channel for?"
+                />
+              </label>
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="wizard-step">
+              <h3>Repos</h3>
+              <p className="help">
+                Attach workspaces to this channel. Each becomes a pingable <code>@alias</code>.
+                One repo must be primary — its agent receives the kickoff message.
+              </p>
+              <div className="repo-list-step">
+                <input
                   className="repo-filter"
+                  placeholder="Filter workspaces…"
                   value={filter}
                   onChange={(e) => setFilter(e.target.value)}
-                  onKeyDown={onFilterKeyDown}
-                  placeholder="filter by path, alias, or workspace id · ↑↓ navigate · Space toggle · Esc clear"
                 />
                 <div className="repo-rows">
                   {visible.length === 0 ? (
-                    <div className="empty">No repos match “{filter}”.</div>
+                    <div className="rail-empty">
+                      {repos.length === 0
+                        ? "No registered workspaces. Run `rly up` in a repo first."
+                        : "No match"}
+                    </div>
                   ) : (
-                    visible.map(({ row, origIndex }, i) => {
+                    visible.map(({ row, origIndex }) => {
                       const isPrimary =
                         row.selected && primaryWorkspaceId === row.workspace.workspaceId;
                       return (
-                        <div
-                          key={row.workspace.workspaceId}
-                          className={`repo-row ${i === highlightIdx ? "highlighted" : ""}`}
-                          onClick={() => setHighlightIdx(i)}
-                        >
+                        <div key={row.workspace.workspaceId} className="repo-row">
                           <input
                             type="checkbox"
                             checked={row.selected}
                             onChange={() => toggleSelected(origIndex)}
-                            title="Include this repo in the channel"
                           />
                           <span className="repo-path" title={row.workspace.repoPath}>
                             {basename(row.workspace.repoPath)}
-                            {isPrimary && <span className="primary-badge">PRIMARY</span>}
+                            {isPrimary && <span className="primary-badge">primary</span>}
                           </span>
                           <input
                             className="alias-input"
@@ -297,14 +255,8 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                             placeholder="alias"
                             disabled={!row.selected}
                           />
-                          {/* Primary radio: only rendered on selected rows.
-                              The label is the clickable surface; clicking the
-                              radio explicitly promotes this repo to primary. */}
                           {row.selected ? (
-                            <label
-                              className="repo-primary-radio"
-                              title="Primary agent runs in the GUI main chat"
-                            >
+                            <label className="repo-primary-radio">
                               <input
                                 type="radio"
                                 name="primary-workspace"
@@ -316,15 +268,8 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                           ) : (
                             <span className="repo-primary-radio placeholder" />
                           )}
-                          {/* Spawn checkbox: opt-in, visible only for
-                              non-primary selected rows. The primary agent
-                              runs in the main chat, so "spawn" doesn't
-                              apply to it. */}
                           {row.selected && !isPrimary ? (
-                            <label
-                              className="repo-spawn-toggle"
-                              title="Launch an external Terminal agent for this repo on channel create"
-                            >
+                            <label className="repo-spawn-toggle" title="Open an external Terminal agent">
                               <input
                                 type="checkbox"
                                 checked={row.spawn}
@@ -340,23 +285,74 @@ export function NewChannelModal({ open, onClose, onCreated }: Props) {
                     })
                   )}
                 </div>
-              </>
-            )}
-          </div>
+              </div>
+            </div>
+          )}
+
+          {step === 3 && (
+            <div className="wizard-step">
+              <h3>Kick-off</h3>
+              <p className="help">
+                This first message goes straight to the primary agent (@{
+                  selectedRows.find((r) => r.workspace.workspaceId === primaryWorkspaceId)?.alias
+                }). The classifier assigns a tier and plans tickets.
+              </p>
+              <label>
+                First message (optional)
+                <textarea
+                  value={firstMessage}
+                  onChange={(e) => setFirstMessage(e.target.value)}
+                  placeholder="Describe the work you want to kick off…"
+                  rows={6}
+                />
+              </label>
+            </div>
+          )}
+
           {error && <div className="error">{error}</div>}
           {spawnWarning && <div className="warning">{spawnWarning}</div>}
         </div>
         <div className="modal-footer">
-          <button onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
-          <button className="primary" onClick={submit} disabled={busy}>
-            {busy ? "Creating…" : "Create"}
-          </button>
+          <div className="steps">
+            <span className={`step-dot ${step >= 1 ? "active" : ""}`} />
+            <span className={`step-dot ${step >= 2 ? "active" : ""}`} />
+            <span className={`step-dot ${step >= 3 ? "active" : ""}`} />
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            {step > 1 && (
+              <button onClick={() => setStep((s) => (s - 1) as Step)} disabled={busy}>
+                Back
+              </button>
+            )}
+            {step < 3 && (
+              <button
+                className="primary"
+                onClick={() => setStep((s) => (s + 1) as Step)}
+                disabled={(step === 1 && !canNextFromStep1) || (step === 2 && !canNextFromStep2)}
+              >
+                Next
+              </button>
+            )}
+            {step === 3 && (
+              <button className="primary" onClick={submit} disabled={busy}>
+                {busy ? "Creating…" : "Create channel"}
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>
   );
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 function basename(p: string): string {
@@ -364,8 +360,5 @@ function basename(p: string): string {
 }
 
 function defaultAlias(repoPath: string): string {
-  return basename(repoPath)
-    .replace(/[^a-z0-9-]/gi, "")
-    .toLowerCase()
-    .slice(0, 12);
+  return basename(repoPath).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(0, 12);
 }

--- a/gui/src/components/RepoChipRow.tsx
+++ b/gui/src/components/RepoChipRow.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import type { Channel, WorkspaceEntry } from "../types";
+
+type Props = {
+  channel: Channel;
+  onChanged: () => void;
+};
+
+export function RepoChipRow({ channel, onChanged }: Props) {
+  const [openChipId, setOpenChipId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onClickOutside = (e: MouseEvent) => {
+      if (!rowRef.current) return;
+      if (!rowRef.current.contains(e.target as Node)) {
+        setOpenChipId(null);
+        setAddOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpenChipId(null);
+        setAddOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClickOutside);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClickOutside);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  const primaryId = channel.primaryWorkspaceId ?? channel.repoAssignments[0]?.workspaceId;
+
+  const setPrimary = async (workspaceId: string) => {
+    try {
+      await api.setPrimaryRepo(channel.channelId, workspaceId);
+      onChanged();
+      setOpenChipId(null);
+    } catch (err) {
+      alert(`Promote failed: ${err}`);
+    }
+  };
+
+  const detach = async (workspaceId: string) => {
+    const remaining = channel.repoAssignments.filter((r) => r.workspaceId !== workspaceId);
+    try {
+      await api.updateChannelRepos(
+        channel.channelId,
+        remaining.map((r) => ({
+          alias: r.alias,
+          workspaceId: r.workspaceId,
+          repoPath: r.repoPath,
+        }))
+      );
+      onChanged();
+      setOpenChipId(null);
+    } catch (err) {
+      alert(`Detach failed: ${err}`);
+    }
+  };
+
+  const spawnInTerminal = async (alias: string, repoPath: string) => {
+    try {
+      await api.spawnAgent(channel.channelId, alias, repoPath);
+      setOpenChipId(null);
+    } catch (err) {
+      alert(`Spawn failed: ${err}`);
+    }
+  };
+
+  return (
+    <div className="repo-chip-row" ref={rowRef}>
+      {channel.repoAssignments.map((r) => {
+        const isPrimary = r.workspaceId === primaryId;
+        const open = openChipId === r.workspaceId;
+        return (
+          <div key={r.workspaceId} style={{ position: "relative" }}>
+            <button
+              className={`repo-chip ${isPrimary ? "primary" : "attached"}`}
+              onClick={() => setOpenChipId(open ? null : r.workspaceId)}
+              title={r.repoPath}
+            >
+              <span>@{r.alias}</span>
+              {!isPrimary && (
+                <span
+                  className="detach-x"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    detach(r.workspaceId);
+                  }}
+                  title="Detach"
+                >
+                  ×
+                </span>
+              )}
+            </button>
+            {open && (
+              <div className="popover" style={{ top: "calc(100% + 4px)", left: 0 }}>
+                <div className="popover-header">@{r.alias}</div>
+                {!isPrimary && (
+                  <div className="popover-item" onClick={() => setPrimary(r.workspaceId)}>
+                    Set as primary
+                  </div>
+                )}
+                <div
+                  className="popover-item"
+                  onClick={() => spawnInTerminal(r.alias, r.repoPath)}
+                >
+                  Spawn in Terminal
+                </div>
+                {!isPrimary ? (
+                  <div className="popover-item danger" onClick={() => detach(r.workspaceId)}>
+                    Detach
+                  </div>
+                ) : (
+                  <div className="popover-item disabled" title="Promote another repo first">
+                    Detach (primary)
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <div style={{ position: "relative" }}>
+        <button className="repo-chip add" onClick={() => setAddOpen((v) => !v)} title="Attach repo">
+          +
+        </button>
+        {addOpen && (
+          <AddRepoPopover
+            channel={channel}
+            onClose={() => setAddOpen(false)}
+            onAttached={() => {
+              onChanged();
+              setAddOpen(false);
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AddRepoPopover({
+  channel,
+  onClose,
+  onAttached,
+}: {
+  channel: Channel;
+  onClose: () => void;
+  onAttached: () => void;
+}) {
+  const [workspaces, setWorkspaces] = useState<WorkspaceEntry[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    api.listWorkspaces().then(setWorkspaces).catch(() => setWorkspaces([]));
+  }, []);
+
+  const attachedIds = new Set(channel.repoAssignments.map((r) => r.workspaceId));
+  const available = workspaces.filter((w) => !attachedIds.has(w.workspaceId));
+
+  const attach = async (w: WorkspaceEntry) => {
+    if (busy) return;
+    setBusy(true);
+    const alias = basename(w.repoPath).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(0, 12);
+    const next = [
+      ...channel.repoAssignments.map((r) => ({
+        alias: r.alias,
+        workspaceId: r.workspaceId,
+        repoPath: r.repoPath,
+      })),
+      { alias, workspaceId: w.workspaceId, repoPath: w.repoPath },
+    ];
+    try {
+      await api.updateChannelRepos(channel.channelId, next);
+      onAttached();
+    } catch (err) {
+      alert(`Attach failed: ${err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="popover" style={{ top: "calc(100% + 4px)", right: 0 }}>
+      <div className="popover-header">Attach repo</div>
+      {available.length === 0 ? (
+        <div className="popover-item disabled" onClick={onClose}>
+          No unattached workspaces
+        </div>
+      ) : (
+        available.map((w) => (
+          <div key={w.workspaceId} className="popover-item" onClick={() => attach(w)}>
+            <span>{basename(w.repoPath)}</span>
+            <span className="item-sub">{w.repoPath}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function basename(p: string): string {
+  return p.split("/").filter(Boolean).pop() ?? p;
+}

--- a/gui/src/components/RightPane.tsx
+++ b/gui/src/components/RightPane.tsx
@@ -1,243 +1,291 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
-import type { Channel, ChannelRunLink, RunIndexEntry, Spawn, TrackedPrRow } from "../types";
+import type {
+  Channel,
+  ChannelRunLink,
+  Decision,
+  PendingPlan,
+  RunIndexEntry,
+  TrackedPrRow,
+} from "../types";
 import { SessionList } from "./SessionList";
 
+type Tab = "threads" | "decisions" | "prs";
+
 type Props = {
-  channel: Channel | null;
+  channel: Channel;
   sessionId: string | null;
   onSelectSession: (sessionId: string | null) => void;
   refreshTick: number;
+  onRefresh: () => void;
 };
 
-export function RightPane({ channel, sessionId, onSelectSession, refreshTick }: Props) {
-  const [runs, setRuns] = useState<RunInfo[]>([]);
-
-  useEffect(() => {
-    if (!channel) {
-      setRuns([]);
-      return;
-    }
-    let cancelled = false;
-    (async () => {
-      const links = await api.listChannelRuns(channel.channelId);
-      const all = await Promise.all(
-        links.map(async (link: ChannelRunLink) => {
-          const ws = await api.listRuns(link.workspaceId);
-          const match = ws.find((r) => r.runId === link.runId);
-          return match ? { run: match, workspaceId: link.workspaceId } : null;
-        })
-      );
-      if (cancelled) return;
-      setRuns(all.filter((x): x is RunInfo => x !== null));
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [channel?.channelId, refreshTick]);
-
-  if (!channel) {
-    return <div className="panel" />;
-  }
-
-  return (
-    <div className="panel">
-      <div className="panel-header">{channel.name}</div>
-
-      <SessionList
-        channelId={channel.channelId}
-        selectedSessionId={sessionId}
-        onSelect={onSelectSession}
-        refreshTick={refreshTick}
-      />
-
-      <div className="section">
-        <h4>Members ({channel.members.length})</h4>
-        {channel.members.map((m) => (
-          <div key={m.agentId} className="row">
-            <span>{m.displayName}</span>
-            <span className="right">{m.role}</span>
-          </div>
-        ))}
-      </div>
-
-      <div className="section">
-        <h4>Repos ({channel.repoAssignments.length})</h4>
-        {channel.repoAssignments.map((r) => {
-          const isPrimary =
-            channel.primaryWorkspaceId && r.workspaceId === channel.primaryWorkspaceId;
-          return (
-            <div key={r.workspaceId} className="row">
-              <span>
-                @{r.alias}
-                {isPrimary && <span className="primary-badge">PRIMARY</span>}
-              </span>
-              <span className="right" title={r.repoPath}>
-                {basename(r.repoPath)}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-
-      <SpawnedAgents channelId={channel.channelId} refreshTick={refreshTick} />
-
-      <div className="section">
-        <h4>Runs ({runs.length})</h4>
-        {runs.length === 0 && <div className="row">No runs</div>}
-        {runs.map(({ run }) => (
-          <div key={run.runId} className="row">
-            <span>{run.featureRequest.slice(0, 24)}</span>
-            <span className={`badge ${stateClass(run.state)}`}>{run.state}</span>
-          </div>
-        ))}
-      </div>
-
-      <TrackedPrs channelId={channel.channelId} refreshTick={refreshTick} />
-    </div>
-  );
-}
-
-/**
- * Tracked PRs strip — mirrors `rly pr-status` for the current channel.
- * Hidden when the channel has never tracked a PR. Columns collapse in the
- * narrow right pane: state / CI / review get a colored dot instead of
- * text (kept accessible via `title`).
- */
-function TrackedPrs({ channelId, refreshTick }: { channelId: string; refreshTick: number }) {
-  const [rows, setRows] = useState<TrackedPrRow[]>([]);
+export function RightPane({
+  channel,
+  sessionId,
+  onSelectSession,
+  refreshTick,
+  onRefresh,
+}: Props) {
+  const [tab, setTab] = useState<Tab>("threads");
+  const [decisions, setDecisions] = useState<Decision[]>([]);
+  const [prs, setPrs] = useState<TrackedPrRow[]>([]);
+  const [runs, setRuns] = useState<Array<{ run: RunIndexEntry; workspaceId: string }>>([]);
 
   useEffect(() => {
     let cancelled = false;
-    api
-      .listTrackedPrs(channelId)
-      .then((r) => {
-        if (!cancelled) setRows(r);
+    Promise.all([
+      api.listChannelDecisions(channel.channelId),
+      api.listTrackedPrs(channel.channelId),
+      api.listChannelRuns(channel.channelId),
+    ])
+      .then(async ([d, p, links]) => {
+        if (cancelled) return;
+        setDecisions(d);
+        setPrs(p);
+        const all = await Promise.all(
+          links.map(async (link: ChannelRunLink) => {
+            const ws = await api.listRuns(link.workspaceId);
+            const match = ws.find((r) => r.runId === link.runId);
+            return match ? { run: match, workspaceId: link.workspaceId } : null;
+          })
+        );
+        if (!cancelled) {
+          setRuns(all.filter((x): x is { run: RunIndexEntry; workspaceId: string } => x !== null));
+        }
       })
       .catch(() => {
-        if (!cancelled) setRows([]);
+        /* surfaces don't need to be perfectly in sync; next refreshTick retries */
       });
     return () => {
       cancelled = true;
     };
-  }, [channelId, refreshTick]);
+  }, [channel.channelId, refreshTick]);
 
-  if (rows.length === 0) return null;
+  useEffect(() => {
+    if (prs.some((r) => r.ci === "failing")) setTab("prs");
+  }, [prs]);
 
   return (
-    <div className="section">
-      <h4>Tracked PRs ({rows.length})</h4>
-      {rows.map((r) => (
-        <div key={`${r.ticketId}-${r.number}`} className="row tracked-pr-row">
-          <span title={r.ticketId} className="tracked-pr-ticket">
-            {r.ticketId.slice(0, 10)}
-          </span>
-          <a
-            href={r.url}
-            className="tracked-pr-link"
-            title={r.branch}
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            #{r.number}
-          </a>
-          <span className="right tracked-pr-badges">
-            <span
-              className={`pr-dot pr-state-${r.prState ?? "unknown"}`}
-              title={`state: ${r.prState ?? "-"}`}
-            />
-            <span className={`pr-dot pr-ci-${r.ci ?? "unknown"}`} title={`ci: ${r.ci ?? "-"}`} />
-            <span
-              className={`pr-dot pr-review-${r.review ?? "unknown"}`}
-              title={`review: ${r.review ?? "-"}`}
-            />
-          </span>
+    <div className="right-rail">
+      <div className="rail-tabs">
+        {(["threads", "decisions", "prs"] as Tab[]).map((t) => (
+          <div key={t} className={`rail-tab ${tab === t ? "active" : ""}`} onClick={() => setTab(t)}>
+            {t === "threads" ? "Threads" : t === "decisions" ? "Decisions" : "PRs"}
+          </div>
+        ))}
+      </div>
+      <div className="rail-scroll">
+        {tab === "threads" && (
+          <SessionList
+            channelId={channel.channelId}
+            selectedSessionId={sessionId}
+            onSelect={onSelectSession}
+            refreshTick={refreshTick}
+          />
+        )}
+        {tab === "decisions" && <DecisionsTab decisions={decisions} />}
+        {tab === "prs" && (
+          <PrsTab
+            channel={channel}
+            prs={prs}
+            runs={runs}
+            refreshTick={refreshTick}
+            onRefresh={onRefresh}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DecisionsTab({ decisions }: { decisions: Decision[] }) {
+  if (decisions.length === 0) return <div className="rail-empty">No decisions</div>;
+  return (
+    <>
+      {decisions.map((d) => (
+        <div key={d.decisionId} className="rail-list-item">
+          <div className="title">{d.title}</div>
+          <div className="meta">
+            {d.decidedByName} · {new Date(d.createdAt).toLocaleDateString()}
+          </div>
         </div>
       ))}
-    </div>
+    </>
   );
 }
 
-type RunInfo = { run: RunIndexEntry; workspaceId: string };
+function PrsTab({
+  channel,
+  prs,
+  runs,
+  refreshTick,
+  onRefresh,
+}: {
+  channel: Channel;
+  prs: TrackedPrRow[];
+  runs: Array<{ run: RunIndexEntry; workspaceId: string }>;
+  refreshTick: number;
+  onRefresh: () => void;
+}) {
+  return (
+    <>
+      <PendingPlanCta channel={channel} refreshTick={refreshTick} onChanged={onRefresh} />
+      {prs.length === 0 && runs.length === 0 && <div className="rail-empty">No PRs tracked</div>}
+      {prs.length > 0 && (
+        <div style={{ marginBottom: 16 }}>
+          <h4
+            style={{
+              fontSize: "var(--font-size-xs)",
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+              color: "var(--color-text-dim)",
+              margin: "0 0 8px",
+            }}
+          >
+            Tracked PRs ({prs.length})
+          </h4>
+          {prs.map((r) => (
+            <div key={`${r.ticketId}-${r.number}`} className="tracked-pr-row">
+              <span className="tracked-pr-ticket" title={r.ticketId}>
+                {r.ticketId.slice(0, 10)}
+              </span>
+              <a
+                href={r.url}
+                className="tracked-pr-link"
+                target="_blank"
+                rel="noreferrer noopener"
+                title={r.branch}
+              >
+                #{r.number}
+              </a>
+              <span
+                style={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  fontSize: "var(--font-size-xs)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {r.branch}
+              </span>
+              <span className="tracked-pr-badges">
+                <span
+                  className={`pr-dot pr-state-${r.prState ?? "unknown"}`}
+                  title={`state: ${r.prState ?? "-"}`}
+                />
+                <span className={`pr-dot pr-ci-${r.ci ?? "unknown"}`} title={`ci: ${r.ci ?? "-"}`} />
+                <span
+                  className={`pr-dot pr-review-${r.review ?? "unknown"}`}
+                  title={`review: ${r.review ?? "-"}`}
+                />
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {runs.length > 0 && (
+        <div>
+          <h4
+            style={{
+              fontSize: "var(--font-size-xs)",
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+              color: "var(--color-text-dim)",
+              margin: "0 0 8px",
+            }}
+          >
+            Runs ({runs.length})
+          </h4>
+          {runs.map(({ run }) => (
+            <div key={run.runId} className="rail-list-item">
+              <div className="title">{run.featureRequest.slice(0, 48)}</div>
+              <div className="meta">{run.state}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
 
-/**
- * Spawned agents panel — shows external Terminal-hosted agents launched
- * from this channel via the spawn flow. Empty state hides the whole
- * section (opt-in concept; not primary UI).
- *
- * We refetch on mount, on channelId change, and on every refreshTick so
- * the list stays roughly in sync with backend state even when other
- * surfaces trigger spawns. Kill is optimistic: we drop the row from
- * local state before the async call resolves, then rollback if it fails.
- */
-function SpawnedAgents({ channelId, refreshTick }: { channelId: string; refreshTick: number }) {
-  const [spawns, setSpawns] = useState<Spawn[]>([]);
-  const [killError, setKillError] = useState<string | null>(null);
+function PendingPlanCta({
+  channel,
+  refreshTick,
+  onChanged,
+}: {
+  channel: Channel;
+  refreshTick: number;
+  onChanged: () => void;
+}) {
+  const [plans, setPlans] = useState<PendingPlan[]>([]);
+  const [busyRunId, setBusyRunId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     api
-      .listSpawns(channelId)
-      .then((rows) => {
-        if (!cancelled) setSpawns(rows);
+      .listPendingPlans()
+      .then((p) => {
+        if (!cancelled) setPlans(p);
       })
       .catch(() => {
-        // Silently fall back to empty. listSpawns might fail if Task #24
-        // hasn't registered its Tauri command yet; the section just
-        // hides rather than showing a scary error.
-        if (!cancelled) setSpawns([]);
+        if (!cancelled) setPlans([]);
       });
     return () => {
       cancelled = true;
     };
-  }, [channelId, refreshTick]);
+  }, [refreshTick]);
 
-  if (spawns.length === 0) return null;
+  const relevant = plans.filter((p) => !p.channelId || p.channelId === channel.channelId);
+  if (relevant.length === 0) return null;
 
-  const kill = async (alias: string) => {
-    setKillError(null);
-    const before = spawns;
-    // Optimistic remove.
-    setSpawns((prev) => prev.filter((s) => s.alias !== alias));
+  const act = async (plan: PendingPlan, decision: "approve" | "reject") => {
+    setBusyRunId(plan.runId);
+    setError(null);
     try {
-      await api.killSpawnedAgent(channelId, alias);
-    } catch (e) {
-      setKillError(`Failed to kill @${alias}: ${e}`);
-      setSpawns(before);
+      if (decision === "approve") await api.approvePlan(plan.runId);
+      else await api.rejectPlan(plan.runId);
+      onChanged();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusyRunId(null);
     }
   };
 
   return (
-    <div className="section">
-      <h4>Spawned agents ({spawns.length})</h4>
-      <div className="spawn-list">
-        {spawns.map((s) => (
-          <div key={s.alias} className="spawn-row">
-            <span className="spawn-alias">@{s.alias}</span>
-            <span className="spawn-repo" title={s.repoPath}>
-              {basename(s.repoPath)}
-            </span>
+    <div style={{ marginBottom: 16 }}>
+      {relevant.map((p) => (
+        <div
+          key={p.runId}
+          style={{
+            padding: 12,
+            background: "rgba(232, 154, 43, 0.12)",
+            borderRadius: 6,
+            marginBottom: 8,
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>Plan awaiting approval</div>
+          <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-muted)", marginBottom: 8 }}>
+            {p.featureRequest.slice(0, 80)}
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
             <button
-              className="kill-button"
-              onClick={() => kill(s.alias)}
-              title="Kill this spawned agent"
+              className="primary"
+              disabled={busyRunId === p.runId}
+              onClick={() => act(p, "approve")}
             >
-              Kill
+              {busyRunId === p.runId ? "…" : "Approve"}
+            </button>
+            <button disabled={busyRunId === p.runId} onClick={() => act(p, "reject")}>
+              Reject
             </button>
           </div>
-        ))}
-      </div>
-      {killError && <div className="error">{killError}</div>}
+        </div>
+      ))}
+      {error && <div className="error">{error}</div>}
     </div>
   );
-}
-
-function basename(p: string): string {
-  return p.split("/").filter(Boolean).pop() ?? p;
-}
-
-function stateClass(state: string): string {
-  if (state === "DONE" || state === "COMPLETED") return "ok";
-  if (state === "FAILED" || state === "ERROR") return "error";
-  return "warn";
 }

--- a/gui/src/components/SettingsPage.tsx
+++ b/gui/src/components/SettingsPage.tsx
@@ -1,0 +1,191 @@
+import { useState } from "react";
+import { api } from "../api";
+import type { GuiSettings } from "../types";
+
+type Section = "ticketing" | "general";
+
+type Props = {
+  settings: GuiSettings;
+  onSaved: (next: GuiSettings) => void;
+  onClose: () => void;
+};
+
+export function SettingsPage({ settings, onSaved, onClose }: Props) {
+  const [section, setSection] = useState<Section>("ticketing");
+  const [draft, setDraft] = useState<GuiSettings>(settings);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = async (next: GuiSettings) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateSettings(next);
+      setDraft(next);
+      onSaved(next);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="settings-page">
+      <aside className="settings-sidebar">
+        <h3>Settings</h3>
+        <button
+          className={`settings-nav-item ${section === "ticketing" ? "active" : ""}`}
+          onClick={() => setSection("ticketing")}
+        >
+          Ticketing
+        </button>
+        <button
+          className={`settings-nav-item ${section === "general" ? "active" : ""}`}
+          onClick={() => setSection("general")}
+        >
+          General
+        </button>
+        <div style={{ marginTop: 24 }}>
+          <button onClick={onClose}>← Back to channels</button>
+        </div>
+      </aside>
+      <div className="settings-main">
+        {section === "ticketing" && (
+          <TicketingSection draft={draft} onChange={save} saving={saving} error={error} />
+        )}
+        {section === "general" && (
+          <GeneralSection />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TicketingSection({
+  draft,
+  onChange,
+  saving,
+  error,
+}: {
+  draft: GuiSettings;
+  onChange: (next: GuiSettings) => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const providers: Array<{
+    value: GuiSettings["ticketProvider"];
+    title: string;
+    desc: string;
+  }> = [
+    {
+      value: "relay",
+      title: "Relay-native",
+      desc: "Tickets created by Relay's planner live directly in the channel board.",
+    },
+    {
+      value: "linear",
+      title: "Linear",
+      desc:
+        "Mirror issues from a Linear project onto the channel board. Polled on an interval.",
+    },
+    {
+      value: "none",
+      title: "None",
+      desc: "Hide the board tab. Chat only.",
+    },
+  ];
+
+  return (
+    <>
+      <h2>Ticketing</h2>
+      <div className="settings-section">
+        <h3>Provider</h3>
+        <p className="help">
+          Choose where tickets on the channel board come from. Applies globally.
+        </p>
+        <div className="settings-radio-group">
+          {providers.map((p) => (
+            <label
+              key={p.value}
+              className={draft.ticketProvider === p.value ? "selected" : ""}
+            >
+              <input
+                type="radio"
+                name="ticket-provider"
+                checked={draft.ticketProvider === p.value}
+                onChange={() => onChange({ ...draft, ticketProvider: p.value })}
+              />
+              <span>
+                <span className="settings-radio-title">{p.title}</span>
+                <span className="settings-radio-desc" style={{ display: "block" }}>
+                  {p.desc}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {draft.ticketProvider === "linear" && (
+        <div className="settings-section">
+          <h3>Linear</h3>
+          <p className="help">
+            Relay polls Linear every{" "}
+            <strong>{draft.linearPollSeconds}s</strong> and mirrors issues tagged to the channel.
+          </p>
+          <label>
+            API token
+            <input
+              type="password"
+              value={draft.linearApiToken}
+              onChange={(e) =>
+                onChange({ ...draft, linearApiToken: e.target.value })
+              }
+              placeholder="lin_api_…"
+            />
+          </label>
+          <label>
+            Workspace slug
+            <input
+              value={draft.linearWorkspace}
+              onChange={(e) =>
+                onChange({ ...draft, linearWorkspace: e.target.value })
+              }
+              placeholder="acme-inc"
+            />
+          </label>
+          <label>
+            Poll interval (seconds)
+            <input
+              type="number"
+              min={10}
+              value={draft.linearPollSeconds}
+              onChange={(e) =>
+                onChange({ ...draft, linearPollSeconds: Number(e.target.value) || 30 })
+              }
+            />
+          </label>
+        </div>
+      )}
+
+      {saving && <div className="warning">Saving…</div>}
+      {error && <div className="error">{error}</div>}
+    </>
+  );
+}
+
+function GeneralSection() {
+  return (
+    <>
+      <h2>General</h2>
+      <div className="settings-section">
+        <h3>About Relay</h3>
+        <p className="help">
+          Relay runs coding agents across your registered workspaces. Channels are repo-scoped
+          execution contexts; each (channel, repo) pair has its own agent instance.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -47,7 +47,7 @@ export function Sidebar({
       await api.setChannelStarred(c.channelId, !c.starred);
       onRefresh();
     } catch (err) {
-      console.warn("[star] failed:", err);
+      alert(`Failed to ${c.starred ? "unstar" : "star"} #${c.name}: ${err}`);
     }
   };
 

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { api } from "../api";
 import type { Channel } from "../types";
 
@@ -9,25 +9,17 @@ type Props = {
   onSelect: (id: string) => void;
   onNewChannel: () => void;
   onToggleIncludeArchived: (next: boolean) => void;
-  onArchived: (id: string) => void;
   onRefresh: () => void;
 };
 
-/**
- * Sort by most-recent activity (updatedAt desc) so the channel you're
- * actively working in — or last worked in — stays at the top. Falls back to
- * createdAt, then name. Channels missing both timestamps sink to the bottom.
- * Pure, safe to call every render.
- */
 function sortByActivity(channels: Channel[]): Channel[] {
-  const activityTs = (c: Channel): number => {
+  const ts = (c: Channel): number => {
     const raw = c.updatedAt ?? c.createdAt;
-    if (!raw) return 0;
-    const parsed = Date.parse(raw);
+    const parsed = raw ? Date.parse(raw) : NaN;
     return Number.isFinite(parsed) ? parsed : 0;
   };
   return [...channels].sort((a, b) => {
-    const diff = activityTs(b) - activityTs(a);
+    const diff = ts(b) - ts(a);
     if (diff !== 0) return diff;
     return a.name.localeCompare(b.name);
   });
@@ -40,92 +32,196 @@ export function Sidebar({
   onSelect,
   onNewChannel,
   onToggleIncludeArchived,
-  onArchived,
   onRefresh,
 }: Props) {
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const sorted = sortByActivity(channels);
+  const [starredOpen, setStarredOpen] = useState(true);
+  const [channelsOpen, setChannelsOpen] = useState(true);
 
-  const handleArchive = async (c: Channel) => {
-    if (busyId) return;
-    const label = c.status === "archived" ? "Unarchive" : "Archive";
-    if (!confirm(`${label} #${c.name}?`)) return;
-    setBusyId(c.channelId);
+  const sorted = useMemo(() => sortByActivity(channels), [channels]);
+  const starred = sorted.filter((c) => c.starred && c.status === "active");
+  const active = sorted.filter((c) => !c.starred && c.status === "active");
+  const archived = sorted.filter((c) => c.status === "archived");
+
+  const toggleStar = async (c: Channel) => {
     try {
-      if (c.status === "archived") {
-        await api.unarchiveChannel(c.channelId);
-      } else {
-        await api.archiveChannel(c.channelId);
-        // Intentionally only on archive — unarchive never needs to drop the
-        // selection since the row stays visible (either under the
-        // "Show archived" toggle or after it becomes active again).
-        onArchived(c.channelId);
-      }
+      await api.setChannelStarred(c.channelId, !c.starred);
       onRefresh();
     } catch (err) {
-      alert(`${label} failed: ${err}`);
-    } finally {
-      setBusyId(null);
+      console.warn("[star] failed:", err);
     }
   };
 
   return (
-    <div className="panel">
-      <div className="panel-header">
-        <span>Channels</span>
-        <button onClick={onNewChannel} title="New channel">
-          +
-        </button>
+    <div className="sidebar">
+      <div className="sidebar-header">
+        <div className="ws-avatar">R</div>
+        <div>
+          <div className="ws-title">Relay</div>
+          <div className="ws-sub">local workspace</div>
+        </div>
       </div>
-      <label className="sidebar-toggle">
-        <input
-          type="checkbox"
-          checked={includeArchived}
-          onChange={(e) => onToggleIncludeArchived(e.target.checked)}
-        />
-        Show archived
-      </label>
-      <div className="list">
-        {sorted.length === 0 && (
-          <div className="empty">{includeArchived ? "No channels" : "No active channels"}</div>
-        )}
-        {sorted.map((c) => {
-          const archived = c.status === "archived";
-          return (
-            <div
-              key={c.channelId}
-              className={`list-item ${c.channelId === selectedId ? "active" : ""} ${
-                archived ? "archived" : ""
-              }`}
-              onClick={() => onSelect(c.channelId)}
-            >
-              <div className="list-item-row">
-                <div className="list-item-body">
-                  <div className="name">
-                    #{c.name}
-                    {archived && <span className="archived-badge">archived</span>}
-                  </div>
-                  <div className="meta">
-                    {c.members.length} agents · {c.repoAssignments.length} repos
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  className="channel-archive-btn"
-                  title={archived ? "Unarchive channel" : "Archive channel"}
-                  disabled={busyId === c.channelId}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleArchive(c);
-                  }}
-                >
-                  {archived ? "↺" : "✕"}
-                </button>
-              </div>
+
+      <div className="sidebar-scroll">
+        <ActivityBlock channels={active} />
+
+        <section className="sidebar-section">
+          <header
+            className="sidebar-section-head"
+            onClick={() => setStarredOpen((v) => !v)}
+            role="button"
+          >
+            <span>★ Starred</span>
+            <span className="count">{starred.length}</span>
+          </header>
+          {starredOpen && (
+            <div>
+              {starred.length === 0 && (
+                <div className="sidebar-empty">No starred channels</div>
+              )}
+              {starred.map((c) => (
+                <ChannelRow
+                  key={c.channelId}
+                  channel={c}
+                  active={c.channelId === selectedId}
+                  onSelect={() => onSelect(c.channelId)}
+                  onStarToggle={() => toggleStar(c)}
+                />
+              ))}
             </div>
-          );
-        })}
+          )}
+        </section>
+
+        <section className="sidebar-section">
+          <header
+            className="sidebar-section-head"
+            onClick={() => setChannelsOpen((v) => !v)}
+            role="button"
+          >
+            <span># Channels</span>
+            <span style={{ display: "inline-flex", gap: 8, alignItems: "center" }}>
+              <span className="count">{active.length}</span>
+              <button
+                className="add-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onNewChannel();
+                }}
+                title="New channel"
+              >
+                +
+              </button>
+            </span>
+          </header>
+          {channelsOpen && (
+            <div>
+              {active.length === 0 && (
+                <div className="sidebar-empty">No active channels</div>
+              )}
+              {active.map((c) => (
+                <ChannelRow
+                  key={c.channelId}
+                  channel={c}
+                  active={c.channelId === selectedId}
+                  onSelect={() => onSelect(c.channelId)}
+                  onStarToggle={() => toggleStar(c)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="sidebar-section">
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "6px 12px",
+              color: "var(--color-text-on-dark-muted)",
+              fontSize: "var(--font-size-xs)",
+              cursor: "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={includeArchived}
+              onChange={(e) => onToggleIncludeArchived(e.target.checked)}
+            />
+            Show archived
+          </label>
+          {includeArchived &&
+            archived.map((c) => (
+              <ChannelRow
+                key={c.channelId}
+                channel={c}
+                active={c.channelId === selectedId}
+                onSelect={() => onSelect(c.channelId)}
+                onStarToggle={() => toggleStar(c)}
+                archived
+              />
+            ))}
+        </section>
       </div>
     </div>
+  );
+}
+
+function ChannelRow({
+  channel,
+  active,
+  onSelect,
+  onStarToggle,
+  archived,
+}: {
+  channel: Channel;
+  active: boolean;
+  onSelect: () => void;
+  onStarToggle: () => void;
+  archived?: boolean;
+}) {
+  return (
+    <div
+      className={`sidebar-item ${active ? "active" : ""} ${archived ? "archived" : ""}`}
+      onClick={onSelect}
+    >
+      <span className="ch-sigil">#</span>
+      <span className="ch-name">{channel.name}</span>
+      {channel.repoAssignments.length > 0 && (
+        <span className="ch-badge">{channel.repoAssignments.length}</span>
+      )}
+      <button
+        className="add-btn"
+        style={{ color: channel.starred ? "var(--color-accent-amber)" : undefined }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onStarToggle();
+        }}
+        title={channel.starred ? "Unstar" : "Star"}
+      >
+        {channel.starred ? "★" : "☆"}
+      </button>
+    </div>
+  );
+}
+
+function ActivityBlock({ channels }: { channels: Channel[] }) {
+  const recent = channels.slice(0, 3);
+  if (recent.length === 0) return null;
+  return (
+    <section className="sidebar-section">
+      <header className="sidebar-section-head">
+        <span>◔ Activity</span>
+      </header>
+      {recent.map((c) => (
+        <div
+          key={c.channelId}
+          className="sidebar-item"
+          style={{ cursor: "default", opacity: 0.85 }}
+        >
+          <span className="ch-sigil">#</span>
+          <span className="ch-name">{c.name}</span>
+        </div>
+      ))}
+    </section>
   );
 }

--- a/gui/src/components/WorkspaceRail.tsx
+++ b/gui/src/components/WorkspaceRail.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  onOpenSettings: () => void;
+};
+
+export function WorkspaceRail({ onOpenSettings }: Props) {
+  return (
+    <div className="workspace-rail">
+      <div className="rail-avatar" title="Relay workspace">R</div>
+      <div className="rail-spacer" />
+      <button className="rail-btn" title="Settings" onClick={onOpenSettings}>
+        ⚙
+      </button>
+    </div>
+  );
+}

--- a/gui/src/lib/channel.ts
+++ b/gui/src/lib/channel.ts
@@ -32,8 +32,13 @@ export function toUiChannel(c: Channel, now: Date = new Date()): UiChannel {
     (c.primaryWorkspaceId &&
       c.repoAssignments.find((r) => r.workspaceId === c.primaryWorkspaceId)) ||
     c.repoAssignments[0];
-  const primaryRepo = primaryAssignment?.alias ?? "";
-  const repos = sortPrimaryFirst(c.repoAssignments, primaryRepo).map((r) => r.alias);
+  // Aliases are case-insensitive throughout the UI (mention lookup, routing,
+  // render chips). Lowercasing here keeps one convention end-to-end even if a
+  // user types `UI` in the alias input.
+  const primaryRepo = primaryAssignment?.alias.toLowerCase() ?? "";
+  const repos = sortPrimaryFirst(c.repoAssignments, primaryAssignment?.alias ?? "").map((r) =>
+    r.alias.toLowerCase()
+  );
   return {
     id: c.channelId,
     name: c.name,

--- a/gui/src/lib/channel.ts
+++ b/gui/src/lib/channel.ts
@@ -1,0 +1,102 @@
+import type { Channel, ChannelMember, ChannelTier, RepoAssignment } from "../types";
+
+/**
+ * UI-facing projection of a Channel. Collapses the backend's workspaceId-
+ * centric shape into the alias-centric shape the Tidewater design uses
+ * throughout: `repos: string[]` of aliases, `primaryRepo: string` alias,
+ * `topic` instead of `description`, etc.
+ *
+ * Keep all rename churn in this file so components consume UiChannel
+ * directly and don't deal with both spellings.
+ */
+export type UiChannel = {
+  id: string;
+  name: string;
+  topic: string;
+  tier?: ChannelTier;
+  starred: boolean;
+  status: string;
+  repos: string[];
+  primaryRepo: string;
+  primaryWorkspaceId?: string;
+  agents: string[];
+  members: ChannelMember[];
+  repoAssignments: RepoAssignment[];
+  activeAt: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export function toUiChannel(c: Channel, now: Date = new Date()): UiChannel {
+  const primaryAssignment =
+    (c.primaryWorkspaceId &&
+      c.repoAssignments.find((r) => r.workspaceId === c.primaryWorkspaceId)) ||
+    c.repoAssignments[0];
+  const primaryRepo = primaryAssignment?.alias ?? "";
+  const repos = sortPrimaryFirst(c.repoAssignments, primaryRepo).map((r) => r.alias);
+  return {
+    id: c.channelId,
+    name: c.name,
+    topic: c.description,
+    tier: c.tier,
+    starred: c.starred ?? false,
+    status: c.status,
+    repos,
+    primaryRepo,
+    primaryWorkspaceId: c.primaryWorkspaceId,
+    agents: c.members.map((m) => m.agentId),
+    members: c.members,
+    repoAssignments: c.repoAssignments,
+    activeAt: humanizeRelative(c.updatedAt ?? c.createdAt, now),
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  };
+}
+
+export function primaryAlias(c: Channel): string | null {
+  if (c.repoAssignments.length === 0) return null;
+  if (c.primaryWorkspaceId) {
+    const match = c.repoAssignments.find((r) => r.workspaceId === c.primaryWorkspaceId);
+    if (match) return match.alias;
+  }
+  return c.repoAssignments[0].alias;
+}
+
+export function aliasToWorkspaceId(c: Channel, alias: string): string | undefined {
+  return c.repoAssignments.find((r) => r.alias === alias)?.workspaceId;
+}
+
+export function workspaceIdToAlias(c: Channel, workspaceId: string): string | undefined {
+  return c.repoAssignments.find((r) => r.workspaceId === workspaceId)?.alias;
+}
+
+function sortPrimaryFirst<T extends { alias: string }>(rows: T[], primary: string): T[] {
+  if (!primary) return rows;
+  return [...rows].sort((a, b) => {
+    if (a.alias === primary) return -1;
+    if (b.alias === primary) return 1;
+    return 0;
+  });
+}
+
+/**
+ * Humanize an ISO timestamp as a short "2m" / "3h" / "4d" / "2w" string.
+ * Falls back to the raw ISO date for anything older than ~4 weeks, and
+ * returns an empty string for missing input so callers can render `—`.
+ */
+export function humanizeRelative(iso: string | undefined, now: Date = new Date()): string {
+  if (!iso) return "";
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return "";
+  const seconds = Math.floor((now.getTime() - parsed) / 1000);
+  if (seconds < 45) return `${Math.max(seconds, 1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) return `${weeks}w`;
+  return new Date(parsed).toISOString().slice(0, 10);
+}

--- a/gui/src/lib/mentions.tsx
+++ b/gui/src/lib/mentions.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import type { UiChannel } from "./channel";
+
+// `@alias` | `**bold**` | `` `code` ``. No other markdown, no autolinks.
+const TOKEN_RE = /(@[a-zA-Z0-9][a-zA-Z0-9_-]*)|(\*\*[^*]+\*\*)|(`[^`]+`)/g;
+
+type ChannelLike = Pick<UiChannel, "repos" | "primaryRepo"> | null | undefined;
+
+/**
+ * Render a message body as React nodes, recognising mention chips and
+ * lightweight inline markdown (bold + inline code). Matches the Tidewater
+ * spec: a single render path for chat / DM / decisions bodies.
+ */
+export function renderWithMentions(text: string, channel: ChannelLike): ReactNode[] {
+  if (!text) return [];
+  const aliasSet = new Set(channel?.repos ?? []);
+  const primary = channel?.primaryRepo ?? "";
+  const nodes: ReactNode[] = [];
+  let lastIdx = 0;
+  let key = 0;
+  for (const match of text.matchAll(TOKEN_RE)) {
+    const idx = match.index ?? 0;
+    if (idx > lastIdx) {
+      nodes.push(<span key={key++}>{text.slice(lastIdx, idx)}</span>);
+    }
+    const tok = match[0];
+    if (tok.startsWith("**")) {
+      nodes.push(<strong key={key++}>{tok.slice(2, -2)}</strong>);
+    } else if (tok.startsWith("`")) {
+      nodes.push(
+        <code key={key++} className="mention-code">
+          {tok.slice(1, -1)}
+        </code>
+      );
+    } else {
+      const alias = tok.slice(1);
+      const handle = alias.toLowerCase();
+      const isRepo = aliasSet.has(handle);
+      const isPrimary = isRepo && primary === handle;
+      const cls = isPrimary
+        ? "mention mention-repo-primary"
+        : isRepo
+        ? "mention mention-repo-attached"
+        : "mention mention-human";
+      nodes.push(
+        <span key={key++} className={cls}>
+          {tok}
+        </span>
+      );
+    }
+    lastIdx = idx + tok.length;
+  }
+  if (lastIdx < text.length) {
+    nodes.push(<span key={key++}>{text.slice(lastIdx)}</span>);
+  }
+  return nodes;
+}
+
+/**
+ * Extract `@xxx` tokens from a body without classifying them as repo/human
+ * (the caller knows the channel). Useful for mention routing / notification
+ * derivation in the composer.
+ */
+export function extractMentions(text: string): Array<{ alias: string; offset: number }> {
+  const out: Array<{ alias: string; offset: number }> = [];
+  for (const match of text.matchAll(/@([a-zA-Z0-9][a-zA-Z0-9_-]*)/g)) {
+    out.push({ alias: match[1], offset: match.index ?? 0 });
+  }
+  return out;
+}

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1,27 +1,5 @@
-:root {
-  /* Catppuccin Mocha palette.
-     Mantle for sidebars is darker than base so the center pane sits a touch
-     elevated; alt surfaces stay sunken. */
-  --bg: #1e1e2e;            /* base */
-  --bg-alt: #181825;        /* mantle — sunken card / entry surface */
-  --bg-panel: #11111b;      /* crust — darker sidebars */
-  --bg-hover: #313244;      /* surface0 */
-  --border: #45475a;        /* surface1 */
-  --text: #cdd6f4;          /* text */
-  --text-dim: #bac2de;      /* subtext1 */
-  --text-muted: #7f849c;    /* overlay1 */
-  --accent: #89b4fa;        /* blue */
-  --accent-dim: #74c7ec;    /* sapphire — used for secondary accent hits */
-  --user: #a6e3a1;          /* green */
-  --assistant: #89b4fa;     /* blue */
-  --system: #cba6f7;        /* mauve */
-  --activity: #f9e2af;      /* yellow */
-  --error: #f38ba8;         /* red */
-  --ok: #a6e3a1;            /* green */
-  --warn: #fab387;          /* peach */
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  color-scheme: dark;
-}
+@import "./styles/tokens.css";
+@import "./styles/mentions.css";
 
 * {
   box-sizing: border-box;
@@ -31,8 +9,10 @@ html, body, #root {
   margin: 0;
   padding: 0;
   height: 100vh;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--color-ink-deepest);
+  color: var(--color-text-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-base);
   overflow: hidden;
 }
 
@@ -40,1032 +20,1253 @@ button {
   font: inherit;
   color: inherit;
   background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 4px 10px;
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-5);
   cursor: pointer;
+  transition: var(--anim-hover-fast);
 }
-button:hover { background: var(--bg-hover); }
-/* Primary buttons sit on a light sapphire background, so inherit-color
-   (Catppuccin text is near-white) gives low-contrast light-on-light. Pin
-   an explicit dark foreground so the label reads on the accent fill. */
+button:hover:not(:disabled) { background: var(--color-paper-alt); }
 button.primary {
-  background: var(--accent-dim);
-  border-color: var(--accent);
-  color: var(--bg-panel);
-  font-weight: 600;
+  background: var(--color-accent-coral);
+  border-color: var(--color-accent-coral);
+  color: #fff;
+  font-weight: var(--font-weight-semibold);
 }
 button.primary:hover:not(:disabled) {
-  background: var(--accent);
-  color: var(--bg-panel);
+  background: #d24b41;
+  border-color: #d24b41;
 }
-button.primary:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
+button.primary:disabled { opacity: 0.55; cursor: not-allowed; }
+button:disabled { opacity: 0.55; cursor: not-allowed; }
+
+/* ── App shell ─────────────────────────────────────────────────── */
 
 .app {
   display: grid;
-  grid-template-columns: 240px 1fr 300px;
+  grid-template-columns: var(--layout-workspace-rail) var(--layout-sidebar) 1fr var(--layout-right-rail);
   height: 100vh;
-  font-size: 13px;
+  background: var(--color-paper-base);
+}
+.app.rail-collapsed {
+  grid-template-columns: var(--layout-workspace-rail) var(--layout-sidebar) 1fr 0;
 }
 
-.panel {
-  background: var(--bg-panel);
-  border-right: 1px solid var(--border);
+/* ── Workspace rail (far left, 58px, ink) ─────────────────────── */
+
+.workspace-rail {
+  background: var(--color-ink-deepest);
+  border-right: 1px solid var(--color-ink-line);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-5) 0;
+  gap: var(--space-5);
+  color: var(--color-text-on-dark);
+}
+.workspace-rail .rail-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-lg);
+  background: var(--color-accent-coral);
+  color: #fff;
+  font-weight: var(--font-weight-bold);
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.workspace-rail .rail-spacer { flex: 1; }
+.workspace-rail .rail-btn {
+  background: transparent;
+  border: none;
+  color: var(--color-text-on-dark-muted);
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 16px;
+}
+.workspace-rail .rail-btn:hover { color: var(--color-text-on-dark); background: var(--color-ink-panel); }
+
+/* ── Sidebar (230px, ink-deep) ────────────────────────────────── */
+
+.sidebar {
+  background: var(--color-ink-deep);
+  color: var(--color-text-on-dark);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--color-ink-line);
+}
+.sidebar-header {
+  padding: var(--space-5) var(--space-6) var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+.sidebar-header .ws-avatar {
+  width: 28px; height: 28px;
+  border-radius: var(--radius-md);
+  background: var(--color-accent-coral);
+  color: #fff; font-weight: var(--font-weight-bold);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 13px;
+}
+.sidebar-header .ws-title { font-weight: var(--font-weight-semibold); font-size: var(--font-size-md); }
+.sidebar-header .ws-sub { font-size: var(--font-size-xs); color: var(--color-text-on-dark-muted); }
+
+.sidebar-scroll { flex: 1; overflow-y: auto; padding: var(--space-4) 0 var(--space-8); }
+
+.sidebar-section { padding: var(--space-4) var(--space-5) var(--space-2); }
+.sidebar-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-3);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-uppercase);
+  color: var(--color-text-on-dark-muted);
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--radius-sm);
+}
+.sidebar-section-head:hover { background: var(--color-ink-panel); }
+.sidebar-section-head .count {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-on-dark-muted);
+  font-weight: var(--font-weight-medium);
+}
+.sidebar-section-head .add-btn {
+  background: transparent;
+  border: none;
+  color: var(--color-text-on-dark-muted);
+  cursor: pointer;
+  padding: 0 var(--space-3);
+  font-size: 14px;
+  line-height: 1;
+}
+.sidebar-section-head .add-btn:hover { color: var(--color-text-on-dark); }
+
+.sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  color: var(--color-text-on-dark-muted);
+  border-radius: var(--radius-sm);
+  margin: 0 var(--space-3);
+}
+.sidebar-item:hover { background: var(--color-ink-panel); color: var(--color-text-on-dark); }
+.sidebar-item.active {
+  background: var(--color-accent-coral);
+  color: #fff;
+}
+.sidebar-item.active .ch-sigil { color: #fff; }
+.sidebar-item .ch-sigil {
+  font-family: var(--font-mono);
+  color: var(--color-text-on-dark-muted);
+  font-weight: var(--font-weight-medium);
+}
+.sidebar-item .ch-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sidebar-item .ch-badge {
+  font-size: var(--font-size-xs);
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--color-ink-raised);
+  color: var(--color-text-on-dark-muted);
+}
+.sidebar-item.active .ch-badge { background: rgba(255,255,255,0.2); color: #fff; }
+.sidebar-item.archived { opacity: 0.5; }
+
+.sidebar-empty {
+  padding: var(--space-5);
+  color: var(--color-text-on-dark-muted);
+  font-size: var(--font-size-xs);
+  font-style: italic;
+}
+
+/* ── Center pane (paper) ──────────────────────────────────────── */
+
+.center-pane {
+  background: var(--color-paper-base);
   display: flex;
   flex-direction: column;
   min-width: 0;
-  /* Without min-height: 0, flex children with overflow-y: auto grow to their
-     natural content height and blow past the grid row, so nothing appears
-     scrollable — the outer `html { overflow: hidden }` just clips them. */
   min-height: 0;
-  /* Belt-and-braces: clip at the panel boundary so runaway content can't
-     push the composer / sidebars off-screen. */
   overflow: hidden;
 }
-.panel:last-child { border-right: none; border-left: 1px solid var(--border); }
 
-.panel-header {
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--border);
-  font-weight: 600;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  /* Pin so .content / .list can flex-grow into the remaining space. */
-  flex-shrink: 0;
-}
-
-.list { flex: 1; overflow-y: auto; }
-.list-item {
-  padding: 8px 12px;
-  cursor: pointer;
-  border-left: 2px solid transparent;
-}
-.list-item:hover { background: var(--bg-hover); }
-.list-item.active {
-  background: var(--bg-hover);
-  border-left-color: var(--accent);
-}
-.list-item.archived { opacity: 0.55; }
-.list-item.archived:hover { opacity: 0.8; }
-.list-item .name {
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.list-item .meta { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
-.list-item-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-}
-.list-item-body { flex: 1; min-width: 0; }
-.channel-archive-btn {
-  flex-shrink: 0;
-  padding: 2px 6px;
-  font-size: 12px;
-  line-height: 1;
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--text-muted);
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-.list-item:hover .channel-archive-btn,
-.channel-archive-btn:focus-visible {
-  opacity: 1;
-}
-.channel-archive-btn:hover:not(:disabled) {
-  border-color: var(--warn);
-  color: var(--warn);
-  background: transparent;
-}
-.channel-archive-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.archived-badge {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 1px 5px;
-  border-radius: 2px;
-  background: var(--bg-hover);
-  color: var(--text-muted);
-  font-weight: 500;
-}
-.sidebar-toggle {
+.center-empty {
+  flex: 1;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 11px;
-  color: var(--text-muted);
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-  user-select: none;
+  justify-content: center;
+  color: var(--color-text-dim);
+  font-size: var(--font-size-md);
+}
+
+/* ── Channel header (2-row) ──────────────────────────────────── */
+
+.channel-header {
+  border-bottom: 1px solid var(--color-paper-line);
+  background: var(--color-paper-base);
   flex-shrink: 0;
 }
-.sidebar-toggle input { margin: 0; }
-.sidebar-toggle:hover { color: var(--text-dim); }
-
-.tabs {
+.channel-header-row1 {
   display: flex;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-alt);
-  /* Pin so .content can claim remaining vertical space. */
-  flex-shrink: 0;
-}
-.tab {
-  padding: 10px 16px;
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  font-size: 12px;
-}
-.tab:hover { color: var(--text); }
-.tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
-
-.content { flex: 1; overflow-y: auto; padding: 12px 16px; min-height: 0; }
-/* Board tab manages its own per-column scroll, so the outer container must
-   not itself overflow — otherwise the columns stretch to natural height. */
-.content.board-content { overflow-y: hidden; display: flex; flex-direction: column; }
-
-.feed-entry {
-  margin-bottom: 12px;
-  padding: 8px 10px;
-  border-radius: 4px;
-  background: var(--bg-alt);
-  border-left: 2px solid var(--border);
-}
-.feed-entry .feed-header {
-  display: flex;
-  gap: 8px;
-  font-size: 11px;
-  color: var(--text-muted);
-  margin-bottom: 4px;
-}
-.feed-entry .feed-author { color: var(--accent); font-weight: 500; }
-.feed-entry .feed-content { word-break: break-word; }
-.feed-entry .feed-content .md > :first-child { margin-top: 0; }
-.feed-entry .feed-content .md > :last-child { margin-bottom: 0; }
-.md p { margin: 0 0 8px; line-height: 1.45; }
-.md ul, .md ol { margin: 0 0 8px; padding-left: 20px; }
-.md li { margin-bottom: 2px; }
-.md li > p { margin: 0; }
-.md h1, .md h2, .md h3, .md h4, .md h5, .md h6 {
-  margin: 12px 0 6px;
-  line-height: 1.3;
-}
-.md h1 { font-size: 17px; }
-.md h2 { font-size: 15px; }
-.md h3 { font-size: 14px; }
-.md h4, .md h5, .md h6 { font-size: 13px; }
-.md code {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-}
-.md pre {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  padding: 8px 10px;
-  border-radius: 4px;
-  overflow-x: auto;
-  margin: 0 0 8px;
-}
-.md pre code {
-  background: transparent;
-  border: none;
-  padding: 0;
-  font-size: 12px;
-}
-.md blockquote {
-  margin: 0 0 8px;
-  padding: 2px 10px;
-  border-left: 2px solid var(--border);
-  color: var(--text-muted);
-}
-.md a { color: var(--accent); text-decoration: underline; }
-.md table {
-  border-collapse: collapse;
-  margin: 0 0 8px;
-  font-size: 12px;
-}
-.md th, .md td {
-  border: 1px solid var(--border);
-  padding: 4px 8px;
-  text-align: left;
-}
-.md hr {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 10px 0;
-}
-.md img { max-width: 100%; }
-.feed-entry .feed-header-right {
-  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  margin-left: auto;
+  gap: var(--space-5);
+  padding: var(--space-5) var(--space-8);
+  min-height: 48px;
 }
-.rewind-btn {
-  font-size: 10px;
-  padding: 2px 6px;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  background: transparent;
-  color: var(--text-dim);
-  cursor: pointer;
-  line-height: 1.2;
-}
-.rewind-btn:hover:not(:disabled) {
-  border-color: var(--warn);
-  color: var(--warn);
-}
-.rewind-btn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-.rewind-repo-list {
-  margin: 8px 0;
-  padding: 6px 8px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  font-size: 12px;
-}
-.rewind-repo-row {
+.channel-header-name {
   display: flex;
-  gap: 8px;
-  align-items: center;
-  padding: 2px 0;
+  align-items: baseline;
+  gap: var(--space-3);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
 }
-.rewind-repo-row code {
-  color: var(--accent);
-  flex-shrink: 0;
-}
-.rewind-repo-path {
-  color: var(--text-muted);
-  font-size: 11px;
+.channel-header-name .sigil { color: var(--color-text-dim); }
+.channel-header-topic {
+  flex: 1;
+  min-width: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.rewind-warning {
-  color: var(--warn);
-  font-size: 12px;
-  background: rgba(250, 179, 135, 0.08);
-  border-left: 2px solid var(--warn);
-  padding: 6px 8px;
-  margin: 8px 0 0;
-}
-
-.feed-entry.role-user { border-left-color: var(--user); }
-.feed-entry.role-assistant { border-left-color: var(--assistant); }
-.feed-entry.role-system { border-left-color: var(--system); }
-.feed-entry.role-activity {
-  border-left-color: var(--activity);
+.channel-header-star {
   background: transparent;
-  font-size: 11px;
-  color: var(--text-dim);
-  font-style: italic;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-dim);
+  font-size: 16px;
+  padding: 0 var(--space-2);
+}
+.channel-header-star.starred { color: var(--color-accent-amber); }
+.channel-header-tier {
+  padding: 2px var(--space-4);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-uppercase);
+}
+.channel-header-tier.tier-feature_large { background: rgba(196, 77, 138, 0.15); color: var(--color-accent-magenta); }
+.channel-header-tier.tier-feature       { background: rgba(74, 127, 208, 0.15); color: var(--color-accent-sky); }
+.channel-header-tier.tier-bugfix        { background: var(--color-accent-coral-soft); color: var(--color-accent-coral); }
+.channel-header-tier.tier-chore         { background: var(--color-paper-alt); color: var(--color-text-muted); }
+.channel-header-tier.tier-question      { background: rgba(232, 154, 43, 0.15); color: var(--color-accent-amber); }
+
+.agent-stack { display: inline-flex; }
+.agent-stack .agent-avatar {
+  width: 24px; height: 24px;
+  border-radius: 50%;
+  background: var(--color-paper-alt);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: -6px;
+  border: 2px solid var(--color-paper-base);
+}
+.agent-stack .agent-avatar:first-child { margin-left: 0; }
+
+.rail-toggle {
+  background: transparent;
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+.rail-toggle:hover { background: var(--color-paper-alt); color: var(--color-text-primary); }
+
+.channel-header-row2 {
+  display: flex;
+  align-items: center;
+  padding: 0 var(--space-8);
+  border-top: 1px solid var(--color-paper-line);
+  gap: var(--space-6);
+}
+.channel-tabs {
+  display: flex;
+  gap: var(--space-5);
+  flex-shrink: 0;
+}
+.channel-tab {
+  padding: var(--space-4) 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+}
+.channel-tab:hover { color: var(--color-text-primary); }
+.channel-tab.active {
+  color: var(--color-accent-coral);
+  border-bottom-color: var(--color-accent-coral);
+  font-weight: var(--font-weight-semibold);
+}
+.channel-header-row2 .row2-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
 }
 
-.empty {
-  color: var(--text-muted);
+/* ── Repo chip row ─────────────────────────────────────────── */
+
+.repo-chip-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  padding: var(--space-3) 0;
+}
+.repo-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-4);
+  height: var(--layout-chip-height);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  position: relative;
+  transition: var(--anim-hover-fast);
+}
+.repo-chip.primary {
+  background: var(--color-mention-primary-bg);
+  color: var(--color-mention-primary-fg);
+  border: 1px solid var(--color-mention-primary-line);
+}
+.repo-chip.attached {
+  background: var(--color-mention-attached-bg);
+  color: var(--color-mention-attached-fg);
+  border: 1px solid var(--color-mention-attached-line);
+}
+.repo-chip.add {
+  background: var(--color-paper-alt);
+  color: var(--color-text-muted);
+  border: 1px dashed var(--color-paper-line);
+}
+.repo-chip:hover { filter: brightness(0.97); }
+.repo-chip .detach-x {
+  opacity: 0;
+  margin-left: var(--space-2);
+  color: var(--color-text-muted);
+}
+.repo-chip:hover .detach-x { opacity: 1; }
+.repo-chip.primary .detach-x { display: none; }
+
+.gear-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+.gear-btn:hover { background: var(--color-paper-alt); color: var(--color-text-primary); }
+
+/* Floating popover anchored to a repo chip or the + chip */
+.popover {
+  position: absolute;
+  background: var(--color-paper-base);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-popover);
+  min-width: 200px;
+  z-index: 100;
+  padding: var(--space-3);
+  font-size: var(--font-size-base);
+}
+.popover-header {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-uppercase);
+  color: var(--color-text-dim);
+  padding: var(--space-2) var(--space-3);
+}
+.popover-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-primary);
+}
+.popover-item:hover { background: var(--color-paper-alt); }
+.popover-item.danger { color: var(--color-accent-coral); }
+.popover-item .item-sub {
+  margin-left: auto;
+  color: var(--color-text-dim);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+}
+.popover-item.disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* ── Chat content ──────────────────────────────────────────── */
+
+.chat-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6) var(--space-8);
+  min-height: 0;
+}
+.chat-scroll.board, .chat-scroll.decisions { padding: var(--space-6) var(--space-8); }
+
+.message {
+  display: grid;
+  grid-template-columns: var(--layout-message-avatar) 1fr;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+.message .msg-avatar {
+  width: var(--layout-message-avatar);
+  height: var(--layout-message-avatar);
+  border-radius: var(--radius-md);
+  background: var(--color-paper-alt);
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+.message.role-assistant .msg-avatar { background: var(--color-accent-sky); color: #fff; }
+.message.role-system .msg-avatar { background: var(--color-accent-magenta); color: #fff; }
+.message.role-user .msg-avatar { background: var(--color-accent-coral); color: #fff; }
+.message .msg-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  font-size: var(--font-size-base);
+}
+.message .msg-author { font-weight: var(--font-weight-semibold); }
+.message .msg-time { font-size: var(--font-size-xs); color: var(--color-text-dim); }
+.message .msg-actions { margin-left: auto; display: inline-flex; gap: var(--space-2); opacity: 0; }
+.message:hover .msg-actions { opacity: 1; }
+.message .msg-action-btn {
+  font-size: var(--font-size-xs);
+  padding: 2px var(--space-3);
+  border: 1px solid var(--color-paper-line);
+  background: var(--color-paper-base);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-muted);
+}
+.message .msg-action-btn:hover { color: var(--color-accent-coral); border-color: var(--color-accent-coral); }
+.message .msg-body {
+  font-size: var(--font-size-md);
+  line-height: var(--line-relaxed);
+  color: var(--color-text-primary);
+  word-wrap: break-word;
+}
+.message .msg-body pre {
+  background: var(--color-paper-alt);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  margin: var(--space-3) 0;
+}
+
+.chat-empty {
+  color: var(--color-text-dim);
   font-style: italic;
-  padding: 20px;
+  padding: var(--space-12);
   text-align: center;
 }
 
-.section {
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--border);
+.stream-card {
+  background: var(--color-paper-alt);
+  border: 1px solid var(--color-paper-line);
+  border-left: 3px solid var(--color-accent-amber);
+  border-radius: var(--radius-card);
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-6);
 }
-.section h4 {
-  margin: 0 0 6px;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-}
-.section .row {
-  font-size: 12px;
-  padding: 3px 0;
+.stream-card-head {
   display: flex;
-  justify-content: space-between;
-  gap: 8px;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
 }
-.section .row .right { color: var(--text-muted); font-size: 11px; }
-
-.badge {
-  display: inline-block;
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 10px;
-  background: var(--bg-hover);
-  color: var(--text-dim);
+.stream-card-head .dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent-amber);
+  animation: var(--anim-pulse);
 }
-.badge.ok { color: var(--ok); }
-.badge.warn { color: var(--warn); }
-.badge.error { color: var(--error); }
-
-.board-columns {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 12px;
-  /* Fill the board-content flex track without `height: 100%`, which resolves
-     to auto inside a flex parent in some browsers and lets the columns grow
-     to natural content height. */
-  flex: 1 1 auto;
-  min-height: 0;
-  align-items: stretch;
-}
-.board-column {
+.stream-card-head .author { color: var(--color-accent-coral); font-weight: var(--font-weight-semibold); }
+.stream-activity {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  /* Without overflow hidden, the column's natural content height wins and
-     board-column-body's overflow-y has nothing to scroll against. */
-  overflow: hidden;
+  gap: var(--space-1);
 }
-.board-column h4 {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-  margin: 0 0 8px;
-  flex-shrink: 0;
+.stream-activity.expanded { max-height: 220px; overflow-y: auto; }
+.stream-activity-line {
+  display: flex; gap: var(--space-3);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.board-column-body {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 4px;
-}
-.ticket {
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 8px;
-  margin-bottom: 6px;
-  font-size: 12px;
-}
-.ticket.clickable {
+.stream-activity-line.newest { color: var(--color-text-primary); }
+.stream-activity-more {
+  margin-top: var(--space-2);
+  background: transparent;
+  border: none;
+  color: var(--color-accent-sky);
   cursor: pointer;
-  transition: border-color 80ms ease, background 80ms ease;
+  font-size: var(--font-size-xs);
+  padding: var(--space-2) 0;
+  text-align: left;
 }
-.ticket.clickable:hover {
-  border-color: var(--accent);
-  background: var(--bg);
-}
-.ticket.clickable:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-.ticket .ticket-meta { color: var(--text-muted); font-size: 10px; margin-top: 4px; }
-
-/* Small "@alias" pill on ticket cards + inline in other surfaces. Uses the
-   sapphire accent at low opacity so it reads as secondary metadata, not a
-   status signal. */
-.ticket-alias-chip {
-  display: inline-block;
-  margin-top: 4px;
-  padding: 1px 6px;
-  font-size: 10px;
-  line-height: 1.4;
-  border-radius: 10px;
-  background: var(--accent-dim);
-  color: var(--text);
+.stream-body {
+  margin-top: var(--space-3);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
+  line-height: var(--line-relaxed);
 }
 
-/* Linear mirror tickets: a magenta-ish border + "Linear · ENG-42" chip so
-   read-only mirror rows are distinguishable from Relay-scheduled tickets. */
-.ticket.ticket-linear {
-  border-left: 3px solid #c678dd;
-}
+/* ── Composer ─────────────────────────────────────────────── */
 
-.ticket-linear-chip {
-  display: inline-block;
-  margin-bottom: 4px;
-  padding: 1px 6px;
-  font-size: 10px;
-  line-height: 1.4;
-  border-radius: 10px;
-  background: rgba(198, 120, 221, 0.15);
-  color: #c678dd;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
-/* PRIMARY tag — rendered next to the selected primary row in the new-channel
-   modal and in the right pane's repo list. Mauve keeps it distinct from the
-   alias chip (sapphire) and from the accent-blue used for active channels. */
-.primary-badge {
-  display: inline-block;
-  margin-left: 6px;
-  padding: 1px 5px;
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  border-radius: 3px;
-  background: var(--system);
-  color: var(--bg);
-  vertical-align: middle;
-}
-
-/* Ticket detail modal */
-.ticket-modal {
-  width: 520px;
-}
-.ticket-modal .detail-row {
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 8px;
-  align-items: baseline;
-  font-size: 13px;
-}
-.ticket-modal .detail-row-block {
-  display: block;
-}
-.ticket-modal .detail-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-}
-.ticket-modal code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  background: var(--bg);
-  padding: 1px 4px;
-  border-radius: 3px;
-}
-.ticket-modal .dep-list {
-  margin: 6px 0 0;
-  padding: 0;
-  list-style: none;
+.composer {
+  border-top: 1px solid var(--color-paper-line);
+  padding: var(--space-5) var(--space-8);
+  background: var(--color-paper-base);
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-3);
 }
-.ticket-modal .dep-list li {
-  padding: 6px 8px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font-size: 12px;
-}
-.ticket-modal .dep-status {
-  margin-left: 4px;
-  padding: 1px 6px;
-  border-radius: 10px;
-  background: var(--bg);
-  color: var(--text-dim);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.ticket-modal .dep-title {
-  margin-top: 4px;
-  color: var(--text-muted);
-}
-
-.decision {
-  margin-bottom: 16px;
-  padding: 10px;
-  background: var(--bg-alt);
-  border-left: 2px solid var(--system);
-  border-radius: 4px;
-}
-.decision h4 { margin: 0 0 4px; }
-.decision .meta { font-size: 11px; color: var(--text-muted); margin-bottom: 6px; }
-.decision p { margin: 4px 0; }
-
-/* Composer */
-.composer {
+.composer-routing {
   display: flex;
-  gap: 8px;
-  padding: 10px 12px;
-  border-top: 1px solid var(--border);
-  background: var(--bg-alt);
-  align-items: flex-end;
-  /* Pinned at the bottom of the panel — must not be squeezed when the chat
-     feed grows. */
-  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
-.composer-input-wrap {
+.composer-routing .route-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 2px var(--space-3);
+  background: var(--color-mention-primary-bg);
+  color: var(--color-mention-primary-fg);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-semibold);
+}
+.composer-body {
   position: relative;
-  flex: 1;
   display: flex;
+  gap: var(--space-4);
+  align-items: flex-end;
 }
 .composer textarea {
   flex: 1;
-  resize: vertical;
-  min-height: 36px;
-  max-height: 200px;
-  padding: 8px 10px;
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
+  resize: none;
+  min-height: 40px;
+  max-height: 240px;
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-paper-alt);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-lg);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--font-size-md);
+  line-height: var(--line-normal);
 }
-.composer textarea:focus { outline: none; border-color: var(--accent); }
-.mention-popover {
-  position: absolute;
-  bottom: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  max-height: 200px;
-  overflow-y: auto;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
-  z-index: 10;
-  padding: 4px;
-}
-.mention-option {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  width: 100%;
-  padding: 6px 8px;
-  background: transparent;
-  border: none;
-  border-radius: 3px;
-  color: var(--text);
-  text-align: left;
-  font: inherit;
-  font-size: 12px;
-  cursor: pointer;
-}
-.mention-option:hover,
-.mention-option.active {
-  background: var(--bg-alt);
-}
-.mention-alias {
-  color: var(--accent);
-  font-weight: 500;
-}
-.mention-path {
-  color: var(--text-muted);
-  font-size: 11px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.composer-error {
-  position: absolute;
-  margin-top: -28px;
-  background: var(--error);
-  color: white;
-  padding: 2px 8px;
-  border-radius: 3px;
-  font-size: 11px;
+.composer textarea:focus {
+  outline: none;
+  border-color: var(--color-accent-coral);
+  background: var(--color-paper-base);
 }
 .composer-controls {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: stretch;
-}
-.auto-approve {
-  font-size: 10px;
-  color: var(--text-dim);
-  display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-4);
+}
+.composer-controls .auto-approve {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
   cursor: pointer;
-  white-space: nowrap;
 }
-.auto-approve input { margin: 0; }
-.stream-activity {
-  font-size: 11px;
-  color: var(--text-dim);
-  font-style: italic;
-  margin: 4px 0 8px;
-  border-left: 2px solid var(--activity);
-  padding: 4px 8px;
-  background: rgba(250, 179, 135, 0.04);
-  border-radius: 0 3px 3px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.stream-activity.expanded {
-  max-height: 280px;
-  overflow-y: auto;
-}
-.stream-activity-line {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  line-height: 1.5;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: rgba(150, 150, 180, 0.9);
-}
-.stream-activity-line.newest {
-  color: rgb(200, 200, 230);
-}
-.stream-activity-line .activity-text {
+.composer-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dim);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
 }
-.activity-badge {
-  display: inline-block;
-  padding: 0 5px;
-  border-radius: 2px;
-  background: rgba(80, 80, 100, 0.55);
-  color: #1a1a1a;
-  font-style: normal;
-  font-size: 10px;
-  letter-spacing: 0.2px;
-  flex-shrink: 0;
+.composer-error {
+  font-size: var(--font-size-xs);
+  color: var(--color-accent-coral);
+  background: var(--color-accent-coral-soft);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
 }
-.activity-icon {
-  color: rgb(150, 150, 180);
-  font-style: normal;
-  flex-shrink: 0;
+.mention-popover {
+  position: absolute;
+  bottom: calc(100% + var(--space-2));
+  left: 0;
+  background: var(--color-paper-base);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-popover);
+  min-width: 260px;
+  max-height: 220px;
+  overflow-y: auto;
+  z-index: 50;
+  padding: var(--space-2);
 }
-.stream-activity-empty {
+.mention-option {
   display: flex;
   align-items: center;
-  gap: 6px;
-  color: var(--text-muted);
-}
-.activity-ellipsis {
-  font-style: italic;
-}
-.stream-activity-more {
-  align-self: flex-start;
-  margin-top: 2px;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
   background: transparent;
   border: none;
-  color: var(--accent-dim);
-  font-size: 10px;
-  cursor: pointer;
-  padding: 2px 0;
-  font-style: italic;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  font-size: var(--font-size-base);
 }
-.stream-activity-more:hover {
-  color: var(--accent);
-  text-decoration: underline;
+.mention-option:hover, .mention-option.active { background: var(--color-paper-alt); }
+.mention-option .mention-alias {
+  font-family: var(--font-mono);
+  color: var(--color-accent-coral);
+  font-weight: var(--font-weight-semibold);
 }
-.stream-activity-meta {
-  margin-top: 2px;
-  color: var(--text-muted);
-  font-size: 10px;
-  font-style: normal;
-}
-.feed-entry.streaming {
-  border: 1px solid var(--accent-dim);
-  border-radius: 4px;
-  padding: 8px 10px;
-  background: rgba(116, 199, 236, 0.04);
-}
-.stream-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--accent-dim);
-  font-size: 11px;
-}
-.stream-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  animation: stream-pulse 1.2s ease-in-out infinite;
-}
-@keyframes stream-pulse {
-  0%, 100% { opacity: 0.3; transform: scale(0.85); }
-  50%      { opacity: 1;   transform: scale(1.1); }
-}
+.mention-option .mention-path { margin-left: auto; color: var(--color-text-dim); font-size: var(--font-size-xs); }
 
-/* Sessions panel */
-.section-head {
+/* ── Right rail (tabs + collapsible) ──────────────────────── */
+
+.right-rail {
+  background: var(--color-paper-base);
+  border-left: 1px solid var(--color-paper-line);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 6px;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
 }
-.section-head h4 { margin: 0; }
-.section-head button {
-  padding: 0 8px;
-  font-size: 14px;
-  line-height: 1.5;
-}
-.session-row {
-  padding: 6px 8px;
-  margin: 2px -4px;
-  border-radius: 4px;
-  cursor: pointer;
-  border-left: 2px solid transparent;
-}
-.session-row:hover { background: var(--bg-hover); }
-.session-row.active {
-  background: var(--bg-hover);
-  border-left-color: var(--accent);
-}
-.session-title { font-size: 12px; font-weight: 500; }
-.session-meta { font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+.right-rail.collapsed { display: none; }
 
-/* Modal */
+.rail-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--color-paper-line);
+  background: var(--color-paper-alt);
+}
+.rail-tab {
+  flex: 1;
+  padding: var(--space-5) var(--space-4);
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+}
+.rail-tab:hover { color: var(--color-text-primary); }
+.rail-tab.active {
+  color: var(--color-accent-coral);
+  border-bottom-color: var(--color-accent-coral);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-paper-base);
+}
+
+.rail-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-5) var(--space-6);
+}
+
+.rail-list-item {
+  padding: var(--space-4);
+  border-radius: var(--radius-card);
+  cursor: pointer;
+  margin-bottom: var(--space-3);
+  background: var(--color-paper-alt);
+  border: 1px solid transparent;
+}
+.rail-list-item:hover { border-color: var(--color-paper-line); }
+.rail-list-item .title { font-weight: var(--font-weight-semibold); font-size: var(--font-size-base); }
+.rail-list-item .meta { font-size: var(--font-size-xs); color: var(--color-text-muted); margin-top: var(--space-1); }
+
+.rail-empty {
+  color: var(--color-text-dim);
+  font-style: italic;
+  padding: var(--space-8);
+  text-align: center;
+  font-size: var(--font-size-base);
+}
+
+/* ── Modal shell ──────────────────────────────────────────── */
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(14, 20, 32, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
 }
 .modal {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  width: 480px;
-  max-height: 80vh;
+  background: var(--color-paper-base);
+  border-radius: var(--radius-modal);
+  box-shadow: var(--shadow-modal);
+  width: 640px;
+  max-width: 92vw;
+  max-height: 84vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
+.modal.modal-sm { width: 480px; }
 .modal-header {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
-  font-weight: 600;
+  padding: var(--space-6) var(--space-8);
+  border-bottom: 1px solid var(--color-paper-line);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-lg);
 }
+.modal-header .close-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--color-text-dim);
+}
+.modal-header .close-btn:hover { color: var(--color-text-primary); }
 .modal-body {
-  padding: 16px;
+  padding: var(--space-8);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-5);
+  flex: 1;
+  font-size: var(--font-size-base);
 }
 .modal-body label {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 11px;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
+  letter-spacing: var(--letter-uppercase);
+  color: var(--color-text-muted);
 }
-.modal-body input {
-  padding: 6px 8px;
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
+.modal-body input[type="text"],
+.modal-body input:not([type]),
+.modal-body textarea {
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-paper-base);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--font-size-base);
   text-transform: none;
   letter-spacing: normal;
 }
-.modal-body input:focus { outline: none; border-color: var(--accent); }
-.modal-subhead {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-  margin-bottom: 4px;
+.modal-body textarea { min-height: 80px; resize: vertical; }
+.modal-body input:focus, .modal-body textarea:focus {
+  outline: none;
+  border-color: var(--color-accent-coral);
 }
-/* Restructured for filterable repo picker: outer .repo-list wraps the
-   head + filter input + scrollable body. Body keeps its own overflow so
-   the filter / counter stay pinned while the rows scroll. */
-.repo-list { display: flex; flex-direction: column; gap: 6px; min-height: 0; }
-.repo-list-head {
+.modal-footer {
+  padding: var(--space-5) var(--space-8);
+  border-top: 1px solid var(--color-paper-line);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
+  gap: var(--space-4);
 }
-.repo-filter {
-  padding: 6px 8px;
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font: inherit;
-  font-size: 12px;
-  text-transform: none;
-  letter-spacing: normal;
+.modal-footer .steps {
+  display: inline-flex;
+  gap: var(--space-2);
+  color: var(--color-text-dim);
+  font-size: var(--font-size-xs);
 }
-.repo-filter:focus { outline: none; border-color: var(--accent); }
-.repo-rows {
+.modal-footer .step-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--color-paper-line);
+}
+.modal-footer .step-dot.active { background: var(--color-accent-coral); }
+
+/* Wizard step containers */
+.wizard-step h3 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+.wizard-step p.help {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+  margin: 0 0 var(--space-4);
+}
+
+/* ── Drawer (right-side slide-over) ──────────────────────── */
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 20, 32, 0.35);
+  z-index: 900;
+}
+.drawer {
+  position: fixed;
+  top: 0; right: 0; bottom: 0;
+  width: 460px;
+  max-width: 92vw;
+  background: var(--color-paper-base);
+  box-shadow: var(--shadow-drawer);
+  z-index: 950;
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  max-height: 260px;
-  overflow-y: auto;
-  padding-right: 4px;
 }
-.repo-row {
-  /* Columns: selected checkbox · path (grows) · alias input · primary radio
-     · spawn checkbox. The primary/spawn slots use fixed widths so rows
-     line up across checked/unchecked states (placeholders fill the gap
-     when the row is unselected). */
-  display: grid;
-  grid-template-columns: auto 1fr 110px 72px 68px;
-  gap: 8px;
-  align-items: center;
-  font-size: 12px;
-  padding: 4px 6px;
-  border-radius: 3px;
-  cursor: default;
-}
-.repo-primary-radio,
-.repo-spawn-toggle {
-  font-size: 10px;
-  color: var(--text-dim);
+.drawer-header {
+  padding: var(--space-6) var(--space-8);
+  border-bottom: 1px solid var(--color-paper-line);
   display: flex;
   align-items: center;
-  gap: 4px;
-  cursor: pointer;
-  white-space: nowrap;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  justify-content: space-between;
 }
-.repo-primary-radio input,
-.repo-spawn-toggle input {
+.drawer-header h3 {
   margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
 }
-.repo-primary-radio.placeholder,
-.repo-spawn-toggle.placeholder {
-  visibility: hidden;
-}
-.repo-row.highlighted {
-  background: var(--bg-hover);
-  outline: 1px solid var(--accent-dim);
-}
-.repo-path { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.alias-input {
-  padding: 4px 6px !important;
-  font-size: 12px !important;
-}
-.error {
-  color: var(--error);
-  font-size: 12px;
-  padding: 6px 8px;
-  background: rgba(247, 118, 142, 0.1);
-  border-radius: 4px;
-}
-.modal-footer {
-  padding: 10px 16px;
-  border-top: 1px solid var(--border);
+.drawer-tabs {
   display: flex;
-  justify-content: flex-end;
-  gap: 8px;
+  border-bottom: 1px solid var(--color-paper-line);
+  padding: 0 var(--space-8);
+  gap: var(--space-5);
 }
-
-/* Non-fatal warning — used in the new-channel modal when the channel is
-   created but one or more spawn calls failed. Warmer than .error and not
-   blocking. */
-.warning {
-  color: var(--warn);
-  font-size: 12px;
-  padding: 6px 8px;
-  background: rgba(250, 179, 135, 0.1);
-  border-radius: 4px;
+.drawer-tab {
+  padding: var(--space-4) 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
 }
-
-/* Spawned-agents panel (RightPane). Mirrors .repo-row spacing so it reads
-   as peer visual weight to the Repos section just above it. */
-.spawn-list {
+.drawer-tab.active {
+  color: var(--color-accent-coral);
+  border-bottom-color: var(--color-accent-coral);
+  font-weight: var(--font-weight-semibold);
+}
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6) var(--space-8);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-5);
 }
-.spawn-row {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 8px;
-  align-items: center;
-  font-size: 12px;
-  padding: 3px 0;
-}
-.spawn-row .spawn-alias { color: var(--accent); font-weight: 500; }
-.spawn-row .spawn-repo {
-  color: var(--text-muted);
-  font-size: 11px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.kill-button {
-  padding: 2px 8px;
-  font-size: 10px;
+.drawer-section h4 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  background: transparent;
-  border-radius: 3px;
+  letter-spacing: var(--letter-uppercase);
+  color: var(--color-text-dim);
+}
+
+/* ── Board view (dense list + kanban toggle) ─────────────── */
+
+.board-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.board-toolbar input {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  min-width: 220px;
+}
+.board-view-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.board-view-toggle button {
+  border: none;
+  background: var(--color-paper-base);
+  padding: var(--space-3) var(--space-5);
+  border-radius: 0;
+  font-size: var(--font-size-base);
+}
+.board-view-toggle button.active {
+  background: var(--color-accent-coral);
+  color: #fff;
+}
+
+/* Dense list */
+.board-list {
+  background: var(--color-paper-base);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+}
+.board-list-row {
+  display: grid;
+  grid-template-columns: 80px 100px 1fr 120px 80px;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--color-paper-line);
+  font-size: var(--font-size-base);
+  align-items: center;
   cursor: pointer;
 }
-.kill-button:hover {
-  color: var(--error);
-  border-color: var(--error);
-  background: rgba(243, 139, 168, 0.08);
+.board-list-row:last-child { border-bottom: none; }
+.board-list-row:hover { background: var(--color-paper-alt); }
+.board-list-row .ticket-id {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.board-list-row .status-pill {
+  padding: 2px var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: #fff;
+  text-align: center;
+  text-transform: capitalize;
+}
+.status-pill.status-pending   { background: var(--color-status-pending); color: var(--color-text-primary); }
+.status-pill.status-ready     { background: var(--color-status-ready); }
+.status-pill.status-executing { background: var(--color-status-executing); }
+.status-pill.status-verifying { background: var(--color-status-verifying); }
+.status-pill.status-completed { background: var(--color-status-completed); }
+.status-pill.status-failed    { background: var(--color-status-failed); }
+.status-pill.status-blocked   { background: var(--color-status-blocked); }
+.status-pill.status-retry     { background: var(--color-status-retry); }
+
+.board-list-row .ticket-title { font-weight: var(--font-weight-medium); }
+.board-list-row .agent-chip {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.board-list-row .linear-tag {
+  background: rgba(196, 77, 138, 0.14);
+  color: var(--color-accent-magenta);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-pill);
+  margin-left: var(--space-2);
 }
 
-/* --- OSS-05 parity additions --- */
+/* Kanban (existing column layout, repainted) */
+.board-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-5);
+  flex: 1;
+  min-height: 0;
+}
+.board-column {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-paper-alt);
+  border-radius: var(--radius-card);
+  padding: var(--space-4);
+  min-height: 0;
+  overflow: hidden;
+}
+.board-column h4 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-uppercase);
+  color: var(--color-text-muted);
+}
+.board-column-body { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: var(--space-3); }
+.ticket-card {
+  background: var(--color-paper-base);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-card);
+  padding: var(--space-4);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+}
+.ticket-card:hover { border-color: var(--color-accent-coral); }
+.ticket-card .title { font-weight: var(--font-weight-medium); }
+.ticket-card .meta { font-size: var(--font-size-xs); color: var(--color-text-muted); margin-top: var(--space-2); }
 
-/* Plan-approval CTA card shown above tabs in CenterPane */
+/* ── Decisions ─────────────────────────────────────────── */
+
+.decision-card {
+  background: var(--color-paper-alt);
+  border-left: 3px solid var(--color-accent-magenta);
+  border-radius: var(--radius-card);
+  padding: var(--space-5);
+  margin-bottom: var(--space-5);
+}
+.decision-card h4 { margin: 0 0 var(--space-2); font-size: var(--font-size-md); }
+.decision-card .meta { font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-3); }
+.decision-card p { margin: var(--space-2) 0; }
+
+/* ── Plan approval CTA ───────────────────────────────────── */
+
 .plan-cta {
-  border-bottom: 1px solid var(--border);
-  background: rgba(249, 226, 175, 0.08);
-  padding: 8px 12px;
+  padding: var(--space-5) var(--space-8);
+  background: rgba(232, 154, 43, 0.10);
+  border-bottom: 1px solid var(--color-paper-line);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 .plan-cta-row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 4px 0;
+  gap: var(--space-5);
 }
-.plan-cta-body {
+.plan-cta-body { flex: 1; display: flex; flex-direction: column; gap: var(--space-1); }
+.plan-cta-body strong { color: var(--color-text-primary); }
+.plan-cta-feature { font-size: var(--font-size-base); color: var(--color-text-primary); }
+.plan-cta-meta { font-size: var(--font-size-xs); color: var(--color-text-muted); }
+.plan-cta-buttons { display: inline-flex; gap: var(--space-3); }
+
+/* ── Tracked PRs ─────────────────────────────────────────── */
+
+.tracked-pr-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) 0;
+  font-size: var(--font-size-base);
+}
+.tracked-pr-ticket { font-family: var(--font-mono); color: var(--color-text-dim); font-size: var(--font-size-xs); }
+.tracked-pr-link { color: var(--color-accent-sky); text-decoration: none; font-weight: var(--font-weight-semibold); }
+.tracked-pr-link:hover { text-decoration: underline; }
+.tracked-pr-badges { display: inline-flex; gap: var(--space-2); }
+.pr-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--color-status-pending);
+}
+.pr-state-open { background: var(--color-status-completed); }
+.pr-state-merged { background: var(--color-accent-magenta); }
+.pr-state-closed { background: var(--color-text-dim); }
+.pr-ci-passing { background: var(--color-status-completed); }
+.pr-ci-failing { background: var(--color-status-failed); }
+.pr-ci-pending { background: var(--color-status-executing); }
+.pr-review-approved { background: var(--color-status-completed); }
+.pr-review-changes_requested { background: var(--color-status-failed); }
+.pr-review-pending { background: var(--color-status-executing); }
+
+/* ── Settings page ───────────────────────────────────────── */
+
+.settings-page {
   flex: 1;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  background: var(--color-paper-base);
+  min-height: 0;
+  overflow: hidden;
+}
+.settings-sidebar {
+  background: var(--color-paper-alt);
+  padding: var(--space-6) var(--space-5);
+  border-right: 1px solid var(--color-paper-line);
+  overflow-y: auto;
+}
+.settings-sidebar h3 {
+  margin: 0 0 var(--space-5);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
+}
+.settings-nav-item {
+  display: block;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+.settings-nav-item.active {
+  background: var(--color-accent-coral);
+  color: #fff;
+  font-weight: var(--font-weight-semibold);
+}
+.settings-main {
+  padding: var(--space-12);
+  overflow-y: auto;
+}
+.settings-main h2 {
+  margin: 0 0 var(--space-6);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+}
+.settings-section {
+  background: var(--color-paper-base);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-card);
+  padding: var(--space-8);
+  margin-bottom: var(--space-6);
+}
+.settings-section h3 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-md);
+}
+.settings-section p.help {
+  margin: 0 0 var(--space-5);
+  color: var(--color-text-muted);
+}
+.settings-radio-group { display: flex; flex-direction: column; gap: var(--space-3); }
+.settings-radio-group label {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  flex-direction: row !important;
+  text-transform: none !important;
+  letter-spacing: normal !important;
+  font-size: var(--font-size-base) !important;
 }
-.plan-cta-feature {
-  font-size: 12px;
-  color: var(--text);
+.settings-radio-group label.selected {
+  border-color: var(--color-accent-coral);
+  background: var(--color-accent-coral-soft);
 }
-.plan-cta-meta {
-  font-size: 10px;
-  color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+.settings-radio-group label .settings-radio-title {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
 }
-.plan-cta-buttons {
-  display: flex;
-  gap: 6px;
-}
-.plan-cta-buttons button {
-  padding: 4px 12px;
-  font-size: 12px;
+.settings-radio-group label .settings-radio-desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
 }
 
-/* Tracked-PR strip in RightPane */
-.tracked-pr-row {
+/* ── New-channel modal repo step ─────────────────────────── */
+
+.repo-list-step { display: flex; flex-direction: column; gap: var(--space-3); }
+.repo-filter {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+}
+.repo-rows {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  max-height: 320px; overflow-y: auto;
+}
+.repo-row {
+  display: grid;
+  grid-template-columns: auto 1fr 120px 80px 72px;
+  gap: var(--space-4);
   align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  border: 1px solid transparent;
+  font-size: var(--font-size-base);
 }
-.tracked-pr-ticket {
-  font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  color: var(--text-dim);
+.repo-row:hover { background: var(--color-paper-alt); }
+.repo-row.highlighted { border-color: var(--color-accent-coral); background: var(--color-accent-coral-soft); }
+.repo-row .repo-path { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.repo-row .primary-badge {
+  margin-left: var(--space-2);
+  padding: 1px var(--space-3);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-accent-coral);
+  color: #fff;
+  border-radius: var(--radius-pill);
+  letter-spacing: var(--letter-uppercase);
+  text-transform: uppercase;
 }
-.tracked-pr-link {
-  color: var(--accent, #89b4fa);
-  text-decoration: none;
-  font-weight: 600;
+.repo-row .alias-input {
+  padding: var(--space-2) var(--space-3) !important;
+  font-size: var(--font-size-base) !important;
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
 }
-.tracked-pr-link:hover {
-  text-decoration: underline;
-}
-.tracked-pr-badges {
+.repo-row .repo-primary-radio,
+.repo-row .repo-spawn-toggle {
   display: inline-flex;
-  gap: 4px;
   align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-uppercase);
+  color: var(--color-text-muted);
+  white-space: nowrap;
 }
-.pr-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--text-dim);
+.repo-row .repo-primary-radio.placeholder,
+.repo-row .repo-spawn-toggle.placeholder { visibility: hidden; }
+
+/* ── Utility: errors + warnings ──────────────────────────── */
+
+.error {
+  color: var(--color-accent-coral);
+  font-size: var(--font-size-base);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-accent-coral-soft);
+  border-radius: var(--radius-md);
 }
-.pr-state-open { background: #a6e3a1; }
-.pr-state-merged { background: #cba6f7; }
-.pr-state-closed { background: var(--text-dim); }
-.pr-ci-passing { background: #a6e3a1; }
-.pr-ci-failing { background: #f38ba8; }
-.pr-ci-pending { background: #f9e2af; }
-.pr-ci-none { background: var(--text-dim); }
-.pr-review-approved { background: #a6e3a1; }
-.pr-review-changes_requested { background: #f38ba8; }
-.pr-review-pending { background: #f9e2af; }
-.pr-review-none { background: var(--text-dim); }
+.warning {
+  color: var(--color-accent-amber);
+  font-size: var(--font-size-base);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(232, 154, 43, 0.10);
+  border-radius: var(--radius-md);
+}

--- a/gui/src/styles/mentions.css
+++ b/gui/src/styles/mentions.css
@@ -1,0 +1,42 @@
+/* Mention chips + inline code — rendered by renderWithMentions. */
+
+.mention {
+  display: inline-flex;
+  align-items: baseline;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-tight);
+  vertical-align: baseline;
+}
+
+.mention-repo-primary {
+  background: var(--color-mention-primary-bg);
+  color: var(--color-mention-primary-fg);
+  border: 1px solid var(--color-mention-primary-line);
+  padding: 0 var(--space-3) 0 var(--space-2);
+}
+
+.mention-repo-attached {
+  background: var(--color-mention-attached-bg);
+  color: var(--color-mention-attached-fg);
+  border: 1px solid var(--color-mention-attached-line);
+  padding: 0 var(--space-3) 0 var(--space-2);
+}
+
+.mention-human {
+  background: var(--color-mention-human-bg);
+  color: var(--color-mention-human-fg);
+  padding: 0 var(--space-2);
+}
+
+.mention-code {
+  background: var(--color-paper-alt);
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--color-text-primary);
+}

--- a/gui/src/styles/tokens.css
+++ b/gui/src/styles/tokens.css
@@ -1,0 +1,143 @@
+/* Tidewater design tokens — generated from agent_docs/tidewater_handoff/tokens.json */
+
+:root {
+  color-scheme: light;
+
+  /* Surfaces — ink (deep rail) vs paper (warm content) */
+  --color-ink-deepest: #0e1420;
+  --color-ink-deep:    #141b2a;
+  --color-ink-panel:   #1a2232;
+  --color-ink-raised:  #232c40;
+  --color-ink-line:    #2b3550;
+
+  --color-paper-base:  #fbf9f4;
+  --color-paper-alt:   #f3f0e7;
+  --color-paper-line:  #e5e1d5;
+
+  /* Text */
+  --color-text-primary:      #1b1f2a;
+  --color-text-muted:        #5b6579;
+  --color-text-dim:          #8a93a5;
+  --color-text-on-dark:      #e8ecf4;
+  --color-text-on-dark-muted:#8a93a5;
+
+  /* Accents — coral is the only strong accent; reserve for primary CTAs, active tabs, primary repo, selection */
+  --color-accent-coral:      #e65a4f;
+  --color-accent-coral-soft: #fbe1dd;
+  --color-accent-amber:      #e89a2b;
+  --color-accent-mint:       #3fb984;
+  --color-accent-mint-soft:  #d9f1e6;
+  --color-accent-sky:        #4a7fd0;
+  --color-accent-magenta:    #c44d8a;
+
+  /* Ticket / run status palette */
+  --color-status-pending:   #d0d4de;
+  --color-status-ready:     #86a6d9;
+  --color-status-executing: #e89a2b;
+  --color-status-verifying: #7a6fd0;
+  --color-status-completed: #3fb984;
+  --color-status-failed:    #e65a4f;
+  --color-status-blocked:   #9ba3b6;
+  --color-status-retry:     #d88a3b;
+
+  /* Mention chips */
+  --color-mention-primary-bg:    #fbe1dd;
+  --color-mention-primary-fg:    #e65a4f;
+  --color-mention-primary-line:  rgba(230, 90, 79, 0.33);
+  --color-mention-attached-bg:   #dce6f5;
+  --color-mention-attached-fg:   #3a5fa0;
+  --color-mention-attached-line: #b3c5e0;
+  --color-mention-human-bg:      #d9f1e6;
+  --color-mention-human-fg:      #2a7a5a;
+
+  /* Typography */
+  --font-ui:   "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --font-size-xs:   10.5px;
+  --font-size-sm:   11.5px;
+  --font-size-base: 13px;
+  --font-size-body: 14px;
+  --font-size-md:   14.5px;
+  --font-size-lg:   16px;
+  --font-size-xl:   18px;
+
+  --font-weight-regular:  400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
+
+  --letter-tight:     -0.01em;
+  --letter-normal:    0;
+  --letter-uppercase: 0.04em;
+
+  --line-tight:   1.3;
+  --line-normal:  1.5;
+  --line-relaxed: 1.55;
+
+  /* Radius */
+  --radius-xs:    2px;
+  --radius-sm:    3px;
+  --radius-md:    4px;
+  --radius-base:  5px;
+  --radius-card:  6px;
+  --radius-pill:  14px;
+  --radius-lg:    8px;
+  --radius-xl:    10px;
+  --radius-modal: 12px;
+
+  /* Shadows */
+  --shadow-card:    0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-popover: 0 6px 18px rgba(0, 0, 0, 0.08);
+  --shadow-modal:   0 24px 80px rgba(0, 0, 0, 0.20);
+  --shadow-drawer:  -16px 0 48px rgba(0, 0, 0, 0.15);
+  --shadow-frame:   0 24px 60px rgba(0, 0, 0, 0.25);
+
+  /* Spacing scale */
+  --space-1:  2px;
+  --space-2:  4px;
+  --space-3:  6px;
+  --space-4:  8px;
+  --space-5:  10px;
+  --space-6:  12px;
+  --space-7:  14px;
+  --space-8:  16px;
+  --space-10: 20px;
+  --space-12: 24px;
+  --space-16: 32px;
+
+  /* Layout fixed rails */
+  --layout-workspace-rail: 58px;
+  --layout-sidebar:        230px;
+  --layout-right-rail:     360px;
+  --layout-channel-header: 82px;
+  --layout-message-avatar: 32px;
+  --layout-chip-height:    20px;
+
+  /* Animation */
+  --anim-pulse:      relay-pulse 1.6s ease-in-out infinite;
+  --anim-hover-fast: all 0.15s ease;
+}
+
+@keyframes relay-pulse {
+  0%, 100% { opacity: 0.55; transform: scale(0.92); }
+  50%      { opacity: 1;    transform: scale(1.08); }
+}
+
+/* Local-only font fallback: the design bundles Inter + JetBrains Mono,
+   but we defer the .woff2 download (see gui/public/fonts/README.md).
+   Falls back to OS-installed Inter/JetBrains Mono, then generic stacks. */
+@font-face {
+  font-family: "Inter";
+  src: local("Inter"), local("Inter-Regular");
+  font-weight: 400 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "JetBrains Mono";
+  src: local("JetBrains Mono"), local("JetBrainsMono-Regular");
+  font-weight: 400 600;
+  font-style: normal;
+  font-display: swap;
+}

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -157,9 +157,9 @@ export type AgentNameEntry = {
 };
 
 // An agent process launched into its own external terminal window via the
-// spawn flow. Mirrors the shape documented in Task #24's contract. Fields
-// other than alias/repoPath are populated best-effort by the platform
-// Terminal adapter and may be undefined when the adapter can't report them.
+// spawn flow. Fields other than alias/repoPath are populated best-effort by
+// the platform Terminal adapter and may be undefined when the adapter can't
+// report them.
 export type Spawn = {
   alias: string;
   repoPath: string;

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -25,6 +25,16 @@ export type ChannelRef = {
   label: string;
 };
 
+export type ChannelTier = "feature_large" | "feature" | "bugfix" | "chore" | "question";
+
+export type GuiSettings = {
+  ticketProvider: "relay" | "linear" | "none";
+  linearApiToken: string;
+  linearWorkspace: string;
+  linearPollSeconds: number;
+  rightRailOpen: boolean;
+};
+
 export type Channel = {
   channelId: string;
   name: string;
@@ -37,6 +47,10 @@ export type Channel = {
   // for back-compat with older channel files; when unset, UI falls back to
   // the first entry in `repoAssignments`.
   primaryWorkspaceId?: string;
+  // Classifier-assigned tier. Optional — older channels omit.
+  tier?: ChannelTier;
+  // Pinned to the Starred section of the sidebar.
+  starred?: boolean;
   // ISO 8601; optional for back-compat with older channel files.
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
## Summary

Full rebuild of the Relay Tauri GUI to match the Tidewater design handoff (Direction C). Replaces the Catppuccin dark 3-pane shell with the ink/paper Slack-style chat UI specified in \`agent_docs/tidewater_handoff/\`.

- 58 / 230 / flex / 360 four-rail shell (workspace rail + sidebar + center + collapsible right rail)
- Interactive channel header (tier badge, star toggle, agent stack, RepoChipRow, gear)
- \`ChannelSettingsDrawer\` right-side slide-over (Repos / Members / About)
- \`renderWithMentions\` as the single message-body render path (@alias / \*\*bold\*\* / \`code\`)
- 3-step NewChannelModal wizard (Basics → Repos → Kick-off)
- Global Settings page with pluggable ticket provider (Relay-native | Linear | none), persisted to \`~/.relay/gui-settings.json\`
- Backend additions: \`Channel.tier\`, \`Channel.starred\`, \`set_primary_repo\` / \`set_channel_starred\` / \`set_channel_tier\` / \`get_settings\` / \`update_settings\` Tauri commands

## Commits

- \`8e9f67d\` — phase 0 + 5 foundation (tokens, adapter, mentions, Channel fields, Tauri commands)
- \`400087f\` — phases 1–4,6 UI rebuild

## What's preserved

- Rewind — relocated to per-message hover actions; snapshot-on-send unchanged
- Spawn-to-Terminal — surfaced in RepoChipRow chip popover + ChannelSettingsDrawer > Repos
- Archive / Unarchive — moved to ChannelSettingsDrawer > About
- Pending plan approval CTA — moved to right rail PRs tab
- Tracked PRs — right rail PRs tab
- Existing mention autocomplete + \`@alias\` routing in the composer
- Session threads — right rail Threads tab

## What's deferred (explicit user call)

- DMs, \`/new\` slash command, DM→channel promote — v2
- Multi-workspace switcher (workspace rail is decorative for v1)
- Tier classifier wiring (field added; manual tier selection in About tab; backend auto-emission is a separate change)
- Bundled Inter + JetBrains Mono .woff2 (local() OS fallback wired; TODO in \`gui/public/fonts/README.md\`)

## What's dropped

- \`react-markdown\` + \`remark-gfm\` — Tidewater §4.7 mandates \`renderWithMentions\` as the single body render path (no GFM, no autolinks). Messages lose fenced code blocks / tables; tracked as v2 extension if needed.

## Test plan

- [ ] \`pnpm -C gui exec tsc --noEmit\` clean
- [ ] \`cargo check --workspace\` clean
- [ ] \`pnpm -C gui tauri dev\` opens — channel list renders, palette is ink-deep + warm paper
- [ ] Create channel via 3-step wizard → lands on channel with primary repo chip in coral
- [ ] Type \`@\` in composer — mention autocomplete shows attached repos
- [ ] Click gear → ChannelSettingsDrawer opens; promote a repo, detach, spawn-to-Terminal, archive
- [ ] Star a channel in the sidebar and in the header — persists across refresh
- [ ] Right rail — collapse via header toggle (⋮›), switch Threads / Decisions / PRs tabs
- [ ] Send a message with a user \`@alias\` prefix — routes to that repo's agent
- [ ] Hover a user turn with \`rewindKey\` metadata → Rewind button appears in the actions slot
- [ ] Workspace rail gear → Settings page opens; toggle ticket provider between Relay-native and Linear
- [ ] Switch provider to Relay-native → Linear chips disappear from BoardView
- [ ] BoardView: list view (default) + kanban toggle + search + status multi-select all work

## Do not merge

Per the repo's CLAUDE.md workflow, this PR is opened for review only. Wait for explicit approval before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)