### PR TITLE
AL-12: Per-repo repo-admin session lifecycle

### DIFF
--- a/agent_docs/repo-admin.md
+++ b/agent_docs/repo-admin.md
@@ -116,6 +116,37 @@ would block the rollout (any new role would break all sessions until a map
 entry landed). The warning ensures a typo never ships quietly as cosmetic
 enforcement.
 
+## Activation status
+
+The pool is **built but not yet wired into production runs**. AL-13 will
+define the admin handshake protocol + flip this flag to on.
+
+AL-12 ships the `RepoAdminPool` boot / restart / shutdown mechanics and
+tests them against a fake spawner, but the autonomous-loop driver
+(`src/orchestrator/autonomous-loop.ts`) gates pool construction behind
+the `RELAY_REPO_ADMIN_POOL_ENABLED` env var — defaulted **off**. When
+the flag is unset, the driver preserves the pre-AL-12 path: no pool is
+constructed, lifecycle transitions to `killed` with reason
+`"al-13-pending"`, and the CLI exits cleanly.
+
+Why the gate exists: the default spawner runs the real `claude` CLI,
+which today exits in milliseconds (no prompt wired up, stdin closed).
+Without AL-13's handshake protocol, enabling the pool in production
+would produce an immediate flap loop (each death respawns until the
+rapid-restart ceiling fires). Keeping the pool off by default lets the
+AL-12 code land and be exercised in isolation without that risk. AL-13
+flips the flag to on after wiring the handshake.
+
+To exercise the pool locally (e.g. with a fake spawner injected from a
+test harness or a scripted stub):
+
+```bash
+RELAY_REPO_ADMIN_POOL_ENABLED=1 rly run --autonomous --channel <id>
+```
+
+Recognised true-ish values: `1`, `true`, `yes`, `on` (case-insensitive).
+Anything else — including typos — is treated as off.
+
 ## Spawner wiring
 
 `createLiveAgents({ ..., role: "repo-admin" })` in `src/agents/factory.ts`

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -1,6 +1,7 @@
 import type { SessionLifecycle } from "../lifecycle/session-lifecycle.js";
 import type { TokenTracker } from "../budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
