### PR TITLE
AL-14: Repo-admin spawns workers in per-ticket worktrees

### DIFF
--- a/agent_docs/repo-admin.md
+++ b/agent_docs/repo-admin.md
@@ -118,34 +118,64 @@ enforcement.
 
 ## Activation status
 
-The pool is **built but not yet wired into production runs**. AL-13 will
-define the admin handshake protocol + flip this flag to on.
+The autonomous-loop driver (`src/orchestrator/autonomous-loop.ts`) gates
+pool + worker-drain behaviour behind **two** env flags. Both default to
+**off** so production `rly run --autonomous` invocations keep the pre-
+AL-12 behaviour (clean `killed / al-13-pending` exit) until an operator
+opts in.
 
-AL-12 ships the `RepoAdminPool` boot / restart / shutdown mechanics and
-tests them against a fake spawner, but the autonomous-loop driver
-(`src/orchestrator/autonomous-loop.ts`) gates pool construction behind
-the `RELAY_REPO_ADMIN_POOL_ENABLED` env var — defaulted **off**. When
-the flag is unset, the driver preserves the pre-AL-12 path: no pool is
-constructed, lifecycle transitions to `killed` with reason
-`"al-13-pending"`, and the CLI exits cleanly.
+### `RELAY_REPO_ADMIN_POOL_ENABLED`
+
+Gates AL-12's repo-admin pool (boot + restart-on-death + graceful
+shutdown) and AL-13's ticket router. When unset, no pool is constructed
+and the lifecycle transitions to `killed` with reason `"al-13-pending"`.
+When set (and `RELAY_AL14_WORKER_DRAIN` is unset), the pool boots, the
+router routes each ready ticket to its matching admin's pending queue,
+and the lifecycle transitions to `killed` with reason `"al-14-pending"`
+(no workers spawned, no worktrees created — this exercises boot +
+routing in isolation).
 
 Why the gate exists: the default spawner runs the real `claude` CLI,
 which today exits in milliseconds (no prompt wired up, stdin closed).
 Without AL-13's handshake protocol, enabling the pool in production
 would produce an immediate flap loop (each death respawns until the
 rapid-restart ceiling fires). Keeping the pool off by default lets the
-AL-12 code land and be exercised in isolation without that risk. AL-13
-flips the flag to on after wiring the handshake.
+AL-12 code land and be exercised in isolation without that risk.
 
-To exercise the pool locally (e.g. with a fake spawner injected from a
-test harness or a scripted stub):
+### `RELAY_AL14_WORKER_DRAIN`
+
+Gates AL-14's worker spawn + drain phase. Only has an effect when
+`RELAY_REPO_ADMIN_POOL_ENABLED` is also on. When set, for each admin
+whose session is live (`state === "ready"`), the driver constructs a
+`TicketRunner`, spawns workers in per-ticket git worktrees, monitors
+them until exit, and transitions tickets to `verifying` / `failed` on
+the channel board. Drains are serialized inside each admin and parallel
+across admins. The lifecycle transitions to `killed` with reason
+`"al-16-pending"` once every admin's queue is drained.
+
+**Known leak until AL-4 lands:** a ticket that reaches `awaiting-merge`
+state (worker exited 0 with a PR URL) leaves its worktree on disk until
+a merge event is plumbed to `TicketRunner.handlePrMerged`. AL-4 owns
+that plumbing. This is why the drain is gated behind its own flag —
+operators opt into the leak knowingly, rather than inheriting it by
+flipping the pool flag. The CLI log line names the leak explicitly
+when the drain is enabled.
+
+### Exercising the flags locally
 
 ```bash
+# Pool boot + router only (safe, no worker spawn, no worktree leak).
 RELAY_REPO_ADMIN_POOL_ENABLED=1 rly run --autonomous --channel <id>
+
+# Full AL-14: pool + router + worker drain.
+# (Be aware that any ticket that reaches `awaiting-merge` leaves a
+# worktree on disk until AL-4 ships.)
+RELAY_REPO_ADMIN_POOL_ENABLED=1 RELAY_AL14_WORKER_DRAIN=1 \
+  rly run --autonomous --channel <id>
 ```
 
-Recognised true-ish values: `1`, `true`, `yes`, `on` (case-insensitive).
-Anything else — including typos — is treated as off.
+Recognised true-ish values for both flags: `1`, `true`, `yes`, `on`
+(case-insensitive). Anything else — including typos — is treated as off.
 
 ## Spawner wiring
 

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -3,9 +3,36 @@ import type { TokenTracker } from "../budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import { ChannelStore } from "../channels/channel-store.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
+import type { RepoAdminProcessSpawner } from "./repo-admin-session.js";
 import { TicketRouter } from "./ticket-router.js";
 import { TicketRunner } from "./ticket-runner.js";
 import { WorkerSpawner } from "./worker-spawner.js";
+
+/**
+ * Env var gating AL-14's worker-drain phase. Distinct from the pool-enabled
+ * flag so an operator can flip the pool on (AL-12 boot/restart/shutdown
+ * exercise) without automatically enabling worker spawning + drain. The
+ * split exists because AL-4's merge-detection cleanup has not shipped yet:
+ * every worker that reaches `awaiting-merge` state leaves its worktree on
+ * disk until AL-4 lands, and we want operators to opt into that leak
+ * deliberately. Default **off**.
+ *
+ * Recognised true-ish values: `"1"`, `"true"`, `"yes"`, `"on"`
+ * (case-insensitive). Anything else — including typos — is treated as off
+ * so a misconfigured flag doesn't silently leak worktrees.
+ */
+export const RELAY_AL14_WORKER_DRAIN = "RELAY_AL14_WORKER_DRAIN";
+
+/**
+ * Parse {@link RELAY_AL14_WORKER_DRAIN} into a bool. See the constant's
+ * docstring for the "why two flags" rationale.
+ */
+export function isWorkerDrainEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[RELAY_AL14_WORKER_DRAIN];
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
 
 /**
  * Options handed to {@link startAutonomousSession} by the CLI entrypoint
@@ -39,29 +66,74 @@ export interface StartAutonomousSessionOptions {
    * every assignment on the channel. AL-4 uses this as a filter at dispatch
    * time. */
   allowedRepos: RepoAssignment[];
+  /**
+   * **Test-only** injection hooks. Production callers MUST NOT set these —
+   * they exist solely so the AL-14 drain integration test can exercise the
+   * pool-boot + router + runner drain path end-to-end without a real
+   * `claude` binary. Three seams are exposed:
+   *
+   *  - `channelStore`: replaces the default `new ChannelStore()` so tests
+   *    can drive a tmp-dir-backed store with seeded channels + tickets.
+   *  - `repoAdminSpawner`: threaded into the `RepoAdminPool` so its per-
+   *    admin children are fakes (no real CLI).
+   *  - `workerSpawner`: replaces `new WorkerSpawner()` so the runner's
+   *    spawn + monitor loop fires deterministically against a fake.
+   *
+   * All three are optional and ALL must be `undefined` in production.
+   * Presence of any field constitutes a test invocation.
+   */
+  testOverrides?: {
+    channelStore?: ChannelStore;
+    repoAdminSpawner?: RepoAdminProcessSpawner;
+    workerSpawner?: WorkerSpawner;
+    /**
+     * Override the pool's `~/.relay` base dir so the test's tmp dir is
+     * used instead of the real home dir for session/admin logs.
+     */
+    rootDir?: string;
+  };
 }
 
 /**
- * Autonomous-loop driver entrypoint. At AL-14 the loop:
+ * Autonomous-loop driver entrypoint. The behaviour is gated by two env
+ * flags so AL-12's pool lifecycle and AL-14's worker drain can be rolled
+ * out independently:
  *
- *   1. When {@link RELAY_REPO_ADMIN_POOL_ENABLED} is on:
- *      - Boots the repo-admin pool (AL-12).
- *      - Reads the channel's ticket board and routes each ready ticket
- *        through {@link TicketRouter} so the matching repo-admin queues
- *        it (AL-13).
- *      - For each admin, drains its pending queue via {@link TicketRunner}:
- *        spawn a worker in a per-ticket worktree, monitor until the
- *        worker exits, and mark the ticket `verifying` (PR opened) /
- *        `failed` (AC4) on the board. Serialized inside each admin;
- *        parallel across admins.
- *      - Transitions the lifecycle to `killed` with reason
- *        `"al-16-pending"`. AL-14 owns spawn + drain; inter-admin
- *        coordination + the steady-state driver loop are still pending.
- *   2. When the flag is off: preserves the pre-AL-13 behaviour — no pool,
- *      no routing, lifecycle transitions to `killed / al-13-pending`.
- *   3. Tears down pool + lifecycle + tracker. Errors during teardown are
+ *   1. When {@link RELAY_REPO_ADMIN_POOL_ENABLED} is off:
+ *      Preserves the pre-AL-12 behaviour — no pool, no routing, lifecycle
+ *      transitions to `killed` with reason `"al-13-pending"`. This is the
+ *      safe default.
+ *   2. When only the pool flag is on:
+ *      Boots the repo-admin pool (AL-12) and routes each ready ticket
+ *      through {@link TicketRouter} (AL-13) so the matching admin queues
+ *      it. Workers are NOT spawned and queues are NOT drained — the
+ *      lifecycle transitions to `killed` with reason `"al-14-pending"`.
+ *      This mode exercises boot + routing in production without leaking
+ *      worktrees.
+ *   3. When BOTH {@link RELAY_REPO_ADMIN_POOL_ENABLED} and
+ *      {@link RELAY_AL14_WORKER_DRAIN} are on:
+ *      Full AL-14 behaviour. For each admin whose session is live
+ *      (`state === "ready"`), drain its pending queue via
+ *      {@link TicketRunner} — spawn a worker in a per-ticket worktree,
+ *      monitor until the worker exits, and mark the ticket `verifying`
+ *      (PR opened) / `failed` (AC4) on the board. Serialized inside each
+ *      admin; parallel across admins. On completion the lifecycle
+ *      transitions to `killed` with reason `"al-16-pending"`.
+ *   4. Tears down pool + lifecycle + tracker. Errors during teardown are
  *      logged and swallowed: a cosmetic shutdown failure must not turn a
  *      successful handoff into a non-zero CLI exit.
+ *
+ * ## Why two flags
+ *
+ * AL-14 owns spawn + drain but NOT PR-merge cleanup (AL-4's scope). A
+ * ticket whose worker opens a PR transitions to `awaiting-merge` and its
+ * worktree persists on disk until a merge event reaches
+ * {@link TicketRunner.handlePrMerged}. Until AL-4 ships merge-detection
+ * wiring, every pool-enabled autonomous run with the drain on leaks one
+ * worktree per successful ticket. Gating the drain behind its own flag
+ * lets operators opt into that leak knowingly — and keeps a clean opt-
+ * out path for AL-12/AL-13 exercise runs that shouldn't spawn workers at
+ * all.
  *
  * PR-merge cleanup (AC3) is NOT driven here — the runner exposes
  * {@link TicketRunner.handlePrMerged}; the autonomous-loop's steady-
@@ -71,7 +143,7 @@ export interface StartAutonomousSessionOptions {
  * hook is dormant here.
  */
 export async function startAutonomousSession(opts: StartAutonomousSessionOptions): Promise<void> {
-  const { sessionId, lifecycle, tracker, channel, allowedRepos } = opts;
+  const { sessionId, lifecycle, tracker, channel, allowedRepos, testOverrides } = opts;
 
   // AL-12 built the repo-admin pool, but the admin-process handshake
   // protocol it relies on is AL-14's deliverable. Without that protocol
@@ -81,16 +153,32 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   // `rly run --autonomous` invocations keep the pre-AL-12 behaviour
   // (clean `killed / al-13-pending` exit) until AL-14 flips the flag.
   const poolEnabled = isRepoAdminPoolEnabled();
+  // AL-14 spawn + drain is gated by a SEPARATE flag from the pool flag.
+  // Until AL-4 ships merge-detection cleanup, every ticket that reaches
+  // `awaiting-merge` leaves a worktree on disk — the two-flag split lets
+  // operators opt into that leak explicitly rather than inheriting it
+  // by flipping the pool flag. When the drain flag is off but the pool
+  // flag is on, the loop still routes tickets (AL-13) but no workers
+  // are spawned, and the lifecycle exits with reason `al-14-pending`.
+  const drainEnabled = poolEnabled && isWorkerDrainEnabled();
 
   if (!poolEnabled) {
     console.log(
       `[autonomous-loop] dispatcher not yet implemented — ` +
         `Session ${sessionId} marked as killed with reason "al-13-pending".`
     );
+  } else if (!drainEnabled) {
+    console.log(
+      `[autonomous-loop] repo-admin pool + router enabled; worker drain disabled ` +
+        `(RELAY_AL14_WORKER_DRAIN unset) — Session ${sessionId} will route tickets and ` +
+        `mark killed with reason "al-14-pending".`
+    );
   } else {
     console.log(
       `[autonomous-loop] routing channel tickets + draining repo-admin queues — ` +
-        `Session ${sessionId} will mark killed with reason "al-16-pending" once drained.`
+        `Session ${sessionId} will mark killed with reason "al-16-pending" once drained. ` +
+        `worker drain enabled; tickets that reach awaiting-merge state will leave ` +
+        `worktrees on disk until AL-4 lands merge-detection cleanup.`
     );
   }
 
@@ -100,6 +188,8 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         allowedAliases: allowedRepos.map((r) => r.alias),
         fullAccess: channel.fullAccess ?? false,
         lifecycle,
+        spawner: testOverrides?.repoAdminSpawner,
+        rootDir: testOverrides?.rootDir,
       })
     : null;
 
@@ -116,17 +206,17 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   }
 
   // AL-13: drain the channel's ticket board through the router exactly
