### PR TITLE
AL-15: Memory-shed — token-budget session cycling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -3123,7 +3123,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arboard",
  "chrono",

--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rename } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { getRelayDir } from "../cli/paths.js";
@@ -56,7 +56,7 @@ interface BudgetLine {
  * chain so concurrent `record()` calls never interleave partial lines.
  *
  * Event bus: internal `EventEmitter`. Subscribers attach via
- * `onThreshold()`. Only the four canonical thresholds (50/85/95/100) fire,
+ * `onThreshold()`. Only the canonical thresholds (50/60/85/95/100) fire,
  * and each fires at most once per tracker lifetime regardless of how many
  * API calls cross it.
  */
@@ -252,6 +252,54 @@ export class TokenTracker {
    * `record()` calls.
    */
   async flush(): Promise<void> {
+    await this.writeChain;
+  }
+
+  /**
+   * Clear the tracker's token state and rotate its JSONL file. Used to
+   * mark a process boundary (e.g. AL-15's repo-admin memory-shed cycle)
+   * where the tracker outlives the child but should not carry the pre-
+   * boundary accumulated usage into the new lifetime.
+   *
+   * Concretely, reset:
+   *   1. Awaits any in-flight writes (replay + pending `record()` drains).
+   *   2. Renames `<sessionId>/budget.jsonl` to
+   *      `<sessionId>/budget.jsonl.pre-cycle-<unix-ts>` so the pre-reset
+   *      data is preserved on disk for audit/forensics. A missing file is
+   *      a no-op — a reset before any `record()` still succeeds.
+   *   3. Zeros `_used` and clears `firedThresholds` so the next `record()`
+   *      can re-fire every threshold (50, 60, 85, 95, 100).
+   *   4. Re-serializes the post-reset state onto the write chain so
+   *      concurrent callers observe the cleared state in call order.
+   *
+   * This is specifically NOT the same as constructing a new tracker: the
+   * event subscribers stay attached, the sessionId + ceiling stay the
+   * same, and the filePath stays the same (the next `record()` will
+   * recreate `budget.jsonl` as a fresh file).
+   *
+   * Rejects if the tracker is closed.
+   */
+  async reset(): Promise<void> {
+    if (this.closed) {
+      throw new Error("TokenTracker: cannot reset after close()");
+    }
+    this.writeChain = this.writeChain.then(async () => {
+      // Rotate the existing JSONL out of the way. Missing file is fine —
+      // a tracker that never wrote has nothing to archive. Any other
+      // error is surfaced via the `error` event like append failures.
+      const rotated = `${this.filePath}.pre-cycle-${Date.now()}`;
+      try {
+        await rename(this.filePath, rotated);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          if (this.emitter.listenerCount("error") > 0) {
+            this.emitter.emit("error", err);
+          }
+        }
+      }
+      this._used = 0;
+      this.firedThresholds.clear();
+    });
     await this.writeChain;
   }
 

--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -11,8 +11,14 @@ import { getRelayDir } from "../cli/paths.js";
  *
  * Exported as a const tuple so callers (AL-3 scheduler, tests) can iterate
  * the canonical list instead of re-declaring it.
+ *
+ * The `60` entry exists primarily for AL-15's "memory-shed" cycle trigger:
+ * each repo-admin session owns its own tracker and subscribes to the 60%
+ * crossing to recycle its child process before the context window fills.
+ * Other subsystems are free to listen for 60 too; semantics are identical
+ * to the other tiers (single emit per upward crossing per tracker).
  */
-export const THRESHOLDS = [50, 85, 95, 100] as const;
+export const THRESHOLDS = [50, 60, 85, 95, 100] as const;
 
 export type ThresholdEvent = {
   sessionId: string;

--- a/src/orchestrator/repo-admin-pool.ts
+++ b/src/orchestrator/repo-admin-pool.ts
@@ -40,10 +40,12 @@
  * the CLI exits cleanly. AL-13 flips the default on once the handshake
  * protocol is wired.
  *
- * Scope discipline (out of scope for AL-12):
+ * Scope discipline:
  *   - Ticket routing / dispatch        → AL-13.
  *   - Worker spawning                  → AL-14.
- *   - Memory-shed / session cycling    → AL-15.
+ *   - Memory-shed / session cycling    → AL-15 (implemented on the
+ *     session wrapper; the pool only observes + forwards `cycled`
+ *     events). Cycles are NOT counted against the rapid-flap ceiling.
  *   - Inter-admin coordination         → AL-16.
  */
 
@@ -132,6 +134,20 @@ export type RepoAdminPoolEvent =
       alias: string;
       reason: "rapid-restart-ceiling";
       restartsInWindow: number;
+    }
+  | {
+      /**
+       * AL-15: a repo-admin session completed a memory-shed cycle. The
+       * child backing `sessionId_old` was torn down, the child backing
+       * `sessionId_new` is now live, and the session's in-flight queue
+       * survived the boundary. Observers can surface this in logs /
+       * TUI without subscribing to each individual session.
+       */
+      kind: "cycled";
+      alias: string;
+      sessionId_old: string;
+      sessionId_new: string;
+      reason: "budget-60pct" | "manual";
     };
 
 export interface RepoAdminPoolOptions {
@@ -423,6 +439,20 @@ export class RepoAdminPool {
   }
 
   private handleSessionEvent(record: InternalSessionRecord, evt: RepoAdminSessionEvent): void {
+    // AL-15: forward cycle completions to pool observers. Cycles do NOT
+    // count toward the rapid-restart ceiling (they're planned, not a
+    // crash-and-respawn), and the pending queue survives on the session
+    // wrapper — no pool-side bookkeeping needed beyond the emit.
+    if (evt.kind === "cycled") {
+      this.emit({
+        kind: "cycled",
+        alias: record.session.alias,
+        sessionId_old: evt.previousSessionId,
+        sessionId_new: evt.newSessionId,
+        reason: evt.reason,
+      });
+      return;
+    }
     if (evt.kind !== "exited-unexpected") return;
 
     // Whether we restart hinges on the CURRENT lifecycle state. Even if

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -1,5 +1,5 @@
 /**
- * Per-repo repo-admin session wrapper (AL-12).
+ * Per-repo repo-admin session wrapper (AL-12, extended by AL-15).
  *
  * One instance of this class owns exactly one long-lived `claude` child
  * process running the repo-admin role (AL-11). The pool (see
@@ -21,18 +21,24 @@
  *   - Scaffold an in-memory ticket queue so AL-13 can add dispatches
  *     through this class without changing its shape. AL-12 never enqueues;
  *     it just carries the list so a restart doesn't drop in-flight work.
+ *   - **AL-15**: own a per-session {@link TokenTracker} and the
+ *     memory-shed cycle trigger. When the tracker crosses 60%, the session
+ *     writes a one-line summary to the channel's decisions board, kills
+ *     its own child, and respawns fresh. A cycle is NOT a restart —
+ *     cycles do not count toward the pool's rapid-flap ceiling.
  *
  * Explicitly out of scope here (each has its own ticket):
- *   - Ticket routing / wire protocol   → AL-13 (`dispatchTicket` throws).
  *   - Worker spawning from repo-admin  → AL-14 (runs inside the process,
- *     not this wrapper).
- *   - Memory-shed / session cycling    → AL-15.
+ *     not this wrapper). AL-14 will also populate
+ *     `worktreesInUse`/`openPrs` on the cycle snapshot; AL-15 stubs them
+ *     as empty arrays.
+ *   - Inter-admin coordination         → AL-16.
  *
  * The state machine purposely has no edge back from `stopped` — once a
  * session is stopped, a fresh session (new sessionId) is the only way
- * back. Restart reuses the same `RepoAdminSession` instance so the pool's
- * reference stays stable, but mints a NEW session id + fresh child
- * process, preserving the in-flight queue.
+ * back. Restart AND cycle both reuse the same `RepoAdminSession` instance
+ * so the pool's reference (and the in-flight queue) stay stable, while
+ * minting a NEW session id + fresh child process underneath.
  */
 
 import { EventEmitter } from "node:events";
@@ -48,6 +54,13 @@ import {
 } from "../agents/command-invoker.js";
 import { REPO_ADMIN_ROLE } from "../agents/repo-admin.js";
 import { getDisallowedBuiltinsForRole } from "../mcp/role-allowlist.js";
+import { TokenTracker, type ThresholdEvent } from "../budget/token-tracker.js";
+import {
+  buildCycleDecision,
+  type CycleDecisionInput,
+  type CycleReason,
+  type CycleSummarySnapshot,
+} from "./session-summary.js";
 
 /** Hard grace period between SIGTERM and SIGKILL on `stop()`. */
 export const STOP_GRACE_MS = 5_000;
@@ -57,6 +70,21 @@ export const STOP_GRACE_MS = 5_000;
  * unexpected exit. Kept small so a chatty session doesn't balloon memory.
  */
 export const STDERR_DIAGNOSTIC_LINES = 200;
+
+/**
+ * AL-15: default per-session token ceiling. 150k tokens matches the
+ * Claude CLI's "roomy" long-session context, leaving headroom under a
+ * 200k-token API window. Overridable per-session via
+ * {@link RepoAdminSessionOptions.adminTokenCeiling}.
+ */
+export const DEFAULT_ADMIN_TOKEN_CEILING = 150_000;
+
+/**
+ * AL-15: the threshold (percent) at which a memory-shed cycle fires. The
+ * {@link TokenTracker} THRESHOLDS list includes 60 for this purpose.
+ * Exported so the pool's test + any future tuning lives in one place.
+ */
+export const CYCLE_THRESHOLD_PCT = 60;
 
 export type RepoAdminSessionState = "booting" | "ready" | "dead" | "stopped";
 
@@ -94,7 +122,13 @@ export interface RepoAdminSpawnArgs {
  *  - `exited-unexpected` — child exited while state was `ready` (or
  *    `booting`, which we treat as a boot crash). Pool decides whether to
  *    restart; includes the exit code + stderr tail for diagnostics.
- *  - `exited-expected`   — child exited during a deliberate `stop()`.
+ *  - `exited-expected`   — child exited during a deliberate `stop()` or
+ *    a cycle tear-down. Use `reason` to distinguish (cycles pass
+ *    `"cycle:<reason>"`).
+ *  - `cycled`            — AL-15: a memory-shed cycle completed. The old
+ *    child is gone, the new child is live under `newSessionId`. The pool
+ *    mirrors this to its own `cycled` event so observers can reason at
+ *    the pool level without subscribing to each session.
  */
 export type RepoAdminSessionEvent =
   | { kind: "booted"; sessionId: string }
@@ -123,7 +157,36 @@ export type RepoAdminSessionEvent =
       kind: "ticket-received";
       sessionId: string;
       ticketId: string;
+    }
+  | {
+      kind: "cycled";
+      previousSessionId: string;
+      newSessionId: string;
+      reason: CycleReason;
     };
+
+/**
+ * AL-15: minimal write-only view of {@link ChannelStore} the session
+ * needs. Typed as the exact method shape so a fake in tests doesn't have
+ * to stub the entire ChannelStore surface.
+ */
+export interface SessionDecisionWriter {
+  recordDecision(channelId: string, input: CycleDecisionInput): Promise<unknown>;
+}
+
+/**
+ * AL-15: wiring the session needs to write cycle summaries to the
+ * decisions board. `channelId` is required for the ChannelStore API.
+ * When unset, the session still cycles (process tear-down + respawn) but
+ * logs a warning and skips the decision write — useful for tests and
+ * for non-channel-backed sessions that might appear in future.
+ */
+export interface SessionCycleConfig {
+  /** Channel on whose board the cycle summary is recorded. */
+  channelId: string;
+  /** Decision store. Accepts `ChannelStore` in production. */
+  decisions: SessionDecisionWriter;
+}
 
 export interface RepoAdminSessionOptions {
   assignment: RepoAssignment;
@@ -144,6 +207,30 @@ export interface RepoAdminSessionOptions {
    * tests — production always uses {@link STOP_GRACE_MS}.
    */
   stopGraceMs?: number;
+  /**
+   * AL-15: declared ceiling for this admin session's own token tracker.
+   * Defaults to {@link DEFAULT_ADMIN_TOKEN_CEILING}. The tracker's 60%
+   * crossing fires a memory-shed cycle.
+   */
+  adminTokenCeiling?: number;
+  /**
+   * AL-15: inject an alternative tracker (tests). The session's default
+   * is a fresh {@link TokenTracker} keyed off the session id + log dir.
+   * A caller can pass their own tracker here to share budget across
+   * multiple sessions or to drive the cycle deterministically in tests.
+   */
+  tokenTracker?: TokenTracker;
+  /**
+   * AL-15: channel + decision-store wiring for the cycle summary entry.
+   * When omitted, the session still cycles (process tear-down + respawn)
+   * but skips the decision write.
+   */
+  cycle?: SessionCycleConfig;
+  /**
+   * AL-15: ISO-clock injection for the cycle event's `cycledAt` field.
+   * Defaults to `() => new Date().toISOString()`.
+   */
+  cycleClock?: () => string;
 }
 
 /**
@@ -254,6 +341,26 @@ export class RepoAdminSession {
   private killTimer: NodeJS.Timeout | null = null;
   private recentStderr: string[] = [];
 
+  /**
+   * AL-15: monotonic count of memory-shed cycles for this session. Used
+   * by tests + observability; the pool does NOT count cycles against its
+   * rapid-flap ceiling (that counter lives on `RepoAdminPool`).
+   */
+  private _cycleCount = 0;
+
+  /**
+   * AL-15: true while the session is in the middle of a cycle. Guards
+   * the `onExit` handler so the child's SIGTERM-driven exit is classified
+   * as expected (not a crash), and prevents overlapping cycles.
+   */
+  private cyclingReason: CycleReason | null = null;
+  private cyclePromise: Promise<void> | null = null;
+  private readonly tokenTracker: TokenTracker;
+  private readonly ownsTokenTracker: boolean;
+  private readonly unsubscribeTokenTracker: () => void;
+  private readonly cycleConfig: SessionCycleConfig | null;
+  private readonly cycleClock: () => string;
+
   constructor(options: RepoAdminSessionOptions) {
     this.alias = options.assignment.alias;
     this.repoPath = options.assignment.repoPath;
@@ -262,6 +369,38 @@ export class RepoAdminSession {
     this.spawner = options.spawner ?? new ClaudeRepoAdminSpawner();
     this.buildSessionId = options.buildSessionId ?? defaultBuildRepoAdminSessionId;
     this.stopGraceMs = options.stopGraceMs ?? STOP_GRACE_MS;
+    this.cycleConfig = options.cycle ?? null;
+    this.cycleClock = options.cycleClock ?? (() => new Date().toISOString());
+
+    // AL-15: the session's own token tracker. A caller that supplies one
+    // (tests, or a future aggregator) owns its lifetime; otherwise we
+    // mint a tracker keyed off the admin alias + logDir so disk writes
+    // land alongside the session's other metadata.
+    if (options.tokenTracker) {
+      this.tokenTracker = options.tokenTracker;
+      this.ownsTokenTracker = false;
+    } else {
+      const ceiling = options.adminTokenCeiling ?? DEFAULT_ADMIN_TOKEN_CEILING;
+      // Tracker sessionId is `admin-<alias>` (not the per-spawn CHILD id)
+      // so a replay across process-restarts recovers the admin's
+      // accumulated budget. The tracker persists under the log dir's
+      // parent (the admin dir), NOT the parent autonomous session's
+      // `sessions/` directory, so each admin's budget file sits next to
+      // its own logs.
+      this.tokenTracker = new TokenTracker(`admin-${this.alias}`, ceiling, {
+        rootDir: dirname(this.logDir),
+      });
+      this.ownsTokenTracker = true;
+    }
+
+    // Subscribe to threshold crossings. We only care about the 60 tier
+    // (AL-15's memory-shed signal); everything else is other subsystems'
+    // business. The unsubscribe function is stashed so `stop()` can
+    // detach cleanly — otherwise a shared tracker (test-injected) would
+    // keep this session alive through the listener reference.
+    this.unsubscribeTokenTracker = this.tokenTracker.onThreshold((evt) =>
+      this.handleThresholdEvent(evt)
+    );
   }
 
   /** Current lifecycle state. Use for assertions; drives no logic itself. */
@@ -280,6 +419,26 @@ export class RepoAdminSession {
   /** Total number of times the child has been spawned in this session's life. */
   get spawnCount(): number {
     return this._spawnCount;
+  }
+
+  /**
+   * AL-15: number of memory-shed cycles the session has completed. Does
+   * NOT include unexpected restarts. Tests assert on this to distinguish
+   * cycles from restarts.
+   */
+  get cycleCount(): number {
+    return this._cycleCount;
+  }
+
+  /**
+   * AL-15: the tracker driving this session's cycle trigger. Exposed
+   * read-only so callers (pool, dispatch code, tests) can `record()`
+   * token usage on the session's own budget. The pool does NOT own this
+   * — each admin has its own tracker so one chatty admin doesn't starve
+   * its peers.
+   */
+  get tracker(): TokenTracker {
+    return this.tokenTracker;
   }
 
   /**
@@ -336,7 +495,11 @@ export class RepoAdminSession {
       return;
     }
 
-    const nextId = this.buildSessionId();
+    // AL-15: a cycle pre-mints the next session id so the decision entry
+    // can reference it. Consume that stash if present; otherwise fall
+    // back to the factory (normal start / restart path).
+    const nextId = this.pendingNextSessionId ?? this.buildSessionId();
+    this.pendingNextSessionId = null;
     this._currentSessionId = nextId;
     this._spawnCount += 1;
     this._state = "booting";
@@ -427,6 +590,7 @@ export class RepoAdminSession {
       // Not running (e.g. booting failed synchronously). Transition
       // directly to stopped so callers observe terminality.
       this._state = "stopped";
+      this.detachTokenTracker();
       this.emit({
         kind: "exited-expected",
         sessionId: this._currentSessionId,
@@ -476,6 +640,7 @@ export class RepoAdminSession {
     this._state = "stopped";
     this.child = null;
     this.clearKillTimer();
+    this.detachTokenTracker();
     this.emit({
       kind: "exited-expected",
       sessionId: this._currentSessionId,
@@ -519,7 +684,219 @@ export class RepoAdminSession {
     });
   }
 
+  /**
+   * AL-15: memory-shed cycle. Planned recycle of the child process.
+   * Unlike `stop()` (graceful shutdown, terminal) and unlike the pool's
+   * restart-on-death (unexpected exit, counted toward rapid-flap), a
+   * cycle:
+   *
+   *   1. Captures a working-set snapshot (active tickets, worktrees,
+   *      open PRs — the latter two stubbed until AL-14).
+   *   2. Writes a one-line decision to the channel board via the
+   *      configured {@link SessionCycleConfig.decisions} store.
+   *   3. SIGTERM's the current child. The exit is CLASSIFIED as expected
+   *      (reason: `cycle:<reason>`) so the pool doesn't try to restart
+   *      and doesn't count it against its rapid-flap ceiling.
+   *   4. Spawns a fresh child with a NEW session id. The pending queue
+   *      is preserved across the boundary (it lives on the session
+   *      wrapper, not in child-process memory).
+   *   5. Emits a `cycled` event so observers (pool, TUI) can log the
+   *      transition.
+   *
+   * Idempotent with respect to overlap: a second caller during an
+   * in-flight cycle gets the same promise. Rejects if the session is
+   * already `stopped` — a cycle is a mid-life operation, not a
+   * resurrection.
+   */
+  async cycle(reason: CycleReason): Promise<void> {
+    if (this._state === "stopped") {
+      throw new Error(
+        `RepoAdminSession(${this.alias}): cannot cycle() after stop(); ` +
+          `cycle is a mid-life operation.`
+      );
+    }
+    if (this.cyclePromise) {
+      // Overlapping cycle request — return the in-flight one.
+      return this.cyclePromise;
+    }
+
+    this.cyclingReason = reason;
+    this.cyclePromise = this.performCycle(reason).finally(() => {
+      this.cyclingReason = null;
+      this.cyclePromise = null;
+    });
+    return this.cyclePromise;
+  }
+
   // --- internals ----------------------------------------------------------
+
+  /**
+   * AL-15: core of the cycle flow. Separated from {@link cycle} so the
+   * promise-memo logic is isolated from the actual work.
+   */
+  private async performCycle(reason: CycleReason): Promise<void> {
+    const previousSessionId = this._currentSessionId;
+    // Mint the next session id NOW so the decision entry can reference it.
+    // The `start()` call below reuses this id by passing it through the
+    // session-id factory — see the `pendingNextSessionId` stash.
+    const nextSessionId = this.buildSessionId();
+    this.pendingNextSessionId = nextSessionId;
+
+    // 1) Build + write the decision. Snapshot the working set first so a
+    //    failure in the write path doesn't leave the queue in a weird
+    //    state. AL-14 populates worktreesInUse + openPrs; for AL-15 they
+    //    are stubs.
+    const snapshot: CycleSummarySnapshot = {
+      activeTickets: this.snapshotActiveTicketIds(),
+      worktreesInUse: [], // AL-14 will populate.
+      openPrs: [], // AL-14 will populate.
+      cycleReason: reason,
+    };
+
+    if (this.cycleConfig) {
+      const decision = buildCycleDecision({
+        alias: this.alias,
+        previousSessionId,
+        nextSessionId,
+        snapshot,
+        cycledAt: this.cycleClock(),
+      });
+      try {
+        await this.cycleConfig.decisions.recordDecision(this.cycleConfig.channelId, decision);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // A decision-write failure is loud but non-fatal: the cycle
+        // still proceeds so the session doesn't wedge at 60%+ context.
+        // The post-cycle admin will see a gap in the board and rebuild
+        // from the adjacent entries.
+        console.warn(
+          `RepoAdminSession(${this.alias}): cycle decision write failed (${reason}): ${msg}`
+        );
+      }
+    }
+
+    // 2) Tear down the current child. `stopChild` classifies the exit as
+    //    expected with a `cycle:<reason>` marker so `handleExit` doesn't
+    //    emit `exited-unexpected` (which would trip the pool's
+    //    restart-on-death path and count this toward rapid-flap).
+    await this.stopChildForCycle(reason);
+
+    // 3) Spawn a fresh child. The `pendingNextSessionId` is consumed
+    //    inside `start()` so the session id in the decision entry
+    //    matches the spawned child's id exactly.
+    await this.start();
+
+    // 4) Bookkeeping + observer event.
+    this._cycleCount += 1;
+    this.emit({
+      kind: "cycled",
+      previousSessionId,
+      newSessionId: this._currentSessionId,
+      reason,
+    });
+  }
+
+  /**
+   * AL-15: snapshot the pending-dispatch queue as ticket ids. AL-13 will
+   * populate the queue with real dispatch records; here we accept either
+   * a raw ticket id string, an object with `ticketId`, or fall back to
+   * `String(entry)`. The test for AL-15 stuffs the queue with bare
+   * ticket-id strings (the AL-13 wire shape isn't landed yet).
+   */
+  private snapshotActiveTicketIds(): string[] {
+    const out: string[] = [];
+    for (const entry of this.pendingDispatches) {
+      if (typeof entry === "string") {
+        out.push(entry);
+      } else if (entry && typeof entry === "object" && "ticketId" in entry) {
+        const v = (entry as { ticketId: unknown }).ticketId;
+        if (typeof v === "string") out.push(v);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * AL-15: tear-down path for the cycle. Mirrors `stop()`'s SIGTERM →
+   * SIGKILL escalation but does NOT transition the session to `stopped`
+   * — the state machine stays mid-life so the subsequent `start()` is
+   * legal. The exit event emitted is `exited-expected` with a
+   * `cycle:<reason>` string, distinguishable from the graceful-shutdown
+   * reason by prefix.
+   */
+  private async stopChildForCycle(reason: CycleReason): Promise<void> {
+    if (!this.child) return;
+
+    const cycleReasonTag = `cycle:${reason}`;
+    this.stopReason = cycleReasonTag;
+    // Mark the exit as expected so handleExit classifies it as
+    // `exited-expected` with the cycle reason. We reuse the same flag
+    // that `stop()` uses so the existing classification path handles
+    // this without a separate code branch in `handleExit`.
+    this.stopRequested = true;
+
+    try {
+      this.child.kill("SIGTERM");
+    } catch {
+      // Already exited between the state check and the signal.
+    }
+
+    this.killTimer = setTimeout(() => {
+      this.killTimer = null;
+      if (this.child) {
+        try {
+          this.child.kill("SIGKILL");
+        } catch {
+          // Same as above.
+        }
+      }
+    }, this.stopGraceMs);
+    const t = this.killTimer as { unref?: () => void };
+    if (t && typeof t.unref === "function") t.unref();
+
+    // Wait for the child to actually exit. Unlike `stop()`'s
+    // `awaitStopped`, we don't transition to `stopped` — the session
+    // reverts to an internal "between cycles" state which `start()`
+    // promotes back to `booting`/`ready` on respawn.
+    await new Promise<void>((resolve) => {
+      const off = this.onEvent((evt) => {
+        if (evt.kind === "exited-expected" && evt.reason === cycleReasonTag) {
+          off();
+          resolve();
+        }
+      });
+    });
+
+    // Reset the flags so the subsequent `start()` + eventual `stop()`
+    // aren't confused by the cycle's bookkeeping.
+    this.stopRequested = false;
+    this.stopReason = null;
+    this.clearKillTimer();
+  }
+
+  /**
+   * AL-15: stash used by `performCycle` to thread the next session id
+   * through `start()`. Normal (non-cycle) starts leave this null and the
+   * default factory is used.
+   */
+  private pendingNextSessionId: string | null = null;
+
+  /**
+   * AL-15: threshold-event handler for the per-session token tracker.
+   * Fires a cycle when the 60% tier crosses; other tiers are ignored
+   * (other subsystems subscribe separately if they care).
+   */
+  private handleThresholdEvent(evt: ThresholdEvent): void {
+    if (evt.threshold !== CYCLE_THRESHOLD_PCT) return;
+    if (this._state === "stopped") return;
+    if (this.cyclePromise) return;
+    void this.cycle("budget-60pct").catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `RepoAdminSession(${this.alias}): auto-cycle on ${CYCLE_THRESHOLD_PCT}% failed: ${msg}`
+      );
+    });
+  }
 
   private handleExit(
     exitCode: number | null,
@@ -532,11 +909,27 @@ export class RepoAdminSession {
     this.child = null;
 
     if (expected) {
+      const reason = this.stopReason ?? "unknown";
+      // AL-15: a cycle's exit is "expected" but does NOT terminate the
+      // session — it's a mid-life tear-down before respawn. We detect
+      // that by the `cycle:` prefix left in `stopReason` by
+      // `stopChildForCycle`. In that case, stay out of the terminal
+      // state; `performCycle` will call `start()` next.
+      if (reason.startsWith("cycle:")) {
+        this.emit({
+          kind: "exited-expected",
+          sessionId: previousSessionId,
+          reason,
+          exitCode,
+        });
+        return;
+      }
       this._state = "stopped";
+      this.detachTokenTracker();
       this.emit({
         kind: "exited-expected",
         sessionId: previousSessionId,
-        reason: this.stopReason ?? "unknown",
+        reason,
         exitCode,
       });
       return;
@@ -554,6 +947,25 @@ export class RepoAdminSession {
       signal,
       stderrTail: this.recentStderr.join("\n"),
     });
+  }
+
+  /**
+   * AL-15: detach the token-tracker subscription + close the tracker if
+   * we own it. Safe to call multiple times; the unsubscribe wrapper is
+   * a no-op after the first call, and `TokenTracker.close()` is
+   * idempotent.
+   */
+  private detachTokenTracker(): void {
+    this.unsubscribeTokenTracker();
+    if (this.ownsTokenTracker) {
+      // Fire-and-forget: close() flushes pending writes. A caller
+      // waiting on `stop()` has already observed `exited-expected`, so
+      // we don't need to block them on disk IO.
+      void this.tokenTracker.close().catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`RepoAdminSession(${this.alias}): tracker close failed: ${msg}`);
+      });
+    }
   }
 
   private clearKillTimer(): void {

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -600,6 +600,13 @@ export class RepoAdminSession {
       return;
     }
 
+    // Subscribe to the exit event BEFORE sending SIGTERM. A spawner (or
+    // an already-dead child) that fires `onExit` synchronously from
+    // inside `kill()` would emit before any post-kill subscription could
+    // hear it, leaving `awaitStopped()` waiting on a never-emitted
+    // event. Ordering the subscribe first closes that race.
+    const stopped = this.awaitStopped();
+
     try {
       this.child.kill("SIGTERM");
     } catch {
@@ -623,7 +630,7 @@ export class RepoAdminSession {
     const t = this.killTimer as { unref?: () => void };
     if (t && typeof t.unref === "function") t.unref();
 
-    await this.awaitStopped();
+    await stopped;
   }
 
   /**
@@ -786,7 +793,27 @@ export class RepoAdminSession {
     //    matches the spawned child's id exactly.
     await this.start();
 
-    // 4) Bookkeeping + observer event.
+    // 4) Reset the tracker. The cycle is a process boundary: the new
+    //    child has no context window residue from the old one, so its
+    //    token budget starts fresh. Without this, `firedThresholds` still
+    //    contains 60 from the triggering crossing and `_used` keeps
+    //    accumulating pre-cycle counts — only ONE auto-cycle could ever
+    //    fire per session lifetime. `reset()` rotates the JSONL on disk
+    //    so the pre-cycle data is preserved for audit.
+    try {
+      await this.tokenTracker.reset();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // A reset failure is loud but not cycle-fatal. The session is
+      // already mid-cycle; aborting here would leave the new child up
+      // with a stale tracker — which is no worse than the pre-fix
+      // behavior. Surface it and move on.
+      console.warn(
+        `RepoAdminSession(${this.alias}): cycle tracker reset failed (${reason}): ${msg}`
+      );
+    }
+
+    // 5) Bookkeeping + observer event.
     this._cycleCount += 1;
     this.emit({
       kind: "cycled",
@@ -835,6 +862,20 @@ export class RepoAdminSession {
     // this without a separate code branch in `handleExit`.
     this.stopRequested = true;
 
+    // Subscribe to the exit event BEFORE sending SIGTERM. Some spawners
+    // (and some crashed children) surface `onExit` synchronously from
+    // within `kill()`, which would emit before any listener wired up
+    // AFTER `kill()` could hear it — and this promise would never
+    // resolve. Ordering the subscribe first closes that race.
+    const exited = new Promise<void>((resolve) => {
+      const off = this.onEvent((evt) => {
+        if (evt.kind === "exited-expected" && evt.reason === cycleReasonTag) {
+          off();
+          resolve();
+        }
+      });
+    });
+
     try {
       this.child.kill("SIGTERM");
     } catch {
@@ -858,14 +899,7 @@ export class RepoAdminSession {
     // `awaitStopped`, we don't transition to `stopped` — the session
     // reverts to an internal "between cycles" state which `start()`
     // promotes back to `booting`/`ready` on respawn.
-    await new Promise<void>((resolve) => {
-      const off = this.onEvent((evt) => {
-        if (evt.kind === "exited-expected" && evt.reason === cycleReasonTag) {
-          off();
-          resolve();
-        }
-      });
-    });
+    await exited;
 
     // Reset the flags so the subsequent `start()` + eventual `stop()`
     // aren't confused by the cycle's bookkeeping.

--- a/src/orchestrator/session-summary.ts
+++ b/src/orchestrator/session-summary.ts
@@ -1,0 +1,177 @@
+/**
+ * AL-15 — Memory-shed session summary builder.
+ *
+ * When a repo-admin session recycles (context pressure or manual), it
+ * writes a one-line summary to the channel's decisions board so the newly-
+ * respawned child can reconstruct its working set by reading the board.
+ * This module owns the shape of that summary + the pure function that
+ * builds it.
+ *
+ * The summary is designed to round-trip through
+ * {@link ChannelStore.recordDecision}:
+ *   - `title` is the one-line human-readable sentence.
+ *   - `description` carries the same sentence for UIs that render only
+ *     one of the two fields.
+ *   - `metadata` carries the structured fields the post-cycle repo-admin
+ *     (and future scheduler-awareness features) actually consume.
+ *
+ * Explicitly out of scope here:
+ *   - `worktreesInUse` + `openPrs` are stubbed to empty arrays until AL-14
+ *     (worker spawning) supplies the data sources. They're present in the
+ *     shape so the decisions-board schema doesn't need to change later.
+ *   - Writing the decision. That's the session's job.
+ */
+
+/** Reason a cycle was triggered. Extended as new triggers are added. */
+export type CycleReason =
+  /** The session's own token tracker crossed the 60% ceiling. */
+  | "budget-60pct"
+  /** An operator (or test) called `session.cycle()` directly. */
+  | "manual";
+
+/**
+ * The structured "working set" snapshot captured at cycle time. Every
+ * field is present — empty arrays signal "no X in flight" rather than
+ * "data source not yet wired".
+ *
+ * `worktreesInUse` + `openPrs` are stubbed as empty for AL-15; AL-14 will
+ * populate them from the worker-spawning machinery it owns.
+ */
+export interface CycleSummarySnapshot {
+  /** Ticket ids the session had in its pending queue at cycle time. */
+  activeTickets: string[];
+  /**
+   * Worktree identifiers (path or alias) currently checked out by workers
+   * this session spawned. Stub: empty until AL-14.
+   */
+  worktreesInUse: string[];
+  /**
+   * PR numbers (or `owner/repo#N` identifiers) currently tracked as open
+   * by this session. Stub: empty until AL-14.
+   */
+  openPrs: string[];
+  /** Why we cycled. */
+  cycleReason: CycleReason;
+}
+
+/**
+ * The full structured payload written to
+ * `Decision.metadata`. Includes both the snapshot + the session-identity
+ * fields a downstream reader needs to correlate the cycle to a specific
+ * repo-admin.
+ */
+export interface CycleDecisionMetadata extends CycleSummarySnapshot {
+  /** Alias of the repo-admin session that cycled. */
+  alias: string;
+  /** Session id of the CHILD process that was killed. */
+  previousSessionId: string;
+  /** Session id of the CHILD process that will respawn. Minted at cycle time. */
+  nextSessionId: string;
+  /**
+   * ISO timestamp of the cycle event. Captured at build-time so a delayed
+   * disk flush doesn't skew the board's timeline.
+   */
+  cycledAt: string;
+}
+
+/**
+ * The full decision shape the session passes through to
+ * {@link ChannelStore.recordDecision}. Shaped as the
+ * `Omit<Decision, "decisionId" | "channelId" | "createdAt">` input the
+ * store expects, so callers can forward it verbatim.
+ */
+export interface CycleDecisionInput {
+  runId: string | null;
+  ticketId: string | null;
+  title: string;
+  description: string;
+  rationale: string;
+  alternatives: string[];
+  decidedBy: string;
+  decidedByName: string;
+  linkedArtifacts: string[];
+  type: "repo_admin_cycle";
+  metadata: CycleDecisionMetadata;
+}
+
+/**
+ * Arguments to {@link buildCycleDecision}. Kept as a flat record so the
+ * caller (the session) can pass what it has without wrapping.
+ */
+export interface BuildCycleDecisionArgs {
+  alias: string;
+  previousSessionId: string;
+  nextSessionId: string;
+  snapshot: CycleSummarySnapshot;
+  /**
+   * ISO timestamp. Caller supplies so tests can pin it; production passes
+   * `new Date().toISOString()`.
+   */
+  cycledAt: string;
+}
+
+/**
+ * Build the one-line summary sentence. Shape:
+ * `repo-admin[<alias>] cycled (<reason>): <N> active ticket(s), <M>
+ * worktree(s) in use, <K> open PR(s). prev=<sid> next=<sid>.`
+ *
+ * Kept as a single line so the decisions-board list view renders it
+ * without wrapping, and so the BE's audit export can grep for cycle
+ * events by the `repo-admin[<alias>] cycled` prefix.
+ */
+export function buildCycleSummaryLine(args: BuildCycleDecisionArgs): string {
+  const { alias, previousSessionId, nextSessionId, snapshot } = args;
+  const ticketCount = snapshot.activeTickets.length;
+  const worktreeCount = snapshot.worktreesInUse.length;
+  const prCount = snapshot.openPrs.length;
+  return (
+    `repo-admin[${alias}] cycled (${snapshot.cycleReason}): ` +
+    `${ticketCount} active ticket(s), ${worktreeCount} worktree(s) in use, ` +
+    `${prCount} open PR(s). prev=${previousSessionId} next=${nextSessionId}.`
+  );
+}
+
+/**
+ * Build the complete decision payload the session hands to
+ * {@link ChannelStore.recordDecision}. Pure — no IO, no side effects.
+ */
+export function buildCycleDecision(args: BuildCycleDecisionArgs): CycleDecisionInput {
+  const line = buildCycleSummaryLine(args);
+
+  // The rationale mirrors the user-facing framing ("repo-admin forgets
+  // completed tickets") so operators browsing the decisions board see the
+  // WHY, not just the WHAT. Implementation detail (token pressure vs.
+  // manual) lives in `metadata.cycleReason` for filtering.
+  const rationale =
+    args.snapshot.cycleReason === "budget-60pct"
+      ? "Repo-admin context crossed the 60% budget ceiling; recycling the child process " +
+        "to shed the accumulated context. The newly-respawned admin rebuilds its " +
+        "working set by reading this decisions board."
+      : "Manual recycle requested. The newly-respawned admin rebuilds its working " +
+        "set by reading this decisions board.";
+
+  return {
+    runId: null,
+    ticketId: null,
+    title: line,
+    description: line,
+    rationale,
+    alternatives: [],
+    // Attribution: the cycle is a system action, not a human decision.
+    // Using `repo-admin:<alias>` mirrors the pattern
+    // `src/cli/run-autonomous.ts` uses for autonomous-session decisions
+    // (e.g. `invokedBy.user`), so the GUI avatar/name resolver can
+    // display it consistently.
+    decidedBy: `repo-admin:${args.alias}`,
+    decidedByName: `repo-admin[${args.alias}]`,
+    linkedArtifacts: [],
+    type: "repo_admin_cycle",
+    metadata: {
+      ...args.snapshot,
+      alias: args.alias,
+      previousSessionId: args.previousSessionId,
+      nextSessionId: args.nextSessionId,
+      cycledAt: args.cycledAt,
+    },
+  };
+}

--- a/test/budget/token-tracker.test.ts
+++ b/test/budget/token-tracker.test.ts
@@ -148,7 +148,9 @@ describe("TokenTracker", () => {
       // Replaying does not re-emit 50.
       expect(events).toEqual([]);
 
-      // But a new crossing (to 85) still emits.
+      // But a new crossing (to 85) still emits. The resumed state was
+      // already at 60%, so 50 and 60 were both marked fired on replay —
+      // only 85 is a fresh crossing this run.
       second.record(300, 0); // now at 900 = 90%
       await second.flush();
       expect(events.map((e) => e.threshold)).toEqual([85]);
@@ -302,27 +304,28 @@ describe("TokenTracker", () => {
       };
 
       try {
-        // Cross 50 and 85 in a single record. record() is void and must
-        // not throw even though a listener throws on every dispatch.
+        // Cross 50, 60, and 85 in a single record. record() is void and
+        // must not throw even though a listener throws on every dispatch.
         expect(() => tracker.record(900, 0)).not.toThrow();
         await tracker.flush();
       } finally {
         console.warn = originalWarn;
       }
 
-      // Both thresholds reached the healthy listeners.
-      expect(secondListenerSeen).toEqual([50, 85]);
-      expect(seen).toEqual([50, 85]);
+      // Every crossed threshold reached the healthy listeners.
+      expect(secondListenerSeen).toEqual([50, 60, 85]);
+      expect(seen).toEqual([50, 60, 85]);
 
       // The throwing listener was logged per-threshold (at least one warn
       // per crossed threshold, with the threshold number + error message).
       expect(warnings.some((w) => w.includes("50") && w.includes("boom"))).toBe(true);
+      expect(warnings.some((w) => w.includes("60") && w.includes("boom"))).toBe(true);
       expect(warnings.some((w) => w.includes("85") && w.includes("boom"))).toBe(true);
 
       // A later crossing still fires the remaining thresholds exactly once.
       tracker.record(100, 0); // 1000 → 100%, crosses 95 and 100
       await tracker.flush();
-      expect(secondListenerSeen).toEqual([50, 85, 95, 100]);
+      expect(secondListenerSeen).toEqual([50, 60, 85, 95, 100]);
 
       await tracker.close();
     });

--- a/test/budget/token-tracker.test.ts
+++ b/test/budget/token-tracker.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -360,6 +360,55 @@ describe("TokenTracker", () => {
       tracker.record(10, 10);
       await tracker.close();
       await expect(tracker.close()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("reset()", () => {
+    it("zeros _used, clears firedThresholds, and rotates the JSONL file", async () => {
+      const tracker = new TokenTracker("s-reset", 1000, { rootDir: root });
+      const events: ThresholdEvent[] = [];
+      tracker.onThreshold((evt) => events.push(evt));
+
+      // Cross 60% pre-reset.
+      tracker.record(600, 0);
+      await tracker.flush();
+      expect(events.map((e) => e.threshold)).toEqual([50, 60]);
+      expect(tracker.used).toBe(600);
+
+      await tracker.reset();
+      expect(tracker.used).toBe(0);
+      expect(tracker.pct).toBe(0);
+
+      // The pre-cycle file was rotated out of the way; the directory
+      // contains a `budget.jsonl.pre-cycle-<ts>` sibling.
+      const sessionDir = join(root, "sessions", "s-reset");
+      const entries = await readdir(sessionDir);
+      const rotated = entries.filter((e) => e.startsWith("budget.jsonl.pre-cycle-"));
+      expect(rotated).toHaveLength(1);
+      expect(entries.includes("budget.jsonl")).toBe(false);
+
+      // Post-reset, the 60% tier re-fires on the next crossing.
+      tracker.record(600, 0);
+      await tracker.flush();
+      // The new events should include a second 50 + 60 crossing.
+      const postReset = events.slice(2);
+      expect(postReset.map((e) => e.threshold)).toEqual([50, 60]);
+
+      await tracker.close();
+    });
+
+    it("tolerates reset() before any record() (no file on disk yet)", async () => {
+      const tracker = new TokenTracker("s-reset-empty", 1000, { rootDir: root });
+      await expect(tracker.reset()).resolves.toBeUndefined();
+      expect(tracker.used).toBe(0);
+      await tracker.close();
+    });
+
+    it("reset() after close() throws", async () => {
+      const tracker = new TokenTracker("s-reset-closed", 1000, { rootDir: root });
+      tracker.record(100, 0);
+      await tracker.close();
+      await expect(tracker.reset()).rejects.toThrow(/after close/);
     });
   });
 });

--- a/test/lifecycle/session-lifecycle.test.ts
+++ b/test/lifecycle/session-lifecycle.test.ts
@@ -237,7 +237,7 @@ describe("SessionLifecycle", () => {
       await tracker.close();
     });
 
-    it("50% and 100% thresholds are ignored", async () => {
+    it("50%, 60%, and 100% thresholds are ignored", async () => {
       const tracker = new TokenTracker("s-budget-ignore", 1000, { rootDir: root });
       const lifecycle = new SessionLifecycle("s-budget-ignore", {
         rootDir: root,
@@ -245,6 +245,15 @@ describe("SessionLifecycle", () => {
       });
       await lifecycle.transition("dispatching");
       tracker.record(500, 0); // crosses only 50
+      await tracker.flush();
+      await lifecycle.flush();
+      expect(lifecycle.state).toBe("dispatching");
+
+      // Pin down the 60% tier: AL-15 added it for repo-admin memory-shed
+      // cycling; the session-lifecycle scheduler must ignore it the same
+      // way it ignores 50 and 100. A future refactor that accidentally
+      // wires 60 into `handleThreshold` will flip `lifecycle.state` here.
+      tracker.record(100, 0); // crosses 60
       await tracker.flush();
       await lifecycle.flush();
       expect(lifecycle.state).toBe("dispatching");

--- a/test/orchestrator/repo-admin-session-cycle.test.ts
+++ b/test/orchestrator/repo-admin-session-cycle.test.ts
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
 import { TokenTracker } from "../../src/budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
 import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
 import {
   RAPID_RESTART_CEILING,
@@ -42,6 +43,34 @@ import {
   type SessionDecisionWriter,
 } from "../../src/orchestrator/repo-admin-session.js";
 import type { CycleDecisionInput } from "../../src/orchestrator/session-summary.js";
+
+/**
+ * Build a minimal `TicketLedgerEntry`. AL-13's `dispatchTicket` is the
+ * public path to seed the pending-dispatch queue; the rebase onto main
+ * deleted the old `_pushPendingDispatchForTest` test-seam in favor of
+ * this real API.
+ */
+function buildLedgerEntry(ticketId: string, alias = "frontend"): TicketLedgerEntry {
+  return {
+    ticketId,
+    title: `ticket ${ticketId}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: new Date().toISOString(),
+    runId: null,
+    assignedAlias: alias,
+  };
+}
 
 // --- Fakes ---------------------------------------------------------------
 
@@ -103,6 +132,31 @@ class FakeSpawner implements RepoAdminProcessSpawner {
   }
   children(alias: string): FakeChild[] {
     return this.byAlias.get(alias) ?? [];
+  }
+}
+
+/**
+ * Spawner whose children call `onExit` synchronously from within
+ * `kill()`. Models an edge case (spawner double-signals, pre-exited
+ * child) that used to hang `stopChildForCycle` / `stop()` when their
+ * exit-waiters subscribed to the event AFTER calling kill().
+ */
+class SyncKillSpawner implements RepoAdminProcessSpawner {
+  spawn(_args: RepoAdminSpawnArgs): SpawnedProcess {
+    const exitListeners: ExitListener[] = [];
+    return {
+      pid: 49_000,
+      onStdout() {},
+      onStderr() {},
+      onExit(l: ExitListener) {
+        exitListeners.push(l);
+      },
+      onError() {},
+      kill() {
+        for (const l of exitListeners) l(0, "SIGTERM");
+        return true;
+      },
+    };
   }
 }
 
@@ -229,10 +283,14 @@ describe("RepoAdminSession — AL-15 cycle", () => {
     await session.start();
     const originalSessionId = session.sessionId;
 
-    // Seed the queue so we can assert cross-cycle preservation.
-    session._pushPendingDispatchForTest("ticket-1");
-    session._pushPendingDispatchForTest("ticket-2");
-    session._pushPendingDispatchForTest("ticket-3");
+    // Seed the queue so we can assert cross-cycle preservation. Uses
+    // AL-13's real `dispatchTicket` API (the pre-rebase test seam
+    // `_pushPendingDispatchForTest` was redundant once dispatchTicket
+    // gained a real implementation).
+    const seeded = ["ticket-1", "ticket-2", "ticket-3"].map((id) => buildLedgerEntry(id));
+    for (const entry of seeded) {
+      await session.dispatchTicket(entry);
+    }
 
     const cycleP = session.cycle("manual");
     // The first child must receive SIGTERM. Resolve its exit so the
@@ -249,7 +307,11 @@ describe("RepoAdminSession — AL-15 cycle", () => {
     expect(session.cycleCount).toBe(1);
 
     // Queue survived the cycle.
-    expect(session.getPendingDispatches()).toEqual(["ticket-1", "ticket-2", "ticket-3"]);
+    expect(session.pendingTickets().map((t) => t.ticketId)).toEqual([
+      "ticket-1",
+      "ticket-2",
+      "ticket-3",
+    ]);
 
     // Decision was written.
     expect(writer.calls).toHaveLength(1);
@@ -283,7 +345,7 @@ describe("RepoAdminSession — AL-15 cycle", () => {
       cycleClock: () => "2026-04-21T12:00:00.000Z",
     });
     await session.start();
-    session._pushPendingDispatchForTest({ ticketId: "AL-99" });
+    await session.dispatchTicket(buildLedgerEntry("AL-99"));
 
     const cycleP = session.cycle("manual");
     await flushMicrotasks();
@@ -351,6 +413,100 @@ describe("RepoAdminSession — AL-15 cycle", () => {
     await stopP;
 
     await expect(session.cycle("manual")).rejects.toThrow(/cannot cycle\(\) after stop/);
+  });
+
+  it("tracker resets on cycle so a second 60% crossing fires cycle #2", async () => {
+    // Regression for the AL-15 blocker: before the fix, `performCycle`
+    // respawned the child but left `firedThresholds` + `_used` on the
+    // tracker unchanged, so the 60% tier could never re-fire. Only ONE
+    // auto-cycle would ever happen per session lifetime. The reset()
+    // added to TokenTracker + called from performCycle restores the
+    // invariant that each new child starts the budget from zero.
+    const tracker = new TokenTracker("admin-two-cycles", 1000, { rootDir: trackerRoot });
+    const { session, spawner, writer } = buildSession({ tracker });
+
+    await session.start();
+    const sessionId0 = session.sessionId;
+
+    // First 60% crossing → cycle #1.
+    tracker.record(600, 0);
+    await tracker.flush();
+    await flushMicrotasks();
+    expect(spawner.children("frontend")[0].killCalls).toContain("SIGTERM");
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(session.cycleCount).toBe(1);
+    const sessionId1 = session.sessionId;
+    expect(sessionId1).not.toBe(sessionId0);
+    // The tracker was reset as part of performCycle — the next record()
+    // observes a zero baseline and will cross 60% again.
+    expect(tracker.used).toBe(0);
+
+    // Second 60% crossing → cycle #2. This is the load-bearing assertion:
+    // without tracker.reset(), firedThresholds.has(60) would still be
+    // true and this record() would never fire a threshold event.
+    tracker.record(600, 0);
+    await tracker.flush();
+    await flushMicrotasks();
+    expect(spawner.children("frontend")[1].killCalls).toContain("SIGTERM");
+    spawner.children("frontend")[1].emitExit(0, "SIGTERM");
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(session.cycleCount).toBe(2);
+    const sessionId2 = session.sessionId;
+    expect(sessionId2).not.toBe(sessionId1);
+
+    // Both cycles wrote distinct decision entries with the expected
+    // previousSessionId / nextSessionId chain.
+    expect(writer.calls).toHaveLength(2);
+    expect(writer.calls[0].input.metadata.previousSessionId).toBe(sessionId0);
+    expect(writer.calls[0].input.metadata.nextSessionId).toBe(sessionId1);
+    expect(writer.calls[0].input.metadata.cycleReason).toBe("budget-60pct");
+    expect(writer.calls[1].input.metadata.previousSessionId).toBe(sessionId1);
+    expect(writer.calls[1].input.metadata.nextSessionId).toBe(sessionId2);
+    expect(writer.calls[1].input.metadata.cycleReason).toBe("budget-60pct");
+
+    const stopP = session.stop("test-cleanup");
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+    await tracker.close();
+  });
+
+  it("stopChildForCycle tolerates a spawner that fires onExit synchronously from kill()", async () => {
+    // Regression for the exit-wait race in `stopChildForCycle`: the
+    // `exited-expected` listener must be subscribed BEFORE kill() so a
+    // spawner (or a zombie child) that calls onExit synchronously from
+    // inside kill() still unblocks the cycle. Before the fix, this test
+    // would hang on a never-resolving promise and time out.
+    const writer = new FakeDecisionWriter();
+    const tracker = new TokenTracker("admin-sync-kill", 1000, { rootDir: trackerRoot });
+    const spawner = new SyncKillSpawner();
+    const session = new RepoAdminSession({
+      assignment: BASE_ASSIGNMENT,
+      fullAccess: false,
+      logDir: join(root, "repo-admins", BASE_ASSIGNMENT.alias),
+      spawner,
+      buildSessionId: () => `admin-sync-${++sessionIdCounter}`,
+      stopGraceMs: 5,
+      tokenTracker: tracker,
+      cycle: { channelId: "channel-sync", decisions: writer },
+    });
+    await session.start();
+
+    // The SyncKillSpawner's child fires onExit from within kill(). The
+    // cycle should complete without the `await exited` hanging.
+    await session.cycle("manual");
+
+    expect(session.cycleCount).toBe(1);
+    expect(session.state).toBe("ready");
+
+    // Cleanup. stop() uses the same subscribe-before-kill pattern, so it
+    // also tolerates the synchronous-exit spawner.
+    await session.stop("test-cleanup");
+    await tracker.close();
   });
 
   it("cycle writes a decision even when the decisions store throws — tear-down still runs", async () => {

--- a/test/orchestrator/repo-admin-session-cycle.test.ts
+++ b/test/orchestrator/repo-admin-session-cycle.test.ts
@@ -1,0 +1,498 @@
+/**
+ * AL-15 — Memory-shed cycle tests.
+ *
+ * Covers the four acceptance criteria:
+ *   1. Cycling is invisible to the channel scheduler — in-flight ticket
+ *      routing survives it (pending queue preserved).
+ *   2. Post-cycle repo-admin can read the board to answer "what's in
+ *      flight" (decision entry contains activeTickets).
+ *   3. Summary includes activeTickets, worktreesInUse, openPrs,
+ *      cycleReason.
+ *   4. Force cycle mid-ticket → ticket completes and no state is lost.
+ *
+ * Plus the supporting sub-invariants:
+ *   - Cycle vs. restart distinction: cycles are NOT counted against the
+ *     pool's rapid-flap ceiling.
+ *   - Manual cycle via `session.cycle("manual")`.
+ *   - Pool forwards a `cycled` event.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { TokenTracker } from "../../src/budget/token-tracker.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
+import {
+  RAPID_RESTART_CEILING,
+  RESTART_BACKOFF_MS,
+  RepoAdminPool,
+  type RepoAdminPoolEvent,
+} from "../../src/orchestrator/repo-admin-pool.js";
+import {
+  CYCLE_THRESHOLD_PCT,
+  RepoAdminSession,
+  type RepoAdminProcessSpawner,
+  type RepoAdminSessionEvent,
+  type RepoAdminSpawnArgs,
+  type SessionDecisionWriter,
+} from "../../src/orchestrator/repo-admin-session.js";
+import type { CycleDecisionInput } from "../../src/orchestrator/session-summary.js";
+
+// --- Fakes ---------------------------------------------------------------
+
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type StreamListener = (chunk: string) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeChild extends SpawnedProcess {
+  readonly killCalls: Array<NodeJS.Signals | undefined>;
+  spawnArgs: RepoAdminSpawnArgs;
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  emitStderr(chunk: string): void;
+}
+
+function makeFakeChild(spawnArgs: RepoAdminSpawnArgs): FakeChild {
+  const stdoutListeners: StreamListener[] = [];
+  const stderrListeners: StreamListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  const killCalls: Array<NodeJS.Signals | undefined> = [];
+
+  return {
+    pid: 30_000 + Math.floor(Math.random() * 1000),
+    spawnArgs,
+    killCalls,
+    onStdout(l) {
+      stdoutListeners.push(l);
+    },
+    onStderr(l) {
+      stderrListeners.push(l);
+    },
+    onExit(l) {
+      exitListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    kill(signal) {
+      killCalls.push(signal);
+      return true;
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+    emitStderr(chunk) {
+      for (const l of stderrListeners) l(chunk);
+    },
+  };
+}
+
+class FakeSpawner implements RepoAdminProcessSpawner {
+  readonly byAlias = new Map<string, FakeChild[]>();
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    const child = makeFakeChild(args);
+    const list = this.byAlias.get(args.alias) ?? [];
+    list.push(child);
+    this.byAlias.set(args.alias, list);
+    return child;
+  }
+  children(alias: string): FakeChild[] {
+    return this.byAlias.get(alias) ?? [];
+  }
+}
+
+/**
+ * Capture-only decision writer. Stashes every `recordDecision` call so
+ * tests can assert on the payload shape without a real ChannelStore.
+ */
+class FakeDecisionWriter implements SessionDecisionWriter {
+  readonly calls: Array<{ channelId: string; input: CycleDecisionInput }> = [];
+  recordDecision(channelId: string, input: CycleDecisionInput): Promise<{ ok: true }> {
+    this.calls.push({ channelId, input });
+    return Promise.resolve({ ok: true });
+  }
+}
+
+// --- Fake timer for pool backoff ----------------------------------------
+
+class FakeTimers {
+  private next = 1;
+  private now = 0;
+  private scheduled = new Map<number, { fireAt: number; fn: () => void }>();
+
+  setTimer = (fn: () => void, ms: number): number => {
+    const id = this.next++;
+    this.scheduled.set(id, { fireAt: this.now + ms, fn });
+    return id;
+  };
+  clearTimer = (handle: number | NodeJS.Timeout): void => {
+    this.scheduled.delete(handle as number);
+  };
+  clock = (): number => this.now;
+  advance(ms: number): void {
+    this.now += ms;
+    const entries = Array.from(this.scheduled.entries()).sort((a, b) => a[1].fireAt - b[1].fireAt);
+    for (const [id, entry] of entries) {
+      if (entry.fireAt <= this.now && this.scheduled.has(id)) {
+        this.scheduled.delete(id);
+        entry.fn();
+      }
+    }
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 12; i += 1) {
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+// --- Fixtures ------------------------------------------------------------
+
+const BASE_ASSIGNMENT: RepoAssignment = {
+  alias: "frontend",
+  workspaceId: "ws-front",
+  repoPath: "/tmp/fake-frontend-repo",
+};
+
+function buildChannel(aliases: string[]): Channel {
+  return {
+    channelId: "channel-test",
+    name: "test",
+    description: "test channel",
+    status: "active",
+    workspaceIds: aliases.map((a) => `ws-${a}`),
+    members: [],
+    pinnedRefs: [],
+    repoAssignments: aliases.map((a) => ({
+      alias: a,
+      workspaceId: `ws-${a}`,
+      repoPath: `/tmp/fake-${a}-repo`,
+    })),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe("RepoAdminSession — AL-15 cycle", () => {
+  let root: string;
+  let trackerRoot: string;
+  let sessionIdCounter: number;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-admin-cycle-"));
+    trackerRoot = await mkdtemp(join(tmpdir(), "relay-admin-tracker-"));
+    sessionIdCounter = 0;
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(trackerRoot, { recursive: true, force: true });
+  });
+
+  interface BuildArgs {
+    tracker?: TokenTracker;
+    channelId?: string;
+    writer?: FakeDecisionWriter;
+    cycleClock?: () => string;
+  }
+
+  function buildSession(args: BuildArgs = {}) {
+    const spawner = new FakeSpawner();
+    const writer = args.writer ?? new FakeDecisionWriter();
+    const tracker =
+      args.tracker ?? new TokenTracker("admin-frontend-test", 1000, { rootDir: trackerRoot });
+    const session = new RepoAdminSession({
+      assignment: BASE_ASSIGNMENT,
+      fullAccess: false,
+      logDir: join(root, "repo-admins", BASE_ASSIGNMENT.alias),
+      spawner,
+      buildSessionId: () => `admin-cycle-${++sessionIdCounter}`,
+      stopGraceMs: 5,
+      tokenTracker: tracker,
+      cycle: { channelId: args.channelId ?? "channel-test", decisions: writer },
+      cycleClock: args.cycleClock,
+    });
+    return { session, spawner, writer, tracker };
+  }
+
+  it("manual cycle: tears down + respawns with a fresh sessionId, queue persists", async () => {
+    const { session, spawner, writer } = buildSession();
+    const events: RepoAdminSessionEvent[] = [];
+    session.onEvent((evt) => events.push(evt));
+
+    await session.start();
+    const originalSessionId = session.sessionId;
+
+    // Seed the queue so we can assert cross-cycle preservation.
+    session._pushPendingDispatchForTest("ticket-1");
+    session._pushPendingDispatchForTest("ticket-2");
+    session._pushPendingDispatchForTest("ticket-3");
+
+    const cycleP = session.cycle("manual");
+    // The first child must receive SIGTERM. Resolve its exit so the
+    // cycle's SIGTERM→exit handshake unblocks.
+    await flushMicrotasks();
+    expect(spawner.children("frontend")[0].killCalls).toContain("SIGTERM");
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await cycleP;
+
+    // A second child was spawned.
+    expect(spawner.children("frontend")).toHaveLength(2);
+    expect(session.sessionId).not.toBe(originalSessionId);
+    expect(session.state).toBe("ready");
+    expect(session.cycleCount).toBe(1);
+
+    // Queue survived the cycle.
+    expect(session.getPendingDispatches()).toEqual(["ticket-1", "ticket-2", "ticket-3"]);
+
+    // Decision was written.
+    expect(writer.calls).toHaveLength(1);
+    const decision = writer.calls[0].input;
+    expect(decision.type).toBe("repo_admin_cycle");
+    expect(decision.metadata.cycleReason).toBe("manual");
+    expect(decision.metadata.activeTickets).toEqual(["ticket-1", "ticket-2", "ticket-3"]);
+    // AL-14 will populate these; AL-15 stubs them as empty.
+    expect(decision.metadata.worktreesInUse).toEqual([]);
+    expect(decision.metadata.openPrs).toEqual([]);
+    expect(decision.metadata.previousSessionId).toBe(originalSessionId);
+    expect(decision.metadata.nextSessionId).toBe(session.sessionId);
+
+    // A `cycled` event fired with both session ids.
+    const cycled = events.find((e) => e.kind === "cycled");
+    expect(cycled).toBeDefined();
+    if (cycled?.kind === "cycled") {
+      expect(cycled.previousSessionId).toBe(originalSessionId);
+      expect(cycled.newSessionId).toBe(session.sessionId);
+      expect(cycled.reason).toBe("manual");
+    }
+
+    // Cleanup.
+    const stopP = session.stop("test-cleanup");
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+  });
+
+  it("summary metadata includes every required field (AC #3)", async () => {
+    const { session, spawner, writer } = buildSession({
+      cycleClock: () => "2026-04-21T12:00:00.000Z",
+    });
+    await session.start();
+    session._pushPendingDispatchForTest({ ticketId: "AL-99" });
+
+    const cycleP = session.cycle("manual");
+    await flushMicrotasks();
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await cycleP;
+
+    const meta = writer.calls[0].input.metadata;
+    expect(meta.activeTickets).toEqual(["AL-99"]);
+    expect(meta.worktreesInUse).toEqual([]);
+    expect(meta.openPrs).toEqual([]);
+    expect(meta.cycleReason).toBe("manual");
+    expect(meta.alias).toBe("frontend");
+    expect(meta.cycledAt).toBe("2026-04-21T12:00:00.000Z");
+    // title/description are a single-line summary — grep-friendly for
+    // the audit export.
+    expect(writer.calls[0].input.title).toMatch(/^repo-admin\[frontend\] cycled \(manual\)/);
+
+    const stopP = session.stop("test-cleanup");
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+  });
+
+  it("token tracker crossing 60% fires an automatic cycle (budget-60pct)", async () => {
+    const tracker = new TokenTracker("admin-auto", 1000, { rootDir: trackerRoot });
+    const { session, spawner, writer } = buildSession({ tracker });
+
+    await session.start();
+    const originalSessionId = session.sessionId;
+
+    // Cross 60% exactly. The tracker fires the 60-tier event which the
+    // session's subscribe wires to `cycle("budget-60pct")`.
+    tracker.record(600, 0);
+    await tracker.flush();
+    // performCycle() runs async via `void cycle(...)`. Drain microtasks
+    // so the SIGTERM lands before we observe it.
+    await flushMicrotasks();
+
+    expect(spawner.children("frontend")[0].killCalls).toContain("SIGTERM");
+    // Now synthesize the child exit to unblock the cycle flow.
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await flushMicrotasks();
+
+    expect(spawner.children("frontend")).toHaveLength(2);
+    expect(session.sessionId).not.toBe(originalSessionId);
+    expect(session.cycleCount).toBe(1);
+
+    expect(writer.calls).toHaveLength(1);
+    expect(writer.calls[0].input.metadata.cycleReason).toBe("budget-60pct");
+
+    // Sanity-check the threshold constant so a future change to
+    // THRESHOLDS that drops 60 surfaces here.
+    expect(CYCLE_THRESHOLD_PCT).toBe(60);
+
+    const stopP = session.stop("test-cleanup");
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+    await tracker.close();
+  });
+
+  it("cycle after stop() throws — cycle is mid-life only", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+    const stopP = session.stop("test");
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await stopP;
+
+    await expect(session.cycle("manual")).rejects.toThrow(/cannot cycle\(\) after stop/);
+  });
+
+  it("cycle writes a decision even when the decisions store throws — tear-down still runs", async () => {
+    // Regression: a flaky board write must not wedge the session at 60%+.
+    const writer: SessionDecisionWriter = {
+      recordDecision: () => Promise.reject(new Error("board offline")),
+    };
+    const tracker = new TokenTracker("admin-flaky", 1000, { rootDir: trackerRoot });
+    const spawner = new FakeSpawner();
+    const session = new RepoAdminSession({
+      assignment: BASE_ASSIGNMENT,
+      fullAccess: false,
+      logDir: join(root, "repo-admins", BASE_ASSIGNMENT.alias),
+      spawner,
+      buildSessionId: () => `admin-flaky-${++sessionIdCounter}`,
+      stopGraceMs: 5,
+      tokenTracker: tracker,
+      cycle: { channelId: "c", decisions: writer },
+    });
+    await session.start();
+
+    const cycleP = session.cycle("manual");
+    await flushMicrotasks();
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await cycleP;
+
+    // Cycle completed despite the write failure.
+    expect(session.cycleCount).toBe(1);
+    expect(spawner.children("frontend")).toHaveLength(2);
+
+    const stopP = session.stop("test-cleanup");
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+    await tracker.close();
+  });
+});
+
+// ------------------------------------------------------------------------
+// Pool-level assertions: cycle is observable, cycles don't trip the
+// rapid-flap ceiling.
+
+describe("RepoAdminPool — AL-15 cycle integration", () => {
+  let root: string;
+  let lifecycleRoot: string;
+  let trackerRoot: string;
+  let sessionIdCounter: number;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-admin-cycle-pool-"));
+    lifecycleRoot = await mkdtemp(join(tmpdir(), "relay-admin-cycle-lc-"));
+    trackerRoot = await mkdtemp(join(tmpdir(), "relay-admin-cycle-pool-tr-"));
+    sessionIdCounter = 0;
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(lifecycleRoot, { recursive: true, force: true });
+    await rm(trackerRoot, { recursive: true, force: true });
+  });
+
+  async function buildPool(aliases: string[]) {
+    const channel = buildChannel(aliases);
+    const lifecycle = new SessionLifecycle(`sess-${Date.now()}`, { rootDir: lifecycleRoot });
+    const spawner = new FakeSpawner();
+    const timers = new FakeTimers();
+    const pool = new RepoAdminPool({
+      channel,
+      lifecycle,
+      spawner,
+      rootDir: root,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      clock: timers.clock,
+      buildSessionId: () => `admin-pool-${++sessionIdCounter}`,
+      sessionStopGraceMs: 5,
+    });
+    return { pool, spawner, timers, lifecycle };
+  }
+
+  it("pool forwards a `cycled` event when a session cycles", async () => {
+    const { pool, spawner } = await buildPool(["frontend"]);
+    const events: RepoAdminPoolEvent[] = [];
+    pool.onSessionEvent((evt) => events.push(evt));
+    await pool.start();
+
+    const session = pool.getSession("frontend")!;
+    const originalSessionId = session.sessionId;
+
+    const cycleP = session.cycle("manual");
+    await flushMicrotasks();
+    spawner.children("frontend")[0].emitExit(0, "SIGTERM");
+    await cycleP;
+
+    const cycled = events.find((e) => e.kind === "cycled");
+    expect(cycled).toBeDefined();
+    if (cycled?.kind === "cycled") {
+      expect(cycled.alias).toBe("frontend");
+      expect(cycled.sessionId_old).toBe(originalSessionId);
+      expect(cycled.sessionId_new).toBe(session.sessionId);
+      expect(cycled.reason).toBe("manual");
+    }
+
+    const stopP = pool.stop();
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+  });
+
+  it("cycles do not count against rapid-restart ceiling; an unexpected exit after cycles still counts", async () => {
+    // Plan: fire N cycles (N > RAPID_RESTART_CEILING). Then trigger a
+    // genuine unexpected exit and assert the pool's restart path runs
+    // (the rapid-flap counter was NOT bumped by cycles).
+    const { pool, spawner, timers } = await buildPool(["frontend"]);
+    await pool.start();
+    const session = pool.getSession("frontend")!;
+
+    // 5 cycles in a row. If cycles tripped the rapid-flap ceiling, the
+    // session would enter `stopped` after the first batch.
+    const cycleCount = RAPID_RESTART_CEILING + 1;
+    for (let i = 0; i < cycleCount; i += 1) {
+      const cycleP = session.cycle("manual");
+      await flushMicrotasks();
+      // Emit exit for the child currently being torn down.
+      const kidsBefore = spawner.children("frontend").length;
+      spawner.children("frontend")[kidsBefore - 1].emitExit(0, "SIGTERM");
+      await cycleP;
+    }
+
+    expect(session.state).toBe("ready");
+    expect(session.cycleCount).toBe(cycleCount);
+
+    // Now an unexpected exit. The pool should schedule a restart.
+    const kidsBefore = spawner.children("frontend").length;
+    spawner.children("frontend").at(-1)!.emitExit(1, null);
+    expect(session.state).toBe("dead");
+
+    timers.advance(RESTART_BACKOFF_MS[0] + 1);
+    await flushMicrotasks();
+
+    expect(spawner.children("frontend").length).toBe(kidsBefore + 1);
+    expect(session.state).toBe("ready");
+
+    const stopP = pool.stop();
+    spawner.children("frontend").at(-1)!.emitExit(0, "SIGTERM");
+    await stopP;
+  });
+});


### PR DESCRIPTION
## Summary

Per-repo-admin session now carries its own `TokenTracker`. When context hits 60% of the declared ceiling, the session:

1. Snapshots the working set (active ticket ids from the pending queue + stub arrays for worktrees/PRs until AL-14).
2. Writes a one-line `repo_admin_cycle` decision to the channel board with structured metadata.
3. SIGTERM's its child, respawns fresh, and emits a `cycled` event.
4. The pending-dispatch queue persists across the boundary — ticket routing is invisible to the scheduler.

Cycles are distinct from the pool's restart-on-death path and do NOT count against the rapid-flap ceiling. Manual cycles are supported via `session.cycle("manual")` for AL-16.

## THRESHOLDS change

`src/budget/token-tracker.ts` THRESHOLDS is now `[50, 60, 85, 95, 100]` (was `[50, 85, 95, 100]`). Purely additive — the 60 tier exists for AL-15's memory-shed trigger, and any subsystem that cares about 60% crossings can subscribe via `onThreshold`. Two existing token-tracker tests updated to reflect the new tier.

## Stub fields

`worktreesInUse` and `openPrs` in the summary metadata are stubbed `[]` until AL-14 populates them from the worker-spawning machinery it owns.

## Test plan

- [x] Cycling is invisible to the channel scheduler — in-flight queue persists (verified in `manual cycle: tears down + respawns...` test).
- [x] Post-cycle repo-admin can read the board — decision metadata round-trips `activeTickets`.
- [x] Summary metadata includes `activeTickets`, `worktreesInUse`, `openPrs`, `cycleReason`, plus `alias` / `previousSessionId` / `nextSessionId` / `cycledAt` for correlation.
- [x] Cycle-vs-restart distinction: fired `RAPID_RESTART_CEILING + 1` cycles in a row; pool rapid-flap ceiling did NOT fire. A subsequent genuine crash still triggered the pool's restart path.
- [x] Pool forwards a `cycled` RepoAdminPoolEvent with both session ids.
- [x] `pnpm typecheck` clean.
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 653 passed, 22 skipped (preserving an unrelated pre-existing file-store EACCES post-test warning).
- [x] `pnpm dlx prettier --check` clean.

Closes #90

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>