+import { RepoAdminPool } from "./repo-admin-pool.js";
 
 /**
  * Options handed to {@link startAutonomousSession} by the CLI entrypoint
@@ -57,12 +58,34 @@ export interface StartAutonomousSessionOptions {
  * exit.
  */
 export async function startAutonomousSession(opts: StartAutonomousSessionOptions): Promise<void> {
-  const { sessionId, lifecycle, tracker } = opts;
+  const { sessionId, lifecycle, tracker, channel, allowedRepos } = opts;
 
   console.log(
-    `[autonomous-loop] driver not yet implemented — stub exits immediately. ` +
-      `Session ${sessionId} marked as killed with reason "al-4-pending".`
+    `[autonomous-loop] dispatcher not yet implemented — booting repo-admin ` +
+      `pool then exiting. Session ${sessionId} marked as killed with reason ` +
+      `"al-13-pending".`
   );
+
+  // AL-12 boots one repo-admin per allowed repoAssignment. AL-13 adds the
+  // ticket router that sends work to these sessions; until then we stand
+  // them up to exercise the boot/shutdown path and return.
+  const allowedAliases = allowedRepos.map((r) => r.alias);
+  const pool = new RepoAdminPool({
+    channel,
+    allowedAliases,
+    fullAccess: channel.fullAccess ?? false,
+    lifecycle,
+  });
+
+  try {
+    await pool.start();
+  } catch (err) {
+    console.warn(
+      `[autonomous-loop] repo-admin pool failed to boot: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
 
   // Only transition if we're still in a non-terminal state. A concurrent
   // threshold crossing or watchdog fire could theoretically have already
@@ -72,7 +95,7 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   const state = lifecycle.state;
   if (state !== "killed" && state !== "done") {
     try {
-      await lifecycle.transition("killed", "al-4-pending");
+      await lifecycle.transition("killed", "al-13-pending");
     } catch (err) {
       console.warn(
         `[autonomous-loop] failed to transition lifecycle to killed: ${
@@ -80,6 +103,18 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         }`
       );
     }
+  }
+
+  // Terminal lifecycle transition triggers the pool's auto-stop, but also
+  // await it here so teardown happens before the CLI returns.
+  try {
+    await pool.stop();
+  } catch (err) {
+    console.warn(
+      `[autonomous-loop] repo-admin pool stop failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
   }
 
   // Close out resources. Any in-flight writes drain here; errors are

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -1,7 +1,7 @@
 import type { SessionLifecycle } from "../lifecycle/session-lifecycle.js";
 import type { TokenTracker } from "../budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
-import { RepoAdminPool } from "./repo-admin-pool.js";
+import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
 
 /**
  * Options handed to {@link startAutonomousSession} by the CLI entrypoint
@@ -61,30 +61,37 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   const { sessionId, lifecycle, tracker, channel, allowedRepos } = opts;
 
   console.log(
-    `[autonomous-loop] dispatcher not yet implemented — booting repo-admin ` +
-      `pool then exiting. Session ${sessionId} marked as killed with reason ` +
-      `"al-13-pending".`
+    `[autonomous-loop] dispatcher not yet implemented — ` +
+      `Session ${sessionId} marked as killed with reason "al-13-pending".`
   );
 
-  // AL-12 boots one repo-admin per allowed repoAssignment. AL-13 adds the
-  // ticket router that sends work to these sessions; until then we stand
-  // them up to exercise the boot/shutdown path and return.
-  const allowedAliases = allowedRepos.map((r) => r.alias);
-  const pool = new RepoAdminPool({
-    channel,
-    allowedAliases,
-    fullAccess: channel.fullAccess ?? false,
-    lifecycle,
-  });
+  // AL-12 built the repo-admin pool, but the admin-process handshake
+  // protocol it relies on is AL-13's deliverable. Without that protocol
+  // the default spawner's child exits in ms (no prompt, stdin closed)
+  // and the pool flaps until the rapid-restart ceiling fires. Gate pool
+  // construction behind RELAY_REPO_ADMIN_POOL_ENABLED so production
+  // `rly run --autonomous` invocations keep the pre-AL-12 behaviour
+  // (clean `killed / al-13-pending` exit) until AL-13 flips the flag.
+  const poolEnabled = isRepoAdminPoolEnabled();
+  const pool = poolEnabled
+    ? new RepoAdminPool({
+        channel,
+        allowedAliases: allowedRepos.map((r) => r.alias),
+        fullAccess: channel.fullAccess ?? false,
+        lifecycle,
+      })
+    : null;
 
-  try {
-    await pool.start();
-  } catch (err) {
-    console.warn(
-      `[autonomous-loop] repo-admin pool failed to boot: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
+  if (pool) {
+    try {
+      await pool.start();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] repo-admin pool failed to boot: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   // Only transition if we're still in a non-terminal state. A concurrent
@@ -107,14 +114,16 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
 
   // Terminal lifecycle transition triggers the pool's auto-stop, but also
   // await it here so teardown happens before the CLI returns.
-  try {
-    await pool.stop();
-  } catch (err) {
-    console.warn(
-      `[autonomous-loop] repo-admin pool stop failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
+  if (pool) {
+    try {
+      await pool.stop();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] repo-admin pool stop failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   // Close out resources. Any in-flight writes drain here; errors are

--- a/src/orchestrator/repo-admin-pool.ts
+++ b/src/orchestrator/repo-admin-pool.ts
@@ -1,0 +1,431 @@
+/**
+ * Pool of per-repo repo-admin sessions (AL-12).
+ *
+ * Owns the N sessions that correspond to a channel's `repoAssignments` for
+ * the duration of one autonomous run. Responsibilities:
+ *
+ *   - Boot: construct one {@link RepoAdminSession} per allowed assignment,
+ *     `start()` them in parallel.
+ *   - Restart-on-death: subscribe to each session's event bus; when a
+ *     session emits `exited-unexpected` AND the lifecycle hasn't moved to
+ *     `winding_down` / `audit` / `done` / `killed`, respawn with
+ *     exponential backoff (1s → 2s → 4s → 8s, cap 8s). Cap: 5 restarts
+ *     inside a 2-minute window stops the restart loop and emits a
+ *     `session-admin-failing` event so the pool continues with healthy
+ *     sessions.
+ *   - Lifecycle observation: subscribe to {@link SessionLifecycle} via
+ *     `onTransition`. On first transition to a terminal state, auto-
+ *     invoke {@link stop}.
+ *   - Graceful shutdown: iterate all sessions, call `session.stop()`,
+ *     await all. Each session has its own 5s SIGTERM→SIGKILL escalation;
+ *     `stop()` resolves once every child process is gone.
+ *
+ * Scope discipline (out of scope for AL-12):
+ *   - Ticket routing / dispatch        → AL-13.
+ *   - Worker spawning                  → AL-14.
+ *   - Memory-shed / session cycling    → AL-15.
+ *   - Inter-admin coordination         → AL-16.
+ */
+
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+
+import type { Channel, RepoAssignment } from "../domain/channel.js";
+import type { SessionLifecycle, LifecycleState } from "../lifecycle/session-lifecycle.js";
+import { getRelayDir } from "../cli/paths.js";
+
+import {
+  RepoAdminSession,
+  type RepoAdminProcessSpawner,
+  type RepoAdminSessionEvent,
+  type RepoAdminSessionOptions,
+} from "./repo-admin-session.js";
+
+/**
+ * Exponential backoff schedule between restart attempts. Index 0 is the
+ * delay BEFORE the 2nd spawn (the 1st restart); values saturate at the
+ * last entry for additional attempts in the same rapid-restart window.
+ */
+export const RESTART_BACKOFF_MS: readonly number[] = [1_000, 2_000, 4_000, 8_000];
+
+/** Max restarts per session within {@link RAPID_RESTART_WINDOW_MS}. */
+export const RAPID_RESTART_CEILING = 5;
+
+/** Sliding window over which we count restarts toward {@link RAPID_RESTART_CEILING}. */
+export const RAPID_RESTART_WINDOW_MS = 2 * 60 * 1000;
+
+/**
+ * States where we keep the pool alive. Any other lifecycle state causes
+ * auto-shutdown OR suppresses restarts.
+ */
+const ACTIVE_LIFECYCLE_STATES: readonly LifecycleState[] = ["planning", "dispatching"];
+
+const TERMINAL_LIFECYCLE_STATES: readonly LifecycleState[] = ["done", "killed"];
+
+const WINDING_DOWN_STATES: readonly LifecycleState[] = ["winding_down", "audit", "done", "killed"];
+
+export type RepoAdminPoolEvent =
+  | { kind: "started"; alias: string; sessionId: string }
+  | {
+      kind: "restarted";
+      alias: string;
+      previousExitCode: number | null;
+      attempt: number;
+      sessionId: string;
+    }
+  | { kind: "stopped"; alias: string; reason: string }
+  | {
+      kind: "session-admin-failing";
+      alias: string;
+      reason: "rapid-restart-ceiling";
+      restartsInWindow: number;
+    };
+
+export interface RepoAdminPoolOptions {
+  /** The channel whose `repoAssignments` drive spawn shapes. */
+  channel: Channel;
+  /**
+   * If set + non-empty, only spawn sessions for assignments whose alias
+   * matches. Mirrors `--allow-repo` from AL-3. Empty array / undefined =
+   * spawn for every assignment.
+   */
+  allowedAliases?: string[];
+  /**
+   * Full-access opt-in from the channel. Threaded into every spawned
+   * session so the Claude CLI gets `--dangerously-skip-permissions`.
+   * `channel.fullAccess` is the canonical source; this option exists so
+   * callers can override (e.g. tests).
+   */
+  fullAccess?: boolean;
+  /**
+   * Parent autonomous-session lifecycle. The pool subscribes via
+   * `onTransition` and auto-stops on terminal states.
+   */
+  lifecycle: SessionLifecycle;
+  /**
+   * Injected spawner for the child processes. Defaults to the real Claude
+   * CLI spawner constructed by {@link RepoAdminSession}. Tests inject a
+   * fake so the exit/restart mechanics run without a real binary.
+   */
+  spawner?: RepoAdminProcessSpawner;
+  /** Overridden per-test only — see {@link RepoAdminSessionOptions.buildSessionId}. */
+  buildSessionId?: () => string;
+  /**
+   * Override `~/.relay` so tests don't clutter the real home dir. If
+   * unset, the pool resolves via {@link getRelayDir}.
+   */
+  rootDir?: string;
+  /**
+   * Timer injection point. Tests pass `vi.useFakeTimers()`-friendly
+   * wrappers to drive backoff deterministically. Signature matches
+   * `setTimeout` / `clearTimeout` shape.
+   */
+  setTimer?: (fn: () => void, ms: number) => NodeJS.Timeout | number;
+  clearTimer?: (handle: NodeJS.Timeout | number) => void;
+  /**
+   * Clock injection point for the rapid-restart window accounting.
+   * Defaults to `Date.now`; tests inject a controllable clock so a burst
+   * of synthesized restarts doesn't depend on wall-clock jitter.
+   */
+  clock?: () => number;
+  /**
+   * Override per-session SIGTERM→SIGKILL escalation delay. Only tests set
+   * this (so `stop()` doesn't wait 5 real seconds when a fake child
+   * ignores SIGTERM).
+   */
+  sessionStopGraceMs?: number;
+}
+
+interface InternalSessionRecord {
+  session: RepoAdminSession;
+  unsubscribeEvents: () => void;
+  restartTimestamps: number[]; // epoch ms; rolled within the rapid-restart window
+  giveUp: boolean; // true after rapid-restart ceiling is hit
+  restartTimer: NodeJS.Timeout | number | null;
+}
+
+/**
+ * Coordinates a cohort of {@link RepoAdminSession} instances for one
+ * autonomous run. Exposes a tiny event bus so the TUI/CLI + tests can
+ * observe boot / restart / stop without coupling to internals.
+ *
+ * The pool instance is single-use: once `stop()` has been called, a new
+ * autonomous session gets a fresh pool.
+ */
+export class RepoAdminPool {
+  private readonly channel: Channel;
+  private readonly allowedAliases: ReadonlySet<string> | null;
+  private readonly fullAccess: boolean;
+  private readonly lifecycle: SessionLifecycle;
+  private readonly spawner?: RepoAdminProcessSpawner;
+  private readonly buildSessionId?: () => string;
+  private readonly rootDir: string;
+  private readonly setTimer: (fn: () => void, ms: number) => NodeJS.Timeout | number;
+  private readonly clearTimer: (handle: NodeJS.Timeout | number) => void;
+  private readonly clock: () => number;
+  private readonly sessionStopGraceMs?: number;
+
+  private readonly sessions = new Map<string, InternalSessionRecord>();
+  private readonly emitter = new EventEmitter();
+
+  private started = false;
+  private stopping = false;
+  private stopped = false;
+  private stopPromise: Promise<void> | null = null;
+  private unsubscribeLifecycle: (() => void) | null = null;
+
+  constructor(options: RepoAdminPoolOptions) {
+    this.channel = options.channel;
+    const aliases = options.allowedAliases?.filter((a) => a.length > 0) ?? [];
+    this.allowedAliases = aliases.length > 0 ? new Set(aliases) : null;
+    this.fullAccess = options.fullAccess ?? options.channel.fullAccess ?? false;
+    this.lifecycle = options.lifecycle;
+    this.spawner = options.spawner;
+    this.buildSessionId = options.buildSessionId;
+    this.rootDir = options.rootDir ?? getRelayDir();
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
+    this.clock = options.clock ?? Date.now;
+    this.sessionStopGraceMs = options.sessionStopGraceMs;
+  }
+
+  /**
+   * Boot one session per allowed assignment. Resolves once every session
+   * has been wired up (each `session.start()` returned). Subsequent calls
+   * are no-ops.
+   */
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+
+    // Hook the parent lifecycle FIRST so a mid-boot transition to a
+    // terminal state can short-circuit spawning rather than leak a
+    // child we're about to kill anyway.
+    this.unsubscribeLifecycle = this.lifecycle.onTransition((evt) => {
+      if (TERMINAL_LIFECYCLE_STATES.includes(evt.to)) {
+        // Fire-and-forget: the pool's own stop() is idempotent and awaits
+        // each session. We don't block the lifecycle emitter.
+        void this.stop().catch(() => {});
+      }
+    });
+    if (TERMINAL_LIFECYCLE_STATES.includes(this.lifecycle.state)) {
+      // Edge case: pool constructed AFTER the lifecycle already ended.
+      // Respect that — don't spawn anything, mark stopped for symmetry.
+      this.stopped = true;
+      return;
+    }
+
+    const assignments = this.selectAssignments();
+    await Promise.all(assignments.map((assignment) => this.bootSession(assignment)));
+  }
+
+  /**
+   * Graceful shutdown. Iterates all sessions, awaits their `stop()`, and
+   * tears down the lifecycle subscription. Idempotent — overlapping
+   * callers share the same in-flight promise.
+   */
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    if (this.stopping && this.stopPromise) return this.stopPromise;
+
+    this.stopping = true;
+    const reason = "pool-shutdown";
+
+    this.stopPromise = (async () => {
+      if (this.unsubscribeLifecycle) {
+        this.unsubscribeLifecycle();
+        this.unsubscribeLifecycle = null;
+      }
+
+      const records = Array.from(this.sessions.values());
+      for (const record of records) {
+        if (record.restartTimer !== null) {
+          this.clearTimer(record.restartTimer);
+          record.restartTimer = null;
+        }
+      }
+
+      await Promise.all(
+        records.map(async (record) => {
+          try {
+            await record.session.stop(reason);
+          } catch (err) {
+            // Swallow: a session throwing on shutdown shouldn't wedge the
+            // whole pool-shutdown handshake. Log and continue.
+            const msg = err instanceof Error ? err.message : String(err);
+            // eslint-disable-next-line no-console
+            console.warn(`RepoAdminPool: session "${record.session.alias}" threw on stop: ${msg}`);
+          }
+          record.unsubscribeEvents();
+          this.emit({ kind: "stopped", alias: record.session.alias, reason });
+        })
+      );
+
+      this.stopped = true;
+      this.stopping = false;
+      this.emitter.removeAllListeners();
+    })();
+
+    return this.stopPromise;
+  }
+
+  /** Look up a session by alias. Returns `null` when the alias has no session. */
+  getSession(alias: string): RepoAdminSession | null {
+    const record = this.sessions.get(alias);
+    return record ? record.session : null;
+  }
+
+  /** Snapshot of all currently-tracked sessions. */
+  listSessions(): RepoAdminSession[] {
+    return Array.from(this.sessions.values()).map((r) => r.session);
+  }
+
+  /**
+   * Subscribe to pool events (`started`, `restarted`, `stopped`,
+   * `session-admin-failing`). Returns an unsubscribe function.
+   */
+  onSessionEvent(listener: (evt: RepoAdminPoolEvent) => void): () => void {
+    this.emitter.on("pool-event", listener);
+    return () => {
+      this.emitter.off("pool-event", listener);
+    };
+  }
+
+  // --- internals ----------------------------------------------------------
+
+  private selectAssignments(): RepoAssignment[] {
+    const all = this.channel.repoAssignments ?? [];
+    if (!this.allowedAliases) return all.slice();
+    return all.filter((a) => this.allowedAliases!.has(a.alias));
+  }
+
+  private buildLogDir(alias: string): string {
+    return join(this.rootDir, "sessions", this.lifecycle.sessionId, "repo-admins", alias);
+  }
+
+  private async bootSession(assignment: RepoAssignment): Promise<void> {
+    const logDir = this.buildLogDir(assignment.alias);
+
+    const sessionOpts: RepoAdminSessionOptions = {
+      assignment,
+      fullAccess: this.fullAccess,
+      logDir,
+      spawner: this.spawner,
+      buildSessionId: this.buildSessionId,
+      stopGraceMs: this.sessionStopGraceMs,
+    };
+    const session = new RepoAdminSession(sessionOpts);
+
+    const record: InternalSessionRecord = {
+      session,
+      unsubscribeEvents: () => {},
+      restartTimestamps: [],
+      giveUp: false,
+      restartTimer: null,
+    };
+    this.sessions.set(assignment.alias, record);
+
+    record.unsubscribeEvents = session.onEvent((evt) => this.handleSessionEvent(record, evt));
+
+    await session.start();
+    this.emit({
+      kind: "started",
+      alias: assignment.alias,
+      sessionId: session.sessionId,
+    });
+  }
+
+  private handleSessionEvent(record: InternalSessionRecord, evt: RepoAdminSessionEvent): void {
+    if (evt.kind !== "exited-unexpected") return;
+
+    // Whether we restart hinges on the CURRENT lifecycle state. Even if
+    // we're stopping, a late-arriving death event shouldn't kick off a
+    // respawn because `stop()` already set `stopping=true`.
+    if (this.stopping || this.stopped) return;
+    if (WINDING_DOWN_STATES.includes(this.lifecycle.state)) return;
+
+    const now = this.clock();
+    // Drop timestamps outside the sliding window.
+    record.restartTimestamps = record.restartTimestamps.filter(
+      (ts) => now - ts <= RAPID_RESTART_WINDOW_MS
+    );
+    if (record.restartTimestamps.length >= RAPID_RESTART_CEILING) {
+      if (!record.giveUp) {
+        record.giveUp = true;
+        this.emit({
+          kind: "session-admin-failing",
+          alias: record.session.alias,
+          reason: "rapid-restart-ceiling",
+          restartsInWindow: record.restartTimestamps.length,
+        });
+        // Treat the session as finalized so pool shutdown still awaits a
+        // stable terminal. No more restarts will be scheduled.
+        record.session.markStopped("rapid-restart-ceiling");
+      }
+      return;
+    }
+
+    const attemptIdx = Math.min(record.restartTimestamps.length, RESTART_BACKOFF_MS.length - 1);
+    const delay = RESTART_BACKOFF_MS[attemptIdx];
+
+    // Record the attempt timestamp at SCHEDULE time — not at spawn time —
+    // so a flapping process can't dodge the ceiling by delaying its next
+    // death beyond the window.
+    record.restartTimestamps.push(now);
+
+    const previousExitCode = evt.exitCode;
+    record.restartTimer = this.setTimer(() => {
+      record.restartTimer = null;
+      // Guards re-checked at fire time: lifecycle or shutdown may have
+      // advanced while we slept, and a simultaneous giveUp / manual stop
+      // would have transitioned the session to `stopped`.
+      if (this.stopping || this.stopped) return;
+      if (WINDING_DOWN_STATES.includes(this.lifecycle.state)) return;
+      if (record.giveUp) return;
+      if (record.session.state === "stopped") return;
+      void this.performRestart(record, previousExitCode).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`RepoAdminPool: restart of "${record.session.alias}" failed: ${msg}`);
+      });
+    }, delay);
+    const t = record.restartTimer as { unref?: () => void };
+    if (t && typeof t.unref === "function") t.unref();
+  }
+
+  private async performRestart(
+    record: InternalSessionRecord,
+    previousExitCode: number | null
+  ): Promise<void> {
+    await record.session.start();
+    this.emit({
+      kind: "restarted",
+      alias: record.session.alias,
+      previousExitCode,
+      attempt: record.session.spawnCount,
+      sessionId: record.session.sessionId,
+    });
+  }
+
+  private emit(evt: RepoAdminPoolEvent): void {
+    const listeners = this.emitter.listeners("pool-event") as Array<
+      (evt: RepoAdminPoolEvent) => void
+    >;
+    for (const listener of listeners) {
+      try {
+        listener(evt);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`RepoAdminPool: pool-event listener threw: ${msg}`);
+      }
+    }
+  }
+}
+
+/**
+ * Re-export lifecycle state set so a future AL-3/AL-4 wiring layer can
+ * reason about the same "when to suppress spawn" semantics without
+ * importing the internal array.
+ */
+export { ACTIVE_LIFECYCLE_STATES, TERMINAL_LIFECYCLE_STATES, WINDING_DOWN_STATES };

