### PR TITLE
AL-13: Ticket routing — scheduler → repo-admin

### DIFF
--- a/src/domain/agent.ts
+++ b/src/domain/agent.ts
@@ -18,7 +18,19 @@ export type WorkKind =
   | "review_changes"
   | "run_checks";
 
-export const FailureCategorySchema = z.enum(["fix_code", "fix_test", "bad_command_plan"]);
+// `routing_error` was added in AL-13 so `TicketRouter` can stamp an
+// unroutable ticket's `lastClassification.category` through the same channel
+// the scheduler already uses for retryable failures. It is NEVER produced by
+// the LLM failure classifier — the agent-facing JSON schema below keeps the
+// original three enumerants so the prompt surface stays identical, and
+// failure-routing switches treat `routing_error` as a no-op passthrough
+// (a misrouted ticket is blocked for operator attention, not retried).
+export const FailureCategorySchema = z.enum([
+  "fix_code",
+  "fix_test",
+  "bad_command_plan",
+  "routing_error",
+]);
 
 export type FailureCategory = z.infer<typeof FailureCategorySchema>;
 

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -1,7 +1,9 @@
 import type { SessionLifecycle } from "../lifecycle/session-lifecycle.js";
 import type { TokenTracker } from "../budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
+import { ChannelStore } from "../channels/channel-store.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
+import { TicketRouter } from "./ticket-router.js";
 
 /**
  * Options handed to {@link startAutonomousSession} by the CLI entrypoint
@@ -38,41 +40,48 @@ export interface StartAutonomousSessionOptions {
 }
 
 /**
- * Autonomous-loop driver entrypoint. AL-4 replaces this stub's body with
- * the real scheduler + dispatcher loop. Today (AL-3) it:
+ * Autonomous-loop driver entrypoint. AL-14 will replace the body with the
+ * real scheduler + dispatcher loop. At AL-13 the loop:
  *
- *   1. Logs a one-line "driver not yet implemented" message so operators
- *      who invoke `rly run --autonomous` on a version without AL-4 get a
- *      loud, expected signal rather than silent success.
- *   2. Transitions the lifecycle to `killed` with reason `"al-4-pending"`
- *      so the persisted `lifecycle.json` reflects a terminal state. Without
- *      this, a subsequent `rly run --autonomous` against the same session
- *      directory would replay a non-terminal state and the watchdog would
- *      still be armed.
- *   3. Drains queued writes via `close()` on both the tracker and the
- *      lifecycle so no disk IO races the process exit.
- *
- * Errors during the stub's own shutdown path are swallowed — the CLI
- * already logged a session-start decision, and a cosmetic teardown failure
- * must not turn a successful `rly run --autonomous` handoff into a non-zero
- * exit.
+ *   1. When {@link RELAY_REPO_ADMIN_POOL_ENABLED} is on:
+ *      - Boots the repo-admin pool (AL-12).
+ *      - Reads the channel's ticket board and routes each ready ticket
+ *        through {@link TicketRouter} so the matching repo-admin queues
+ *        it. Worker spawning + execution is AL-14's scope; AL-13 only
+ *        marks intent.
+ *      - Transitions the lifecycle to `killed` with reason
+ *        `"al-14-pending"` (dispatch without execution is still a stub,
+ *        but the routing stage is real — so the reason shifts).
+ *   2. When the flag is off: preserves the pre-AL-13 behaviour — no pool,
+ *      no routing, lifecycle transitions to `killed / al-13-pending`.
+ *   3. Tears down pool + lifecycle + tracker. Errors during teardown are
+ *      logged and swallowed: a cosmetic shutdown failure must not turn a
+ *      successful handoff into a non-zero CLI exit.
  */
 export async function startAutonomousSession(opts: StartAutonomousSessionOptions): Promise<void> {
   const { sessionId, lifecycle, tracker, channel, allowedRepos } = opts;
 
-  console.log(
-    `[autonomous-loop] dispatcher not yet implemented — ` +
-      `Session ${sessionId} marked as killed with reason "al-13-pending".`
-  );
-
   // AL-12 built the repo-admin pool, but the admin-process handshake
-  // protocol it relies on is AL-13's deliverable. Without that protocol
+  // protocol it relies on is AL-14's deliverable. Without that protocol
   // the default spawner's child exits in ms (no prompt, stdin closed)
   // and the pool flaps until the rapid-restart ceiling fires. Gate pool
   // construction behind RELAY_REPO_ADMIN_POOL_ENABLED so production
   // `rly run --autonomous` invocations keep the pre-AL-12 behaviour
-  // (clean `killed / al-13-pending` exit) until AL-13 flips the flag.
+  // (clean `killed / al-13-pending` exit) until AL-14 flips the flag.
   const poolEnabled = isRepoAdminPoolEnabled();
+
+  if (!poolEnabled) {
+    console.log(
+      `[autonomous-loop] dispatcher not yet implemented — ` +
+        `Session ${sessionId} marked as killed with reason "al-13-pending".`
+    );
+  } else {
+    console.log(
+      `[autonomous-loop] routing channel tickets through repo-admin pool — ` +
+        `Session ${sessionId} will mark killed with reason "al-14-pending" once routed.`
+    );
+  }
+
   const pool = poolEnabled
     ? new RepoAdminPool({
         channel,
@@ -94,6 +103,47 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     }
   }
 
+  // AL-13: drain the channel's ticket board through the router exactly
+  // once. The scheduler drains its run ledger on a loop; this autonomous
+  // stub doesn't spin — AL-14 adds the steady-state loop (poll for new
+  // tickets, watch worker completions, spawn replacements, etc.). The
+  // single pass here is enough to satisfy AL-13's "boots pool, routes
+  // tickets to admins (who queue them), exits cleanly" scope.
+  let terminalReason: "al-13-pending" | "al-14-pending" = "al-13-pending";
+  if (pool) {
+    terminalReason = "al-14-pending";
+    try {
+      const channelStore = new ChannelStore();
+      const router = new TicketRouter({ pool, channel, channelStore });
+      const boardTickets = await channelStore.readChannelTickets(channel.channelId);
+      for (const ticket of boardTickets) {
+        if (ticket.status !== "ready") continue;
+        if (ticket.source === "linear") continue; // Linear mirror is read-only.
+        try {
+          const result = await router.route(ticket);
+          if (result.kind === "unroutable") {
+            console.warn(
+              `[autonomous-loop] ticket ${ticket.ticketId} unroutable (${result.reason}); ` +
+                `surfaced to channel board as blocked.`
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[autonomous-loop] router threw on ticket ${ticket.ticketId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] ticket routing pass failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
   // Only transition if we're still in a non-terminal state. A concurrent
   // threshold crossing or watchdog fire could theoretically have already
   // pushed us to `killed`; respect that and skip the transition in that
@@ -102,7 +152,7 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   const state = lifecycle.state;
   if (state !== "killed" && state !== "done") {
     try {
-      await lifecycle.transition("killed", "al-13-pending");
+      await lifecycle.transition("killed", terminalReason);
     } catch (err) {
       console.warn(
         `[autonomous-loop] failed to transition lifecycle to killed: ${

--- a/src/orchestrator/failure-routing.ts
+++ b/src/orchestrator/failure-routing.ts
@@ -15,6 +15,12 @@ export function buildRetryObjective(
       return `${phaseGoal} Prioritize repairing tests, fixtures, mocks, or verification setup before changing product logic.`;
     case "bad_command_plan":
       return `${phaseGoal} Do not change product code first. Repair the verification command plan or execution setup.`;
+    case "routing_error":
+      // Router-sourced classifications are terminal: the ticket is blocked
+      // pending operator fix-up of `assignedAlias` / `repoAssignments`. If a
+      // routing_error ever reaches the retry path something is wrong, but
+      // falling back to the bare objective is safer than crashing the loop.
+      return phaseGoal;
   }
 }
 

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -40,6 +40,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import type { RepoAssignment } from "../domain/channel.js";
+import type { TicketLedgerEntry } from "../domain/ticket.js";
 import {
   NodeCommandInvoker,
   type CommandInvoker,
@@ -109,6 +110,19 @@ export type RepoAdminSessionEvent =
       sessionId: string;
       reason: string;
       exitCode: number | null;
+    }
+  | {
+      /**
+       * AL-13: emitted when {@link RepoAdminSession.dispatchTicket} enqueues
+       * a new ticket on the in-memory queue. The session only records
+       * *intent* here — worker spawning + execution is AL-14's scope. The
+       * event exists so observers (TUI, tests, later the autonomous-loop
+       * driver) can confirm a routing decision landed without polling the
+       * queue.
+       */
+      kind: "ticket-received";
+      sessionId: string;
+      ticketId: string;
     };
 
 export interface RepoAdminSessionOptions {
@@ -221,12 +235,19 @@ export class RepoAdminSession {
   private child: SpawnedProcess | null = null;
 
   /**
-   * Scaffolding for AL-13's ticket dispatch. Nothing enqueues here today;
-   * the field is shaped + documented so the pool-shutdown / restart paths
-   * don't have to change when AL-13 lands. Preserving the queue across
-   * restarts is how we honor the "ticket in-flight survives" criterion.
+   * In-memory queue of tickets routed to this admin. AL-13 writes here via
+   * {@link dispatchTicket}; AL-14 will drain it by spawning worker child
+   * processes. The queue is preserved across restarts — we deliberately do
+   * NOT clear it in `handleExit` so an unexpected death followed by the
+   * pool's respawn leaves in-flight work intact.
+   *
+   * The contents are `TicketLedgerEntry`s (the same shape the channel's
+   * ticket board stores) rather than `TicketDefinition`s because the
+   * router's input is the ledger entry: it already carries the
+   * `assignedAlias` routing decision and the `status` the router will
+   * flip once the admin actually picks it up (AL-14).
    */
-  private readonly pendingDispatches: unknown[] = [];
+  private readonly pendingDispatches: TicketLedgerEntry[] = [];
 
   private stopRequested = false;
   private stopReason: string | null = null;
@@ -262,11 +283,24 @@ export class RepoAdminSession {
   }
 
   /**
-   * Snapshot of pending dispatches. AL-13 will push to this list through
-   * `dispatchTicket`; tests for AL-12 inspect it to confirm restart
-   * preservation.
+   * Snapshot of pending dispatches. AL-13 pushes via `dispatchTicket`;
+   * AL-14 will drain into worker processes. The array returned is a copy
+   * — callers mutating it must not expect the session to see their
+   * changes.
+   *
+   * Kept as `unknown[]` on the public surface for historical reasons (the
+   * AL-12 scaffolding typed it that way to avoid pulling in ticket shapes
+   * before they were needed). New code should prefer {@link pendingTickets}.
    */
   getPendingDispatches(): unknown[] {
+    return this.pendingDispatches.slice();
+  }
+
+  /**
+   * AL-13 + AL-14 consumer API. Returns the current pending queue, typed.
+   * Same copy semantics as {@link getPendingDispatches}.
+   */
+  pendingTickets(): TicketLedgerEntry[] {
     return this.pendingDispatches.slice();
   }
 
@@ -451,12 +485,38 @@ export class RepoAdminSession {
   }
 
   /**
-   * AL-13 placeholder. Signature matches the intended contract so
-   * call-sites (and the typecheck) stay stable when AL-13 wires the
-   * actual dispatch.
+   * AL-13: record a routing decision on this admin. The ticket is pushed
+   * onto {@link pendingDispatches} and a `ticket-received` event fires so
+   * observers can confirm the handoff landed. Worker spawning and actual
+   * execution are AL-14's scope — this method only marks intent.
+   *
+   * Idempotent: dispatching the same `ticketId` twice is a no-op on the
+   * second call (the event still fires so observers can track re-routes
+   * without duplicating work). This matches how the router is likely to
+   * behave in practice: a channel ticket board re-read that happens to
+   * cover tickets already routed in the previous scan shouldn't grow the
+   * queue unboundedly.
+   *
+   * Throws if the session has been stopped — dispatching into a dead
+   * admin is a programming error the router should catch via
+   * `pool.getSession(alias)`.
    */
-  async dispatchTicket(_ticketDef: unknown): Promise<never> {
-    throw new Error("RepoAdminSession.dispatchTicket: ticket dispatch is implemented in AL-13.");
+  async dispatchTicket(ticket: TicketLedgerEntry): Promise<void> {
+    if (this._state === "stopped") {
+      throw new Error(
+        `RepoAdminSession(${this.alias}): cannot dispatchTicket after stop(); ` +
+          `route through a fresh session.`
+      );
+    }
+    const existing = this.pendingDispatches.find((t) => t.ticketId === ticket.ticketId);
+    if (!existing) {
+      this.pendingDispatches.push(ticket);
+    }
+    this.emit({
+      kind: "ticket-received",
+      sessionId: this._currentSessionId,
+      ticketId: ticket.ticketId,
+    });
   }
 
   // --- internals ----------------------------------------------------------

--- a/src/orchestrator/ticket-router.ts
+++ b/src/orchestrator/ticket-router.ts
@@ -1,0 +1,231 @@
+/**
+ * Per-ticket routing (AL-13).
+ *
+ * The autonomous-loop driver reads the channel's ticket board and hands each
+ * ready ticket to this router. The router resolves which
+ * {@link RepoAdminSession} owns the ticket's repo, then calls
+ * `session.dispatchTicket(ticket)` so the admin can queue it for AL-14's
+ * worker-spawn pass.
+ *
+ * Resolution rules (spec from ticket AL-13, Closes #88):
+ *  1. If `ticket.assignedAlias` is set, look up the matching
+ *     `repoAssignment`. No match → unroutable (`unknown-alias`).
+ *  2. If unset, fall back to `ChannelStore.getPrimaryAssignment(channel)`.
+ *     No primary (channel has no assignments at all) → unroutable
+ *     (`no-primary-assignment`).
+ *  3. With the alias pinned, look up the `RepoAdminSession` on the pool.
+ *     No session for that alias → unroutable (`no-admin-for-alias`). This
+ *     happens when `allowedAliases` excluded the admin at pool boot, or
+ *     when the session died and the pool gave up on restarts.
+ *  4. Otherwise: call `session.dispatchTicket(ticket)` and return `routed`.
+ *
+ * Unroutable tickets MUST NOT be silently dropped. The router's caller
+ * (autonomous-loop) relies on this class to:
+ *   - stamp `ticket.status = "blocked"`
+ *   - set `lastClassification` to `{ category: "routing_error", … }` so the
+ *     reason shows up in the TUI's ticket inspector the same way a
+ *     verification failure would
+ *   - mirror the updated entry onto the channel's ticket board via
+ *     `ChannelStore.upsertChannelTickets`
+ *   - post a `status_update` to the channel feed naming the block
+ *
+ * The router itself is scope-disciplined: it does NOT spawn workers
+ * (AL-14), poll for completion (AL-14), or swap admins around (AL-15).
+ * Everything terminates inside `dispatchTicket` or the unroutable-surface
+ * helper.
+ */
+
+import type { Channel } from "../domain/channel.js";
+import type { TicketLedgerEntry } from "../domain/ticket.js";
+import type { ChannelStore } from "../channels/channel-store.js";
+import type { RepoAdminPool } from "./repo-admin-pool.js";
+
+export type TicketRouteReason =
+  | `unknown-alias:${string}`
+  | "no-primary-assignment"
+  | `no-admin-for-alias:${string}`;
+
+export interface TicketRouteRouted {
+  kind: "routed";
+  alias: string;
+}
+
+export interface TicketRouteUnroutable {
+  kind: "unroutable";
+  reason: TicketRouteReason;
+  /**
+   * Alias the router attempted to resolve to. Populated when the ticket had
+   * an explicit `assignedAlias` OR when a primary fallback resolved; absent
+   * when no alias could be determined (empty channel).
+   */
+  attemptedAlias?: string;
+}
+
+export type TicketRouteResult = TicketRouteRouted | TicketRouteUnroutable;
+
+export interface TicketRouterOptions {
+  pool: RepoAdminPool;
+  channel: Channel;
+  channelStore: ChannelStore;
+  /**
+   * Optional clock injection — tests use a deterministic one so the
+   * `updatedAt` stamp on blocked tickets is stable across runs. Defaults to
+   * `() => new Date().toISOString()`.
+   */
+  now?: () => string;
+}
+
+export class TicketRouter {
+  private readonly pool: RepoAdminPool;
+  private readonly channel: Channel;
+  private readonly channelStore: ChannelStore;
+  private readonly now: () => string;
+
+  constructor(options: TicketRouterOptions) {
+    this.pool = options.pool;
+    this.channel = options.channel;
+    this.channelStore = options.channelStore;
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  /**
+   * Route a single ticket. Returns `routed` on success. On failure, the
+   * return value describes the reason AND the ticket is mutated + mirrored
+   * to the channel board as blocked with a `routing_error` classification.
+   *
+   * This method mutates the `ticket` argument in place on the unroutable
+   * path so the caller's board snapshot reflects the new status without a
+   * re-read. The channel-store mirror is a secondary durability hop for
+   * readers that don't hold an in-memory reference.
+   */
+  async route(ticket: TicketLedgerEntry): Promise<TicketRouteResult> {
+    const resolved = this.resolveAlias(ticket);
+    if (resolved.kind === "unresolved") {
+      await this.surfaceUnroutable(ticket, resolved.reason, resolved.attempted);
+      return {
+        kind: "unroutable",
+        reason: resolved.reason,
+        ...(resolved.attempted ? { attemptedAlias: resolved.attempted } : {}),
+      };
+    }
+
+    const alias = resolved.alias;
+    const session = this.pool.getSession(alias);
+    if (!session) {
+      const reason: TicketRouteReason = `no-admin-for-alias:${alias}`;
+      await this.surfaceUnroutable(ticket, reason, alias);
+      return { kind: "unroutable", reason, attemptedAlias: alias };
+    }
+
+    // AL-14's job is what happens inside `dispatchTicket`. The router just
+    // hands off.
+    await session.dispatchTicket(ticket);
+    return { kind: "routed", alias };
+  }
+
+  // --- internals ----------------------------------------------------------
+
+  private resolveAlias(
+    ticket: TicketLedgerEntry
+  ):
+    | { kind: "resolved"; alias: string }
+    | { kind: "unresolved"; reason: TicketRouteReason; attempted?: string } {
+    const assignments = this.channel.repoAssignments ?? [];
+
+    if (ticket.assignedAlias) {
+      const match = assignments.find((a) => a.alias === ticket.assignedAlias);
+      if (!match) {
+        return {
+          kind: "unresolved",
+          reason: `unknown-alias:${ticket.assignedAlias}`,
+          attempted: ticket.assignedAlias,
+        };
+      }
+      return { kind: "resolved", alias: match.alias };
+    }
+
+    const primary = this.channelStore.getPrimaryAssignment(this.channel);
+    if (!primary) {
+      return { kind: "unresolved", reason: "no-primary-assignment" };
+    }
+    return { kind: "resolved", alias: primary.alias };
+  }
+
+  /**
+   * Mark the ticket blocked + mirror to the channel board + post a
+   * `status_update` to the feed. Best-effort writes are awaited so the
+   * caller sees the persisted state — AL-13's acceptance criteria require
+   * the block to be visible, not just attempted.
+   *
+   * Errors from the channel store are caught and logged, never thrown:
+   * losing the mirror write shouldn't mask the routing failure that the
+   * autonomous-loop driver is about to log separately.
+   */
+  private async surfaceUnroutable(
+    ticket: TicketLedgerEntry,
+    reason: TicketRouteReason,
+    attemptedAlias: string | undefined
+  ): Promise<void> {
+    const rationale = buildRationale(reason);
+    const nextAction = buildNextAction(reason);
+
+    ticket.status = "blocked";
+    ticket.lastClassification = {
+      category: "routing_error",
+      rationale,
+      nextAction,
+    };
+    ticket.updatedAt = this.now();
+
+    try {
+      await this.channelStore.upsertChannelTickets(this.channel.channelId, [ticket]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ticket-router] failed to mirror blocked ticket ${ticket.ticketId} onto channel ` +
+          `${this.channel.channelId}: ${message}`
+      );
+    }
+
+    try {
+      await this.channelStore.postEntry(this.channel.channelId, {
+        type: "status_update",
+        fromAgentId: null,
+        fromDisplayName: "Router",
+        content:
+          `Ticket ${ticket.ticketId} is unroutable: ${rationale} ` +
+          `Fix ticket's assignedAlias or the channel's repoAssignments.`,
+        metadata: {
+          ticketId: ticket.ticketId,
+          routingReason: reason,
+          ...(attemptedAlias ? { attemptedAlias } : {}),
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ticket-router] failed to post block entry for ticket ${ticket.ticketId} on channel ` +
+          `${this.channel.channelId}: ${message}`
+      );
+    }
+  }
+}
+
+function buildRationale(reason: TicketRouteReason): string {
+  if (reason.startsWith("unknown-alias:")) {
+    const alias = reason.slice("unknown-alias:".length);
+    return `Ticket's assignedAlias "${alias}" does not match any repoAssignment on the channel.`;
+  }
+  if (reason.startsWith("no-admin-for-alias:")) {
+    const alias = reason.slice("no-admin-for-alias:".length);
+    return `No repo-admin session is running for alias "${alias}" — the pool filtered it via --allow-repo or gave up after rapid restarts.`;
+  }
+  // Exhaustive: narrow reason to the remaining literal.
+  return "Channel has no repoAssignments, so the ticket cannot be routed to any primary repo.";
+}
+
+function buildNextAction(_reason: TicketRouteReason): string {
+  return "fix ticket's assignedAlias or the channel's repoAssignments";
+}

--- a/test/orchestrator/repo-admin-session.test.ts
+++ b/test/orchestrator/repo-admin-session.test.ts
@@ -5,7 +5,8 @@
  *  - boot() wires the child and emits `booted`
  *  - unexpected exit emits `exited-unexpected` with stderr tail
  *  - stop() SIGTERM → SIGKILL escalation
- *  - dispatchTicket() throws (AL-13 stub guard)
+ *  - dispatchTicket() enqueues + emits `ticket-received` (AL-13)
+ *  - dispatchTicket() rejects once the session is `stopped` (AL-13)
  *
  * Uses a FakeSpawner so no real `claude` binary is invoked. The fake
  * exposes hooks for the test to fire onExit / onStderr / onError at the
@@ -20,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
 import type { RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
 import {
   RepoAdminSession,
   STDERR_DIAGNOSTIC_LINES,
@@ -27,6 +29,28 @@ import {
   type RepoAdminSessionEvent,
   type RepoAdminSpawnArgs,
 } from "../../src/orchestrator/repo-admin-session.js";
+
+function buildLedgerEntry(ticketId: string, alias: string): TicketLedgerEntry {
+  return {
+    ticketId,
+    title: `ticket ${ticketId}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: new Date().toISOString(),
+    runId: null,
+    assignedAlias: alias,
+  };
+}
 
 type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
 type StderrListener = (chunk: string) => void;
@@ -262,11 +286,44 @@ describe("RepoAdminSession", () => {
     expect(terms).toHaveLength(1);
   });
 
-  it("dispatchTicket throws — AL-13 stub guard", async () => {
+  it("dispatchTicket enqueues the ticket and emits `ticket-received` (AL-13)", async () => {
+    const { session } = buildSession();
+    const events: RepoAdminSessionEvent[] = [];
+    session.onEvent((evt) => events.push(evt));
+    await session.start();
+
+    const ticket = buildLedgerEntry("t-1", "frontend");
+    await session.dispatchTicket(ticket);
+
+    expect(session.pendingTickets()).toHaveLength(1);
+    expect(session.pendingTickets()[0].ticketId).toBe("t-1");
+
+    const received = events.find((e) => e.kind === "ticket-received");
+    expect(received).toBeDefined();
+    if (received?.kind === "ticket-received") {
+      expect(received.ticketId).toBe("t-1");
+      expect(received.sessionId).toBe(session.sessionId);
+    }
+  });
+
+  it("dispatchTicket is idempotent on duplicate ticketIds (AL-13)", async () => {
     const { session } = buildSession();
     await session.start();
-    await expect(session.dispatchTicket({ ticketId: "t-1" })).rejects.toThrow(
-      /implemented in AL-13/
+    const ticket = buildLedgerEntry("t-dup", "frontend");
+    await session.dispatchTicket(ticket);
+    await session.dispatchTicket(ticket);
+    expect(session.pendingTickets()).toHaveLength(1);
+  });
+
+  it("dispatchTicket rejects after stop() (AL-13)", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+    const stopP = session.stop("test");
+    spawner.last().emitExit(0, "SIGTERM");
+    await stopP;
+
+    await expect(session.dispatchTicket(buildLedgerEntry("t-late", "frontend"))).rejects.toThrow(
+      /after stop/
     );
   });
 

--- a/test/orchestrator/ticket-router.test.ts
+++ b/test/orchestrator/ticket-router.test.ts
@@ -1,0 +1,340 @@
+/**
+ * AL-13 — TicketRouter unit tests.
+ *
+ * Covers the resolve→dispatch flow + the unroutable surface that the ticket
+ * spec requires (AC box 3: "Routing failures surface as a ticket status
+ * update, not a silent drop"). Uses the AL-12 `FakeSpawner` shape so pool
+ * + session lifecycles run without a real `claude` binary.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { Channel } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
+import {
+  RepoAdminPool,
+  type RepoAdminPoolOptions,
+} from "../../src/orchestrator/repo-admin-pool.js";
+import type {
+  RepoAdminProcessSpawner,
+  RepoAdminSpawnArgs,
+} from "../../src/orchestrator/repo-admin-session.js";
+import { TicketRouter } from "../../src/orchestrator/ticket-router.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+type StdListener = (chunk: string) => void;
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeChild extends SpawnedProcess {
+  readonly killCalls: Array<NodeJS.Signals | undefined>;
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  spawnArgs: RepoAdminSpawnArgs;
+}
+
+function makeFakeChild(args: RepoAdminSpawnArgs): FakeChild {
+  const stdoutListeners: StdListener[] = [];
+  const stderrListeners: StdListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  const killCalls: Array<NodeJS.Signals | undefined> = [];
+
+  return {
+    pid: 20_000 + Math.floor(Math.random() * 1000),
+    spawnArgs: args,
+    killCalls,
+    onStdout(l) {
+      stdoutListeners.push(l);
+    },
+    onStderr(l) {
+      stderrListeners.push(l);
+    },
+    onExit(l) {
+      exitListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    kill(signal) {
+      killCalls.push(signal);
+      return true;
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+  };
+}
+
+class FakeSpawner implements RepoAdminProcessSpawner {
+  readonly byAlias = new Map<string, FakeChild[]>();
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    const child = makeFakeChild(args);
+    const list = this.byAlias.get(args.alias) ?? [];
+    list.push(child);
+    this.byAlias.set(args.alias, list);
+    return child;
+  }
+  children(alias: string): FakeChild[] {
+    return this.byAlias.get(alias) ?? [];
+  }
+}
+
+function buildChannel(overrides: Partial<Channel> & { channelId: string }): Channel {
+  return {
+    channelId: overrides.channelId,
+    name: overrides.name ?? "router-test",
+    description: overrides.description ?? "router-test",
+    status: "active",
+    workspaceIds: overrides.workspaceIds ?? [],
+    members: overrides.members ?? [],
+    pinnedRefs: overrides.pinnedRefs ?? [],
+    repoAssignments: overrides.repoAssignments ?? [],
+    primaryWorkspaceId: overrides.primaryWorkspaceId,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function buildTicket(ticketId: string, assignedAlias: string | undefined): TicketLedgerEntry {
+  return {
+    ticketId,
+    title: `ticket ${ticketId}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: new Date().toISOString(),
+    runId: null,
+    ...(assignedAlias !== undefined ? { assignedAlias } : {}),
+  };
+}
+
+/**
+ * Build a pool + channel + router + ChannelStore in one go. Callers pass
+ * the aliases on the channel and (optionally) the subset the pool is
+ * allowed to boot for — mirroring the `allowedAliases` filter from AL-3 so
+ * we can exercise the "no-admin-for-alias" path.
+ */
+async function buildRouterHarness(opts: { aliases: string[]; allowedAliases?: string[] }) {
+  const root = await mkdtemp(join(tmpdir(), "router-test-"));
+  const channelsDir = join(root, "channels");
+  const lifecycleDir = join(root, "lifecycle");
+  const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+  const channelStore = new ChannelStore(channelsDir, harnessStore);
+  const repoAssignments = opts.aliases.map((a) => ({
+    alias: a,
+    workspaceId: `ws-${a}`,
+    repoPath: `/tmp/fake-${a}-repo`,
+  }));
+  // Persist the channel through the store so `postEntry` / the ticket
+  // board have a canonical directory to write into. The store mints its
+  // own `channelId`; we adopt it into our in-memory copy below.
+  const persisted = await channelStore.createChannel({
+    name: "router-test",
+    description: "router-test",
+    workspaceIds: opts.aliases.map((a) => `ws-${a}`),
+    repoAssignments,
+  });
+  const channel = buildChannel({
+    channelId: persisted.channelId,
+    workspaceIds: persisted.workspaceIds,
+    repoAssignments,
+  });
+
+  const lifecycle = new SessionLifecycle(`sess-${Date.now()}`, {
+    rootDir: lifecycleDir,
+  });
+  const spawner = new FakeSpawner();
+
+  const poolOpts: RepoAdminPoolOptions = {
+    channel,
+    lifecycle,
+    spawner,
+    allowedAliases: opts.allowedAliases,
+    rootDir: root,
+    sessionStopGraceMs: 5,
+    buildSessionId: () => `admin-${Math.random().toString(36).slice(2, 8)}`,
+  };
+  const pool = new RepoAdminPool(poolOpts);
+  await pool.start();
+
+  const router = new TicketRouter({
+    pool,
+    channel,
+    channelStore,
+    now: () => "2026-04-21T00:00:00.000Z",
+  });
+
+  const cleanup = async () => {
+    const done = pool.stop();
+    for (const alias of opts.allowedAliases ?? opts.aliases) {
+      const kids = spawner.children(alias);
+      for (const k of kids) k.emitExit(0, "SIGTERM");
+    }
+    await done;
+    await rm(root, { recursive: true, force: true });
+  };
+
+  return { pool, router, channel, channelStore, spawner, lifecycle, cleanup };
+}
+
+describe("TicketRouter", () => {
+  // Hold one harness per test so cleanup can happen even on assertion fail.
+  let cleanup: (() => Promise<void>) | null = null;
+
+  beforeEach(() => {
+    cleanup = null;
+  });
+  afterEach(async () => {
+    if (cleanup) {
+      try {
+        await cleanup();
+      } catch {
+        // Don't let teardown noise mask the real assertion failure.
+      }
+    }
+  });
+
+  it("routes a ticket with assignedAlias to the matching admin", async () => {
+    const harness = await buildRouterHarness({ aliases: ["backend", "frontend"] });
+    cleanup = harness.cleanup;
+
+    const ticket = buildTicket("t-backend", "backend");
+    const result = await harness.router.route(ticket);
+
+    expect(result).toEqual({ kind: "routed", alias: "backend" });
+
+    const backendSession = harness.pool.getSession("backend")!;
+    const frontendSession = harness.pool.getSession("frontend")!;
+    expect(backendSession.pendingTickets().map((t) => t.ticketId)).toEqual(["t-backend"]);
+    expect(frontendSession.pendingTickets()).toHaveLength(0);
+  });
+
+  it("routes a ticket to each admin when both aliases are assigned", async () => {
+    const harness = await buildRouterHarness({ aliases: ["backend", "frontend"] });
+    cleanup = harness.cleanup;
+
+    await harness.router.route(buildTicket("t-back", "backend"));
+    await harness.router.route(buildTicket("t-front", "frontend"));
+
+    expect(
+      harness.pool
+        .getSession("backend")!
+        .pendingTickets()
+        .map((t) => t.ticketId)
+    ).toEqual(["t-back"]);
+    expect(
+      harness.pool
+        .getSession("frontend")!
+        .pendingTickets()
+        .map((t) => t.ticketId)
+    ).toEqual(["t-front"]);
+  });
+
+  it("falls back to the channel's primary when assignedAlias is unset (single-repo back-compat)", async () => {
+    const harness = await buildRouterHarness({ aliases: ["primary-only"] });
+    cleanup = harness.cleanup;
+
+    const ticket = buildTicket("t-no-alias", undefined);
+    const result = await harness.router.route(ticket);
+
+    expect(result).toEqual({ kind: "routed", alias: "primary-only" });
+    expect(
+      harness.pool
+        .getSession("primary-only")!
+        .pendingTickets()
+        .map((t) => t.ticketId)
+    ).toEqual(["t-no-alias"]);
+  });
+
+  it("marks a ticket with an unknown assignedAlias blocked + posts a status update", async () => {
+    const harness = await buildRouterHarness({ aliases: ["backend", "frontend"] });
+    cleanup = harness.cleanup;
+
+    const ticket = buildTicket("t-typo", "typo");
+    const result = await harness.router.route(ticket);
+
+    expect(result.kind).toBe("unroutable");
+    if (result.kind === "unroutable") {
+      expect(result.reason).toBe("unknown-alias:typo");
+      expect(result.attemptedAlias).toBe("typo");
+    }
+
+    // Ticket mutated in place.
+    expect(ticket.status).toBe("blocked");
+    expect(ticket.lastClassification?.category).toBe("routing_error");
+    expect(ticket.lastClassification?.rationale).toMatch(/typo/);
+    expect(ticket.lastClassification?.nextAction).toMatch(/assignedAlias/);
+
+    // No admin's queue picked it up.
+    expect(harness.pool.getSession("backend")!.pendingTickets()).toHaveLength(0);
+    expect(harness.pool.getSession("frontend")!.pendingTickets()).toHaveLength(0);
+
+    // Channel board reflects the block.
+    const board = await harness.channelStore.readChannelTickets(harness.channel.channelId);
+    const mirrored = board.find((t) => t.ticketId === "t-typo");
+    expect(mirrored?.status).toBe("blocked");
+    expect(mirrored?.lastClassification?.category).toBe("routing_error");
+
+    // Channel feed carries an operator-readable note.
+    const feed = await harness.channelStore.readFeed(harness.channel.channelId);
+    const note = feed.find((e) => e.type === "status_update" && e.metadata?.ticketId === "t-typo");
+    expect(note).toBeDefined();
+    expect(note?.metadata.routingReason).toBe("unknown-alias:typo");
+  });
+
+  it("marks the ticket unroutable when no admin is booted for the alias (--allow-repo filter)", async () => {
+    const harness = await buildRouterHarness({
+      aliases: ["backend", "frontend"],
+      allowedAliases: ["backend"],
+    });
+    cleanup = harness.cleanup;
+
+    const ticket = buildTicket("t-filtered", "frontend");
+    const result = await harness.router.route(ticket);
+
+    expect(result.kind).toBe("unroutable");
+    if (result.kind === "unroutable") {
+      expect(result.reason).toBe("no-admin-for-alias:frontend");
+      expect(result.attemptedAlias).toBe("frontend");
+    }
+    expect(ticket.status).toBe("blocked");
+    expect(ticket.lastClassification?.category).toBe("routing_error");
+
+    // Backend admin's queue is still empty.
+    expect(harness.pool.getSession("backend")!.pendingTickets()).toHaveLength(0);
+    // No session exists for frontend.
+    expect(harness.pool.getSession("frontend")).toBeNull();
+  });
+
+  it("does not spawn workers while routing — scope discipline for AL-13", async () => {
+    // Each `dispatchTicket` call must not touch the process spawner (AL-14
+    // will own worker spawning). The FakeSpawner above counts every spawn
+    // via `children(alias).length`; after start() the pool has exactly one
+    // per alias, and routing tickets must not bump that count.
+    const harness = await buildRouterHarness({ aliases: ["backend"] });
+    cleanup = harness.cleanup;
+
+    const before = harness.spawner.children("backend").length;
+    await harness.router.route(buildTicket("t-1", "backend"));
+    await harness.router.route(buildTicket("t-2", "backend"));
+    const after = harness.spawner.children("backend").length;
+    expect(after).toBe(before);
+    expect(harness.pool.getSession("backend")!.pendingTickets()).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #88

## Summary
- `TicketRouter` resolves `ticket.assignedAlias` against the channel's `repoAssignments` (or `ChannelStore.getPrimaryAssignment` when unset) and hands each ticket to the matching `RepoAdminSession` via `dispatchTicket`.
- `RepoAdminSession.dispatchTicket` now enqueues on an in-memory queue and emits `ticket-received` (the AL-12 stub throw is gone); `pendingTickets()` exposes the queue for AL-14 to drain. Worker spawning stays out of scope.
- Unroutable tickets (unknown alias / no admin for alias) are mutated to `status: "blocked"` with `lastClassification.category = "routing_error"` and mirrored onto the channel ticket board + feed so operators see them — never silently dropped.
- `autonomous-loop.ts` drains the channel's ticket board through the router once per invocation when `RELAY_REPO_ADMIN_POOL_ENABLED` is on, then transitions to `killed / al-14-pending`. Flag-off preserves the pre-AL-13 `killed / al-13-pending` behaviour.
- `FailureCategory` gained `"routing_error"` for the router-sourced classification; the agent-facing JSON schema is unchanged (the LLM classifier still only picks from the original three).

## Test plan
- [x] `pnpm typecheck` (no errors).
- [x] `pnpm -C gui build` (Vite build clean).
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 654 pass, 22 skipped (integration gates).
- [x] `pnpm dlx prettier --check 'src/**/*.ts' 'test/**/*.ts' '*.md' 'docs/**/*.md' 'agent_docs/**/*.md'` (clean).
- [x] New unit coverage in `test/orchestrator/ticket-router.test.ts`:
  - routes by `assignedAlias` to the right admin's queue
  - dual-alias routing (backend + frontend) lands tickets independently
  - primary fallback when `assignedAlias` is unset
  - unknown-alias surfaces `unroutable`, mutates ticket to blocked with `routing_error`, mirrors to board + posts `status_update`
  - `no-admin-for-alias` when `allowedAliases` filtered the admin out
  - scope discipline: no extra spawns during routing (AL-14's worker spawn stays untouched)
- [x] Updated AL-12 `dispatchTicket` stub guard test → now asserts enqueue + `ticket-received` emit + idempotency + rejects-after-stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)