-  // once. AL-14 adds a second pass that drains each admin's queue via
-  // TicketRunner — spawn a worker per ticket, wait for it to open a PR
-  // (or fail), then exit. The autonomous-loop's steady-state driver
-  // (AL-4) will replace this single-pass shape; AL-14 just proves the
-  // end-to-end plumbing.
-  let terminalReason: "al-13-pending" | "al-16-pending" = "al-13-pending";
+  // once. AL-14 adds a second pass (gated by RELAY_AL14_WORKER_DRAIN)
+  // that drains each admin's queue via TicketRunner — spawn a worker
+  // per ticket, wait for it to open a PR (or fail), then exit. The
+  // autonomous-loop's steady-state driver (AL-4) will replace this
+  // single-pass shape; AL-14 just proves the end-to-end plumbing.
+  let terminalReason: "al-13-pending" | "al-14-pending" | "al-16-pending" = "al-13-pending";
   if (pool) {
-    terminalReason = "al-16-pending";
+    terminalReason = drainEnabled ? "al-16-pending" : "al-14-pending";
     const runners: TicketRunner[] = [];
     try {
-      const channelStore = new ChannelStore();
+      const channelStore = testOverrides?.channelStore ?? new ChannelStore();
       const router = new TicketRouter({ pool, channel, channelStore });
       const boardTickets = await channelStore.readChannelTickets(channel.channelId);
       for (const ticket of boardTickets) {
@@ -149,37 +239,45 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         }
       }
 
-      // AL-14: drain each admin's pending queue in parallel. Each admin
-      // serializes internally (one worker at a time in its repo); two
-      // different admins DO run in parallel. The drain promise resolves
-      // once every admin's queue is empty AND every in-flight worker has
-      // exited.
-      const spawner = new WorkerSpawner();
-      const admins = pool.listSessions();
-      for (const admin of admins) {
-        const assignment = channel.repoAssignments?.find((a) => a.alias === admin.alias);
-        if (!assignment) continue;
-        runners.push(
-          new TicketRunner({
-            admin,
-            repoAssignment: assignment,
-            channel,
-            channelStore,
-            spawner,
-          })
+      if (drainEnabled) {
+        // AL-14: drain each admin's pending queue in parallel. Each admin
+        // serializes internally (one worker at a time in its repo); two
+        // different admins DO run in parallel. The drain promise resolves
+        // once every admin's queue is empty AND every in-flight worker has
+        // exited.
+        const spawner = testOverrides?.workerSpawner ?? new WorkerSpawner();
+        // Filter to live admins only: `listSessions()` also returns admins
+        // whose child has died / been terminally marked `stopped` by the
+        // pool's rapid-restart ceiling. Dispatching into those sessions
+        // is a programming error (they throw) and surfacing nothing is
+        // the right behaviour — the router already wrote the blocked
+        // status for the routing failure.
+        const admins = pool.listSessions().filter((s) => s.state === "ready");
+        for (const admin of admins) {
+          const assignment = channel.repoAssignments?.find((a) => a.alias === admin.alias);
+          if (!assignment) continue;
+          runners.push(
+            new TicketRunner({
+              admin,
+              repoAssignment: assignment,
+              channel,
+              channelStore,
+              spawner,
+            })
+          );
+        }
+        await Promise.all(
+          runners.map((r) =>
+            r.drain().catch((err) => {
+              console.warn(
+                `[autonomous-loop] ticket runner drain failed: ${
+                  err instanceof Error ? err.message : String(err)
+                }`
+              );
+            })
+          )
         );
       }
-      await Promise.all(
-        runners.map((r) =>
-          r.drain().catch((err) => {
-            console.warn(
-              `[autonomous-loop] ticket runner drain failed: ${
-                err instanceof Error ? err.message : String(err)
-              }`
-            );
-          })
-        )
-      );
     } catch (err) {
       console.warn(
         `[autonomous-loop] ticket routing pass failed: ${

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -4,6 +4,8 @@ import type { Channel, RepoAssignment } from "../domain/channel.js";
 import { ChannelStore } from "../channels/channel-store.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
 import { TicketRouter } from "./ticket-router.js";
+import { TicketRunner } from "./ticket-runner.js";
+import { WorkerSpawner } from "./worker-spawner.js";
 
 /**
  * Options handed to {@link startAutonomousSession} by the CLI entrypoint
@@ -40,23 +42,33 @@ export interface StartAutonomousSessionOptions {
 }
 
 /**
- * Autonomous-loop driver entrypoint. AL-14 will replace the body with the
- * real scheduler + dispatcher loop. At AL-13 the loop:
+ * Autonomous-loop driver entrypoint. At AL-14 the loop:
  *
  *   1. When {@link RELAY_REPO_ADMIN_POOL_ENABLED} is on:
  *      - Boots the repo-admin pool (AL-12).
  *      - Reads the channel's ticket board and routes each ready ticket
  *        through {@link TicketRouter} so the matching repo-admin queues
- *        it. Worker spawning + execution is AL-14's scope; AL-13 only
- *        marks intent.
+ *        it (AL-13).
+ *      - For each admin, drains its pending queue via {@link TicketRunner}:
+ *        spawn a worker in a per-ticket worktree, monitor until the
+ *        worker exits, and mark the ticket `verifying` (PR opened) /
+ *        `failed` (AC4) on the board. Serialized inside each admin;
+ *        parallel across admins.
  *      - Transitions the lifecycle to `killed` with reason
- *        `"al-14-pending"` (dispatch without execution is still a stub,
- *        but the routing stage is real — so the reason shifts).
+ *        `"al-16-pending"`. AL-14 owns spawn + drain; inter-admin
+ *        coordination + the steady-state driver loop are still pending.
  *   2. When the flag is off: preserves the pre-AL-13 behaviour — no pool,
  *      no routing, lifecycle transitions to `killed / al-13-pending`.
  *   3. Tears down pool + lifecycle + tracker. Errors during teardown are
  *      logged and swallowed: a cosmetic shutdown failure must not turn a
  *      successful handoff into a non-zero CLI exit.
+ *
+ * PR-merge cleanup (AC3) is NOT driven here — the runner exposes
+ * {@link TicketRunner.handlePrMerged}; the autonomous-loop's steady-
+ * state driver (AL-4) will plumb PR-poller merge events into that hook
+ * once the loop runs long enough to observe them. AL-14's single-pass
+ * autonomous stub intentionally exits before any PR can merge, so the
+ * hook is dormant here.
  */
 export async function startAutonomousSession(opts: StartAutonomousSessionOptions): Promise<void> {
   const { sessionId, lifecycle, tracker, channel, allowedRepos } = opts;
@@ -77,8 +89,8 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     );
   } else {
     console.log(
-      `[autonomous-loop] routing channel tickets through repo-admin pool — ` +
-        `Session ${sessionId} will mark killed with reason "al-14-pending" once routed.`
+      `[autonomous-loop] routing channel tickets + draining repo-admin queues — ` +
+        `Session ${sessionId} will mark killed with reason "al-16-pending" once drained.`
     );
   }
 
@@ -104,14 +116,15 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   }
 
   // AL-13: drain the channel's ticket board through the router exactly
-  // once. The scheduler drains its run ledger on a loop; this autonomous
-  // stub doesn't spin — AL-14 adds the steady-state loop (poll for new
-  // tickets, watch worker completions, spawn replacements, etc.). The
-  // single pass here is enough to satisfy AL-13's "boots pool, routes
-  // tickets to admins (who queue them), exits cleanly" scope.
-  let terminalReason: "al-13-pending" | "al-14-pending" = "al-13-pending";
+  // once. AL-14 adds a second pass that drains each admin's queue via
+  // TicketRunner — spawn a worker per ticket, wait for it to open a PR
+  // (or fail), then exit. The autonomous-loop's steady-state driver
+  // (AL-4) will replace this single-pass shape; AL-14 just proves the
+  // end-to-end plumbing.
+  let terminalReason: "al-13-pending" | "al-16-pending" = "al-13-pending";
   if (pool) {
-    terminalReason = "al-14-pending";
+    terminalReason = "al-16-pending";
+    const runners: TicketRunner[] = [];
     try {
       const channelStore = new ChannelStore();
       const router = new TicketRouter({ pool, channel, channelStore });
@@ -135,11 +148,58 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
           );
         }
       }
+
+      // AL-14: drain each admin's pending queue in parallel. Each admin
+      // serializes internally (one worker at a time in its repo); two
+      // different admins DO run in parallel. The drain promise resolves
+      // once every admin's queue is empty AND every in-flight worker has
+      // exited.
+      const spawner = new WorkerSpawner();
+      const admins = pool.listSessions();
+      for (const admin of admins) {
+        const assignment = channel.repoAssignments?.find((a) => a.alias === admin.alias);
+        if (!assignment) continue;
+        runners.push(
+          new TicketRunner({
+            admin,
+            repoAssignment: assignment,
+            channel,
+            channelStore,
+            spawner,
+          })
+        );
+      }
+      await Promise.all(
+        runners.map((r) =>
+          r.drain().catch((err) => {
+            console.warn(
+              `[autonomous-loop] ticket runner drain failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          })
+        )
+      );
     } catch (err) {
       console.warn(
         `[autonomous-loop] ticket routing pass failed: ${
           err instanceof Error ? err.message : String(err)
         }`
+      );
+    } finally {
+      // Ensure any in-flight worker is signalled before we unwind. Safe
+      // to call even if drain() already finished — stop() is idempotent
+      // and only hits still-running workers.
+      await Promise.all(
+        runners.map((r) =>
+          r.stop("autonomous-loop-exit").catch((err) => {
+            console.warn(
+              `[autonomous-loop] runner stop failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          })
+        )
       );
     }
   }

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -464,6 +464,26 @@ export class RepoAdminSession {
   }
 
   /**
+   * AL-14 consumer API: pop the head of the pending queue FIFO-style.
+   * Returns `null` when the queue is empty. Called by the ticket runner's
+   * drain loop once per iteration; the returned ticket is NOT re-enqueued
+   * on failure — the runner owns marking it `failed` on the channel board
+   * (AC4), and a retry requires a fresh route through AL-13.
+   *
+   * Throws when the session is `stopped` so a stale reference can't drain
+   * a dead admin. Mirrors the guard on {@link dispatchTicket}.
+   */
+  takeNextPendingTicket(): TicketLedgerEntry | null {
+    if (this._state === "stopped") {
+      throw new Error(
+        `RepoAdminSession(${this.alias}): cannot takeNextPendingTicket after stop(); ` +
+          `route through a fresh session.`
+      );
+    }
+    return this.pendingDispatches.shift() ?? null;
+  }
+
+  /**
    * Subscribe to session events. Returns an unsubscribe function. The pool
    * always subscribes; other callers may (e.g. the TUI for live liveness
    * readouts).

--- a/src/orchestrator/ticket-runner.ts
+++ b/src/orchestrator/ticket-runner.ts
@@ -1,0 +1,584 @@
+/**
+ * Per-ticket runner — AL-14.
+ *
+ * The repo-admin session (AL-12) collects tickets on an in-memory queue
+ * via AL-13's router. AL-14's `TicketRunner` drains that queue: for each
+ * ticket, it asks {@link WorkerSpawner} to create a worktree + spawn a
+ * worker agent, monitors until the worker exits, and advances the ticket's
+ * status on the channel board.
+ *
+ * ## Serialization
+ *
+ * AL-14 MVP **serializes** inside each repo. One repo-admin runs one
+ * worker at a time. The AL-12 design note acknowledged this as a
+ * deliberate trade-off; parallel workers inside the same repo (and the
+ * worktree-clobber risks that come with them) are deferred to a later
+ * ticket. Documented here so a future reader doesn't mistake the single-
+ * threaded drain for an oversight. Two DIFFERENT repo-admins (separate
+ * `TicketRunner` instances, one per admin) DO run in parallel — that's
+ * the whole point of the pool.
+ *
+ * ## Lifecycle of a ticket
+ *
+ * 1. Take from `admin.pendingDispatches` (FIFO).
+ * 2. Spawn a worker via {@link WorkerSpawner}. Mark ticket `executing`,
+ *    stamp `crosslinkSessionId = worker.sessionId`.
+ * 3. Monitor the worker's exit.
+ *    - Exit code 0 + PR URL detected → ticket `verifying`, runner emits
+ *      `worker-pr-opened` so an outer watcher can track the PR through
+ *      merge (AL-5 will later wire the reviewer). Worktree is NOT
+ *      destroyed here — we keep it until PR merge.
+ *    - Exit code 0 + no PR URL → ticket `failed` with `fix_code`
+ *      classification. AC4: the failure surfaces on the feed + an event
+ *      fires on the runner's own emitter so the admin pool can log it.
+ *      Worktree is preserved for operator inspection.
+ *    - Non-zero exit → ticket `failed`, feed entry with stdout/stderr
+ *      tail, worktree preserved. AC4.
+ * 4. When the PR merges, the caller invokes `handlePrMerged(ticketId)`.
+ *    The runner destroys the worktree (AC3) and marks the ticket
+ *    `completed`. The call is idempotent: repeated merge events for the
+ *    same ticket are no-ops.
+ *
+ * ## What lives elsewhere
+ *
+ * - Who dispatches PR-merge events into the runner is NOT AL-14's scope
+ *   — the PR poller (`src/integrations/pr-poller.ts`) already surfaces
+ *   `prState -> merged` transitions; wiring it to `handlePrMerged` is the
+ *   autonomous-loop's job (AL-4 steady-state driver, out of scope here).
+ *   AL-14 provides the hook; AL-4 calls it.
+ * - Reviewer integration (AL-5), approval gates (AL-7/8), and inter-admin
+ *   coordination (AL-16) are all explicitly out of scope.
+ */
+
+import { EventEmitter } from "node:events";
+
+import type { ChannelStore } from "../channels/channel-store.js";
+import type { Channel, RepoAssignment } from "../domain/channel.js";
+import type { TicketLedgerEntry, TicketStatus } from "../domain/ticket.js";
+
+import type { RepoAdminSession } from "./repo-admin-session.js";
+import type { WorkerHandle, WorkerExitEvent, WorkerSpawner } from "./worker-spawner.js";
+import type { SandboxRef } from "../execution/sandbox.js";
+
+export interface TicketRunnerEvent {
+  ticketId: string;
+  workerSessionId: string;
+}
+
+export type TicketRunnerEventMap = {
+  "worker-started": TicketRunnerEvent;
+  "worker-pr-opened": TicketRunnerEvent & { prUrl: string };
+  "worker-completed": TicketRunnerEvent & { prUrl: string | null };
+  "worker-failed": TicketRunnerEvent & {
+    exitCode: number | null;
+    reason: string;
+    worktreePath: string;
+  };
+  "ticket-merged": TicketRunnerEvent & { prUrl: string | null };
+};
+
+export interface TicketRunnerOptions {
+  admin: RepoAdminSession;
+  repoAssignment: RepoAssignment;
+  channel: Channel;
+  channelStore: ChannelStore;
+  spawner: WorkerSpawner;
+  /**
+   * Clock for `updatedAt` stamps. Tests inject deterministic values so the
+   * ticket mirror is snapshot-friendly. Defaults to `() => new Date().toISOString()`.
+   */
+  now?: () => string;
+  /**
+   * Optional PR-URL fallback probe. Invoked with `{branch}` when the worker
+   * exited cleanly but no URL appeared in stdout. Returns the PR URL or
+   * `null`. When omitted, the runner skips the fallback and treats a
+   * missing URL as a failure (AC4 for the "no PR" case).
+   *
+   * The spec's "fallback `gh pr list` query" lives here — injecting it
+   * keeps the runner testable without shelling out in unit tests.
+   */
+  prUrlFallback?: (args: { branch: string; worktreePath: string }) => Promise<string | null>;
+}
+
+/**
+ * Tracker record for a ticket currently in-flight or awaiting its PR to
+ * merge. Kept on the runner so `handlePrMerged` can find the right
+ * sandbox to destroy.
+ */
+interface InflightTicket {
+  ticketId: string;
+  sandboxRef: SandboxRef;
+  worktreePath: string;
+  prUrl: string | null;
+  state: "running" | "awaiting-merge" | "failed" | "completed" | "stopped";
+  workerSessionId: string;
+}
+
+export class TicketRunner {
+  private readonly admin: RepoAdminSession;
+  private readonly repoAssignment: RepoAssignment;
+  private readonly channel: Channel;
+  private readonly channelStore: ChannelStore;
+  private readonly spawner: WorkerSpawner;
+  private readonly now: () => string;
+  private readonly prUrlFallback?: (args: {
+    branch: string;
+    worktreePath: string;
+  }) => Promise<string | null>;
+
+  /**
+   * FIFO in-flight map keyed by ticketId. `state` tells callers whether
+   * the ticket is still running, waiting on the PR, or terminal. Runner
+   * keeps records for terminal tickets until cleanup so `handlePrMerged`
+   * can still map a ticketId to its sandbox when the merge event arrives
+   * after the runner loop has moved on.
+   */
+  private readonly inflight = new Map<string, InflightTicket>();
+
+  private readonly emitter = new EventEmitter();
+  private draining = false;
+  private drainPromise: Promise<void> | null = null;
+  private stopped = false;
+
+  constructor(options: TicketRunnerOptions) {
+    this.admin = options.admin;
+    this.repoAssignment = options.repoAssignment;
+    this.channel = options.channel;
+    this.channelStore = options.channelStore;
+    this.spawner = options.spawner;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.prUrlFallback = options.prUrlFallback;
+  }
+
+  /**
+   * Subscribe to runner events. Uses a typed key so consumers don't guess
+   * the event strings.
+   */
+  on<K extends keyof TicketRunnerEventMap>(
+    event: K,
+    listener: (evt: TicketRunnerEventMap[K]) => void
+  ): () => void {
+    this.emitter.on(event, listener);
+    return () => {
+      this.emitter.off(event, listener);
+    };
+  }
+
+  /**
+   * Drain the admin's pending queue: for each queued ticket, spawn a
+   * worker, monitor its exit, and advance the ticket board. Serializes
+   * at the admin level — see top-of-file doc.
+   *
+   * Subsequent calls while a drain is in flight return the same promise
+   * so the autonomous-loop can fire this opportunistically without
+   * double-processing.
+   */
+  async drain(): Promise<void> {
+    if (this.drainPromise) return this.drainPromise;
+    this.drainPromise = this.runDrainLoop()
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ticket-runner] drain failed for alias=${this.repoAssignment.alias}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      })
+      .finally(() => {
+        this.drainPromise = null;
+      });
+    return this.drainPromise;
+  }
+
+  /**
+   * AC3: worktree cleanup on PR merge. Idempotent — calling twice for the
+   * same ticket is a no-op the second time. Destroys the worktree via the
+   * spawner (which routes to the sandbox provider), transitions the
+   * ticket to `completed`, and posts a feed update.
+   *
+   * Cleanup happens regardless of WHO merged the PR (user, agent, GOD
+   * mode) — the runner doesn't inspect the merge source. That's AC3's
+   * second clause.
+   */
+  async handlePrMerged(ticketId: string): Promise<void> {
+    const record = this.inflight.get(ticketId);
+    if (!record) return;
+    if (record.state === "completed") return; // idempotent
+
+    try {
+      await this.spawner.destroyWorktree(record.sandboxRef);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ticket-runner] failed to destroy worktree for ticket ${ticketId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    record.state = "completed";
+    await this.updateTicket(ticketId, (ticket) => {
+      ticket.status = "completed";
+      ticket.completedAt = this.now();
+      ticket.updatedAt = this.now();
+    });
+
+    await this.channelStore
+      .postEntry(this.channel.channelId, {
+        type: "status_update",
+        fromAgentId: null,
+        fromDisplayName: "repo-admin",
+        content: `Ticket ${ticketId} PR merged. Worktree cleaned up.`,
+        metadata: {
+          ticketId,
+          prUrl: record.prUrl ?? null,
+          worktreePath: record.worktreePath,
+        },
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ticket-runner] failed to post merge status for ticket ${ticketId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+
+    this.emit("ticket-merged", {
+      ticketId,
+      workerSessionId: record.workerSessionId,
+      prUrl: record.prUrl,
+    });
+
+    // Drop the record once we're fully done so the map doesn't grow
+    // unbounded across a long-lived session.
+    this.inflight.delete(ticketId);
+  }
+
+  /**
+   * Stop the runner. After this call, {@link drain} is a no-op and any
+   * in-flight workers are signalled SIGTERM. Does NOT destroy worktrees
+   * — operator inspection of failed workers (AC4) takes precedence over
+   * aggressive cleanup.
+   */
+  async stop(reason: string): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+
+    // Snapshot so handler mutations during iteration don't skip entries.
+    const handles = Array.from(this.activeHandles.values());
+    await Promise.all(
+      handles.map(async (handle) => {
+        try {
+          await handle.stop(reason);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[ticket-runner] handle.stop(${handle.ticketId}) threw: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      })
+    );
+
+    this.emitter.removeAllListeners();
+  }
+
+  /**
+   * Snapshot of in-flight + pending-merge tickets. Useful to tests and the
+   * TUI for a quick "what's this admin working on?" readout.
+   */
+  listInflight(): ReadonlyArray<Readonly<InflightTicket>> {
+    return Array.from(this.inflight.values());
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  /**
+   * Live handles to active workers. Separate from {@link inflight} because a
+   * ticket may remain in `inflight` (awaiting PR merge) long after its
+   * worker handle has gone away.
+   */
+  private readonly activeHandles = new Map<string, WorkerHandle>();
+
+  private async runDrainLoop(): Promise<void> {
+    if (this.stopped) return;
+    this.draining = true;
+    try {
+      // AL-14 MVP: serialize. While the loop is running, new tickets that
+      // land via `dispatchTicket` pile up in the admin queue and get picked
+      // up on the next pass through the while-loop body.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if (this.stopped) return;
+        const ticket = this.admin.takeNextPendingTicket();
+        if (!ticket) return;
+        try {
+          await this.runOneTicket(ticket);
+        } catch (err) {
+          // Defense in depth: runOneTicket already catches + surfaces most
+          // failures via updateTicket + feed posts, but a truly unexpected
+          // throw shouldn't wedge the drain loop. Log and move on.
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[ticket-runner] unexpected error running ticket ${ticket.ticketId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  private async runOneTicket(ticket: TicketLedgerEntry): Promise<void> {
+    if (this.stopped) return;
+
+    // Spawn. Any error during spawn (worktree create, child spawn) → ticket
+    // failed, feed surfaced, runner event fired. Worktree is NOT created
+    // if spawner threw before `create` completed — nothing to clean up.
+    let handle: WorkerHandle;
+    let worktreePath: string;
+    let sandboxRef: SandboxRef;
+    try {
+      const result = await this.spawner.spawn({
+        ticket,
+        repoAssignment: this.repoAssignment,
+        channel: this.channel,
+      });
+      handle = result.handle;
+      worktreePath = result.worktreePath;
+      sandboxRef = result.sandboxRef;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await this.markTicketFailed(ticket.ticketId, {
+        reason,
+        stdoutTail: "",
+        stderrTail: reason,
+        worktreePath: "(never created)",
+        exitCode: null,
+      });
+      return;
+    }
+
+    const inflight: InflightTicket = {
+      ticketId: ticket.ticketId,
+      sandboxRef,
+      worktreePath,
+      prUrl: null,
+      state: "running",
+      workerSessionId: handle.sessionId,
+    };
+    this.inflight.set(ticket.ticketId, inflight);
+    this.activeHandles.set(ticket.ticketId, handle);
+
+    await this.updateTicket(ticket.ticketId, (t) => {
+      t.status = "executing";
+      t.crosslinkSessionId = handle.sessionId;
+      t.startedAt = this.now();
+      t.updatedAt = this.now();
+      t.attempt = (t.attempt ?? 0) + 1;
+    });
+
+    this.emit("worker-started", {
+      ticketId: ticket.ticketId,
+      workerSessionId: handle.sessionId,
+    });
+
+    // Wait for exit. `onExit` already handles the "already-exited" case on
+    // the next microtask, so this promise resolves deterministically.
+    const evt: WorkerExitEvent = await new Promise((resolve) => {
+      const off = handle.onExit((e) => {
+        off();
+        resolve(e);
+      });
+    });
+
+    this.activeHandles.delete(ticket.ticketId);
+
+    // Resolve the PR URL: prefer stdout-tail; fall back to an injected
+    // probe (typically `gh pr list --head <branch>`).
+    let prUrl: string | null = evt.detectedPrUrl;
+    if (!prUrl && evt.exitCode === 0 && this.prUrlFallback) {
+      try {
+        prUrl = await this.prUrlFallback({
+          branch: branchNameFor(sandboxRef),
+          worktreePath,
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ticket-runner] prUrlFallback threw for ticket ${ticket.ticketId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+
+    inflight.prUrl = prUrl;
+
+    if (evt.exitCode === 0 && prUrl) {
+      // Happy path. Ticket is awaiting the PR to merge before we destroy
+      // the worktree (AC3). Status moves to `verifying` so the board
+      // reflects "worker done, PR open".
+      inflight.state = "awaiting-merge";
+      await this.updateTicket(ticket.ticketId, (t) => {
+        t.status = "verifying";
+        t.updatedAt = this.now();
+      });
+      this.emit("worker-pr-opened", {
+        ticketId: ticket.ticketId,
+        workerSessionId: handle.sessionId,
+        prUrl,
+      });
+      this.emit("worker-completed", {
+        ticketId: ticket.ticketId,
+        workerSessionId: handle.sessionId,
+        prUrl,
+      });
+      return;
+    }
+
+    // Failure paths: non-zero exit OR clean exit without a PR URL. Per AC4
+    // the worktree is NOT destroyed here — keep it around for inspection.
+    inflight.state = "failed";
+    await this.markTicketFailed(ticket.ticketId, {
+      reason: evt.reason,
+      stdoutTail: evt.stdoutTail,
+      stderrTail: evt.stderrTail,
+      worktreePath,
+      exitCode: evt.exitCode,
+    });
+    this.emit("worker-failed", {
+      ticketId: ticket.ticketId,
+      workerSessionId: handle.sessionId,
+      exitCode: evt.exitCode,
+      reason: evt.reason,
+      worktreePath,
+    });
+  }
+
+  private async markTicketFailed(
+    ticketId: string,
+    args: {
+      reason: string;
+      stdoutTail: string;
+      stderrTail: string;
+      worktreePath: string;
+      exitCode: number | null;
+    }
+  ): Promise<void> {
+    await this.updateTicket(ticketId, (t) => {
+      t.status = "failed";
+      t.updatedAt = this.now();
+      t.lastClassification = {
+        category: "fix_code",
+        rationale: args.reason || "worker exited without producing a PR",
+        nextAction: "inspect worktree and retry or fix manually",
+      };
+    });
+
+    const tail = lastLines(args.stdoutTail, 20);
+    const content = [
+      `Worker failed on ticket ${ticketId} (exit ${args.exitCode ?? "null"}).`,
+      `Worktree preserved at ${args.worktreePath} for inspection.`,
+      tail ? `Last stdout:\n${tail}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    await this.channelStore
+      .postEntry(this.channel.channelId, {
+        type: "status_update",
+        fromAgentId: null,
+        fromDisplayName: "repo-admin",
+        content,
+        metadata: {
+          ticketId,
+          worktreePath: args.worktreePath,
+          exitCode: args.exitCode,
+          stderrTail: lastLines(args.stderrTail, 20),
+        },
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ticket-runner] failed to post failure status for ticket ${ticketId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+  }
+
+  private async updateTicket(
+    ticketId: string,
+    mutator: (ticket: TicketLedgerEntry) => void
+  ): Promise<void> {
+    try {
+      const board = await this.channelStore.readChannelTickets(this.channel.channelId);
+      const existing = board.find((t) => t.ticketId === ticketId);
+      const base: TicketLedgerEntry = existing ?? {
+        ticketId,
+        title: ticketId,
+        specialty: "general",
+        status: "pending" as TicketStatus,
+        dependsOn: [],
+        assignedAgentId: null,
+        assignedAgentName: null,
+        crosslinkSessionId: null,
+        verification: "pending",
+        lastClassification: null,
+        chosenNextAction: null,
+        attempt: 0,
+        startedAt: null,
+        completedAt: null,
+        updatedAt: this.now(),
+        runId: null,
+      };
+      mutator(base);
+      await this.channelStore.upsertChannelTickets(this.channel.channelId, [base]);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ticket-runner] failed to update ticket ${ticketId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  private emit<K extends keyof TicketRunnerEventMap>(
+    event: K,
+    payload: TicketRunnerEventMap[K]
+  ): void {
+    const listeners = this.emitter.listeners(event) as Array<(p: TicketRunnerEventMap[K]) => void>;
+    for (const listener of listeners) {
+      try {
+        listener(payload);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ticket-runner] listener threw on ${String(event)}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+  }
+}
+
+function lastLines(text: string, n: number): string {
+  if (!text) return "";
+  const lines = text.split("\n");
+  return lines.slice(Math.max(0, lines.length - n)).join("\n");
+}
+
+function branchNameFor(ref: SandboxRef): string {
+  // The git-worktree provider stamps `branch` in `ref.meta`. Fall back to a
+  // reasonable synthetic if a custom provider didn't populate it — the
+  // fallback's only consumer is the PR-URL probe, which tolerates an empty
+  // string gracefully.
+  return ref.meta?.branch ?? "";
+}

--- a/src/orchestrator/worker-spawner.ts
+++ b/src/orchestrator/worker-spawner.ts
@@ -1,0 +1,636 @@
+/**
+ * Worker spawning for AL-14.
+ *
+ * When a repo-admin receives a ticket (AL-13), this module creates a
+ * dedicated git worktree for that ticket, then spawns the matching worker
+ * agent (atlas / pixel / forge / probe / lens / …) scoped to that worktree.
+ * The caller ({@link TicketRunner}) monitors the worker via {@link
+ * WorkerHandle}, and tears down the worktree when the PR merges.
+ *
+ * Design principles:
+ *
+ *   - **Reuse existing infra.** The worktree is created through
+ *     {@link SandboxProvider} (`GitWorktreeSandboxProvider`). The child
+ *     process is spawned through the same `CommandInvoker` path Claude/Codex
+ *     adapters use — we don't resurrect our own subprocess plumbing.
+ *   - **Full-access inheritance.** `channel.fullAccess` is threaded through
+ *     to the child so `--dangerously-skip-permissions` is set when (and only
+ *     when) the channel opted in. Parity with `createLiveAgents` (AL-0).
+ *   - **Observable.** The handle exposes a state getter and `onExit` hook so
+ *     the ticket runner can detect exit, stderr tail, and the spawned
+ *     sessionId without polling.
+ *   - **Idempotent cleanup.** `stop(reason)` + sandbox `destroy` are both
+ *     idempotent; repeated calls never throw.
+ *
+ * Scope discipline:
+ *   - PR-merge cleanup lives here (via `destroyWorktree`) but the decision
+ *     of *when* to call it is the ticket runner's (AL-14).
+ *   - PR-review integration is AL-5's scope — this module only spawns the
+ *     worker and hands back a handle.
+ *   - Inter-admin coordination is AL-16; we serialize at the ticket runner
+ *     layer (see top-of-file doc in `ticket-runner.ts`).
+ */
+
+import { EventEmitter } from "node:events";
+
+import type { Channel, RepoAssignment } from "../domain/channel.js";
+import type { AgentSpecialty } from "../domain/specialty.js";
+import type { TicketLedgerEntry } from "../domain/ticket.js";
+
+import {
+  NodeCommandInvoker,
+  type CommandInvoker,
+  type SpawnedProcess,
+} from "../agents/command-invoker.js";
+import { GitWorktreeSandboxProvider } from "../execution/sandboxes/git-worktree.js";
+import type { SandboxProvider, SandboxRef } from "../execution/sandbox.js";
+
+/**
+ * Stream retention per worker. Workers are long-running; a wedged tail-log
+ * could balloon unbounded without a cap. 200 lines mirrors the repo-admin
+ * session's stderr tail (STDERR_DIAGNOSTIC_LINES).
+ */
+export const WORKER_STDOUT_TAIL_LINES = 200;
+export const WORKER_STDERR_TAIL_LINES = 200;
+
+/**
+ * Env vars a worker's Claude/Codex subprocess is allowed to read from the
+ * parent. Mirrors `CLAUDE_PASS_ENV` from `cli-agents.ts` so a worker spawned
+ * by AL-14 can auth the same way as one spawned by `createLiveAgents`.
+ */
+const WORKER_PASS_ENV: readonly string[] = [
+  // Claude auth
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_MODEL",
+  "CLAUDE_CONFIG_DIR",
+  "CLAUDE_HOME",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  // AWS (Bedrock)
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_PROFILE",
+  // Google (Vertex)
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GCLOUD_PROJECT",
+  "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_CLOUD_QUOTA_PROJECT",
+  "CLOUDSDK_CORE_PROJECT",
+  // Workers use `gh pr create`; keep the token forwarded so the flow works
+  // inside the sanitized subprocess env.
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+];
+
+export type WorkerState = "running" | "completed" | "failed" | "stopped";
+
+export interface WorkerExitEvent {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  reason: string;
+  /** Last {@link WORKER_STDOUT_TAIL_LINES} lines of stdout for diagnostics. */
+  stdoutTail: string;
+  /** Last {@link WORKER_STDERR_TAIL_LINES} lines of stderr for diagnostics. */
+  stderrTail: string;
+  /** PR URL detected in stdout, if any. Used by the ticket runner for AC3. */
+  detectedPrUrl: string | null;
+}
+
+export interface WorkerHandle {
+  readonly ticketId: string;
+  /**
+   * Per-child identifier minted at spawn time. Distinct from the repo-admin
+   * session id that spawned it, so observers can correlate logs to one
+   * worker's life.
+   */
+  readonly sessionId: string;
+  readonly specialty: AgentSpecialty;
+  readonly state: WorkerState;
+  /**
+   * PR URL scraped from the worker's stdout as it ran, updated live. `null`
+   * until the worker prints (or the parent module detects via fallback) a
+   * `github.com/<owner>/<repo>/pull/<n>` URL. Read by the ticket runner on
+   * `onExit` — if still null after the worker exits, the runner triggers a
+   * `gh pr list` fallback probe (see top-of-file doc).
+   */
+  readonly detectedPrUrl: string | null;
+  /**
+   * Absolute path of the worktree this worker is scoped to. Exposed so the
+   * caller can destroy it on PR merge without holding the full `SandboxRef`.
+   */
+  readonly worktreePath: string;
+  /**
+   * Opaque sandbox reference. Kept on the handle so callers that prefer to
+   * use the provider's destroy API (rather than a raw path) have a stable
+   * pointer. Not intended for external mutation.
+   */
+  readonly sandboxRef: SandboxRef;
+
+  /** Graceful stop: SIGTERM → 5s grace → SIGKILL. Idempotent. */
+  stop(reason: string): Promise<void>;
+  /**
+   * Subscribe to the single exit event. Returns an unsubscribe function so
+   * multiple observers can watch without fighting over a shared callback.
+   * If the worker has already exited, the listener is invoked on next tick
+   * with the final event — consumers don't have to race.
+   */
+  onExit(listener: (evt: WorkerExitEvent) => void): () => void;
+}
+
+export interface WorkerSpawnResult {
+  handle: WorkerHandle;
+  worktreePath: string;
+  /** Sandbox reference needed to destroy the worktree later. */
+  sandboxRef: SandboxRef;
+}
+
+export interface WorkerSpawnOptions {
+  ticket: TicketLedgerEntry;
+  repoAssignment: RepoAssignment;
+  /**
+   * Channel the ticket belongs to. AL-0: `channel.fullAccess` is threaded
+   * through so the worker inherits the same "skip permission prompts"
+   * posture the rest of the channel's agents use.
+   */
+  channel: Channel;
+  /**
+   * Base branch to worktree from. Defaults to `"main"` — matches what
+   * `createWorktree` does across the repo. Callers may override for
+   * topic-branch work.
+   */
+  base?: string;
+}
+
+export interface WorkerSpawnerOptions {
+  /**
+   * Sandbox provider. Defaults to `GitWorktreeSandboxProvider`; tests inject
+   * a fake so the worktree path is deterministic without a real git repo.
+   */
+  sandboxProvider?: SandboxProvider;
+  /**
+   * Command invoker for spawning the worker child process. Defaults to
+   * `NodeCommandInvoker`; tests inject a fake so stdout/exit is scripted.
+   */
+  invoker?: CommandInvoker;
+  /** Session-id factory. Tests inject a deterministic one. */
+  buildSessionId?: () => string;
+  /** Clock for short-timestamp branch suffixes. Tests inject a fixed value. */
+  clock?: () => number;
+  /**
+   * SIGTERM→SIGKILL grace period. Only tests override; production always
+   * uses {@link WORKER_STOP_GRACE_MS}.
+   */
+  stopGraceMs?: number;
+}
+
+/** Hard grace period between SIGTERM and SIGKILL on `stop()`. */
+export const WORKER_STOP_GRACE_MS = 5_000;
+
+/**
+ * Regex matching a GitHub PR URL in worker stdout. Deliberately permissive
+ * on host (supports enterprise github.example.com) and tolerant of a
+ * trailing slash / query string. Matches the shape `gh pr create` prints.
+ */
+const PR_URL_PATTERN = /https:\/\/[A-Za-z0-9.-]+\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+
+/**
+ * Map an `AgentSpecialty` to the canonical agent id spawned for that
+ * specialty. Mirrors the `AGENT_SPECS` registry in `factory.ts`; keeping
+ * this mapping local avoids importing the full spec array just to pluck
+ * an id. Default fallback is `"atlas"` per the AL-14 ticket spec.
+ */
+export function specialtyToAgentId(specialty: AgentSpecialty | undefined): string {
+  switch (specialty) {
+    case "ui":
+      return "pixel";
+    case "business_logic":
+    case "api_crud":
+      return "forge";
+    case "testing":
+      return "probe";
+    case "devops":
+      return "forge";
+    case "general":
+    case "repo_admin":
+    case undefined:
+    default:
+      return "atlas";
+  }
+}
+
+/**
+ * Short time-stamp suffix used inside `runId` so two concurrent worker
+ * spawns for the same ticket generate distinct worktree paths. Base-36
+ * keeps the suffix compact while preserving uniqueness within a run.
+ */
+function shortTimestamp(clock: () => number): string {
+  return `${clock().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+/**
+ * Default session-id factory for workers. Format embeds `worker-` prefix +
+ * epoch ms + random suffix so logs unambiguously point at this module.
+ */
+function defaultBuildWorkerSessionId(): string {
+  return `worker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * WorkerSpawner — given a ticket + repo assignment + channel, produce a
+ * live worker scoped to its own git worktree. One call == one worker;
+ * callers own the returned handle's lifecycle.
+ */
+export class WorkerSpawner {
+  private readonly sandboxProvider: SandboxProvider;
+  private readonly invoker: CommandInvoker;
+  private readonly buildSessionId: () => string;
+  private readonly clock: () => number;
+  private readonly stopGraceMs: number;
+
+  constructor(options: WorkerSpawnerOptions = {}) {
+    this.sandboxProvider = options.sandboxProvider ?? new GitWorktreeSandboxProvider();
+    this.invoker = options.invoker ?? new NodeCommandInvoker();
+    this.buildSessionId = options.buildSessionId ?? defaultBuildWorkerSessionId;
+    this.clock = options.clock ?? Date.now;
+    this.stopGraceMs = options.stopGraceMs ?? WORKER_STOP_GRACE_MS;
+  }
+
+  async spawn(options: WorkerSpawnOptions): Promise<WorkerSpawnResult> {
+    if (typeof this.invoker.spawn !== "function") {
+      throw new Error(
+        "WorkerSpawner: injected invoker does not expose spawn(); workers require a streaming-capable invoker."
+      );
+    }
+
+    const { ticket, repoAssignment, channel, base = "main" } = options;
+
+    // Unique per-spawn runId so two tickets (same repo) or the same ticket
+    // retried twice in a row never collide on worktree path or branch name.
+    // The sandbox provider uses `sandbox/<runId>/<ticketId>` — `runId` is the
+    // dial we turn to disambiguate.
+    const runId = `work-${shortTimestamp(this.clock)}`;
+    // The base SandboxProvider interface types create as `(repo, base)` —
+    // the git-worktree impl widens it with an optional `{ runId, ticketId }`
+    // bag so `git worktree list` traces back to the owning ticket. Same
+    // cast shape used by `LocalChildProcessExecutor.start`; providers that
+    // ignore the extra arg (NoopSandboxProvider) stay structurally compat.
+    const provider = this.sandboxProvider as SandboxProvider & {
+      create(
+        repo: { root: string },
+        base: string,
+        options?: { runId: string; ticketId: string }
+      ): Promise<SandboxRef>;
+    };
+    const sandboxRef = await provider.create({ root: repoAssignment.repoPath }, base, {
+      runId,
+      ticketId: ticket.ticketId,
+    });
+
+    if (sandboxRef.workdir.kind !== "local") {
+      // Remote sandboxes are out of AL-14 scope — the worker needs a real
+      // on-disk cwd to run a Claude child. Destroy the sandbox so we don't
+      // leak, then fail loudly.
+      await this.sandboxProvider.destroy(sandboxRef).catch(() => {});
+      throw new Error(
+        `WorkerSpawner: sandbox provider returned a remote workdir (${sandboxRef.workdir.kind}); worker cannot run without a local path.`
+      );
+    }
+
+    const worktreePath = sandboxRef.workdir.path;
+    const sessionId = this.buildSessionId();
+    const specialty = (ticket.specialty ?? "general") as AgentSpecialty;
+
+    // Wire the child process. `claude` is launched with `-p <prompt>` so
+    // the worker runs until it finishes the task, rather than idling for
+    // stdin like a repo-admin session. The worker's own agent role governs
+    // *what* it does; AL-14's scope is the spawn + monitoring, not the
+    // prompt content.
+    const prompt = buildWorkerPrompt(ticket, repoAssignment, specialty);
+    const fullAccess = channel.fullAccess === true;
+
+    const args: string[] = ["-p"];
+    if (fullAccess) {
+      // AC2 — inherit the channel's full-access flag.
+      args.push("--dangerously-skip-permissions");
+    } else {
+      args.push("--permission-mode", "default");
+    }
+    args.push(prompt);
+
+    // Keep `this` bound to the invoker — tests use class-based fakes whose
+    // spawn() relies on `this`; an unbound call would turn `this.spawned`
+    // into `undefined`. `NodeCommandInvoker.spawn` is written as an arrow-
+    // like stateless method so binding is a no-op there.
+    const child = this.invoker.spawn!.call(this.invoker, {
+      command: "claude",
+      args,
+      cwd: worktreePath,
+      // Workers are long-lived; the outer ticket runner owns termination.
+      timeoutMs: 0,
+      env: {
+        RELAY_WORKER_SESSION_ID: sessionId,
+        RELAY_WORKER_TICKET_ID: ticket.ticketId,
+        RELAY_WORKER_AGENT_ID: specialtyToAgentId(specialty),
+      },
+      passEnv: [...WORKER_PASS_ENV],
+    });
+
+    const handle = new LiveWorkerHandle({
+      ticketId: ticket.ticketId,
+      sessionId,
+      specialty,
+      worktreePath,
+      sandboxRef,
+      child,
+      stopGraceMs: this.stopGraceMs,
+    });
+
+    return { handle, worktreePath, sandboxRef };
+  }
+
+  /**
+   * Destroy a worktree. Idempotent via the underlying sandbox provider. On
+   * the dirty case, preserves state for operator inspection (mirrors the
+   * git-worktree provider's semantic). Called by the ticket runner on PR
+   * merge; callers must NOT use this to paper over a worker failure —
+   * failed workers keep their worktree for AC4.
+   */
+  async destroyWorktree(sandboxRef: SandboxRef): Promise<void> {
+    await this.sandboxProvider.destroy(sandboxRef);
+  }
+}
+
+interface LiveWorkerHandleOptions {
+  ticketId: string;
+  sessionId: string;
+  specialty: AgentSpecialty;
+  worktreePath: string;
+  sandboxRef: SandboxRef;
+  child: SpawnedProcess;
+  stopGraceMs: number;
+}
+
+/**
+ * Concrete {@link WorkerHandle}. Keeps its internals private so callers
+ * don't reach into the child process directly — all interaction goes
+ * through `state`, `onExit`, `stop`.
+ */
+class LiveWorkerHandle implements WorkerHandle {
+  readonly ticketId: string;
+  readonly sessionId: string;
+  readonly specialty: AgentSpecialty;
+  readonly worktreePath: string;
+  readonly sandboxRef: SandboxRef;
+
+  private _state: WorkerState = "running";
+  private readonly emitter = new EventEmitter();
+  private readonly child: SpawnedProcess;
+  private readonly stopGraceMs: number;
+
+  private stdoutBuf = "";
+  private stderrBuf = "";
+  private stdoutLines: string[] = [];
+  private stderrLines: string[] = [];
+  private _detectedPrUrl: string | null = null;
+  private finalEvent: WorkerExitEvent | null = null;
+
+  private stopRequested = false;
+  private stopReason: string | null = null;
+  private killTimer: NodeJS.Timeout | null = null;
+
+  constructor(options: LiveWorkerHandleOptions) {
+    this.ticketId = options.ticketId;
+    this.sessionId = options.sessionId;
+    this.specialty = options.specialty;
+    this.worktreePath = options.worktreePath;
+    this.sandboxRef = options.sandboxRef;
+    this.child = options.child;
+    this.stopGraceMs = options.stopGraceMs;
+
+    this.wireChild();
+  }
+
+  get state(): WorkerState {
+    return this._state;
+  }
+
+  get detectedPrUrl(): string | null {
+    return this._detectedPrUrl;
+  }
+
+  onExit(listener: (evt: WorkerExitEvent) => void): () => void {
+    // If the worker already exited, replay the final event on the next
+    // microtask so subscribers don't have to race. Keeps the callback
+    // contract "exactly once, regardless of subscription timing".
+    if (this.finalEvent) {
+      const evt = this.finalEvent;
+      queueMicrotask(() => {
+        try {
+          listener(evt);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `WorkerHandle(${this.ticketId}): onExit listener threw: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      });
+      return () => {};
+    }
+    this.emitter.on("exit", listener);
+    return () => {
+      this.emitter.off("exit", listener);
+    };
+  }
+
+  async stop(reason: string): Promise<void> {
+    if (this._state !== "running") {
+      // Terminal already — second caller still awaits until the final
+      // event has landed so the contract "stop() resolves only when the
+      // child is truly gone" holds.
+      await this.awaitExit();
+      return;
+    }
+    if (this.stopRequested) {
+      await this.awaitExit();
+      return;
+    }
+
+    this.stopRequested = true;
+    this.stopReason = reason;
+
+    try {
+      this.child.kill("SIGTERM");
+    } catch {
+      // Already exited — onExit will finish the transition.
+    }
+
+    this.killTimer = setTimeout(() => {
+      this.killTimer = null;
+      if (this._state === "running") {
+        try {
+          this.child.kill("SIGKILL");
+        } catch {
+          // Same as above.
+        }
+      }
+    }, this.stopGraceMs);
+    const t = this.killTimer as { unref?: () => void };
+    if (t && typeof t.unref === "function") t.unref();
+
+    await this.awaitExit();
+  }
+
+  private wireChild(): void {
+    this.child.onStdout((chunk) => {
+      this.stdoutBuf += chunk;
+      let idx: number;
+      while ((idx = this.stdoutBuf.indexOf("\n")) >= 0) {
+        const line = this.stdoutBuf.slice(0, idx);
+        this.stdoutBuf = this.stdoutBuf.slice(idx + 1);
+        this.pushStdoutLine(line);
+      }
+    });
+    this.child.onStderr((chunk) => {
+      this.stderrBuf += chunk;
+      let idx: number;
+      while ((idx = this.stderrBuf.indexOf("\n")) >= 0) {
+        const line = this.stderrBuf.slice(0, idx);
+        this.stderrBuf = this.stderrBuf.slice(idx + 1);
+        this.pushStderrLine(line);
+      }
+    });
+    this.child.onError((err) => {
+      // Spawn-level error (e.g. ENOENT) — treat as failure.
+      this.stderrLines.push(`[spawn-error] ${err.message}`);
+      this.finish(null, null);
+    });
+    this.child.onExit((code, signal) => {
+      // Flush any leftover partial lines before we stamp the tail.
+      if (this.stdoutBuf) {
+        this.pushStdoutLine(this.stdoutBuf);
+        this.stdoutBuf = "";
+      }
+      if (this.stderrBuf) {
+        this.pushStderrLine(this.stderrBuf);
+        this.stderrBuf = "";
+      }
+      this.finish(code ?? null, signal ?? null);
+    });
+  }
+
+  private pushStdoutLine(line: string): void {
+    if (!line) return;
+    this.stdoutLines.push(line);
+    if (this.stdoutLines.length > WORKER_STDOUT_TAIL_LINES) {
+      this.stdoutLines.splice(0, this.stdoutLines.length - WORKER_STDOUT_TAIL_LINES);
+    }
+    if (!this._detectedPrUrl) {
+      const match = line.match(PR_URL_PATTERN);
+      if (match) this._detectedPrUrl = match[0];
+    }
+  }
+
+  private pushStderrLine(line: string): void {
+    if (!line) return;
+    this.stderrLines.push(line);
+    if (this.stderrLines.length > WORKER_STDERR_TAIL_LINES) {
+      this.stderrLines.splice(0, this.stderrLines.length - WORKER_STDERR_TAIL_LINES);
+    }
+  }
+
+  private finish(exitCode: number | null, signal: NodeJS.Signals | null): void {
+    if (this._state !== "running") return;
+    if (this.killTimer) {
+      clearTimeout(this.killTimer);
+      this.killTimer = null;
+    }
+
+    let state: WorkerState;
+    let reason: string;
+    if (this.stopRequested) {
+      state = "stopped";
+      reason = this.stopReason ?? "stopped";
+    } else if (exitCode === 0) {
+      state = "completed";
+      reason = "completed";
+    } else {
+      state = "failed";
+      reason = `exit ${exitCode ?? "null"}${signal ? ` (signal ${signal})` : ""}`;
+    }
+    this._state = state;
+
+    const evt: WorkerExitEvent = {
+      exitCode,
+      signal,
+      reason,
+      stdoutTail: this.stdoutLines.join("\n"),
+      stderrTail: this.stderrLines.join("\n"),
+      detectedPrUrl: this._detectedPrUrl,
+    };
+    this.finalEvent = evt;
+
+    const listeners = this.emitter.listeners("exit") as Array<(e: WorkerExitEvent) => void>;
+    for (const listener of listeners) {
+      try {
+        listener(evt);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `WorkerHandle(${this.ticketId}): onExit listener threw: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+    this.emitter.removeAllListeners("exit");
+  }
+
+  private async awaitExit(): Promise<void> {
+    if (this.finalEvent) return;
+    await new Promise<void>((resolve) => {
+      const off = this.onExit(() => {
+        off();
+        resolve();
+      });
+    });
+  }
+}
+
+/**
+ * Build the prompt handed to the Claude worker. Kept deliberately thin —
+ * AL-14 is about the spawn + monitor mechanics, not worker prompt
+ * engineering. The prompt names the ticket, the repo, and the PR-creation
+ * expectation so stdout-tail detection of the PR URL remains the cheap
+ * happy path.
+ *
+ * Exported so tests can assert on its shape (otherwise the exact text is
+ * opaque to assertions).
+ */
+export function buildWorkerPrompt(
+  ticket: TicketLedgerEntry,
+  repoAssignment: RepoAssignment,
+  specialty: AgentSpecialty
+): string {
+  const agentId = specialtyToAgentId(specialty);
+  const lines = [
+    `You are ${agentId}, running inside a per-ticket git worktree under Relay.`,
+    ``,
+    `Ticket: ${ticket.ticketId} — ${ticket.title}`,
+    `Specialty: ${specialty}`,
+    `Repo alias: ${repoAssignment.alias}`,
+    `Worktree: ${repoAssignment.repoPath} (you are already cd'd into the worktree)`,
+    ``,
+    `Do the work the ticket describes. Commit your changes, push the branch,`,
+    `and open a pull request via \`gh pr create\`. Print the resulting PR URL`,
+    `on stdout so the orchestrator can track it — this is how Relay detects`,
+    `that the ticket has produced a PR.`,
+  ];
+  return lines.join("\n");
+}

--- a/src/orchestrator/worker-spawner.ts
+++ b/src/orchestrator/worker-spawner.ts
@@ -224,12 +224,24 @@ export function specialtyToAgentId(specialty: AgentSpecialty | undefined): strin
 }
 
 /**
+ * Module-local monotonic counter used to disambiguate runIds minted in the
+ * same millisecond. Replaces the previous `Math.random().slice(2,6)`
+ * suffix which had a non-trivial collision rate at high spawn rates —
+ * two workers spawned in the same ms (which happens in tests, and may
+ * happen in production once parallel drains land in AL-16) could collide
+ * on worktree path. A counter can't collide inside one process.
+ */
+let runIdCounter = 0;
+
+/**
  * Short time-stamp suffix used inside `runId` so two concurrent worker
- * spawns for the same ticket generate distinct worktree paths. Base-36
- * keeps the suffix compact while preserving uniqueness within a run.
+ * spawns for the same ticket generate distinct worktree paths. The
+ * counter suffix is monotonic; the leading `clock()` stamp keeps the id
+ * roughly sortable for a human reader.
  */
 function shortTimestamp(clock: () => number): string {
-  return `${clock().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  const seq = (++runIdCounter).toString(36);
+  return `${clock().toString(36)}-${seq}`;
 }
 
 /**

--- a/test/orchestrator/autonomous-loop-drain.test.ts
+++ b/test/orchestrator/autonomous-loop-drain.test.ts
@@ -1,0 +1,592 @@
+/**
+ * AL-14 — autonomous-loop drain wiring integration tests.
+ *
+ * Covers the end-to-end plumbing that `startAutonomousSession` does when
+ * both `RELAY_REPO_ADMIN_POOL_ENABLED` and `RELAY_AL14_WORKER_DRAIN` are
+ * on. Specifically the pieces that aren't exercised by the `TicketRunner`
+ * unit tests (one admin, one fake) or the `RepoAdminPool` tests (no
+ * router, no runner, no worker-spawn mock):
+ *
+ *   - Two repoAssignments → two admins boot. Both admins get their own
+ *     `TicketRunner`.
+ *   - Each admin's pending queue drains in parallel — the `Promise.all`
+ *     invariant is observable: both admins' first tickets are in-flight
+ *     simultaneously, neither blocking the other.
+ *   - Each admin drains its own queue sequentially (per-admin FIFO).
+ *   - On exit, the lifecycle transitions to `killed` with reason
+ *     `al-16-pending` when the drain flag is on (AL-14 terminal).
+ *   - The `finally` block's `runner.stop("autonomous-loop-exit")` fires
+ *     even on error, and a single admin's drain failure does NOT wedge
+ *     the other admin — the healthy admin still completes its ticket.
+ *
+ * The test uses the `startAutonomousSession`'s `testOverrides` seam to
+ * inject a fake `RepoAdminProcessSpawner` (so the AL-12 pool boots
+ * cleanly without a real Claude binary) and a fake `WorkerSpawner` (so
+ * worker drain is deterministic). No real subprocess, no real git, no
+ * real `claude` CLI.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import type { SandboxRef } from "../../src/execution/sandbox.js";
+import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
+import { TokenTracker } from "../../src/budget/token-tracker.js";
+import {
+  RELAY_AL14_WORKER_DRAIN,
+  startAutonomousSession,
+} from "../../src/orchestrator/autonomous-loop.js";
+import { RELAY_REPO_ADMIN_POOL_ENABLED } from "../../src/orchestrator/repo-admin-pool.js";
+import type {
+  RepoAdminProcessSpawner,
+  RepoAdminSpawnArgs,
+} from "../../src/orchestrator/repo-admin-session.js";
+import type {
+  WorkerExitEvent,
+  WorkerHandle,
+  WorkerSpawner,
+} from "../../src/orchestrator/worker-spawner.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+/**
+ * Fake AL-12 repo-admin child. No-op on all streams; `emitExit` is only
+ * invoked when the pool is tearing down.
+ */
+type StdListener = (chunk: string) => void;
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeAdminChild extends SpawnedProcess {
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  spawnArgs: RepoAdminSpawnArgs;
+}
+
+function makeFakeAdminChild(args: RepoAdminSpawnArgs): FakeAdminChild {
+  const stdoutListeners: StdListener[] = [];
+  const stderrListeners: StdListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  return {
+    pid: 30_000 + Math.floor(Math.random() * 1000),
+    spawnArgs: args,
+    onStdout(l) {
+      stdoutListeners.push(l);
+    },
+    onStderr(l) {
+      stderrListeners.push(l);
+    },
+    onExit(l) {
+      exitListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    kill() {
+      // Emit expected exit so the pool's stop() awaits resolve cleanly.
+      for (const l of exitListeners) l(0, "SIGTERM");
+      return true;
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+  };
+}
+
+class FakeAdminSpawner implements RepoAdminProcessSpawner {
+  readonly byAlias = new Map<string, FakeAdminChild[]>();
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    const child = makeFakeAdminChild(args);
+    const list = this.byAlias.get(args.alias) ?? [];
+    list.push(child);
+    this.byAlias.set(args.alias, list);
+    return child;
+  }
+}
+
+/**
+ * Fake worker handle driven by the test. Identical in shape to the one
+ * used by `ticket-runner.test.ts`, reproduced here so these tests stay
+ * hermetic (no shared-fixture coupling).
+ */
+class FakeWorkerHandle implements WorkerHandle {
+  readonly ticketId: string;
+  readonly sessionId: string;
+  readonly specialty = "general" as const;
+  readonly worktreePath: string;
+  readonly sandboxRef: SandboxRef;
+  private _state: "running" | "completed" | "failed" | "stopped" = "running";
+  private _prUrl: string | null = null;
+  private listeners: Array<(evt: WorkerExitEvent) => void> = [];
+  private finalEvent: WorkerExitEvent | null = null;
+
+  constructor(ticketId: string, sessionId: string, worktreePath: string, sandboxRef: SandboxRef) {
+    this.ticketId = ticketId;
+    this.sessionId = sessionId;
+    this.worktreePath = worktreePath;
+    this.sandboxRef = sandboxRef;
+  }
+  get state(): "running" | "completed" | "failed" | "stopped" {
+    return this._state;
+  }
+  get detectedPrUrl(): string | null {
+    return this._prUrl;
+  }
+  onExit(listener: (evt: WorkerExitEvent) => void): () => void {
+    if (this.finalEvent) {
+      const evt = this.finalEvent;
+      queueMicrotask(() => listener(evt));
+      return () => {};
+    }
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+  stop = vi.fn(async (): Promise<void> => {
+    if (this._state === "running") {
+      this.fire({ exitCode: null });
+    }
+  });
+  fire(args: {
+    exitCode: number | null;
+    prUrl?: string | null;
+    stdoutTail?: string;
+    stderrTail?: string;
+  }): void {
+    if (this.finalEvent) return;
+    this._prUrl = args.prUrl ?? null;
+    const evt: WorkerExitEvent = {
+      exitCode: args.exitCode,
+      signal: null,
+      reason:
+        args.exitCode === 0
+          ? "completed"
+          : args.exitCode === null
+            ? "stopped"
+            : `exit ${args.exitCode}`,
+      stdoutTail: args.stdoutTail ?? "",
+      stderrTail: args.stderrTail ?? "",
+      detectedPrUrl: args.prUrl ?? null,
+    };
+    if (args.exitCode === 0) this._state = "completed";
+    else if (args.exitCode === null) this._state = "stopped";
+    else this._state = "failed";
+    this.finalEvent = evt;
+    const listeners = this.listeners.slice();
+    this.listeners = [];
+    for (const l of listeners) l(evt);
+  }
+}
+
+/**
+ * Programmable worker-spawner. Exposes the spawned handles per alias so
+ * the test can assert on parallel invariants ("both admins' first ticket
+ * spawned before either finished"). `onSpawn` callbacks let the test
+ * observe the exact moment a spawn lands so parallel assertions don't
+ * race.
+ */
+class FakeWorkerSpawner {
+  readonly spawnedByAlias = new Map<string, FakeWorkerHandle[]>();
+  readonly destroyed: SandboxRef[] = [];
+  private counter = 0;
+  private onSpawnListeners: Array<
+    (args: { alias: string; ticketId: string; handle: FakeWorkerHandle }) => void
+  > = [];
+
+  onSpawn(cb: (args: { alias: string; ticketId: string; handle: FakeWorkerHandle }) => void): void {
+    this.onSpawnListeners.push(cb);
+  }
+
+  spawn = vi.fn(
+    async (opts: {
+      ticket: TicketLedgerEntry;
+      repoAssignment: RepoAssignment;
+      channel: Channel;
+    }) => {
+      this.counter += 1;
+      const runId = `fake-run-${this.counter}`;
+      const ticketId = opts.ticket.ticketId;
+      const alias = opts.repoAssignment.alias;
+      const worktreePath = `/tmp/fake-worktree/${alias}/${runId}/${ticketId}`;
+      const sandboxRef: SandboxRef = {
+        id: `sb-${runId}-${ticketId}`,
+        workdir: { kind: "local", path: worktreePath },
+        meta: {
+          branch: `sandbox/${runId}/${ticketId}`,
+          base: "main",
+          runId,
+          ticketId,
+          repoRoot: opts.repoAssignment.repoPath,
+        },
+      };
+      const handle = new FakeWorkerHandle(
+        ticketId,
+        `worker-sess-${this.counter}`,
+        worktreePath,
+        sandboxRef
+      );
+      const list = this.spawnedByAlias.get(alias) ?? [];
+      list.push(handle);
+      this.spawnedByAlias.set(alias, list);
+      for (const cb of this.onSpawnListeners) cb({ alias, ticketId, handle });
+      return { handle, worktreePath, sandboxRef };
+    }
+  );
+
+  destroyWorktree = vi.fn(async (ref: SandboxRef) => {
+    this.destroyed.push(ref);
+  });
+
+  handles(alias: string): FakeWorkerHandle[] {
+    return this.spawnedByAlias.get(alias) ?? [];
+  }
+}
+
+/**
+ * Spin until `pred()` returns truthy. Tests that assert on async
+ * interleavings call this in preference to polling sleep so the failure
+ * mode on a stuck async op is a clean timeout rather than a flaky pass.
+ */
+async function waitUntil(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitUntil timed out");
+    }
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+function makeTicket(id: string, alias: string): TicketLedgerEntry {
+  return {
+    ticketId: id,
+    title: `t-${id}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: "2026-04-21T00:00:00.000Z",
+    runId: null,
+    assignedAlias: alias,
+  };
+}
+
+/**
+ * Seed the on-disk channel with two repo assignments + two tickets per
+ * admin. Tickets carry `assignedAlias` so the router deterministically
+ * dispatches them to their matching admin.
+ */
+async function buildFixture() {
+  const root = await mkdtemp(join(tmpdir(), "al-14-drain-"));
+  const channelsDir = join(root, "channels");
+  const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+  const channelStore = new ChannelStore(channelsDir, harnessStore);
+
+  const assignments: RepoAssignment[] = [
+    { alias: "frontend", workspaceId: "ws-frontend", repoPath: "/tmp/fake-frontend" },
+    { alias: "backend", workspaceId: "ws-backend", repoPath: "/tmp/fake-backend" },
+  ];
+  const persisted = await channelStore.createChannel({
+    name: "al-14-drain",
+    description: "al-14 drain integration test",
+    workspaceIds: ["ws-frontend", "ws-backend"],
+    repoAssignments: assignments,
+  });
+  const channel: Channel = {
+    ...persisted,
+    repoAssignments: assignments,
+    fullAccess: false,
+  };
+
+  const tickets: TicketLedgerEntry[] = [
+    makeTicket("fe-1", "frontend"),
+    makeTicket("fe-2", "frontend"),
+    makeTicket("be-1", "backend"),
+    makeTicket("be-2", "backend"),
+  ];
+  await channelStore.writeChannelTickets(channel.channelId, tickets);
+
+  const sessionId = `auto-${Date.now()}`;
+  const lifecycle = new SessionLifecycle(sessionId, { rootDir: root });
+  // Matches the real CLI flow: start in planning, advance to dispatching
+  // before handoff. SessionLifecycle initializes in `planning`, so the
+  // only transition we need to mirror is `planning → dispatching`.
+  await lifecycle.transition("dispatching", "autonomous-session-started");
+  const tracker = new TokenTracker(sessionId, 100_000, { rootDir: root });
+
+  const adminSpawner = new FakeAdminSpawner();
+  const workerSpawner = new FakeWorkerSpawner();
+
+  const cleanup = async () => {
+    await tracker.close().catch(() => {});
+    await lifecycle.close().catch(() => {});
+    await rm(root, { recursive: true, force: true });
+  };
+
+  return {
+    root,
+    sessionId,
+    channel,
+    channelStore,
+    lifecycle,
+    tracker,
+    adminSpawner,
+    workerSpawner,
+    cleanup,
+    allowedRepos: assignments,
+  };
+}
+
+describe("startAutonomousSession — AL-14 drain wiring", () => {
+  let cleanupFns: Array<() => Promise<void>> = [];
+  let originalPoolFlag: string | undefined;
+  let originalDrainFlag: string | undefined;
+
+  beforeEach(() => {
+    cleanupFns = [];
+    originalPoolFlag = process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    originalDrainFlag = process.env[RELAY_AL14_WORKER_DRAIN];
+    process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = "1";
+    process.env[RELAY_AL14_WORKER_DRAIN] = "1";
+  });
+
+  afterEach(async () => {
+    for (const fn of cleanupFns) await fn();
+    if (originalPoolFlag === undefined) delete process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    else process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = originalPoolFlag;
+    if (originalDrainFlag === undefined) delete process.env[RELAY_AL14_WORKER_DRAIN];
+    else process.env[RELAY_AL14_WORKER_DRAIN] = originalDrainFlag;
+  });
+
+  it("drains both admins in parallel, each serializes internally, and exits killed/al-16-pending", async () => {
+    const fx = await buildFixture();
+    cleanupFns.push(fx.cleanup);
+
+    // Suppress info console noise from the loop — we only want warnings.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    // Fire the autonomous driver. It bootstraps pool, routes tickets,
+    // then starts parallel drains.
+    const driverP = startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    // PARALLEL INVARIANT: both admins must have spawned their FIRST
+    // ticket before EITHER has completed. If the drains were serialized
+    // at the pool level, we'd see one admin's spawn only.
+    await waitUntil(
+      () =>
+        fx.workerSpawner.handles("frontend").length >= 1 &&
+        fx.workerSpawner.handles("backend").length >= 1
+    );
+    expect(fx.workerSpawner.handles("frontend")).toHaveLength(1);
+    expect(fx.workerSpawner.handles("backend")).toHaveLength(1);
+    // Per-admin FIFO invariant: the first spawn for each admin is the
+    // first ticket assigned to it.
+    expect(fx.workerSpawner.handles("frontend")[0].ticketId).toBe("fe-1");
+    expect(fx.workerSpawner.handles("backend")[0].ticketId).toBe("be-1");
+
+    // SERIALIZATION INVARIANT: neither admin has spawned its second
+    // ticket — their first hasn't exited yet.
+    expect(fx.workerSpawner.handles("frontend")).toHaveLength(1);
+    expect(fx.workerSpawner.handles("backend")).toHaveLength(1);
+
+    // Complete fe-1 and be-1 so each admin progresses to its second
+    // ticket (fe-2 / be-2 respectively). PR URLs are distinct so the
+    // verifying-state mirror on the board doesn't collide.
+    fx.workerSpawner
+      .handles("frontend")[0]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/1" });
+    fx.workerSpawner
+      .handles("backend")[0]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/2" });
+
+    await waitUntil(
+      () =>
+        fx.workerSpawner.handles("frontend").length >= 2 &&
+        fx.workerSpawner.handles("backend").length >= 2
+    );
+    expect(fx.workerSpawner.handles("frontend")[1].ticketId).toBe("fe-2");
+    expect(fx.workerSpawner.handles("backend")[1].ticketId).toBe("be-2");
+
+    // Complete the second ticket on each admin.
+    fx.workerSpawner
+      .handles("frontend")[1]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/3" });
+    fx.workerSpawner
+      .handles("backend")[1]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/4" });
+
+    await driverP;
+
+    // LIFECYCLE INVARIANT: drain flag on → `killed / al-16-pending`.
+    const lcRaw = await readFile(join(fx.root, "sessions", fx.sessionId, "lifecycle.json"), "utf8");
+    const lc = JSON.parse(lcRaw);
+    expect(lc.state).toBe("killed");
+    const final = lc.transitions[lc.transitions.length - 1];
+    expect(final.reason).toBe("al-16-pending");
+
+    // TICKET-STATE INVARIANT: each ticket that drove a spawn was
+    // mirrored through upsertChannelTickets. All four move to
+    // `verifying` (worker exited 0 with PR URL).
+    const board = await fx.channelStore.readChannelTickets(fx.channel.channelId);
+    const byId = Object.fromEntries(board.map((t) => [t.ticketId, t]));
+    expect(byId["fe-1"].status).toBe("verifying");
+    expect(byId["fe-2"].status).toBe("verifying");
+    expect(byId["be-1"].status).toBe("verifying");
+    expect(byId["be-2"].status).toBe("verifying");
+
+    // SPAWN-COUNT INVARIANT: exactly one spawn per ticket (no retries,
+    // no duplicates).
+    expect(fx.workerSpawner.spawn).toHaveBeenCalledTimes(4);
+  }, 10_000);
+
+  it("one admin's drain failure does NOT wedge the other admin's drain", async () => {
+    const fx = await buildFixture();
+    cleanupFns.push(fx.cleanup);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    // Make the very first spawn for alias "frontend" throw. The runner
+    // catches spawn failures and marks the ticket failed — that's the
+    // "drain error path" the review calls out. The key assertion is
+    // that "backend" still makes forward progress.
+    const origSpawn = fx.workerSpawner.spawn;
+    fx.workerSpawner.spawn = vi.fn(async (opts) => {
+      if (opts.repoAssignment.alias === "frontend" && opts.ticket.ticketId === "fe-1") {
+        throw new Error("synthetic spawn failure for fe-1");
+      }
+      return origSpawn.call(fx.workerSpawner, opts);
+    }) as typeof fx.workerSpawner.spawn;
+
+    const driverP = startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    // Backend's first ticket must spawn independently of frontend's
+    // failure. This is the key "parallel drains are isolated"
+    // invariant: one admin throwing doesn't lock out the other.
+    await waitUntil(() => fx.workerSpawner.handles("backend").length >= 1);
+    // Complete be-1 → be-2 chain.
+    fx.workerSpawner
+      .handles("backend")[0]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/b1" });
+    await waitUntil(() => fx.workerSpawner.handles("backend").length >= 2);
+    fx.workerSpawner
+      .handles("backend")[1]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/b2" });
+
+    // Frontend: fe-1 failed synthetically, so drain moves to fe-2.
+    // fe-2 spawns via the original spawner and we finish it normally.
+    await waitUntil(() => fx.workerSpawner.handles("frontend").length >= 1);
+    expect(fx.workerSpawner.handles("frontend")[0].ticketId).toBe("fe-2");
+    fx.workerSpawner
+      .handles("frontend")[0]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/f2" });
+
+    await driverP;
+
+    // Terminal lifecycle still reaches killed/al-16-pending — the
+    // synthetic failure did not abort the autonomous loop, it just
+    // routed one ticket into the `failed` bucket.
+    const lcRaw = await readFile(join(fx.root, "sessions", fx.sessionId, "lifecycle.json"), "utf8");
+    const lc = JSON.parse(lcRaw);
+    expect(lc.state).toBe("killed");
+    expect(lc.transitions[lc.transitions.length - 1].reason).toBe("al-16-pending");
+
+    // TICKET-STATE INVARIANTS:
+    //  - fe-1 is `failed` (spawn threw → runner.markTicketFailed)
+    //  - fe-2 / be-1 / be-2 are `verifying` (clean drains)
+    const board = await fx.channelStore.readChannelTickets(fx.channel.channelId);
+    const byId = Object.fromEntries(board.map((t) => [t.ticketId, t]));
+    expect(byId["fe-1"].status).toBe("failed");
+    expect(byId["fe-1"].lastClassification?.category).toBe("fix_code");
+    expect(byId["fe-2"].status).toBe("verifying");
+    expect(byId["be-1"].status).toBe("verifying");
+    expect(byId["be-2"].status).toBe("verifying");
+  }, 10_000);
+
+  it("drain-disabled mode (pool flag on, drain flag off) routes but does not spawn workers", async () => {
+    process.env[RELAY_AL14_WORKER_DRAIN] = "0";
+    const fx = await buildFixture();
+    cleanupFns.push(fx.cleanup);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    await startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    // No worker spawns — drain was gated off.
+    expect(fx.workerSpawner.spawn).not.toHaveBeenCalled();
+
+    // Lifecycle reaches killed with reason `al-14-pending` (pool on, drain off).
+    const lcRaw = await readFile(join(fx.root, "sessions", fx.sessionId, "lifecycle.json"), "utf8");
+    const lc = JSON.parse(lcRaw);
+    expect(lc.state).toBe("killed");
+    expect(lc.transitions[lc.transitions.length - 1].reason).toBe("al-14-pending");
+  });
+});

--- a/test/orchestrator/repo-admin-session.test.ts
+++ b/test/orchestrator/repo-admin-session.test.ts
@@ -306,6 +306,23 @@ describe("RepoAdminSession", () => {
     }
   });
 
+  it("takeNextPendingTicket dequeues FIFO and rejects on stopped sessions (AL-14)", async () => {
+    const { session, spawner } = buildSession();
+    await session.start();
+
+    await session.dispatchTicket(buildLedgerEntry("t-1", "frontend"));
+    await session.dispatchTicket(buildLedgerEntry("t-2", "frontend"));
+
+    expect(session.takeNextPendingTicket()?.ticketId).toBe("t-1");
+    expect(session.takeNextPendingTicket()?.ticketId).toBe("t-2");
+    expect(session.takeNextPendingTicket()).toBeNull();
+
+    const stopP = session.stop("test");
+    spawner.last().emitExit(0, "SIGTERM");
+    await stopP;
+    expect(() => session.takeNextPendingTicket()).toThrow(/after stop/);
+  });
+
   it("dispatchTicket is idempotent on duplicate ticketIds (AL-13)", async () => {
     const { session } = buildSession();
     await session.start();

--- a/test/orchestrator/ticket-runner.test.ts
+++ b/test/orchestrator/ticket-runner.test.ts
@@ -1,0 +1,477 @@
+/**
+ * AL-14 — TicketRunner unit tests.
+ *
+ * Covers the per-ticket drain loop in isolation:
+ *  - serialization inside one admin (AC: serialize)
+ *  - PR-merge cleanup destroys worktree + marks ticket completed (AC3)
+ *  - worker failure surfaces on the feed + emits `worker-failed`; worktree
+ *    is NOT destroyed on failure (AC4)
+ *  - PR-URL fallback probe is invoked when stdout scrape misses
+ *  - stop() terminates in-flight workers without destroying worktrees
+ *
+ * Uses fake WorkerSpawner + fake admin.pendingDispatches so no real git
+ * or claude binary is involved.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import type { SandboxRef } from "../../src/execution/sandbox.js";
+import type { RepoAdminSession } from "../../src/orchestrator/repo-admin-session.js";
+import { TicketRunner } from "../../src/orchestrator/ticket-runner.js";
+import type {
+  WorkerExitEvent,
+  WorkerHandle,
+  WorkerSpawner,
+} from "../../src/orchestrator/worker-spawner.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+/**
+ * Minimal admin stub — only the API the runner actually uses
+ * (`takeNextPendingTicket`) is exercised, so we don't need the full
+ * RepoAdminSession machinery.
+ */
+class FakeAdmin {
+  readonly alias: string;
+  readonly queue: TicketLedgerEntry[] = [];
+
+  constructor(alias: string) {
+    this.alias = alias;
+  }
+
+  enqueue(ticket: TicketLedgerEntry): void {
+    this.queue.push(ticket);
+  }
+
+  takeNextPendingTicket(): TicketLedgerEntry | null {
+    return this.queue.shift() ?? null;
+  }
+}
+
+/**
+ * Programmable fake worker handle. Tests drive exit via `fire()`.
+ */
+class FakeWorkerHandle implements WorkerHandle {
+  readonly ticketId: string;
+  readonly sessionId: string;
+  readonly specialty = "general" as const;
+  readonly worktreePath: string;
+  readonly sandboxRef: SandboxRef;
+  private _state: "running" | "completed" | "failed" | "stopped" = "running";
+  private _prUrl: string | null = null;
+  private listeners: Array<(evt: WorkerExitEvent) => void> = [];
+  private finalEvent: WorkerExitEvent | null = null;
+  readonly stopCalls: string[] = [];
+
+  constructor(ticketId: string, sessionId: string, worktreePath: string, sandboxRef: SandboxRef) {
+    this.ticketId = ticketId;
+    this.sessionId = sessionId;
+    this.worktreePath = worktreePath;
+    this.sandboxRef = sandboxRef;
+  }
+
+  get state(): "running" | "completed" | "failed" | "stopped" {
+    return this._state;
+  }
+  get detectedPrUrl(): string | null {
+    return this._prUrl;
+  }
+
+  onExit(listener: (evt: WorkerExitEvent) => void): () => void {
+    // Replay final event to late subscribers, mirroring LiveWorkerHandle.
+    if (this.finalEvent) {
+      const evt = this.finalEvent;
+      queueMicrotask(() => listener(evt));
+      return () => {};
+    }
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+
+  stop = vi.fn(async (reason: string): Promise<void> => {
+    this.stopCalls.push(reason);
+    if (this._state === "running") {
+      this.fire({ exitCode: null, signal: "SIGTERM", stdoutTail: "", stderrTail: "", prUrl: null });
+    }
+  });
+
+  fire(args: {
+    exitCode: number | null;
+    signal?: NodeJS.Signals | null;
+    stdoutTail?: string;
+    stderrTail?: string;
+    prUrl?: string | null;
+  }): void {
+    if (this.finalEvent) return; // idempotent
+    this._prUrl = args.prUrl ?? null;
+    const evt: WorkerExitEvent = {
+      exitCode: args.exitCode,
+      signal: args.signal ?? null,
+      reason:
+        args.exitCode === 0
+          ? "completed"
+          : args.exitCode === null
+            ? "stopped"
+            : `exit ${args.exitCode}`,
+      stdoutTail: args.stdoutTail ?? "",
+      stderrTail: args.stderrTail ?? "",
+      detectedPrUrl: args.prUrl ?? null,
+    };
+    if (args.exitCode === 0) this._state = "completed";
+    else if (args.exitCode === null) this._state = "stopped";
+    else this._state = "failed";
+    this.finalEvent = evt;
+
+    const listeners = this.listeners.slice();
+    this.listeners = [];
+    for (const l of listeners) l(evt);
+  }
+}
+
+/**
+ * Fake spawner: deterministic worktree + sandbox refs; exposes every
+ * handle it created so tests can drive exits.
+ */
+class FakeSpawner {
+  readonly spawned: FakeWorkerHandle[] = [];
+  readonly destroyed: SandboxRef[] = [];
+  private counter = 0;
+
+  spawn = vi.fn(
+    async (opts: {
+      ticket: TicketLedgerEntry;
+      repoAssignment: RepoAssignment;
+      channel: Channel;
+    }) => {
+      this.counter += 1;
+      const runId = `run-${this.counter}`;
+      const ticketId = opts.ticket.ticketId;
+      const worktreePath = `/tmp/worktree/${runId}/${ticketId}`;
+      const sandboxRef: SandboxRef = {
+        id: `sb-${runId}-${ticketId}`,
+        workdir: { kind: "local", path: worktreePath },
+        meta: {
+          branch: `sandbox/${runId}/${ticketId}`,
+          base: "main",
+          runId,
+          ticketId,
+          repoRoot: opts.repoAssignment.repoPath,
+        },
+      };
+      const handle = new FakeWorkerHandle(
+        ticketId,
+        `worker-sess-${this.counter}`,
+        worktreePath,
+        sandboxRef
+      );
+      this.spawned.push(handle);
+      return { handle, worktreePath, sandboxRef };
+    }
+  );
+
+  destroyWorktree = vi.fn(async (ref: SandboxRef) => {
+    this.destroyed.push(ref);
+  });
+
+  last(): FakeWorkerHandle {
+    const h = this.spawned.at(-1);
+    if (!h) throw new Error("no spawn yet");
+    return h;
+  }
+}
+
+/** Spin briefly until `pred()` returns true, so tests don't race async awaits. */
+async function waitUntil(pred: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitUntil timed out");
+    }
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+function buildTicket(id: string, overrides: Partial<TicketLedgerEntry> = {}): TicketLedgerEntry {
+  return {
+    ticketId: id,
+    title: `ticket ${id}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: "2026-04-21T00:00:00.000Z",
+    runId: null,
+    assignedAlias: "backend",
+    ...overrides,
+  };
+}
+
+async function buildHarness() {
+  const root = await mkdtemp(join(tmpdir(), "runner-test-"));
+  const channelsDir = join(root, "channels");
+  const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+  const channelStore = new ChannelStore(channelsDir, harnessStore);
+
+  const repoAssignments = [
+    { alias: "backend", workspaceId: "ws-backend", repoPath: "/repo/backend" },
+  ];
+  const persisted = await channelStore.createChannel({
+    name: "runner-test",
+    description: "runner-test",
+    workspaceIds: ["ws-backend"],
+    repoAssignments,
+  });
+  const channel: Channel = {
+    ...persisted,
+    repoAssignments,
+    fullAccess: false,
+  };
+
+  const admin = new FakeAdmin("backend");
+  const spawner = new FakeSpawner();
+  const runner = new TicketRunner({
+    admin: admin as unknown as RepoAdminSession,
+    repoAssignment: repoAssignments[0],
+    channel,
+    channelStore,
+    spawner: spawner as unknown as WorkerSpawner,
+    now: () => "2026-04-21T00:00:00.000Z",
+  });
+
+  const cleanup = async () => {
+    await rm(root, { recursive: true, force: true });
+  };
+
+  return { root, channelStore, channel, admin, spawner, runner, cleanup };
+}
+
+describe("TicketRunner", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+  beforeEach(() => {
+    cleanup = null;
+  });
+  afterEach(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  it("serializes multiple queued tickets inside one admin (MVP AC)", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(buildTicket("t-1"));
+    h.admin.enqueue(buildTicket("t-2"));
+
+    // Start the drain. It spawns t-1 but the runner won't move to t-2 until
+    // t-1's worker exits — that's the MVP serialization guarantee.
+    const drainP = h.runner.drain();
+
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    expect(h.spawner.spawned).toHaveLength(1);
+    expect(h.spawner.spawned[0].ticketId).toBe("t-1");
+
+    // Still waiting on t-1 — t-2 hasn't been touched.
+    expect(h.admin.queue.map((t) => t.ticketId)).toEqual(["t-2"]);
+
+    // Complete t-1 with a PR URL so it moves to awaiting-merge.
+    h.spawner.spawned[0].fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/1" });
+
+    await waitUntil(() => h.spawner.spawned.length >= 2);
+    expect(h.spawner.spawned[1].ticketId).toBe("t-2");
+
+    // Finish t-2 so drain() can return.
+    h.spawner.spawned[1].fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/2" });
+    await drainP;
+  });
+
+  it("PR merge triggers worktree destroy + transitions ticket to completed (AC3)", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(buildTicket("t-merge"));
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    h.spawner.last().fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/9" });
+    await drainP;
+
+    // Ticket is in `verifying` while awaiting merge; worktree not yet
+    // destroyed.
+    let board = await h.channelStore.readChannelTickets(h.channel.channelId);
+    const verifyingEntry = board.find((t) => t.ticketId === "t-merge");
+    expect(verifyingEntry?.status).toBe("verifying");
+    expect(h.spawner.destroyed).toHaveLength(0);
+
+    // Simulate PR merge.
+    await h.runner.handlePrMerged("t-merge");
+
+    // Worktree destroyed + ticket completed.
+    expect(h.spawner.destroyed).toHaveLength(1);
+    board = await h.channelStore.readChannelTickets(h.channel.channelId);
+    const completedEntry = board.find((t) => t.ticketId === "t-merge");
+    expect(completedEntry?.status).toBe("completed");
+    expect(completedEntry?.completedAt).toBeTruthy();
+
+    // Second call is a no-op (idempotent).
+    await h.runner.handlePrMerged("t-merge");
+    expect(h.spawner.destroyed).toHaveLength(1);
+  });
+
+  it("worker failure surfaces on feed + does NOT destroy worktree (AC4)", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    const failures: Array<{ ticketId: string; exitCode: number | null }> = [];
+    h.runner.on("worker-failed", (evt) =>
+      failures.push({ ticketId: evt.ticketId, exitCode: evt.exitCode })
+    );
+
+    h.admin.enqueue(buildTicket("t-fail"));
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    h.spawner.last().fire({
+      exitCode: 2,
+      stdoutTail: "line1\nline2",
+      stderrTail: "boom!",
+    });
+    await drainP;
+
+    // Worktree preserved (AC4).
+    expect(h.spawner.destroyed).toHaveLength(0);
+
+    // Ticket marked failed on the board.
+    const board = await h.channelStore.readChannelTickets(h.channel.channelId);
+    const entry = board.find((t) => t.ticketId === "t-fail");
+    expect(entry?.status).toBe("failed");
+    expect(entry?.lastClassification?.category).toBe("fix_code");
+    expect(entry?.lastClassification?.rationale).toContain("exit 2");
+
+    // Feed carries the failure note — not swallowed (AC4).
+    const feed = await h.channelStore.readFeed(h.channel.channelId);
+    const note = feed.find((e) => e.type === "status_update" && e.metadata?.ticketId === "t-fail");
+    expect(note).toBeDefined();
+    expect(String(note?.content ?? "")).toContain("Worktree preserved");
+
+    // Event emitted on the runner (AC4).
+    expect(failures).toEqual([{ ticketId: "t-fail", exitCode: 2 }]);
+  });
+
+  it("clean exit with no PR URL fails the ticket and preserves the worktree", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(buildTicket("t-nopr"));
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    h.spawner.last().fire({ exitCode: 0, prUrl: null, stdoutTail: "done" });
+    await drainP;
+
+    const board = await h.channelStore.readChannelTickets(h.channel.channelId);
+    const entry = board.find((t) => t.ticketId === "t-nopr");
+    expect(entry?.status).toBe("failed");
+    expect(h.spawner.destroyed).toHaveLength(0);
+  });
+
+  it("invokes the PR-URL fallback probe when stdout tail misses", async () => {
+    const root = await mkdtemp(join(tmpdir(), "runner-fallback-"));
+    cleanup = async () => {
+      await rm(root, { recursive: true, force: true });
+    };
+
+    const channelsDir = join(root, "channels");
+    const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+    const channelStore = new ChannelStore(channelsDir, harnessStore);
+    const persisted = await channelStore.createChannel({
+      name: "fb",
+      description: "fb",
+      workspaceIds: ["ws-backend"],
+      repoAssignments: [{ alias: "backend", workspaceId: "ws-backend", repoPath: "/repo/backend" }],
+    });
+    const channel: Channel = {
+      ...persisted,
+      repoAssignments: [{ alias: "backend", workspaceId: "ws-backend", repoPath: "/repo/backend" }],
+      fullAccess: false,
+    };
+    const admin = new FakeAdmin("backend");
+    const spawner = new FakeSpawner();
+
+    const fallback = vi.fn(
+      async (_args: { branch: string; worktreePath: string }): Promise<string | null> =>
+        "https://github.com/o/r/pull/77"
+    );
+
+    const runner = new TicketRunner({
+      admin: admin as unknown as RepoAdminSession,
+      repoAssignment: channel.repoAssignments![0],
+      channel,
+      channelStore,
+      spawner: spawner as unknown as WorkerSpawner,
+      now: () => "2026-04-21T00:00:00.000Z",
+      prUrlFallback: fallback,
+    });
+
+    admin.enqueue(buildTicket("t-fallback"));
+    const drainP = runner.drain();
+    await waitUntil(() => spawner.spawned.length >= 1);
+    spawner.last().fire({ exitCode: 0, prUrl: null });
+    await drainP;
+
+    expect(fallback).toHaveBeenCalledTimes(1);
+    const board = await channelStore.readChannelTickets(channel.channelId);
+    const entry = board.find((t) => t.ticketId === "t-fallback");
+    expect(entry?.status).toBe("verifying");
+    const inflight = runner.listInflight();
+    expect(inflight.find((r) => r.ticketId === "t-fallback")?.prUrl).toBe(
+      "https://github.com/o/r/pull/77"
+    );
+  });
+
+  it("stop() terminates in-flight workers without destroying worktrees", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(buildTicket("t-stop"));
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    // Don't fire exit yet — stop() will drive it.
+    await h.runner.stop("pool-shutdown");
+    await drainP;
+
+    expect(h.spawner.last().stopCalls).toContain("pool-shutdown");
+    // No destroy on stop — operator inspection path.
+    expect(h.spawner.destroyed).toHaveLength(0);
+  });
+
+  it("spawn failure marks the ticket failed with the spawn error (AC4)", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.spawner.spawn.mockImplementationOnce(async () => {
+      throw new Error("worktree path already exists");
+    });
+
+    h.admin.enqueue(buildTicket("t-spawn-fail"));
+    const drainP = h.runner.drain();
+    await drainP;
+
+    const board = await h.channelStore.readChannelTickets(h.channel.channelId);
+    const entry = board.find((t) => t.ticketId === "t-spawn-fail");
+    expect(entry?.status).toBe("failed");
+    expect(entry?.lastClassification?.rationale).toContain("worktree path already exists");
+    expect(h.spawner.destroyed).toHaveLength(0);
+  });
+});

--- a/test/orchestrator/worker-spawner.test.ts
+++ b/test/orchestrator/worker-spawner.test.ts
@@ -1,0 +1,363 @@
+/**
+ * AL-14 — WorkerSpawner unit tests.
+ *
+ * Covers the spawn mechanics in isolation:
+ *  - happy path: worktree created via injected sandbox provider, worker
+ *    child spawned with cwd = worktree path, specialty -> agent id map
+ *  - two-ticket isolation: distinct worktrees + branches per spawn
+ *  - full-access inheritance: channel.fullAccess=true threads
+ *    `--dangerously-skip-permissions` into the child argv
+ *  - PR URL detection: stdout lines containing a GitHub PR URL populate
+ *    `handle.detectedPrUrl` and surface on `onExit`
+ *  - failure path: non-zero exit produces `state=failed` with tails
+ *  - stop() escalates SIGTERM -> SIGKILL
+ *
+ * Sandbox provider + command invoker are fully faked — no real git or
+ * claude binary is invoked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  CommandInvocation,
+  CommandInvoker,
+  CommandResult,
+  SpawnedProcess,
+} from "../../src/agents/command-invoker.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import type {
+  DestroyResult,
+  RepoRef,
+  SandboxProvider,
+  SandboxRef,
+} from "../../src/execution/sandbox.js";
+import { WorkerSpawner } from "../../src/orchestrator/worker-spawner.js";
+
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type StdListener = (chunk: string) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeChild extends SpawnedProcess {
+  readonly invocation: CommandInvocation;
+  readonly killCalls: Array<NodeJS.Signals | undefined>;
+  emitStdout(chunk: string): void;
+  emitStderr(chunk: string): void;
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  emitError(err: Error): void;
+}
+
+function makeFakeChild(invocation: CommandInvocation): FakeChild {
+  const stdoutListeners: StdListener[] = [];
+  const stderrListeners: StdListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  const killCalls: Array<NodeJS.Signals | undefined> = [];
+
+  return {
+    pid: 30_000 + Math.floor(Math.random() * 1000),
+    invocation,
+    killCalls,
+    onStdout(l) {
+      stdoutListeners.push(l);
+    },
+    onStderr(l) {
+      stderrListeners.push(l);
+    },
+    onExit(l) {
+      exitListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    kill(signal) {
+      killCalls.push(signal);
+      return true;
+    },
+    emitStdout(chunk) {
+      for (const l of stdoutListeners) l(chunk);
+    },
+    emitStderr(chunk) {
+      for (const l of stderrListeners) l(chunk);
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+    emitError(err) {
+      for (const l of errorListeners) l(err);
+    },
+  };
+}
+
+class FakeInvoker implements CommandInvoker {
+  readonly spawned: FakeChild[] = [];
+  async exec(_invocation: CommandInvocation): Promise<CommandResult> {
+    // Buffered path is unused by WorkerSpawner; reject to keep tests honest.
+    return Promise.reject(new Error("FakeInvoker: buffered path not supported in these tests"));
+  }
+  spawn(invocation: CommandInvocation): SpawnedProcess {
+    const child = makeFakeChild(invocation);
+    this.spawned.push(child);
+    return child;
+  }
+  last(): FakeChild {
+    const c = this.spawned.at(-1);
+    if (!c) throw new Error("no child spawned yet");
+    return c;
+  }
+}
+
+class FakeSandboxProvider implements SandboxProvider {
+  readonly created: Array<{ repo: RepoRef; base: string; options?: unknown; ref: SandboxRef }> = [];
+  readonly destroyed: SandboxRef[] = [];
+  private counter = 0;
+
+  async create(
+    repo: RepoRef,
+    base: string,
+    options?: { runId: string; ticketId: string }
+  ): Promise<SandboxRef> {
+    this.counter += 1;
+    const runId = options?.runId ?? `run-${this.counter}`;
+    const ticketId = options?.ticketId ?? `t-${this.counter}`;
+    const ref: SandboxRef = {
+      id: `sb-${runId}-${ticketId}`,
+      workdir: { kind: "local", path: `/tmp/worktree/${runId}/${ticketId}` },
+      meta: {
+        branch: `sandbox/${runId}/${ticketId}`,
+        base,
+        runId,
+        ticketId,
+        repoRoot: repo.root,
+      },
+    };
+    this.created.push({ repo, base, options, ref });
+    return ref;
+  }
+
+  async destroy(ref: SandboxRef): Promise<DestroyResult> {
+    this.destroyed.push(ref);
+    return { kind: "removed" };
+  }
+}
+
+function buildTicket(id: string, overrides: Partial<TicketLedgerEntry> = {}): TicketLedgerEntry {
+  return {
+    ticketId: id,
+    title: `ticket ${id}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: "2026-04-21T00:00:00.000Z",
+    runId: null,
+    ...overrides,
+  };
+}
+
+function buildChannel(fullAccess = false): Channel {
+  return {
+    channelId: "ch-test",
+    name: "test",
+    description: "",
+    status: "active",
+    workspaceIds: ["ws-backend"],
+    members: [],
+    pinnedRefs: [],
+    repoAssignments: [{ alias: "backend", workspaceId: "ws-backend", repoPath: "/repo/backend" }],
+    fullAccess,
+    createdAt: "2026-04-21T00:00:00.000Z",
+    updatedAt: "2026-04-21T00:00:00.000Z",
+  };
+}
+
+const BACKEND: RepoAssignment = {
+  alias: "backend",
+  workspaceId: "ws-backend",
+  repoPath: "/repo/backend",
+};
+
+describe("WorkerSpawner", () => {
+  let provider: FakeSandboxProvider;
+  let invoker: FakeInvoker;
+  let spawner: WorkerSpawner;
+  let clockNow: number;
+
+  beforeEach(() => {
+    provider = new FakeSandboxProvider();
+    invoker = new FakeInvoker();
+    clockNow = 1_700_000_000_000;
+    spawner = new WorkerSpawner({
+      sandboxProvider: provider,
+      invoker,
+      clock: () => clockNow++,
+      buildSessionId: (() => {
+        let i = 0;
+        return () => `worker-sess-${++i}`;
+      })(),
+      stopGraceMs: 5,
+    });
+  });
+
+  afterEach(() => {
+    for (const child of invoker.spawned) {
+      child.emitExit(0);
+    }
+  });
+
+  it("creates a worktree and spawns the worker at that cwd (happy path)", async () => {
+    const ticket = buildTicket("t-happy");
+    const channel = buildChannel(false);
+    const result = await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+
+    expect(provider.created).toHaveLength(1);
+    expect(provider.created[0].repo).toEqual({ root: "/repo/backend" });
+    expect(provider.created[0].base).toBe("main");
+    expect((provider.created[0].options as { ticketId: string }).ticketId).toBe("t-happy");
+
+    const workdir = provider.created[0].ref.workdir;
+    expect(workdir.kind).toBe("local");
+    if (workdir.kind === "local") {
+      expect(result.worktreePath).toBe(workdir.path);
+    }
+    expect(result.handle.ticketId).toBe("t-happy");
+    expect(result.handle.sessionId).toBe("worker-sess-1");
+
+    expect(invoker.spawned).toHaveLength(1);
+    expect(invoker.last().invocation.cwd).toBe(result.worktreePath);
+    expect(invoker.last().invocation.command).toBe("claude");
+    expect(invoker.last().invocation.args).not.toContain("--dangerously-skip-permissions");
+    expect(invoker.last().invocation.args).toContain("--permission-mode");
+  });
+
+  it("produces distinct worktrees + branches for two tickets in the same repo (AC1)", async () => {
+    const channel = buildChannel(false);
+    const a = await spawner.spawn({ ticket: buildTicket("t-a"), repoAssignment: BACKEND, channel });
+    const b = await spawner.spawn({ ticket: buildTicket("t-b"), repoAssignment: BACKEND, channel });
+
+    expect(a.worktreePath).not.toBe(b.worktreePath);
+    expect(a.sandboxRef.id).not.toBe(b.sandboxRef.id);
+    expect(a.sandboxRef.meta?.branch).not.toBe(b.sandboxRef.meta?.branch);
+    expect(a.sandboxRef.meta?.branch).toContain("t-a");
+    expect(b.sandboxRef.meta?.branch).toContain("t-b");
+  });
+
+  it("inherits channel.fullAccess into the child argv (AC2)", async () => {
+    const ticket = buildTicket("t-fa");
+    const channel = buildChannel(true);
+    await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+    const args = invoker.last().invocation.args;
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("--permission-mode");
+  });
+
+  it("does not pass --dangerously-skip-permissions when channel.fullAccess is false", async () => {
+    const ticket = buildTicket("t-no-fa");
+    const channel = buildChannel(false);
+    await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+    const args = invoker.last().invocation.args;
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("picks up PR URLs from stdout and surfaces them on the exit event", async () => {
+    const ticket = buildTicket("t-pr");
+    const channel = buildChannel(false);
+    const { handle } = await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+
+    const child = invoker.last();
+    const exitP = new Promise<{ detectedPrUrl: string | null; exitCode: number | null }>(
+      (resolve) => {
+        handle.onExit((e) => resolve({ detectedPrUrl: e.detectedPrUrl, exitCode: e.exitCode }));
+      }
+    );
+
+    child.emitStdout("opening PR...\nhttps://github.com/jcast90/relay/pull/42\ndone\n");
+    child.emitExit(0);
+
+    const evt = await exitP;
+    expect(evt.detectedPrUrl).toBe("https://github.com/jcast90/relay/pull/42");
+    expect(evt.exitCode).toBe(0);
+    expect(handle.state).toBe("completed");
+    expect(handle.detectedPrUrl).toBe("https://github.com/jcast90/relay/pull/42");
+  });
+
+  it("reports failure + stdout/stderr tail on non-zero exit", async () => {
+    const ticket = buildTicket("t-fail");
+    const channel = buildChannel(false);
+    const { handle } = await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+
+    const child = invoker.last();
+    const exitP = new Promise<{
+      exitCode: number | null;
+      stdoutTail: string;
+      stderrTail: string;
+    }>((resolve) => {
+      handle.onExit((e) =>
+        resolve({ exitCode: e.exitCode, stdoutTail: e.stdoutTail, stderrTail: e.stderrTail })
+      );
+    });
+
+    child.emitStdout("working...\nstill working\n");
+    child.emitStderr("error: boom\n");
+    child.emitExit(2);
+
+    const evt = await exitP;
+    expect(evt.exitCode).toBe(2);
+    expect(evt.stdoutTail).toContain("still working");
+    expect(evt.stderrTail).toContain("error: boom");
+    expect(handle.state).toBe("failed");
+  });
+
+  it("stop() sends SIGTERM and escalates to SIGKILL after the grace period", async () => {
+    const ticket = buildTicket("t-stop");
+    const channel = buildChannel(false);
+    const { handle } = await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+
+    const child = invoker.last();
+    const stopP = handle.stop("manual");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(child.killCalls).toContain("SIGTERM");
+    expect(child.killCalls).toContain("SIGKILL");
+
+    child.emitExit(null, "SIGKILL");
+    await stopP;
+    expect(handle.state).toBe("stopped");
+  });
+
+  it("destroyWorktree delegates to the sandbox provider", async () => {
+    const ticket = buildTicket("t-destroy");
+    const channel = buildChannel(false);
+    const { sandboxRef } = await spawner.spawn({
+      ticket,
+      repoAssignment: BACKEND,
+      channel,
+    });
+
+    await spawner.destroyWorktree(sandboxRef);
+    expect(provider.destroyed).toHaveLength(1);
+    expect(provider.destroyed[0].id).toBe(sandboxRef.id);
+  });
+
+  it("replays the final exit event on late subscribers (onExit contract)", async () => {
+    const ticket = buildTicket("t-late");
+    const channel = buildChannel(false);
+    const { handle } = await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
+
+    const child = invoker.last();
+    child.emitExit(0);
+
+    await new Promise((r) => setImmediate(r));
+    const evt = await new Promise<{ exitCode: number | null }>((resolve) => {
+      handle.onExit((e) => resolve({ exitCode: e.exitCode }));
+    });
+    expect(evt.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `WorkerSpawner` wraps `GitWorktreeSandboxProvider` + `NodeCommandInvoker` to create a per-ticket worktree and spawn a Claude worker scoped to it. Threads `channel.fullAccess` through to `--dangerously-skip-permissions` (AC2) and scrapes PR URLs from stdout. Exposes a `WorkerHandle` with `state`, idempotent `stop()`, `onExit` that replays to late subscribers, and `destroyWorktree` for PR-merge cleanup.
- `TicketRunner` drains each admin's pending queue one ticket at a time (serialized inside an admin; parallel across admins per the AL-12 trade-off). Ticket states advance `ready` -> `executing` -> `verifying` on a clean exit with a detected PR URL; `failed` with a `fix_code` classification + feed entry otherwise (AC4). Worktrees are preserved on failure for operator inspection; destroyed only via the idempotent `handlePrMerged(ticketId)` hook (AC3). Optional `prUrlFallback` covers the `gh pr list` safety net.
- `RepoAdminSession.takeNextPendingTicket()` FIFO consumer; guarded against stopped sessions.
- `autonomous-loop.ts` now pairs each pool admin with a `TicketRunner` and awaits drain in parallel before teardown. Terminal reason advances to `"al-16-pending"` when the pool is on (AL-16 = inter-admin coordination, still pending).

Closes #89

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm -C gui build` — clean
- [x] `cargo check -p harness-data -p relay-gui` — clean
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 684 passing (13 new)
- [x] `pnpm dlx prettier --check 'src/**/*.ts' 'test/**/*.ts' '*.md' 'docs/**/*.md' 'agent_docs/**/*.md'` — clean
- [x] Unit suites: two-ticket isolation (AC1), full-access inheritance (AC2), PR-merge cleanup (AC3), failure surfacing + worktree preservation (AC4), serialization, spawn errors, PR URL fallback, SIGTERM/SIGKILL escalation
- [ ] Live integration with real `claude` + `gh` — deferred to the AL-4 steady-state loop PR; this PR only provides the plumbing

## Deviations from the spec

- **PR-detection heuristic**: implemented as stdout-tail scrape with a pluggable `prUrlFallback` on the runner (spec's "fallback `gh pr list`"). The fallback is injected rather than shelling out directly so the unit tests don't need a real `gh`; wiring a real `gh pr list --head <branch>` call is a one-liner for the AL-4 integration.
- **PR-merge cleanup**: `handlePrMerged` is exposed as a public hook but is not yet wired to the PR poller. AL-14's single-pass autonomous stub exits before any PR can merge, so the wiring belongs with the AL-4 steady-state driver.
- **Branch naming**: reuses the sandbox provider's `sandbox/<runId>/<ticketId>` scheme rather than the spec's `work/<ticketId>-<shortTimestamp>`, with `runId` synthesized as `work-<shortTimestamp>`. Preserves the existing `git worktree list` traceability convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)