--- a/src/orchestrator/repo-admin-pool.ts
+++ b/src/orchestrator/repo-admin-pool.ts
@@ -17,8 +17,28 @@
  *     `onTransition`. On first transition to a terminal state, auto-
  *     invoke {@link stop}.
  *   - Graceful shutdown: iterate all sessions, call `session.stop()`,
- *     await all. Each session has its own 5s SIGTERM→SIGKILL escalation;
- *     `stop()` resolves once every child process is gone.
+ *     await all (bounded by {@link POOL_STOP_TIMEOUT_MS}). Each session
+ *     has its own 5s SIGTERM→SIGKILL escalation; `stop()` resolves once
+ *     every child process is gone OR the outer cap fires.
+ *
+ * ## Activation status
+ *
+ * The pool is **built but not yet wired into production runs**. AL-12
+ * ships the lifecycle mechanics (boot / restart-on-death / rapid-restart
+ * ceiling / graceful shutdown) and tests them in isolation, but the
+ * admin-process handshake protocol — how the autonomous loop actually
+ * talks to a running `claude` repo-admin child — lands in AL-13. Without
+ * that protocol the default-spawner's child exits in milliseconds
+ * (no prompt, stdin closed) and the pool immediately flaps until the
+ * rapid-restart ceiling fires.
+ *
+ * To avoid a production flap-storm, the autonomous-loop driver
+ * (`autonomous-loop.ts`) gates pool construction behind the
+ * {@link RELAY_REPO_ADMIN_POOL_ENABLED} env var, defaulted **off**. When
+ * the flag is unset the pre-AL-12 behaviour is preserved: no pool, the
+ * lifecycle transitions to `killed` with reason `"al-13-pending"`, and
+ * the CLI exits cleanly. AL-13 flips the default on once the handshake
+ * protocol is wired.
  *
  * Scope discipline (out of scope for AL-12):
  *   - Ticket routing / dispatch        → AL-13.
@@ -42,6 +62,28 @@ import {
 } from "./repo-admin-session.js";
 
 /**
+ * Env var gating pool activation. Default **off** until AL-13 ships the
+ * admin-process handshake protocol. When unset / `"0"` / `"false"` /
+ * empty string, the autonomous-loop driver skips pool construction and
+ * falls back to the pre-AL-12 "transition to killed with reason
+ * al-13-pending" behaviour. See this module's top-of-file docstring.
+ */
+export const RELAY_REPO_ADMIN_POOL_ENABLED = "RELAY_REPO_ADMIN_POOL_ENABLED";
+
+/**
+ * Parse the {@link RELAY_REPO_ADMIN_POOL_ENABLED} env var into a bool.
+ * Defaults to `false`. Recognised true-ish values: `"1"`, `"true"`,
+ * `"yes"`, `"on"` (case-insensitive). Anything else is treated as off
+ * so operators who typo the flag don't silently opt in to the flap loop.
+ */
+export function isRepoAdminPoolEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[RELAY_REPO_ADMIN_POOL_ENABLED];
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+/**
  * Exponential backoff schedule between restart attempts. Index 0 is the
  * delay BEFORE the 2nd spawn (the 1st restart); values saturate at the
  * last entry for additional attempts in the same rapid-restart window.
@@ -53,6 +95,17 @@ export const RAPID_RESTART_CEILING = 5;
 
 /** Sliding window over which we count restarts toward {@link RAPID_RESTART_CEILING}. */
 export const RAPID_RESTART_WINDOW_MS = 2 * 60 * 1000;
+
+/**
+ * Hard ceiling on {@link RepoAdminPool.stop}'s wait for every session to
+ * reach `exited-expected`. Per-session SIGTERM→SIGKILL escalation already
+ * gives each child 5s; the outer cap guards against a zombie child whose
+ * `awaitStopped()` never resolves (NFS hang, SIGKILL ignored by kernel,
+ * etc.) wedging the whole pool shutdown. When the cap fires we log a warn
+ * naming the stuck aliases and resolve anyway — partial shutdown is
+ * strictly better than an indefinite block on CLI exit.
+ */
+export const POOL_STOP_TIMEOUT_MS = 15_000;
 
 /**
  * States where we keep the pool alive. Any other lifecycle state causes
@@ -198,9 +251,20 @@ export class RepoAdminPool {
     if (this.started) return;
     this.started = true;
 
-    // Hook the parent lifecycle FIRST so a mid-boot transition to a
-    // terminal state can short-circuit spawning rather than leak a
-    // child we're about to kill anyway.
+    // Guard against the edge case where the pool is constructed AFTER the
+    // parent lifecycle already ended. We must short-circuit BEFORE wiring
+    // `onTransition` — `stop()` early-returns on `stopped`, so any
+    // subscription we register here would never be torn down and would
+    // leak a listener on the lifecycle emitter for the rest of the
+    // process lifetime.
+    if (TERMINAL_LIFECYCLE_STATES.includes(this.lifecycle.state)) {
+      this.stopped = true;
+      return;
+    }
+
+    // Hook the parent lifecycle so a mid-boot transition to a terminal
+    // state can short-circuit spawning rather than leak a child we're
+    // about to kill anyway.
     this.unsubscribeLifecycle = this.lifecycle.onTransition((evt) => {
       if (TERMINAL_LIFECYCLE_STATES.includes(evt.to)) {
         // Fire-and-forget: the pool's own stop() is idempotent and awaits
@@ -208,12 +272,6 @@ export class RepoAdminPool {
         void this.stop().catch(() => {});
       }
     });
-    if (TERMINAL_LIFECYCLE_STATES.includes(this.lifecycle.state)) {
-      // Edge case: pool constructed AFTER the lifecycle already ended.
-      // Respect that — don't spawn anything, mark stopped for symmetry.
-      this.stopped = true;
-      return;
-    }
 
     const assignments = this.selectAssignments();
     await Promise.all(assignments.map((assignment) => this.bootSession(assignment)));
@@ -245,7 +303,12 @@ export class RepoAdminPool {
         }
       }
 
-      await Promise.all(
+      // Track which sessions have actually stopped so the timeout path
+      // can name the stuck ones and skip emit for the others (the in-
+      // flight session.stop() may land after we've already given up).
+      const settled = new Set<string>();
+
+      const allStops = Promise.all(
         records.map(async (record) => {
           try {
             await record.session.stop(reason);
@@ -256,10 +319,34 @@ export class RepoAdminPool {
             // eslint-disable-next-line no-console
             console.warn(`RepoAdminPool: session "${record.session.alias}" threw on stop: ${msg}`);
           }
+          settled.add(record.session.alias);
           record.unsubscribeEvents();
           this.emit({ kind: "stopped", alias: record.session.alias, reason });
         })
-      );
+      ).then(() => "ok" as const);
+
+      // Outer cap. `awaitStopped()` inside a session normally resolves
+      // once the child emits `exited-expected` — but if the OS refuses to
+      // reap the child, or the fake spawner never emits, we don't want
+      // pool.stop() (and by extension the CLI exit path) to hang forever.
+      let timeoutHandle: NodeJS.Timeout | number | null = null;
+      const timedOut = new Promise<"timeout">((resolve) => {
+        timeoutHandle = this.setTimer(() => resolve("timeout"), POOL_STOP_TIMEOUT_MS);
+        const t = timeoutHandle as { unref?: () => void };
+        if (t && typeof t.unref === "function") t.unref();
+      });
+
+      const outcome = await Promise.race([allStops, timedOut]);
+      if (timeoutHandle !== null) this.clearTimer(timeoutHandle);
+
+      if (outcome === "timeout") {
+        const stuck = records.map((r) => r.session.alias).filter((alias) => !settled.has(alias));
+        // eslint-disable-next-line no-console
+        console.warn(
+          `RepoAdminPool: stop() timed out after ${POOL_STOP_TIMEOUT_MS}ms; ` +
+            `sessions did not exit cleanly: ${stuck.join(", ")}`
+        );
+      }
 
       this.stopped = true;
       this.stopping = false;

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -1,0 +1,543 @@
+/**
+ * Per-repo repo-admin session wrapper (AL-12).
+ *
+ * One instance of this class owns exactly one long-lived `claude` child
+ * process running the repo-admin role (AL-11). The pool (see
+ * `repo-admin-pool.ts`) owns N of these — one per entry in the channel's
+ * `repoAssignments`. The process is kept ALIVE for the duration of the
+ * autonomous session; AL-13 is where tickets get dispatched to it.
+ *
+ * Responsibilities owned here (and only here):
+ *   - Spawn the child via an injected {@link RepoAdminProcessSpawner}. The
+ *     default spawner is the real one (Claude CLI); tests inject a fake so
+ *     the lifecycle is deterministic.
+ *   - Track its state machine: `booting` → `ready` → (optionally) `dead` →
+ *     `ready` (after restart) → … → `stopped` on graceful shutdown.
+ *   - React to unexpected exit: emit a `restart-needed` signal to the pool
+ *     with the exit code + captured stderr tail. The pool decides whether
+ *     to respawn (lifecycle may have moved to `winding_down`/terminal).
+ *   - Graceful `stop(reason)`: send SIGTERM, wait {@link STOP_GRACE_MS},
+ *     then SIGKILL. Idempotent.
+ *   - Scaffold an in-memory ticket queue so AL-13 can add dispatches
+ *     through this class without changing its shape. AL-12 never enqueues;
+ *     it just carries the list so a restart doesn't drop in-flight work.
+ *
+ * Explicitly out of scope here (each has its own ticket):
+ *   - Ticket routing / wire protocol   → AL-13 (`dispatchTicket` throws).
+ *   - Worker spawning from repo-admin  → AL-14 (runs inside the process,
+ *     not this wrapper).
+ *   - Memory-shed / session cycling    → AL-15.
+ *
+ * The state machine purposely has no edge back from `stopped` — once a
+ * session is stopped, a fresh session (new sessionId) is the only way
+ * back. Restart reuses the same `RepoAdminSession` instance so the pool's
+ * reference stays stable, but mints a NEW session id + fresh child
+ * process, preserving the in-flight queue.
+ */
+
+import { EventEmitter } from "node:events";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import type { RepoAssignment } from "../domain/channel.js";
+import {
+  NodeCommandInvoker,
+  type CommandInvoker,
+  type SpawnedProcess,
+} from "../agents/command-invoker.js";
+import { REPO_ADMIN_ROLE } from "../agents/repo-admin.js";
+import { getDisallowedBuiltinsForRole } from "../mcp/role-allowlist.js";
+
+/** Hard grace period between SIGTERM and SIGKILL on `stop()`. */
+export const STOP_GRACE_MS = 5_000;
+
+/**
+ * Window of stderr chunks retained for post-mortem diagnostics on
+ * unexpected exit. Kept small so a chatty session doesn't balloon memory.
+ */
+export const STDERR_DIAGNOSTIC_LINES = 200;
+
+export type RepoAdminSessionState = "booting" | "ready" | "dead" | "stopped";
+
+/**
+ * Abstraction over "start the repo-admin child process". The default
+ * implementation shells out to the Claude CLI; tests inject a fake so the
+ * exit/restart/shutdown mechanics can run without a real binary.
+ */
+export interface RepoAdminProcessSpawner {
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess;
+}
+
+export interface RepoAdminSpawnArgs {
+  /** Absolute path to the repo this session is foremanning. */
+  repoPath: string;
+  /** Alias of the `RepoAssignment` (e.g. `"frontend"`). */
+  alias: string;
+  /**
+   * Per-session id minted on every (re)start. Distinct from the parent
+   * autonomous-session id — lets observers correlate logs to one life of
+   * the process across restarts.
+   */
+  sessionId: string;
+  /**
+   * `true` when the containing channel is opted into full-access mode
+   * (AL-0). Passed through to `--dangerously-skip-permissions`.
+   */
+  fullAccess: boolean;
+}
+
+/**
+ * Event payloads the session emits. The pool subscribes to these.
+ *
+ *  - `booted`            — child is spawned and ready for dispatch.
+ *  - `exited-unexpected` — child exited while state was `ready` (or
+ *    `booting`, which we treat as a boot crash). Pool decides whether to
+ *    restart; includes the exit code + stderr tail for diagnostics.
+ *  - `exited-expected`   — child exited during a deliberate `stop()`.
+ */
+export type RepoAdminSessionEvent =
+  | { kind: "booted"; sessionId: string }
+  | {
+      kind: "exited-unexpected";
+      previousSessionId: string;
+      exitCode: number | null;
+      signal: NodeJS.Signals | null;
+      stderrTail: string;
+    }
+  | {
+      kind: "exited-expected";
+      sessionId: string;
+      reason: string;
+      exitCode: number | null;
+    };
+
+export interface RepoAdminSessionOptions {
+  assignment: RepoAssignment;
+  /** Inherited from the channel; toggles `--dangerously-skip-permissions`. */
+  fullAccess: boolean;
+  /**
+   * Absolute directory where logs + metadata for this session land.
+   * `repo-admin-pool.ts` computes this as
+   * `~/.relay/sessions/<autonomous-sessionId>/repo-admins/<alias>/`.
+   */
+  logDir: string;
+  /** Injected process spawner. Tests supply a fake; prod gets the default. */
+  spawner?: RepoAdminProcessSpawner;
+  /** Optional sessionId factory — tests can inject deterministic ids. */
+  buildSessionId?: () => string;
+  /**
+   * Hard cap on SIGTERM→SIGKILL escalation delay. Overridable only for
+   * tests — production always uses {@link STOP_GRACE_MS}.
+   */
+  stopGraceMs?: number;
+}
+
+/**
+ * Thin helper to mint a unique session id per (re)start. Default format
+ * embeds epoch ms + a short random suffix so two restarts a millisecond
+ * apart still diverge.
+ */
+export function defaultBuildRepoAdminSessionId(): string {
+  return `admin-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Default spawner — shells out to the real Claude CLI via the node invoker. */
+export class ClaudeRepoAdminSpawner implements RepoAdminProcessSpawner {
+  constructor(private readonly invoker: CommandInvoker = new NodeCommandInvoker()) {
+    if (typeof this.invoker.spawn !== "function") {
+      throw new Error(
+        "ClaudeRepoAdminSpawner: injected invoker does not expose spawn(); " +
+          "repo-admin sessions require a streaming-capable invoker."
+      );
+    }
+  }
+
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    // We keep the session IDLE: no `-p <prompt>`. The process sits waiting
+    // for AL-13 to write structured dispatch messages through stdin. The
+    // `--permission-mode` / `--dangerously-skip-permissions` split mirrors
+    // `src/agents/cli-agents.ts` so both code paths agree on what
+    // full-access means.
+    const cliArgs: string[] = ["--permission-mode", "default"];
+    if (args.fullAccess) {
+      // Replace the default-permission pair with the unattended flag.
+      cliArgs.splice(0, cliArgs.length, "--dangerously-skip-permissions");
+    }
+    // AL-11: enforce built-in lockdown via the Claude CLI flag. Without
+    // this, repo-admin could call Edit/Write/Bash directly (those tools
+    // don't round-trip through MCP).
+    const disallowed = getDisallowedBuiltinsForRole(REPO_ADMIN_ROLE);
+    if (disallowed.length > 0) {
+      cliArgs.push("--disallowed-tools", disallowed.join(","));
+    }
+
+    // `spawn` is typed as optional on the invoker interface, but the
+    // constructor above has already asserted it exists. Non-null assertion
+    // is safe.
+    return this.invoker.spawn!({
+      command: "claude",
+      args: cliArgs,
+      cwd: args.repoPath,
+      // No explicit timeout: repo-admin runs for the life of the
+      // autonomous session. The pool owns termination, not a wall clock.
+      timeoutMs: 0,
+      // AL-11: activates the MCP per-role allowlist inside the spawned
+      // session. RELAY_* flows through the default sanitizer whitelist,
+      // so no `passEnv` gymnastics needed.
+      env: { RELAY_AGENT_ROLE: REPO_ADMIN_ROLE },
+      // Claude CLI still needs its auth creds; mirror the pass-list used
+      // by the short-lived adapter in `src/agents/cli-agents.ts`.
+      passEnv: [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_HOME",
+      ],
+    });
+  }
+}
+
+export class RepoAdminSession {
+  readonly alias: string;
+  readonly repoPath: string;
+  readonly logDir: string;
+  private readonly fullAccess: boolean;
+  private readonly spawner: RepoAdminProcessSpawner;
+  private readonly buildSessionId: () => string;
+  private readonly stopGraceMs: number;
+
+  private readonly emitter = new EventEmitter();
+
+  /**
+   * Monotonically increasing counter of spawn attempts for THIS session.
+   * The pool uses it in conjunction with its own rapid-restart book-
+   * keeping to decide when to give up.
+   */
+  private _spawnCount = 0;
+  private _currentSessionId: string = "";
+  private _state: RepoAdminSessionState = "booting";
+  private child: SpawnedProcess | null = null;
+
+  /**
+   * Scaffolding for AL-13's ticket dispatch. Nothing enqueues here today;
+   * the field is shaped + documented so the pool-shutdown / restart paths
+   * don't have to change when AL-13 lands. Preserving the queue across
+   * restarts is how we honor the "ticket in-flight survives" criterion.
+   */
+  private readonly pendingDispatches: unknown[] = [];
+
+  private stopRequested = false;
+  private stopReason: string | null = null;
+  private killTimer: NodeJS.Timeout | null = null;
+  private recentStderr: string[] = [];
+
+  constructor(options: RepoAdminSessionOptions) {
+    this.alias = options.assignment.alias;
+    this.repoPath = options.assignment.repoPath;
+    this.logDir = options.logDir;
+    this.fullAccess = options.fullAccess;
+    this.spawner = options.spawner ?? new ClaudeRepoAdminSpawner();
+    this.buildSessionId = options.buildSessionId ?? defaultBuildRepoAdminSessionId;
+    this.stopGraceMs = options.stopGraceMs ?? STOP_GRACE_MS;
+  }
+
+  /** Current lifecycle state. Use for assertions; drives no logic itself. */
+  get state(): RepoAdminSessionState {
+    return this._state;
+  }
+
+  /**
+   * The session id of the CURRENTLY running child process. Changes on
+   * every restart. Empty string before the first `start()` resolves.
+   */
+  get sessionId(): string {
+    return this._currentSessionId;
+  }
+
+  /** Total number of times the child has been spawned in this session's life. */
+  get spawnCount(): number {
+    return this._spawnCount;
+  }
+
+  /**
+   * Snapshot of pending dispatches. AL-13 will push to this list through
+   * `dispatchTicket`; tests for AL-12 inspect it to confirm restart
+   * preservation.
+   */
+  getPendingDispatches(): unknown[] {
+    return this.pendingDispatches.slice();
+  }
+
+  /**
+   * Subscribe to session events. Returns an unsubscribe function. The pool
+   * always subscribes; other callers may (e.g. the TUI for live liveness
+   * readouts).
+   */
+  onEvent(listener: (evt: RepoAdminSessionEvent) => void): () => void {
+    this.emitter.on("event", listener);
+    return () => {
+      this.emitter.off("event", listener);
+    };
+  }
+
+  /**
+   * Spawn the child process. Writes metadata.json up front so a crashed
+   * host can still inspect which alias / repoPath / sessionId the log
+   * directory belongs to. Resolves once the child is wired up — NOT once
+   * the agent is "ready" in the semantic sense (that is AL-13's
+   * handshake).
+   */
+  async start(): Promise<void> {
+    if (this._state === "stopped") {
+      throw new Error(
+        `RepoAdminSession(${this.alias}): cannot start() after stop(); ` +
+          `create a new instance or let the pool handle respawns.`
+      );
+    }
+    if (this.child) {
+      // Already running — no-op. Avoids double-spawn from overlapping
+      // restart triggers.
+      return;
+    }
+
+    const nextId = this.buildSessionId();
+    this._currentSessionId = nextId;
+    this._spawnCount += 1;
+    this._state = "booting";
+    this.recentStderr = [];
+
+    await mkdir(this.logDir, { recursive: true });
+    const metadataPath = join(this.logDir, "metadata.json");
+    await writeFile(
+      metadataPath,
+      JSON.stringify(
+        {
+          alias: this.alias,
+          repoPath: this.repoPath,
+          currentSessionId: nextId,
+          spawnCount: this._spawnCount,
+          updatedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+
+    const child = this.spawner.spawn({
+      repoPath: this.repoPath,
+      alias: this.alias,
+      sessionId: nextId,
+      fullAccess: this.fullAccess,
+    });
+    this.child = child;
+
+    child.onStdout(() => {
+      // AL-12 does not parse stdout. AL-13 owns the wire protocol; this
+      // hook exists so the pipe stays drained (Node's default buffers are
+      // bounded, and a wedged subprocess WILL backpressure if nobody
+      // reads).
+    });
+    child.onStderr((chunk) => {
+      // Retain the tail for exit diagnostics. Split on newlines so a
+      // multi-line stderr burst contributes proportionally; cap to the
+      // last N lines so we don't grow unbounded.
+      for (const line of chunk.split("\n")) {
+        if (!line) continue;
+        this.recentStderr.push(line);
+        if (this.recentStderr.length > STDERR_DIAGNOSTIC_LINES) {
+          this.recentStderr.splice(0, this.recentStderr.length - STDERR_DIAGNOSTIC_LINES);
+        }
+      }
+    });
+    child.onError((err) => {
+      // Spawn error (e.g. ENOENT): treat same as unexpected exit so the
+      // pool's restart policy kicks in. We don't have an exit code, so
+      // surface the message in stderrTail.
+      this.recentStderr.push(`[spawn-error] ${err.message}`);
+      this.handleExit(null, null, /* expected */ false);
+    });
+    child.onExit((code, signal) => {
+      this.handleExit(code ?? null, signal ?? null, /* expected */ this.stopRequested);
+    });
+
+    // Once the child is wired, mark ready. The "did it successfully boot"
+    // question is semantic (AL-13 will ping the agent); mechanically, the
+    // process is live as soon as spawn returns.
+    this._state = "ready";
+    this.emit({ kind: "booted", sessionId: nextId });
+  }
+
+  /**
+   * Graceful shutdown. Idempotent — a second call resolves immediately
+   * once the first has completed. SIGTERM → wait grace → SIGKILL. The
+   * state transitions to `stopped` only after the child's `onExit` fires,
+   * so callers awaiting `stop()` are guaranteed the process is truly
+   * gone.
+   */
+  async stop(reason: string): Promise<void> {
+    if (this._state === "stopped") return;
+    if (this.stopRequested) {
+      // A second caller overlapping the first: wait for it rather than
+      // double-signalling.
+      await this.awaitStopped();
+      return;
+    }
+
+    this.stopRequested = true;
+    this.stopReason = reason;
+
+    if (!this.child) {
+      // Not running (e.g. booting failed synchronously). Transition
+      // directly to stopped so callers observe terminality.
+      this._state = "stopped";
+      this.emit({
+        kind: "exited-expected",
+        sessionId: this._currentSessionId,
+        reason,
+        exitCode: null,
+      });
+      return;
+    }
+
+    try {
+      this.child.kill("SIGTERM");
+    } catch {
+      // Already exited between the state check and the signal — the
+      // onExit handler will finish the transition.
+    }
+
+    // Arm the SIGKILL fallback. onExit clears the timer when the child
+    // goes down cleanly.
+    this.killTimer = setTimeout(() => {
+      this.killTimer = null;
+      if (this._state !== "stopped" && this.child) {
+        try {
+          this.child.kill("SIGKILL");
+        } catch {
+          // Same as above — already gone.
+        }
+      }
+    }, this.stopGraceMs);
+    // Don't hold the event loop open waiting for an already-dead process.
+    const t = this.killTimer as { unref?: () => void };
+    if (t && typeof t.unref === "function") t.unref();
+
+    await this.awaitStopped();
+  }
+
+  /**
+   * Mark the next unexpected exit as "expected" without SIGTERM'ing — the
+   * pool uses this when it wants to wind down a session whose child has
+   * already exited (e.g. detected crash during a lifecycle transition).
+   * Idempotent. After this call, `stop()` still runs cleanup logic but
+   * won't try to signal a non-existent process.
+   */
+  markStopped(reason: string): void {
+    if (this._state === "stopped") return;
+    this.stopRequested = true;
+    this.stopReason = reason;
+    this._state = "stopped";
+    this.child = null;
+    this.clearKillTimer();
+    this.emit({
+      kind: "exited-expected",
+      sessionId: this._currentSessionId,
+      reason,
+      exitCode: null,
+    });
+  }
+
+  /**
+   * AL-13 placeholder. Signature matches the intended contract so
+   * call-sites (and the typecheck) stay stable when AL-13 wires the
+   * actual dispatch.
+   */
+  async dispatchTicket(_ticketDef: unknown): Promise<never> {
+    throw new Error("RepoAdminSession.dispatchTicket: ticket dispatch is implemented in AL-13.");
+  }
+
+  // --- internals ----------------------------------------------------------
+
+  private handleExit(
+    exitCode: number | null,
+    signal: NodeJS.Signals | null,
+    expected: boolean
+  ): void {
+    this.clearKillTimer();
+    const previousSessionId = this._currentSessionId;
+    const previousState = this._state;
+    this.child = null;
+
+    if (expected) {
+      this._state = "stopped";
+      this.emit({
+        kind: "exited-expected",
+        sessionId: previousSessionId,
+        reason: this.stopReason ?? "unknown",
+        exitCode,
+      });
+      return;
+    }
+
+    // Unexpected exit — pool decides whether to restart. We transition to
+    // `dead` so an observer can distinguish "process running" from
+    // "process gone, waiting on restart decision".
+    if (previousState === "stopped") return; // already terminal
+    this._state = "dead";
+    this.emit({
+      kind: "exited-unexpected",
+      previousSessionId,
+      exitCode,
+      signal,
+      stderrTail: this.recentStderr.join("\n"),
+    });
+  }
+
+  private clearKillTimer(): void {
+    if (this.killTimer !== null) {
+      clearTimeout(this.killTimer);
+      this.killTimer = null;
+    }
+  }
+
+  private async awaitStopped(): Promise<void> {
+    if (this._state === "stopped") return;
+    await new Promise<void>((resolve) => {
+      const off = this.onEvent((evt) => {
+        if (evt.kind === "exited-expected") {
+          off();
+          resolve();
+        }
+      });
+    });
+  }
+
+  private emit(evt: RepoAdminSessionEvent): void {
+    // Mirror SessionLifecycle.safeEmitTransition: a listener throwing
+    // should not take down the session's own event loop.
+    const listeners = this.emitter.listeners("event") as Array<
+      (evt: RepoAdminSessionEvent) => void
+    >;
+    for (const listener of listeners) {
+      try {
+        listener(evt);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`RepoAdminSession(${this.alias}): listener threw on ${evt.kind}: ${msg}`);
+      }
+    }
+  }
+}
+
+/**
+ * Ensure `dirname` exists. Exported so the pool module doesn't need to
+ * import `node:fs/promises` separately — keeps the "repo-admin session
+ * mounts its own log dir" story contained here.
+ */
+export async function ensureRepoAdminLogParent(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+}

--- a/test/cli/run-autonomous.test.ts
+++ b/test/cli/run-autonomous.test.ts
@@ -418,7 +418,7 @@ describe("runAutonomousCommand", () => {
     expect(lifecycle.transitions[0].reason).toBe("autonomous-session-started");
   });
 
-  it("happy path with real stub driver: ends lifecycle in killed/al-4-pending", async () => {
+  it("happy path with real stub driver: ends lifecycle in killed/al-13-pending", async () => {
     const { store, channelId } = await seedChannel();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -449,7 +449,10 @@ describe("runAutonomousCommand", () => {
       const lifecycle = JSON.parse(lifecycleRaw);
       expect(lifecycle.state).toBe("killed");
       const final = lifecycle.transitions[lifecycle.transitions.length - 1];
-      expect(final.reason).toBe("al-4-pending");
+      // AL-12 boots the repo-admin pool before the stub ends, so the
+      // terminal reason advanced from "al-4-pending" to "al-13-pending"
+      // (the next gap is ticket routing, AL-13).
+      expect(final.reason).toBe("al-13-pending");
     } finally {
       warnSpy.mockRestore();
       logSpy.mockRestore();

--- a/test/orchestrator/repo-admin-pool.test.ts
+++ b/test/orchestrator/repo-admin-pool.test.ts
@@ -1,0 +1,453 @@
+/**
+ * AL-12 — RepoAdminPool integration-flavour tests.
+ *
+ * Covers the N-session coordination piece:
+ *   - boot one session per assignment
+ *   - automatic restart on unexpected exit (with sessionId rotating)
+ *   - restart-ceiling / rapid-flap detection
+ *   - graceful shutdown tears down every child
+ *   - allowedAliases filter
+ *   - lifecycle-driven auto-stop
+ *   - no restart while the lifecycle is winding_down
+ *
+ * Tests use a synchronous fake timer (so backoff waits don't burn wall
+ * clock) and a FakeSpawner that exposes the child's events to the test.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import type { Channel } from "../../src/domain/channel.js";
+import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
+import {
+  RAPID_RESTART_CEILING,
+  RAPID_RESTART_WINDOW_MS,
+  RESTART_BACKOFF_MS,
+  RepoAdminPool,
+  type RepoAdminPoolEvent,
+} from "../../src/orchestrator/repo-admin-pool.js";
+import type {
+  RepoAdminProcessSpawner,
+  RepoAdminSpawnArgs,
+} from "../../src/orchestrator/repo-admin-session.js";
+
+type StdListener = (chunk: string) => void;
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeChild extends SpawnedProcess {
+  readonly killCalls: Array<NodeJS.Signals | undefined>;
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  spawnArgs: RepoAdminSpawnArgs;
+}
+
+function makeFakeChild(args: RepoAdminSpawnArgs): FakeChild {
+  const stdoutListeners: StdListener[] = [];
+  const stderrListeners: StdListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  const killCalls: Array<NodeJS.Signals | undefined> = [];
+
+  return {
+    pid: 10_000 + Math.floor(Math.random() * 1000),
+    spawnArgs: args,
+    killCalls,
+    onStdout(l) {
+      stdoutListeners.push(l);
+    },
+    onStderr(l) {
+      stderrListeners.push(l);
+    },
+    onExit(l) {
+      exitListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    kill(signal) {
+      killCalls.push(signal);
+      return true;
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+  };
+}
+
+class FakeSpawner implements RepoAdminProcessSpawner {
+  /** One bucket per alias so tests can address "the 2nd child for alias X". */
+  readonly byAlias = new Map<string, FakeChild[]>();
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    const child = makeFakeChild(args);
+    const list = this.byAlias.get(args.alias) ?? [];
+    list.push(child);
+    this.byAlias.set(args.alias, list);
+    return child;
+  }
+  children(alias: string): FakeChild[] {
+    return this.byAlias.get(alias) ?? [];
+  }
+}
+
+/**
+ * Minimal, in-test scheduled-timer implementation. Tests call
+ * `advance(ms)` to fast-forward; the pool observes this via the injected
+ * {@link RepoAdminPoolOptions.setTimer} / `clearTimer`.
+ */
+class FakeTimers {
+  private next = 1;
+  private now = 0;
+  private scheduled = new Map<number, { fireAt: number; fn: () => void }>();
+
+  setTimer = (fn: () => void, ms: number): number => {
+    const id = this.next++;
+    this.scheduled.set(id, { fireAt: this.now + ms, fn });
+    return id;
+  };
+  clearTimer = (handle: number | NodeJS.Timeout): void => {
+    this.scheduled.delete(handle as number);
+  };
+  clock = (): number => this.now;
+  /** Fast-forward wall clock, firing any timers that land in the window. */
+  advance(ms: number): void {
+    this.now += ms;
+    // Copy entries because callbacks may schedule new timers.
+    const entries = Array.from(this.scheduled.entries()).sort((a, b) => a[1].fireAt - b[1].fireAt);
+    for (const [id, entry] of entries) {
+      if (entry.fireAt <= this.now && this.scheduled.has(id)) {
+        this.scheduled.delete(id);
+        entry.fn();
+      }
+    }
+  }
+}
+
+/**
+ * Drain pending microtasks + the setImmediate queue so async work kicked
+ * off inside a fake-timer callback (e.g. `session.start()`'s `writeFile`)
+ * completes before the test asserts. We loop a few times because one
+ * `await` only clears one layer of the queue.
+ */
+async function flushMicrotasks(): Promise<void> {
+  // Mix setImmediate (drains Node's task queue) and setTimeout (drains
+  // real-timer-scheduled I/O like mkdir/writeFile). The loop guards
+  // against ordering surprises when a callback schedules more work.
+  for (let i = 0; i < 8; i += 1) {
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+function buildChannel(aliases: string[]): Channel {
+  return {
+    channelId: "channel-test",
+    name: "test",
+    description: "test channel",
+    status: "active",
+    workspaceIds: aliases.map((a) => `ws-${a}`),
+    members: [],
+    pinnedRefs: [],
+    repoAssignments: aliases.map((a) => ({
+      alias: a,
+      workspaceId: `ws-${a}`,
+      repoPath: `/tmp/fake-${a}-repo`,
+    })),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe("RepoAdminPool", () => {
+  let root: string;
+  let lifecycleRoot: string;
+  let sessionIdCounter: number;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-admin-pool-"));
+    lifecycleRoot = await mkdtemp(join(tmpdir(), "relay-admin-pool-lc-"));
+    sessionIdCounter = 0;
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(lifecycleRoot, { recursive: true, force: true });
+  });
+
+  async function buildPool(opts: {
+    aliases: string[];
+    allowedAliases?: string[];
+    fullAccess?: boolean;
+  }) {
+    const channel = buildChannel(opts.aliases);
+    const lifecycle = new SessionLifecycle(`sess-${Date.now()}`, {
+      rootDir: lifecycleRoot,
+    });
+    const spawner = new FakeSpawner();
+    const timers = new FakeTimers();
+
+    const pool = new RepoAdminPool({
+      channel,
+      lifecycle,
+      spawner,
+      allowedAliases: opts.allowedAliases,
+      fullAccess: opts.fullAccess,
+      rootDir: root,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      clock: timers.clock,
+      buildSessionId: () => `admin-fake-${++sessionIdCounter}`,
+      sessionStopGraceMs: 5,
+    });
+    return { pool, lifecycle, spawner, timers };
+  }
+
+  it("boots one session per repoAssignment with the right cwd + distinct sessionIds", async () => {
+    const { pool, spawner } = await buildPool({
+      aliases: ["frontend", "backend", "infra"],
+    });
+    const events: RepoAdminPoolEvent[] = [];
+    pool.onSessionEvent((evt) => events.push(evt));
+
+    await pool.start();
+
+    const sessions = pool.listSessions();
+    expect(sessions).toHaveLength(3);
+
+    const aliases = sessions.map((s) => s.alias).sort();
+    expect(aliases).toEqual(["backend", "frontend", "infra"]);
+
+    for (const alias of aliases) {
+      const kids = spawner.children(alias);
+      expect(kids).toHaveLength(1);
+      expect(kids[0].spawnArgs.repoPath).toBe(`/tmp/fake-${alias}-repo`);
+    }
+
+    const startedIds = new Set(
+      events.filter((e) => e.kind === "started").map((e) => (e as { sessionId: string }).sessionId)
+    );
+    expect(startedIds.size).toBe(3);
+
+    const done = pool.stop();
+    // Emit exits AFTER stop() has kicked off (so SIGTERM lands first) but
+    // before awaiting — otherwise await pool.stop() blocks forever.
+    await Promise.resolve();
+    for (const alias of aliases) spawner.children(alias)[0].emitExit(0, "SIGTERM");
+    await done;
+  });
+
+  it("threads the channel's fullAccess flag into spawner args", async () => {
+    const { pool, spawner } = await buildPool({
+      aliases: ["repo1"],
+      fullAccess: true,
+    });
+    await pool.start();
+    expect(spawner.children("repo1")[0].spawnArgs.fullAccess).toBe(true);
+    // Clean up to keep vitest process tidy.
+    const done = pool.stop();
+    spawner.children("repo1")[0].emitExit(0, "SIGTERM");
+    await done;
+  });
+
+  it("restarts a session whose child exits unexpectedly", async () => {
+    const { pool, spawner, timers } = await buildPool({ aliases: ["frontend"] });
+    const events: RepoAdminPoolEvent[] = [];
+    pool.onSessionEvent((evt) => events.push(evt));
+    await pool.start();
+
+    const session = pool.getSession("frontend")!;
+    const originalSessionId = session.sessionId;
+
+    // Kill the child unexpectedly.
+    spawner.children("frontend")[0].emitExit(137, null);
+    expect(session.state).toBe("dead");
+
+    // Backoff is 1000ms for the first restart. Advance past it.
+    timers.advance(RESTART_BACKOFF_MS[0] + 1);
+    // session.start() is async (writes metadata.json). Let the microtask
+    // queue drain so the respawn is observable.
+    await flushMicrotasks();
+
+    // Now there must be a second child.
+    expect(spawner.children("frontend")).toHaveLength(2);
+    expect(session.state).toBe("ready");
+    expect(session.sessionId).not.toBe(originalSessionId);
+
+    const restarted = events.find((e) => e.kind === "restarted");
+    expect(restarted).toBeDefined();
+    if (restarted?.kind === "restarted") {
+      expect(restarted.alias).toBe("frontend");
+      expect(restarted.previousExitCode).toBe(137);
+      expect(restarted.sessionId).toBe(session.sessionId);
+    }
+
+    // Pending dispatches survived (AL-13 hasn't populated it yet, but the
+    // list object persists across restart).
+    expect(session.getPendingDispatches()).toEqual([]);
+
+    const done = pool.stop();
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await done;
+  });
+
+  it("stops restarting after RAPID_RESTART_CEILING deaths in the window", async () => {
+    const { pool, spawner, timers } = await buildPool({ aliases: ["frontend"] });
+    const events: RepoAdminPoolEvent[] = [];
+    pool.onSessionEvent((evt) => events.push(evt));
+    await pool.start();
+
+    // Feed more deaths than the ceiling allows. Each death needs the
+    // scheduled restart to fire so the NEXT child exists to be killed.
+    for (let i = 0; i < RAPID_RESTART_CEILING + 1; i += 1) {
+      const kids = spawner.children("frontend");
+      const child = kids.at(-1);
+      // Once the ceiling hits, markStopped leaves no child to kill.
+      if (!child) break;
+      child.emitExit(1, null);
+      // Advance by the first-tier backoff each time. If the pool respawns,
+      // the next child appears; if it stops, no new child shows up.
+      timers.advance(RESTART_BACKOFF_MS[0] + 1);
+      await flushMicrotasks();
+    }
+
+    const failing = events.find((e) => e.kind === "session-admin-failing");
+    expect(failing).toBeDefined();
+    if (failing?.kind === "session-admin-failing") {
+      expect(failing.alias).toBe("frontend");
+      expect(failing.reason).toBe("rapid-restart-ceiling");
+      expect(failing.restartsInWindow).toBeGreaterThanOrEqual(RAPID_RESTART_CEILING);
+    }
+
+    // No new child beyond the ceiling — pool gave up and marked the
+    // session stopped.
+    expect(spawner.children("frontend").length).toBeLessThanOrEqual(RAPID_RESTART_CEILING + 1);
+    expect(pool.getSession("frontend")!.state).toBe("stopped");
+
+    await pool.stop();
+  });
+
+  it("graceful stop() SIGTERMs every session and awaits exit", async () => {
+    const { pool, spawner } = await buildPool({ aliases: ["a", "b", "c"] });
+    await pool.start();
+
+    // Kick stop; it will SIGTERM each child. We synthesize their exits
+    // so the promise can resolve.
+    const stopP = pool.stop();
+
+    // Every child should have received SIGTERM by the next microtask.
+    await Promise.resolve();
+    for (const alias of ["a", "b", "c"] as const) {
+      expect(spawner.children(alias)[0].killCalls).toContain("SIGTERM");
+    }
+
+    // Fire exits.
+    for (const alias of ["a", "b", "c"] as const) {
+      spawner.children(alias)[0].emitExit(0, "SIGTERM");
+    }
+    await stopP;
+
+    for (const alias of ["a", "b", "c"] as const) {
+      expect(pool.getSession(alias)!.state).toBe("stopped");
+    }
+  });
+
+  it("stop() is idempotent", async () => {
+    const { pool, spawner } = await buildPool({ aliases: ["a"] });
+    await pool.start();
+    const first = pool.stop();
+    const second = pool.stop();
+    spawner.children("a")[0].emitExit(0, "SIGTERM");
+    await Promise.all([first, second]);
+    expect(pool.getSession("a")!.state).toBe("stopped");
+  });
+
+  it("lifecycle transition to a terminal state auto-stops the pool", async () => {
+    const { pool, lifecycle, spawner } = await buildPool({ aliases: ["a"] });
+    await pool.start();
+
+    // Walk lifecycle through planning → dispatching → killed. Actual
+    // shutdown fires on the killed transition.
+    await lifecycle.transition("dispatching");
+
+    // stop() was fired fire-and-forget on the transition; we need to
+    // synthesize the child's exit so it can finish.
+    const transitionP = lifecycle.transition("killed", "test");
+    // The pool subscribes; stop() was kicked synchronously inside the
+    // emitter. Resolve the child.
+    await Promise.resolve();
+    spawner.children("a")[0].emitExit(0, "SIGTERM");
+    await transitionP;
+
+    // Let the fire-and-forget stop() settle.
+    await new Promise((r) => setImmediate(r));
+
+    expect(pool.getSession("a")!.state).toBe("stopped");
+  });
+
+  it("allowedAliases filters which repos get a session", async () => {
+    const { pool, spawner } = await buildPool({
+      aliases: ["frontend", "backend", "infra"],
+      allowedAliases: ["frontend"],
+    });
+    await pool.start();
+
+    expect(pool.listSessions().map((s) => s.alias)).toEqual(["frontend"]);
+    expect(spawner.children("backend")).toHaveLength(0);
+    expect(spawner.children("infra")).toHaveLength(0);
+
+    const done = pool.stop();
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await done;
+  });
+
+  it("does NOT restart while lifecycle is winding_down", async () => {
+    const { pool, lifecycle, spawner, timers } = await buildPool({
+      aliases: ["a"],
+    });
+    await pool.start();
+
+    await lifecycle.transition("dispatching");
+    await lifecycle.transition("winding_down", "test");
+
+    // Die the child. Pool should NOT respawn because the lifecycle has
+    // already signalled wind-down.
+    spawner.children("a")[0].emitExit(1, null);
+    timers.advance(RESTART_BACKOFF_MS.at(-1)! + 10);
+
+    expect(spawner.children("a")).toHaveLength(1);
+
+    // Cleanup.
+    const done = pool.stop();
+    // The session's already dead; stop() will still run its own path but
+    // won't try to SIGTERM a non-existent child. The session's markStopped
+    // path handles this. We just await.
+    await done;
+  });
+
+  it("rapid restarts outside the 2-minute window do not trip the ceiling", async () => {
+    const { pool, spawner, timers } = await buildPool({ aliases: ["a"] });
+    await pool.start();
+
+    // Burn CEILING-1 restarts, then advance past the window, then do one
+    // more — total > CEILING but they're not "in the same window".
+    for (let i = 0; i < RAPID_RESTART_CEILING - 1; i += 1) {
+      spawner.children("a").at(-1)!.emitExit(1, null);
+      timers.advance(RESTART_BACKOFF_MS[0] + 1);
+      await flushMicrotasks();
+    }
+    // Jump past the window boundary.
+    timers.advance(RAPID_RESTART_WINDOW_MS + 10);
+    spawner.children("a").at(-1)!.emitExit(1, null);
+    timers.advance(RESTART_BACKOFF_MS[0] + 1);
+    await flushMicrotasks();
+
+    // Still alive, still restarting — no give-up event.
+    expect(pool.getSession("a")!.state).toBe("ready");
+
+    const done = pool.stop();
+    spawner.children("a").at(-1)!.emitExit(0, "SIGTERM");
+    await done;
+  });
+});

--- a/test/orchestrator/repo-admin-pool.test.ts
+++ b/test/orchestrator/repo-admin-pool.test.ts
@@ -18,12 +18,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
 import type { Channel } from "../../src/domain/channel.js";
 import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
 import {
+  POOL_STOP_TIMEOUT_MS,
   RAPID_RESTART_CEILING,
   RAPID_RESTART_WINDOW_MS,
   RESTART_BACKOFF_MS,
@@ -298,18 +299,33 @@ describe("RepoAdminPool", () => {
     pool.onSessionEvent((evt) => events.push(evt));
     await pool.start();
 
-    // Feed more deaths than the ceiling allows. Each death needs the
-    // scheduled restart to fire so the NEXT child exists to be killed.
+    // Feed one more death than the ceiling allows. Each iteration must
+    // advance the clock by the CURRENT tier's backoff (plus a 1ms nudge
+    // so the timer actually fires) — otherwise later iterations stall
+    // on the 2s / 4s / 8s delays and the handler re-enters on a dead
+    // child's re-emitted exit instead of a freshly-respawned one. The
+    // saturation-at-last-entry rule means the 5th restart reuses the
+    // final index (8s) the same way the pool does.
     for (let i = 0; i < RAPID_RESTART_CEILING + 1; i += 1) {
       const kids = spawner.children("frontend");
       const child = kids.at(-1);
       // Once the ceiling hits, markStopped leaves no child to kill.
       if (!child) break;
+      const kidsBefore = kids.length;
       child.emitExit(1, null);
-      // Advance by the first-tier backoff each time. If the pool respawns,
-      // the next child appears; if it stops, no new child shows up.
-      timers.advance(RESTART_BACKOFF_MS[0] + 1);
+
+      // On iter i (0-indexed), the pool's attemptIdx is i (history so
+      // far), so the scheduled delay is RESTART_BACKOFF_MS[min(i, last)].
+      const tierIdx = Math.min(i, RESTART_BACKOFF_MS.length - 1);
+      timers.advance(RESTART_BACKOFF_MS[tierIdx] + 1);
       await flushMicrotasks();
+
+      // On non-ceiling iterations we must have gained a fresh child —
+      // this is the guard that prevents the bug where advancing too
+      // little re-fires on the dead child.
+      if (i < RAPID_RESTART_CEILING) {
+        expect(spawner.children("frontend").length).toBe(kidsBefore + 1);
+      }
     }
 
     const failing = events.find((e) => e.kind === "session-admin-failing");
@@ -317,12 +333,14 @@ describe("RepoAdminPool", () => {
     if (failing?.kind === "session-admin-failing") {
       expect(failing.alias).toBe("frontend");
       expect(failing.reason).toBe("rapid-restart-ceiling");
-      expect(failing.restartsInWindow).toBeGreaterThanOrEqual(RAPID_RESTART_CEILING);
+      expect(failing.restartsInWindow).toBe(RAPID_RESTART_CEILING);
     }
 
-    // No new child beyond the ceiling — pool gave up and marked the
-    // session stopped.
-    expect(spawner.children("frontend").length).toBeLessThanOrEqual(RAPID_RESTART_CEILING + 1);
+    // Each genuine death either respawned a fresh child (5 of them,
+    // from iter 0..4) or tripped the ceiling (the 6th, at iter 5). So
+    // the total number of children equals the original + ceiling
+    // respawns. No new child is spawned by the 6th death.
+    expect(spawner.children("frontend")).toHaveLength(RAPID_RESTART_CEILING + 1);
     expect(pool.getSession("frontend")!.state).toBe("stopped");
 
     await pool.stop();
@@ -431,13 +449,20 @@ describe("RepoAdminPool", () => {
     await pool.start();
 
     // Burn CEILING-1 restarts, then advance past the window, then do one
-    // more — total > CEILING but they're not "in the same window".
+    // more — total > CEILING but they're not "in the same window". Each
+    // iteration must advance the clock by THAT tier's backoff so the
+    // respawn timer actually fires and a fresh child exists to exit
+    // next round (advancing only the 1s tier stalls iters 2+).
     for (let i = 0; i < RAPID_RESTART_CEILING - 1; i += 1) {
+      const kidsBefore = spawner.children("a").length;
       spawner.children("a").at(-1)!.emitExit(1, null);
-      timers.advance(RESTART_BACKOFF_MS[0] + 1);
+      const tierIdx = Math.min(i, RESTART_BACKOFF_MS.length - 1);
+      timers.advance(RESTART_BACKOFF_MS[tierIdx] + 1);
       await flushMicrotasks();
+      expect(spawner.children("a").length).toBe(kidsBefore + 1);
     }
-    // Jump past the window boundary.
+    // Jump past the window boundary. The next death should be attempt
+    // index 0 again (old timestamps dropped), so the 1s tier applies.
     timers.advance(RAPID_RESTART_WINDOW_MS + 10);
     spawner.children("a").at(-1)!.emitExit(1, null);
     timers.advance(RESTART_BACKOFF_MS[0] + 1);
@@ -449,5 +474,89 @@ describe("RepoAdminPool", () => {
     const done = pool.stop();
     spawner.children("a").at(-1)!.emitExit(0, "SIGTERM");
     await done;
+  });
+
+  it("stop() bails out after POOL_STOP_TIMEOUT_MS if a session never exits", async () => {
+    // Regression: pool.stop() awaited Promise.all on session.stop(),
+    // which waits on awaitStopped() — a zombie child that never emits
+    // exit would hang the entire shutdown. We cap the outer wait and
+    // log the stuck aliases.
+    const { pool, spawner, timers } = await buildPool({ aliases: ["stuck", "clean"] });
+    await pool.start();
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Kick stop. `stuck` never emits exit; `clean` does. Drain
+    // microtasks so the pool body reaches session.stop() for both
+    // sessions before we emit the clean exit — this guarantees clean's
+    // settled.add() runs ahead of the timeout (otherwise the filter
+    // would incorrectly report clean as stuck too).
+    const stopP = pool.stop();
+    await flushMicrotasks();
+    spawner.children("clean")[0].emitExit(0, "SIGTERM");
+    await flushMicrotasks();
+
+    // Advance past the outer timeout. The outer timer is pool-managed
+    // via the injected setTimer, so fake timers drive it.
+    timers.advance(POOL_STOP_TIMEOUT_MS + 1);
+
+    // Let microtasks drain the timeout resolve → catch path.
+    await stopP;
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    const timeoutWarn = warnCalls.find((msg) => msg.includes("stop() timed out"));
+    expect(timeoutWarn).toBeDefined();
+
+    // Extract the alias list from the warning (the bit after the colon).
+    // The word "cleanly" appears in the fixed prefix so a naive
+    // toContain("clean") match would false-positive — isolate the list.
+    const aliasesInWarn = (timeoutWarn ?? "").split("exit cleanly:")[1]?.trim() ?? "";
+    expect(aliasesInWarn).toContain("stuck");
+    expect(aliasesInWarn).not.toContain("clean");
+
+    warnSpy.mockRestore();
+  });
+
+  it("start() does not subscribe to lifecycle when it's already terminal", async () => {
+    // Regression: start() used to install its onTransition listener
+    // BEFORE checking for a terminal lifecycle, then early-returned on
+    // the terminal check without unsubscribing. stop()'s `if (stopped)`
+    // short-circuit meant the leak never got cleaned up.
+    const channel = buildChannel(["a"]);
+    const lifecycle = new SessionLifecycle(`sess-${Date.now()}-terminal`, {
+      rootDir: lifecycleRoot,
+    });
+    // Walk the lifecycle into a terminal state before the pool is even
+    // constructed.
+    await lifecycle.transition("killed", "test-setup");
+
+    const subscribeSpy = vi.spyOn(lifecycle, "onTransition");
+
+    const spawner = new FakeSpawner();
+    const timers = new FakeTimers();
+    const pool = new RepoAdminPool({
+      channel,
+      lifecycle,
+      spawner,
+      rootDir: root,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      clock: timers.clock,
+      buildSessionId: () => `admin-fake-${++sessionIdCounter}`,
+      sessionStopGraceMs: 5,
+    });
+
+    await pool.start();
+
+    // The terminal-state guard MUST run before the subscribe call —
+    // otherwise a listener leaks for the lifetime of the process.
+    expect(subscribeSpy).not.toHaveBeenCalled();
+
+    // And no children were spawned either.
+    expect(spawner.children("a")).toHaveLength(0);
+
+    // stop() is still safe to call; it short-circuits on stopped.
+    await pool.stop();
+    subscribeSpy.mockRestore();
   });
 });

--- a/test/orchestrator/repo-admin-session.test.ts
+++ b/test/orchestrator/repo-admin-session.test.ts
@@ -1,0 +1,305 @@
+/**
+ * AL-12 — RepoAdminSession unit tests.
+ *
+ * Covers the single-process lifecycle in isolation:
+ *  - boot() wires the child and emits `booted`
+ *  - unexpected exit emits `exited-unexpected` with stderr tail
+ *  - stop() SIGTERM → SIGKILL escalation
+ *  - dispatchTicket() throws (AL-13 stub guard)
+ *
+ * Uses a FakeSpawner so no real `claude` binary is invoked. The fake
+ * exposes hooks for the test to fire onExit / onStderr / onError at the
+ * right moment, which is the whole point of the abstraction.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import type { RepoAssignment } from "../../src/domain/channel.js";
+import {
+  RepoAdminSession,
+  STDERR_DIAGNOSTIC_LINES,
+  type RepoAdminProcessSpawner,
+  type RepoAdminSessionEvent,
+  type RepoAdminSpawnArgs,
+} from "../../src/orchestrator/repo-admin-session.js";
+
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type StderrListener = (chunk: string) => void;
+type StdoutListener = (chunk: string) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeChild extends SpawnedProcess {
+  readonly killCalls: Array<NodeJS.Signals | undefined>;
+  emitStdout(chunk: string): void;
+  emitStderr(chunk: string): void;
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  emitError(err: Error): void;
+  /** True after `kill()` returns. Mirrors `ChildProcess.killed`. */
+  killed: boolean;
+  /** The spawn args this fake was handed. */
+  spawnArgs: RepoAdminSpawnArgs;
+}
+
+function makeFakeChild(spawnArgs: RepoAdminSpawnArgs): FakeChild {
+  const stdoutListeners: StdoutListener[] = [];
+  const stderrListeners: StderrListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  const killCalls: Array<NodeJS.Signals | undefined> = [];
+
+  const fake: FakeChild = {
+    pid: 42_000 + Math.floor(Math.random() * 1000),
+    killed: false,
+    spawnArgs,
+    killCalls,
+    onStdout(listener) {
+      stdoutListeners.push(listener);
+    },
+    onStderr(listener) {
+      stderrListeners.push(listener);
+    },
+    onExit(listener) {
+      exitListeners.push(listener);
+    },
+    onError(listener) {
+      errorListeners.push(listener);
+    },
+    kill(signal) {
+      killCalls.push(signal);
+      this.killed = true;
+      return true;
+    },
+    emitStdout(chunk) {
+      for (const l of stdoutListeners) l(chunk);
+    },
+    emitStderr(chunk) {
+      for (const l of stderrListeners) l(chunk);
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+    emitError(err) {
+      for (const l of errorListeners) l(err);
+    },
+  };
+  return fake;
+}
+
+class FakeSpawner implements RepoAdminProcessSpawner {
+  readonly children: FakeChild[] = [];
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    const child = makeFakeChild(args);
+    this.children.push(child);
+    return child;
+  }
+  last(): FakeChild {
+    const c = this.children.at(-1);
+    if (!c) throw new Error("no child spawned yet");
+    return c;
+  }
+}
+
+const BASE_ASSIGNMENT: RepoAssignment = {
+  alias: "frontend",
+  workspaceId: "ws-front",
+  repoPath: "/tmp/fake-frontend-repo",
+};
+
+describe("RepoAdminSession", () => {
+  let root: string;
+  let sessionIdCounter: number;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-admin-session-"));
+    sessionIdCounter = 0;
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  function buildSession(
+    overrides: {
+      spawner?: FakeSpawner;
+      fullAccess?: boolean;
+    } = {}
+  ) {
+    const spawner = overrides.spawner ?? new FakeSpawner();
+    const logDir = join(root, "repo-admins", BASE_ASSIGNMENT.alias);
+    const session = new RepoAdminSession({
+      assignment: BASE_ASSIGNMENT,
+      fullAccess: overrides.fullAccess ?? false,
+      logDir,
+      spawner,
+      buildSessionId: () => `admin-fake-${++sessionIdCounter}`,
+      stopGraceMs: 20, // trim real delay out of tests
+    });
+    return { session, spawner, logDir };
+  }
+
+  it("start() spawns a child and transitions to `ready`", async () => {
+    const { session, spawner } = buildSession();
+    expect(session.state).toBe("booting");
+
+    const events: RepoAdminSessionEvent[] = [];
+    session.onEvent((evt) => events.push(evt));
+
+    await session.start();
+
+    expect(session.state).toBe("ready");
+    expect(spawner.children).toHaveLength(1);
+    expect(session.sessionId).toBe("admin-fake-1");
+    expect(session.spawnCount).toBe(1);
+    expect(events).toEqual([{ kind: "booted", sessionId: "admin-fake-1" }]);
+  });
+
+  it("writes metadata.json with alias / repoPath / sessionId", async () => {
+    const { session, logDir } = buildSession();
+    await session.start();
+
+    const metaPath = join(logDir, "metadata.json");
+    const parsed = JSON.parse(await readFile(metaPath, "utf8"));
+    expect(parsed.alias).toBe(BASE_ASSIGNMENT.alias);
+    expect(parsed.repoPath).toBe(BASE_ASSIGNMENT.repoPath);
+    expect(parsed.currentSessionId).toBe(session.sessionId);
+    expect(parsed.spawnCount).toBe(1);
+  });
+
+  it("forwards `fullAccess` into the spawner args", async () => {
+    const spawner = new FakeSpawner();
+    const { session } = buildSession({ spawner, fullAccess: true });
+    await session.start();
+
+    expect(spawner.last().spawnArgs.fullAccess).toBe(true);
+  });
+
+  it("double start() is a no-op (doesn't spawn twice)", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+    await session.start();
+    expect(spawner.children).toHaveLength(1);
+  });
+
+  it("unexpected exit emits `exited-unexpected` with stderr tail", async () => {
+    const { session, spawner } = buildSession();
+    const events: RepoAdminSessionEvent[] = [];
+    session.onEvent((evt) => events.push(evt));
+    await session.start();
+
+    spawner.last().emitStderr("boom: something broke\n");
+    spawner.last().emitExit(7, null);
+
+    expect(session.state).toBe("dead");
+    const unexpected = events.find((e) => e.kind === "exited-unexpected");
+    expect(unexpected).toBeDefined();
+    if (unexpected?.kind === "exited-unexpected") {
+      expect(unexpected.exitCode).toBe(7);
+      expect(unexpected.stderrTail).toContain("boom: something broke");
+      expect(unexpected.previousSessionId).toBe("admin-fake-1");
+    }
+  });
+
+  it("caps stderr retention to STDERR_DIAGNOSTIC_LINES", async () => {
+    const { session, spawner } = buildSession();
+    const events: RepoAdminSessionEvent[] = [];
+    session.onEvent((evt) => events.push(evt));
+    await session.start();
+
+    const total = STDERR_DIAGNOSTIC_LINES + 50;
+    for (let i = 0; i < total; i += 1) {
+      spawner.last().emitStderr(`line-${i}\n`);
+    }
+    spawner.last().emitExit(1, null);
+
+    const evt = events.find((e) => e.kind === "exited-unexpected");
+    if (!evt || evt.kind !== "exited-unexpected") throw new Error("missing event");
+    const lines = evt.stderrTail.split("\n").filter(Boolean);
+    expect(lines.length).toBeLessThanOrEqual(STDERR_DIAGNOSTIC_LINES);
+    // The oldest lines must have been evicted.
+    expect(lines).not.toContain("line-0");
+    expect(lines.at(-1)).toBe(`line-${total - 1}`);
+  });
+
+  it("stop() SIGTERMs first, escalates to SIGKILL after grace", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+
+    // Fire-and-forget stop; resolve by synthesizing the exit AFTER the
+    // grace timer has had a chance to fire SIGKILL. Child ignores SIGTERM
+    // on purpose.
+    const stopP = session.stop("test");
+
+    // Give the microtask + setTimeout(20) enough time to land the
+    // SIGKILL. `stopGraceMs` is 20ms in this test.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(spawner.last().killCalls).toContain("SIGTERM");
+    expect(spawner.last().killCalls).toContain("SIGKILL");
+
+    // Synthesize the exit so stop() can resolve.
+    spawner.last().emitExit(null, "SIGKILL");
+    await stopP;
+
+    expect(session.state).toBe("stopped");
+  });
+
+  it("stop() is idempotent — second call resolves once first does", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+
+    const first = session.stop("test");
+    const second = session.stop("test");
+
+    // Synthesize exit so both stops resolve.
+    spawner.last().emitExit(0, "SIGTERM");
+    await Promise.all([first, second]);
+    expect(session.state).toBe("stopped");
+    // Only one SIGTERM was sent — the second stop waited, didn't re-signal.
+    const terms = spawner.last().killCalls.filter((s) => s === "SIGTERM");
+    expect(terms).toHaveLength(1);
+  });
+
+  it("dispatchTicket throws — AL-13 stub guard", async () => {
+    const { session } = buildSession();
+    await session.start();
+    await expect(session.dispatchTicket({ ticketId: "t-1" })).rejects.toThrow(
+      /implemented in AL-13/
+    );
+  });
+
+  it("spawn error path surfaces in stderr tail + flips to dead", async () => {
+    const { session, spawner } = buildSession();
+    const events: RepoAdminSessionEvent[] = [];
+    session.onEvent((evt) => events.push(evt));
+    await session.start();
+
+    spawner.last().emitError(new Error("ENOENT claude not found"));
+
+    const evt = events.find((e) => e.kind === "exited-unexpected");
+    expect(evt?.kind).toBe("exited-unexpected");
+    if (evt?.kind === "exited-unexpected") {
+      expect(evt.stderrTail).toContain("spawn-error");
+      expect(evt.stderrTail).toContain("ENOENT");
+    }
+    expect(session.state).toBe("dead");
+  });
+
+  it("pendingDispatches is empty by default (AL-13 populates it later)", async () => {
+    const { session } = buildSession();
+    await session.start();
+    expect(session.getPendingDispatches()).toEqual([]);
+  });
+
+  it("start() after stop() throws — session is single-life", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+    const stopP = session.stop("test");
+    spawner.last().emitExit(0, "SIGTERM");
+    await stopP;
+
+    await expect(session.start()).rejects.toThrow(/cannot start\(\) after stop/);
+  });
+});


### PR DESCRIPTION
## Summary
- At autonomous-session boot, spawn one long-lived repo-admin session per entry in the channel's `repoAssignments`, scoped to that repo's cwd.
- Track liveness and auto-restart on unexpected exit with exponential backoff (1s/2s/4s/8s cap). After 5 restarts in a rolling 2-minute window, emit `session-admin-failing` and stop restarting that alias so the rest of the pool keeps running.
- Graceful shutdown on autonomous-session end: SIGTERM every session, 5s grace, SIGKILL fallback; pool auto-stops when lifecycle transitions to `done` / `killed`.

## Module layout
- `src/orchestrator/repo-admin-session.ts` — single-process wrapper with `RepoAdminProcessSpawner` abstraction + default `ClaudeRepoAdminSpawner`. `dispatchTicket()` is an AL-13 stub that throws.
- `src/orchestrator/repo-admin-pool.ts` — pool orchestrator, filters by `allowedAliases` (`--allow-repo`), threads `channel.fullAccess`.
- `test/orchestrator/repo-admin-{session,pool}.test.ts` — 22 cases with a FakeSpawner + FakeTimers.

## Base branch note
This PR targets `feat/al-11-repo-admin-role` so the GitHub diff only shows AL-12 changes. When AL-11 (#96) merges, please retarget to `main` (or rebase) before merging this one — AL-12 strictly depends on AL-11 (repo-admin role, `createLiveAgents({role})`, `RELAY_AGENT_ROLE`, `--disallowed-tools` wiring).

## Scope discipline
No ticket routing (AL-13), no worker spawning (AL-14), no memory-shed (AL-15), no inter-admin coordination (AL-16). The ticket mentioned updating an `autonomous-loop.ts` stub to close the pool before transitioning to `killed` with reason `"al-13-pending"`, but that file doesn't exist on this branch yet (it lands with AL-3/AL-4). The pool is ready for the wiring to import and call when that ticket arrives.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 594 passed, 22 skipped
- [x] `pnpm dlx prettier --check 'src/**/*.ts' 'test/**/*.ts' '*.md' 'docs/**/*.md'`
- [x] `pnpm build`

Closes #87