### PR TITLE
AL-16: Repo-admin ↔ repo-admin coordination protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -3123,7 +3123,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "chrono",

--- a/gui/src/components/Composer.tsx
+++ b/gui/src/components/Composer.tsx
@@ -260,7 +260,11 @@ export function Composer({
   // workspaces. The user can still send — we just surface a heads-up that
   // those agents won't be routed to. One-click attach per offender.
   const unattachedMentions = computeUnattachedMentions(text, channel, workspaces);
-  const attachFromWarning = async (ws: { workspaceId: string; repoPath: string; alias: string }) => {
+  const attachFromWarning = async (ws: {
+    workspaceId: string;
+    repoPath: string;
+    alias: string;
+  }) => {
     setAttaching(ws.workspaceId);
     try {
       const next = [
@@ -440,16 +444,17 @@ function computeUnattachedMentions(
 ): Array<{ workspaceId: string; repoPath: string; alias: string }> {
   if (!text.trim()) return [];
   const attachedAliases = new Set(channel.repoAssignments.map((r) => r.alias.toLowerCase()));
-  const attachedWorkspaceIds = new Set(
-    channel.repoAssignments.map((r) => r.workspaceId)
-  );
+  const attachedWorkspaceIds = new Set(channel.repoAssignments.map((r) => r.workspaceId));
   const candidatesByAlias = new Map<
     string,
     { workspaceId: string; repoPath: string; alias: string }
   >();
   for (const w of workspaces) {
     if (attachedWorkspaceIds.has(w.workspaceId)) continue;
-    const alias = basename(w.repoPath).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(0, 12);
+    const alias = basename(w.repoPath)
+      .replace(/[^a-z0-9-]/gi, "")
+      .toLowerCase()
+      .slice(0, 12);
     if (!alias) continue;
     if (!candidatesByAlias.has(alias)) {
       candidatesByAlias.set(alias, { workspaceId: w.workspaceId, repoPath: w.repoPath, alias });

--- a/src/agents/repo-admin.ts
+++ b/src/agents/repo-admin.ts
@@ -17,7 +17,12 @@
  *   - routing (deciding which repo-admin gets a ticket) -> AL-13
  *   - worker spawning (the `spawn_worker` MCP tool body)-> AL-14
  *   - memory-shed (bounded working set across sessions) -> AL-15
- *   - inter-admin coordination                          -> AL-16
+ *
+ * AL-16 extends the role surface with typed inter-repo coordination:
+ *   - adds `coordination_send` to the allowlist
+ *   - documents in the system prompt WHEN to use each typed shape
+ *     (`blocked-on-repo`, `repo-ready`, `merge-order-proposal`) and
+ *     forbids free-texting the same information into the channel feed.
  *
  * Source of truth for repo-admin state is the channel board + decisions +
  * git log. Repo-admin is a caching / coordination layer on top of those,
@@ -47,6 +52,15 @@ export const REPO_ADMIN_ROLE = "repo-admin";
  */
 export const REPO_ADMIN_MEMORY_POLICY_MARKER =
   "source of truth is the board and the decisions file";
+
+/**
+ * AL-16: marker substring that must appear in the system prompt so the
+ * typed-coordination guidance is present and assertable. Tests pin on
+ * this string so a well-meaning copy edit that drops the protocol
+ * documentation fails CI rather than silently sending repo-admins back
+ * to free-text handoffs.
+ */
+export const REPO_ADMIN_COORDINATION_POLICY_MARKER = "use the typed `coordination_send` tool";
 
 export interface RepoAdminRoleInput {
   /** Absolute path to the repo the admin is foremanning. */
@@ -127,6 +141,40 @@ export function buildRepoAdminSystemPrompt(input: RepoAdminRoleInput): string {
     "`channel_post` — a single append-only entry with the rationale. That",
     "entry is what future repo-admin sessions re-read via `channel_get` to",
     "reconstruct state; if it isn't on the feed, it didn't happen.",
+    "",
+    "## Cross-repo coordination (AL-16)",
+    "When your work depends on — or unblocks — another repo-admin, " +
+      `${REPO_ADMIN_COORDINATION_POLICY_MARKER}, not the channel feed. ` +
+      "The tool takes a `to` alias and a typed payload; the MCP layer " +
+      "validates the shape and the coordinator routes it to the target " +
+      "admin and audits the decision. Three shapes, three use cases:",
+    "",
+    "  - `blocked-on-repo` — send when one of YOUR tickets cannot make",
+    "    forward progress until ANOTHER admin's ticket completes. Include",
+    "    `requester` (your alias), `blocker` (target alias), `ticketId`",
+    "    (the one being held up), `dependsOnTicketId` (the ticket you're",
+    "    waiting on), a short `reason`, and `requestedAt` (ISO timestamp).",
+    "    The coordinator rejects a send that would form a cycle with an",
+    "    existing block, so if you receive `{ok: false, reason: ",
+    '    "would-form-cycle"}` ask the worker to revise rather than retry.',
+    "",
+    "  - `repo-ready` — send when a PR you own has opened OR merged and",
+    "    another repo-admin may be waiting on it. Include `alias` (yours),",
+    "    `ticketId`, `prUrl`, `mergedAt` (optional — present once merged),",
+    "    and `announcedAt`. This is how blockers resolve.",
+    "",
+    "  - `merge-order-proposal` — send when you have cross-repo visibility",
+    "    and want to put a proposed merge sequence on the record. Include",
+    "    `proposer` (yours), `sequence` (ordered `{alias, ticketId,",
+    "    prUrl}` triples), `rationale`, and `proposedAt`. This is",
+    "    advisory: the scheduler reads it; it does NOT enforce.",
+    "",
+    "Do NOT free-text these handoffs into the channel feed. The",
+    "coordinator validates the shape, records each send as a typed",
+    "decision on the board (type `coordination_message`), and lets",
+    "peers consume them programmatically. A bad payload returns",
+    '`{ok: false, reason: "malformed", ...}` — fix the shape, don\'t',
+    "retry with prose.",
   ].join("\n");
 }
 
@@ -137,6 +185,12 @@ export function buildRepoAdminSystemPrompt(input: RepoAdminRoleInput): string {
  */
 export { REPO_ADMIN_ALLOWED_TOOLS, REPO_ADMIN_TOOL_STUBS, denyToolEnvelope, isToolAllowedForRole };
 export type { ToolDenialEnvelope };
+
+/**
+ * Expose the AL-16 coordination-policy marker for tests + future
+ * consumers that need to assert the prompt still references the typed
+ * handoff surface.
+ */
 
 /**
  * Handler for the stubbed `spawn_worker` tool (AL-14 replaces this).

--- a/src/crosslink/coordinator.ts
+++ b/src/crosslink/coordinator.ts
@@ -1,0 +1,514 @@
+/**
+ * AL-16: inter-admin coordination bus.
+ *
+ * The {@link Coordinator} is the runtime half of the AL-16 protocol. It
+ * validates payloads against the schemas in `./messages.ts`, routes them
+ * between admin aliases, stamps the decisions board for audit, tracks
+ * block relationships so cycles are rejected up front, and exposes a
+ * `waitFor` helper so an admin can pause until a specific shape lands.
+ *
+ * ## Design notes
+ *
+ * - **Not a merge gate.** The bus is an advisory channel. It records
+ *   proposals and block requests; the scheduler (AL-5 / AL-7) is the
+ *   only layer that acts on them. Keeping the bus dumb means we can
+ *   swap the enforcement layer later without rewriting wire format.
+ *
+ * - **Pool-scoped.** One Coordinator instance per autonomous session,
+ *   wired inside `startAutonomousSession` alongside the
+ *   {@link RepoAdminPool}. Admin aliases are its addressing scheme
+ *   because a pool's membership is stable within a single run
+ *   (assignments don't mutate mid-session).
+ *
+ * - **Fail-fast on validation.** `send()` validates via zod; a malformed
+ *   payload resolves to `{ ok: false, reason: "malformed" }` with the
+ *   full issues list. We NEVER silently drop a bad message — AC4.
+ *
+ * - **Deadlock prevention.** We track directed block edges (requester →
+ *   blocker per ticketId). A second `blocked-on-repo` that would close
+ *   a cycle is rejected with `{ ok: false, reason: "would-form-cycle" }`.
+ *   This is the simplest useful form — richer graph reasoning
+ *   (transitive cycles, timeouts on stale blocks) is deferred.
+ *
+ * - **Audit via decisions.** Every routed message writes a
+ *   `coordination_message` entry to the channel's decisions board
+ *   (type-tagged so future TUI/GUI filters are cheap). Failures to
+ *   audit are warned but never surfaced — the message still reaches
+ *   the subscriber. Disk is best-effort; the bus is the source of
+ *   truth within the run.
+ */
+
+import { EventEmitter } from "node:events";
+
+import type { ChannelStore } from "../channels/channel-store.js";
+import type { RepoAdminPool } from "../orchestrator/repo-admin-pool.js";
+import { parseCoordinationMessage, type CoordinationMessage } from "./messages.js";
+
+/**
+ * Payload a caller hands to {@link Coordinator.send}. The coordinator
+ * re-validates before routing so callers that build the object by hand
+ * can pass a loosely-typed record — the bus enforces the shape.
+ */
+export type CoordinationPayload = CoordinationMessage | Record<string, unknown>;
+
+/** Success envelope returned by {@link Coordinator.send}. */
+export interface SendOk {
+  ok: true;
+  kind: CoordinationMessage["kind"];
+  from: string;
+  to: string;
+  routedAt: string;
+}
+
+/**
+ * Failure envelope for {@link Coordinator.send}. `reason` is a short
+ * stable code the repo-admin prompt can pattern-match on; `detail`
+ * carries the human-readable explanation (e.g. the zod issue summary).
+ */
+export interface SendErr {
+  ok: false;
+  reason:
+    | "malformed"
+    | "no-such-admin"
+    | "would-form-cycle"
+    | "coordinator-closed"
+    | "self-addressed";
+  detail: string;
+  issues?: unknown;
+}
+
+export type SendResult = SendOk | SendErr;
+
+/**
+ * A listener receives every routed message addressed to its admin
+ * alias. Listeners may be sync or async; the coordinator awaits async
+ * listeners so a throw in one subscriber doesn't race with the next
+ * `send()` but never lets one slow listener wedge the whole bus
+ * (per-listener try/catch inside {@link Coordinator.fanout}).
+ */
+export type CoordinationListener = (msg: CoordinationMessage) => void | Promise<void>;
+
+export interface WaitForOptions {
+  /**
+   * How long to wait before rejecting with `wait-timeout`. Required so
+   * a typo'd predicate can't wedge the caller forever; the AL-16
+   * integration test uses a small value, while production callers
+   * inside the autonomous loop pass a larger ceiling.
+   */
+  timeoutMs: number;
+  /** Human label for error messages + audit. */
+  label?: string;
+}
+
+/**
+ * Internal block-edge record used by the cycle detector. `requester`
+ * is blocked on `blocker`; if the graph already has `blocker` blocked
+ * on `requester`, the new edge would close a cycle and must be
+ * rejected.
+ */
+interface BlockEdge {
+  requester: string;
+  blocker: string;
+  ticketId: string;
+  dependsOnTicketId: string;
+}
+
+export interface CoordinatorOptions {
+  /**
+   * Pool of repo-admin sessions. Used exclusively to validate that
+   * `send(from, to, ...)` targets an alias the run knows about; the
+   * coordinator never reaches into a session's internals.
+   */
+  pool: Pick<RepoAdminPool, "getSession" | "listSessions">;
+  /**
+   * Channel board for decision-audit mirrors. Every routed message
+   * writes a `coordination_message` decision — future TUI/GUI surfaces
+   * can replay them to reconstruct inter-admin coordination post-mortem.
+   */
+  channelStore: Pick<ChannelStore, "recordDecision">;
+  /** Channel id the audit decisions land under. */
+  channelId: string;
+  /**
+   * Clock injection. Tests pin this so `requestedAt` / `routedAt` are
+   * deterministic; production passes the default `Date.now`-based
+   * ISO string emitter.
+   */
+  now?: () => string;
+}
+
+export class Coordinator {
+  private readonly pool: Pick<RepoAdminPool, "getSession" | "listSessions">;
+  private readonly channelStore: Pick<ChannelStore, "recordDecision">;
+  private readonly channelId: string;
+  private readonly now: () => string;
+
+  private readonly listeners = new Map<string, Set<CoordinationListener>>();
+  private readonly blockEdges: BlockEdge[] = [];
+  private readonly emitter = new EventEmitter();
+  private closed = false;
+
+  constructor(options: CoordinatorOptions) {
+    this.pool = options.pool;
+    this.channelStore = options.channelStore;
+    this.channelId = options.channelId;
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  /**
+   * Validate + route a typed message from `from` to `to`.
+   *
+   * Returns a discriminated {@link SendResult} rather than throwing so
+   * caller ergonomics match the MCP tool surface (the tool returns the
+   * envelope verbatim) and so the repo-admin prompt can branch on a
+   * single-field check.
+   *
+   * Ordering:
+   *  1. Reject if the coordinator has been {@link close}d.
+   *  2. Validate the payload against {@link CoordinationMessageSchema}.
+   *  3. Reject self-addressed messages — sending to yourself is always
+   *     a programming error and the bus refuses rather than eating the
+   *     round trip.
+   *  4. Confirm the `to` alias is registered with the pool.
+   *  5. For `blocked-on-repo`: run the cycle check BEFORE fan-out so a
+   *     cycle-closing request never reaches the blocker.
+   *  6. Fan out to every subscribed listener for `to`.
+   *  7. Audit: append a `coordination_message` decision entry.
+   *  8. Return ok.
+   *
+   * Fan-out happens before audit so a slow disk write can't starve the
+   * subscriber. The audit failure is warned, never surfaced — the
+   * bus is authoritative in-memory.
+   */
+  async send(from: string, to: string, payload: CoordinationPayload): Promise<SendResult> {
+    if (this.closed) {
+      return {
+        ok: false,
+        reason: "coordinator-closed",
+        detail: "Coordinator has been closed; no further sends accepted.",
+      };
+    }
+
+    const parsed = parseCoordinationMessage(payload);
+    if (!parsed.ok) {
+      return {
+        ok: false,
+        reason: "malformed",
+        detail: parsed.error,
+        issues: parsed.issues,
+      };
+    }
+
+    if (from === to) {
+      return {
+        ok: false,
+        reason: "self-addressed",
+        detail: `Admin "${from}" cannot send coordination messages to itself.`,
+      };
+    }
+
+    // Confirm both ends are known to the pool. `from` is trusted (the
+    // MCP layer derives it from the session's role) but we still
+    // reject if the caller passed a bogus source — a typo there is
+    // the same class of programming error as a missing target.
+    const toSession = this.pool.getSession(to);
+    if (!toSession) {
+      return {
+        ok: false,
+        reason: "no-such-admin",
+        detail: `No repo-admin with alias "${to}" is registered in this run.`,
+      };
+    }
+
+    const message = parsed.message;
+
+    // Deadlock prevention. Only `blocked-on-repo` adds graph edges; the
+    // other shapes never introduce a dependency, so we skip the check
+    // for them entirely (avoids running the scan on every announcement).
+    if (message.kind === "blocked-on-repo") {
+      if (message.requester !== from) {
+        return {
+          ok: false,
+          reason: "malformed",
+          detail:
+            `blocked-on-repo.requester ("${message.requester}") must match ` +
+            `the sending admin ("${from}").`,
+        };
+      }
+      if (message.blocker !== to) {
+        return {
+          ok: false,
+          reason: "malformed",
+          detail:
+            `blocked-on-repo.blocker ("${message.blocker}") must match ` +
+            `the receiving admin ("${to}").`,
+        };
+      }
+      if (this.wouldFormCycle(message.requester, message.blocker)) {
+        return {
+          ok: false,
+          reason: "would-form-cycle",
+          detail:
+            `blocked-on-repo from "${message.requester}" to "${message.blocker}" ` +
+            `would close a cycle in the cross-repo block graph.`,
+        };
+      }
+      this.blockEdges.push({
+        requester: message.requester,
+        blocker: message.blocker,
+        ticketId: message.ticketId,
+        dependsOnTicketId: message.dependsOnTicketId,
+      });
+    }
+
+    // `repo-ready` clears any block edges the announcement resolves.
+    // A cross-repo block is only interesting until the blocker has a
+    // merged/open PR for the dependency; once we see ready for that
+    // ticketId, the edge is dead weight in the cycle graph. Drop it.
+    if (message.kind === "repo-ready") {
+      for (let i = this.blockEdges.length - 1; i >= 0; i--) {
+        const edge = this.blockEdges[i];
+        if (edge.blocker === message.alias && edge.dependsOnTicketId === message.ticketId) {
+          this.blockEdges.splice(i, 1);
+        }
+      }
+    }
+
+    const routedAt = this.now();
+
+    await this.fanout(to, message);
+    this.emitter.emit("message", { from, to, message, routedAt });
+    await this.audit(from, to, message, routedAt);
+
+    return { ok: true, kind: message.kind, from, to, routedAt };
+  }
+
+  /**
+   * Subscribe a listener to every message routed to `alias`. Returns
+   * an unsubscribe handle. Safe to call before the admin's session is
+   * live — the coordinator only checks pool membership on `send()`,
+   * so a listener can be wired up during session boot before the
+   * first message arrives.
+   */
+  onMessage(alias: string, listener: CoordinationListener): () => void {
+    let set = this.listeners.get(alias);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(alias, set);
+    }
+    set.add(listener);
+    return () => {
+      const s = this.listeners.get(alias);
+      if (!s) return;
+      s.delete(listener);
+      if (s.size === 0) this.listeners.delete(alias);
+    };
+  }
+
+  /**
+   * Wait for the next message addressed to `alias` whose payload
+   * satisfies `predicate`. Resolves with the matching message, or
+   * rejects with `wait-timeout` after `timeoutMs`.
+   *
+   * Unlike {@link onMessage}, `waitFor` is a one-shot: the listener
+   * auto-unsubscribes as soon as the predicate matches. This is the
+   * primitive the autonomous-loop integration test uses to model
+   * "repo-admin A waits for B's repo-ready before proceeding" (AC3).
+   */
+  waitFor(
+    alias: string,
+    predicate: (msg: CoordinationMessage) => boolean,
+    opts: WaitForOptions
+  ): Promise<CoordinationMessage> {
+    if (this.closed) {
+      return Promise.reject(new Error("coordinator-closed"));
+    }
+    return new Promise((resolve, reject) => {
+      const label = opts.label ?? "waitFor";
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        unsubscribe();
+        reject(new Error(`${label}: wait-timeout after ${opts.timeoutMs}ms`));
+      }, opts.timeoutMs);
+      // Don't wedge node's exit if the wait is still outstanding.
+      const t = timer as unknown as { unref?: () => void };
+      if (t && typeof t.unref === "function") t.unref();
+
+      const unsubscribe = this.onMessage(alias, (msg) => {
+        if (settled) return;
+        let matched = false;
+        try {
+          matched = predicate(msg);
+        } catch (err) {
+          // Predicate threw — treat as non-match but surface on stderr so
+          // buggy predicates don't silently fail every message.
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[coordinator] ${label}: predicate threw on ${msg.kind}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+        if (!matched) return;
+        settled = true;
+        clearTimeout(timer);
+        unsubscribe();
+        resolve(msg);
+      });
+    });
+  }
+
+  /**
+   * Drain subscribers and block further sends. Idempotent. The CLI's
+   * autonomous-loop teardown calls this after the pool has stopped so
+   * late-arriving listeners don't linger past the run.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.listeners.clear();
+    this.blockEdges.length = 0;
+    this.emitter.removeAllListeners();
+  }
+
+  /**
+   * Snapshot of outstanding block edges. Exposed for the pool-event
+   * observer / TUI so "why is this admin waiting?" is answerable
+   * without replaying the bus. Returns a shallow copy so callers can't
+   * mutate internal state.
+   */
+  listOpenBlocks(): ReadonlyArray<Readonly<BlockEdge>> {
+    return this.blockEdges.slice();
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  /**
+   * Cycle detection. A new edge `requester → blocker` closes a cycle
+   * iff there's already a path `blocker → ... → requester` in the
+   * current graph. We only maintain direct edges (per-ticket), so a
+   * DFS over {@link blockEdges} is sufficient for the MVP.
+   *
+   * Not transitively strict by design: the AL-16 MVP protects against
+   * the common pairwise A↔B case that the ticket brief calls out.
+   * Richer graph hygiene (stale-block eviction, ticket-granular
+   * edges) is deferred.
+   */
+  private wouldFormCycle(requester: string, blocker: string): boolean {
+    // DFS from `blocker` following `requester`-outbound edges; if we
+    // reach `requester`, adding requester→blocker closes a cycle.
+    const visited = new Set<string>();
+    const stack = [blocker];
+    while (stack.length > 0) {
+      const cursor = stack.pop()!;
+      if (cursor === requester) return true;
+      if (visited.has(cursor)) continue;
+      visited.add(cursor);
+      for (const edge of this.blockEdges) {
+        if (edge.requester === cursor) stack.push(edge.blocker);
+      }
+    }
+    return false;
+  }
+
+  private async fanout(alias: string, message: CoordinationMessage): Promise<void> {
+    const set = this.listeners.get(alias);
+    if (!set || set.size === 0) return;
+    // Snapshot: a handler that unsubscribes during fan-out shouldn't
+    // affect the current pass. Also fan-out sequentially (await each)
+    // so the `waitFor` resolution happens-before any audit write —
+    // tests assert that invariant.
+    const snapshot = Array.from(set);
+    for (const listener of snapshot) {
+      try {
+        await listener(message);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[coordinator] listener for "${alias}" threw on ${message.kind}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+  }
+
+  private async audit(
+    from: string,
+    to: string,
+    message: CoordinationMessage,
+    routedAt: string
+  ): Promise<void> {
+    try {
+      await this.channelStore.recordDecision(this.channelId, {
+        runId: null,
+        ticketId: deriveTicketIdForAudit(message),
+        title: `coordination: ${message.kind} ${from} → ${to}`,
+        description: describeForAudit(message),
+        rationale: "message" in message ? "" : "", // kept as a hook for future rationale fields
+        alternatives: [],
+        decidedBy: from,
+        decidedByName: `repo-admin:${from}`,
+        linkedArtifacts: [],
+        type: "coordination_message",
+        metadata: {
+          from,
+          to,
+          routedAt,
+          payload: message as unknown as Record<string, unknown>,
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[coordinator] audit write failed for ${message.kind} ${from} → ${to}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+}
+
+/**
+ * Extract the ticket id that should anchor the audit entry. Each shape
+ * carries its own "primary" ticket id — the blocker for `blocked-on-
+ * repo`, the ready ticket for `repo-ready`, and the first item in the
+ * sequence for `merge-order-proposal`. Returning null when nothing
+ * fits is safe — `recordDecision` accepts `ticketId: null`.
+ */
+function deriveTicketIdForAudit(message: CoordinationMessage): string | null {
+  switch (message.kind) {
+    case "blocked-on-repo":
+      return message.ticketId;
+    case "repo-ready":
+      return message.ticketId;
+    case "merge-order-proposal":
+      return message.sequence[0]?.ticketId ?? null;
+  }
+}
+
+/**
+ * Short human-readable description for the decisions board. Kept on
+ * one line so the TUI decision list stays scannable.
+ */
+function describeForAudit(message: CoordinationMessage): string {
+  switch (message.kind) {
+    case "blocked-on-repo":
+      return (
+        `${message.requester} is blocked on ${message.blocker}'s ` +
+        `${message.dependsOnTicketId} (for ${message.ticketId}): ${message.reason}`
+      );
+    case "repo-ready":
+      return (
+        `${message.alias} announces ${message.ticketId} ready at ${message.prUrl}` +
+        (message.mergedAt ? ` (merged ${message.mergedAt})` : " (PR open)")
+      );
+    case "merge-order-proposal":
+      return (
+        `${message.proposer} proposes merge order: ` +
+        message.sequence.map((s) => `${s.alias}/${s.ticketId}`).join(" → ") +
+        ` — ${message.rationale}`
+      );
+  }
+}

--- a/src/crosslink/coordinator.ts
+++ b/src/crosslink/coordinator.ts
@@ -387,13 +387,17 @@ export class Coordinator {
   /**
    * Cycle detection. A new edge `requester → blocker` closes a cycle
    * iff there's already a path `blocker → ... → requester` in the
-   * current graph. We only maintain direct edges (per-ticket), so a
-   * DFS over {@link blockEdges} is sufficient for the MVP.
+   * current graph. We maintain direct edges (per-ticket) and the DFS
+   * below walks them transitively — so A→B→C→A and longer cycles are
+   * caught, not just the pairwise A↔B case. We keep the implementation
+   * intentionally simple (graph is small — bounded by admin count —
+   * and the hot path is `send()`, not an analytics loop).
    *
-   * Not transitively strict by design: the AL-16 MVP protects against
-   * the common pairwise A↔B case that the ticket brief calls out.
-   * Richer graph hygiene (stale-block eviction, ticket-granular
-   * edges) is deferred.
+   * Deferred: stale-block eviction (a `blocked-on-repo` whose dependency
+   * has been abandoned should age out) and ticket-granular reasoning
+   * (today a cycle is rejected even if the conflicting edges refer to
+   * different tickets that won't actually deadlock each other). Both
+   * are safe to bolt on without changing this signature.
    */
   private wouldFormCycle(requester: string, blocker: string): boolean {
     // DFS from `blocker` following `requester`-outbound edges; if we

--- a/src/crosslink/messages.ts
+++ b/src/crosslink/messages.ts
@@ -1,0 +1,175 @@
+/**
+ * AL-16: typed inter-repo coordination messages.
+ *
+ * Repo-admins (AL-11/AL-12) running against different repos need to
+ * coordinate cross-repo work — "my ticket can't ship until your ticket
+ * merges", "my PR is ready, you can unblock", "here's the merge order
+ * that makes sense". Before AL-16 those handoffs went through free-text
+ * chat; the consumer admin had to prompt-engineer the shape out of a
+ * string. That works in a controlled demo and falls apart the moment an
+ * admin rephrases or hallucinates a field.
+ *
+ * AL-16 narrows the channel to three typed shapes. Every cross-admin
+ * message MUST validate against one of the discriminated-union variants
+ * below or it gets rejected with a structured error. The schemas are the
+ * boundary contract; the {@link Coordinator} (see ./coordinator.ts) is
+ * the runtime bus that routes validated messages between admins.
+ *
+ * ## Scope discipline
+ *
+ * These shapes are a message bus + audit trail only. They do NOT encode
+ * merge-order enforcement, approvals, or scheduler decisions — those
+ * belong to AL-5 / AL-7 / AL-8 and intentionally stay out of this layer.
+ * A `merge-order-proposal`, for example, is advisory: a repo-admin
+ * writes it to record the rationale; the scheduler is free to read it
+ * via the decisions board and act or not. Keeping the bus dumb lets us
+ * swap the enforcement layer later without rewriting the wire format.
+ *
+ * ## Why discriminated union on `kind`
+ *
+ * Zod's `discriminatedUnion` gives us O(1) dispatch + exhaustive checks
+ * at compile time. Agents (and tests) pattern-match on `msg.kind` to
+ * branch their handler; adding a new shape requires adding both the
+ * schema and the TS discriminator, which keeps the MCP tool validation
+ * and the consumer code honest.
+ */
+
+import { z } from "zod";
+
+/**
+ * `requester` (the admin raising the block) cannot proceed on
+ * `ticketId` until `blocker` completes `dependsOnTicketId`. The message
+ * is informative — the coordinator records it and relays it to the
+ * blocker, but it does not pause the requester's own execution. The
+ * requester's repo-admin prompt drives the wait via the Coordinator's
+ * {@link Coordinator.waitFor} helper (see ./coordinator.ts).
+ */
+export const BlockedOnRepoSchema = z
+  .object({
+    kind: z.literal("blocked-on-repo"),
+    /** Admin alias raising the block (e.g. `"backend"`). */
+    requester: z.string().min(1),
+    /** Admin alias the request is addressed to (e.g. `"frontend"`). */
+    blocker: z.string().min(1),
+    /** Ticket id the requester is trying to unblock. */
+    ticketId: z.string().min(1),
+    /** Ticket id on the blocker's board that must complete first. */
+    dependsOnTicketId: z.string().min(1),
+    /** Human-readable rationale. Surfaces on the decisions board + feed. */
+    reason: z.string().min(1),
+    /** ISO-8601 timestamp (coordinator stamps on send if omitted in source). */
+    requestedAt: z.string().min(1),
+  })
+  .strict();
+
+export type BlockedOnRepo = z.infer<typeof BlockedOnRepoSchema>;
+
+/**
+ * A repo-admin announces that a ticket it owns has reached a "ready for
+ * the next repo to consume" milestone — either the PR is open or it
+ * has merged. Consumers (admins waiting on {@link BlockedOnRepo}) use
+ * this to unblock. `mergedAt` being set distinguishes "PR open but not
+ * merged yet" from "merged and ready to ship in consumers".
+ */
+export const RepoReadySchema = z
+  .object({
+    kind: z.literal("repo-ready"),
+    /** Admin alias that owns the ticket. */
+    alias: z.string().min(1),
+    /** Ticket id the announcement is about. */
+    ticketId: z.string().min(1),
+    /** PR URL — required so consumers can cross-reference their block. */
+    prUrl: z.string().url(),
+    /** ISO-8601 merge timestamp. Unset = PR open but not merged. */
+    mergedAt: z.string().min(1).optional(),
+    /** ISO-8601 announcement timestamp. */
+    announcedAt: z.string().min(1),
+  })
+  .strict();
+
+export type RepoReady = z.infer<typeof RepoReadySchema>;
+
+/**
+ * Advisory cross-repo merge ordering. A repo-admin that has visibility
+ * across N open PRs can propose a sequence it believes satisfies the
+ * dependency graph. The coordinator audits the proposal; enforcement
+ * (if any) lives in the scheduler (AL-5 / AL-7). A later proposal does
+ * NOT supersede an earlier one — both are recorded so the scheduler
+ * has the full history when it makes its own call.
+ */
+export const MergeOrderProposalSchema = z
+  .object({
+    kind: z.literal("merge-order-proposal"),
+    /** Admin alias putting the proposal on the table. */
+    proposer: z.string().min(1),
+    /** Ordered list of admin/ticket/PR triples representing the sequence. */
+    sequence: z
+      .array(
+        z
+          .object({
+            alias: z.string().min(1),
+            ticketId: z.string().min(1),
+            prUrl: z.string().url(),
+          })
+          .strict()
+      )
+      .min(1),
+    /** Why this sequence — surfaces on the decisions board for audit. */
+    rationale: z.string().min(1),
+    /** ISO-8601 proposal timestamp. */
+    proposedAt: z.string().min(1),
+  })
+  .strict();
+
+export type MergeOrderProposal = z.infer<typeof MergeOrderProposalSchema>;
+
+/**
+ * Discriminated union of every accepted AL-16 coordination shape. This
+ * is the single validation boundary — the MCP tool surface, the
+ * coordinator, and the decisions-board auditor all parse against this
+ * schema. Adding a new shape is a one-liner here + matching handler
+ * code; drive-by additions that skip this union don't type-check.
+ */
+export const CoordinationMessageSchema = z.discriminatedUnion("kind", [
+  BlockedOnRepoSchema,
+  RepoReadySchema,
+  MergeOrderProposalSchema,
+]);
+
+export type CoordinationMessage = z.infer<typeof CoordinationMessageSchema>;
+
+/** Literal set of accepted `kind` values. Handy for MCP tool schemas + tests. */
+export const COORDINATION_MESSAGE_KINDS = [
+  "blocked-on-repo",
+  "repo-ready",
+  "merge-order-proposal",
+] as const;
+
+export type CoordinationMessageKind = (typeof COORDINATION_MESSAGE_KINDS)[number];
+
+/**
+ * Parse a raw payload into a validated {@link CoordinationMessage}.
+ * Returns `{ ok: true, message }` on success or `{ ok: false, error }`
+ * with a short human-readable reason. Callers should prefer this over
+ * `CoordinationMessageSchema.parse(...)` directly so the "malformed →
+ * structured error, never silent drop" (AC4) contract stays in one
+ * place.
+ */
+export function parseCoordinationMessage(
+  raw: unknown
+): { ok: true; message: CoordinationMessage } | { ok: false; error: string; issues: z.ZodIssue[] } {
+  const result = CoordinationMessageSchema.safeParse(raw);
+  if (result.success) {
+    return { ok: true, message: result.data };
+  }
+  // Short, deterministic error summary: `kind: required` > join with `; `.
+  // Full issues list is returned alongside so callers that want structured
+  // detail (MCP tool error envelope) can surface it verbatim.
+  const error = result.error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
+  return { ok: false, error, issues: result.error.issues };
+}

--- a/src/mcp/coordination-tools.ts
+++ b/src/mcp/coordination-tools.ts
@@ -1,0 +1,159 @@
+/**
+ * AL-16 MCP surface: `coordination_send`.
+ *
+ * Exposes {@link Coordinator.send} to repo-admin sessions as a tool call.
+ * The tool is narrow on purpose:
+ *
+ *   - Only callable by repo-admin (added to the role allowlist so a
+ *     worker can't spoof cross-repo coordination).
+ *   - Input must validate against one of the AL-16 message schemas or
+ *     the tool returns a structured `malformed` error (AC4). The
+ *     server never drops a malformed call silently.
+ *   - The Coordinator is optional state: when the MCP server is spun
+ *     up outside an autonomous run (the common developer path), the
+ *     coordination state is absent and the tool returns a clear
+ *     "coordinator not configured" error rather than throwing.
+ *
+ * The tool is modelled on `crosslink/tools.ts` so the shape is
+ * familiar — a pair of (definitions, dispatcher) functions plus a
+ * lightweight state interface the MCP server threads through.
+ */
+
+import type { Coordinator, SendResult } from "../crosslink/coordinator.js";
+import { COORDINATION_MESSAGE_KINDS } from "../crosslink/messages.js";
+
+/**
+ * MCP tool name. Exported so the role allowlist and tests can pattern-
+ * match without re-declaring the string.
+ */
+export const COORDINATION_SEND_TOOL = "coordination_send";
+
+/**
+ * State the MCP server owns and threads into each tool dispatch. A
+ * missing `coordinator` is the dev-mode fallback — the tool returns a
+ * structured error instead of throwing so a misconfigured session sees
+ * an actionable reason, not a 500.
+ */
+export interface CoordinationToolState {
+  /** Admin alias this session represents. Set when the MCP server is
+   * running inside a repo-admin context (RELAY_AGENT_ROLE=repo-admin).
+   * Absent otherwise. */
+  alias: string | null;
+  /** Per-run coordinator instance. Wired by the autonomous-loop driver
+   * (AL-16 follow-up). When null, the tool surfaces a clear error. */
+  coordinator: Coordinator | null;
+}
+
+/** True iff the tool name belongs to the AL-16 surface. */
+export function isCoordinationTool(name: string): boolean {
+  return name === COORDINATION_SEND_TOOL;
+}
+
+/**
+ * MCP tool definitions for `tools/list`. Kept as a function (not a
+ * constant) to match the sibling pattern in `channel-tools.ts` /
+ * `crosslink/tools.ts`.
+ */
+export function getCoordinationToolDefinitions(): object[] {
+  return [
+    {
+      name: COORDINATION_SEND_TOOL,
+      description:
+        "Send a typed cross-repo coordination message to another repo-admin. " +
+        "Use 'blocked-on-repo' when a ticket cannot proceed until another repo's " +
+        "ticket completes; 'repo-ready' to announce that a PR you own is open or " +
+        "merged and downstream repos may be waiting on it; 'merge-order-proposal' " +
+        "to record an ordering rationale across multiple open PRs. DO NOT free-text " +
+        "these coordination handoffs in the channel feed — use this tool so the " +
+        "scheduler and other admins can parse them programmatically.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["to", "payload"],
+        properties: {
+          to: {
+            type: "string",
+            description: "Receiving admin alias (e.g. 'frontend', 'backend').",
+          },
+          payload: {
+            type: "object",
+            description:
+              "One of the typed AL-16 coordination shapes. The `kind` field is the " +
+              "discriminator; see each shape's required fields in the relay docs.",
+            properties: {
+              kind: {
+                type: "string",
+                enum: [...COORDINATION_MESSAGE_KINDS],
+              },
+            },
+            required: ["kind"],
+          },
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * Dispatch a single `coordination_send` call. Returns a plain JSON-
+ * serializable object the MCP server wraps in the usual `content[]`
+ * envelope; see `src/mcp/server.ts` for the outer framing.
+ */
+export async function callCoordinationTool(
+  name: string,
+  args: Record<string, unknown>,
+  state: CoordinationToolState
+): Promise<unknown> {
+  if (name !== COORDINATION_SEND_TOOL) {
+    return {
+      ok: false,
+      error: "unknown-tool",
+      detail: `coordination_send dispatcher received unexpected tool name: ${name}`,
+    };
+  }
+
+  if (!state.alias) {
+    return {
+      ok: false,
+      error: "session-not-repo-admin",
+      detail:
+        "coordination_send is only callable from a repo-admin session. Set " +
+        "RELAY_AGENT_ROLE=repo-admin and bind the session to a repo alias.",
+    };
+  }
+
+  if (!state.coordinator) {
+    return {
+      ok: false,
+      error: "coordinator-not-configured",
+      detail:
+        "No coordinator is wired into this MCP server instance. Coordination " +
+        "messaging requires running inside an autonomous-loop session where " +
+        "the Coordinator is constructed alongside the RepoAdminPool.",
+    };
+  }
+
+  const to = typeof args.to === "string" ? args.to : "";
+  if (!to) {
+    return {
+      ok: false,
+      error: "malformed",
+      detail: "`to` is required and must be a non-empty string.",
+    };
+  }
+  const payload = args.payload;
+  if (payload === null || typeof payload !== "object") {
+    return {
+      ok: false,
+      error: "malformed",
+      detail: "`payload` is required and must be an object matching one of the AL-16 shapes.",
+    };
+  }
+
+  const result: SendResult = await state.coordinator.send(
+    state.alias,
+    to,
+    payload as Record<string, unknown>
+  );
+  return result;
+}

--- a/src/mcp/role-allowlist.ts
+++ b/src/mcp/role-allowlist.ts
@@ -118,6 +118,11 @@ export const REPO_ADMIN_ALLOWED_TOOLS: ReadonlySet<string> = new Set<string>([
   "harness_get_run_detail",
   // Spawn ephemeral workers — declared here; implementation lands in AL-14.
   "spawn_worker",
+  // AL-16: typed cross-repo coordination. Repo-admin is the only role
+  // permitted to send coordination messages — workers are intentionally
+  // barred so cross-repo handoffs stay at the foreman tier where the
+  // ticket board + decisions audit live.
+  "coordination_send",
 ]);
 
 /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -22,6 +22,12 @@ import {
   type CrosslinkToolState,
 } from "../crosslink/tools.js";
 import {
+  callCoordinationTool,
+  getCoordinationToolDefinitions,
+  isCoordinationTool,
+  type CoordinationToolState,
+} from "./coordination-tools.js";
+import {
   allowlistForRole,
   denyToolEnvelope,
   isToolAllowedForRole,
@@ -49,6 +55,14 @@ export interface McpHandlerContext {
   artifactStore: LocalArtifactStore;
   crosslinkState: CrosslinkToolState;
   channelState: ChannelToolState;
+  /**
+   * AL-16 coordination tool state. The MCP server owns an empty
+   * `coordinator: null` by default so the `coordination_send` tool
+   * returns a structured "coordinator-not-configured" error when
+   * invoked outside an autonomous-loop run. The autonomous-loop
+   * driver hands the context a real Coordinator when it spins up.
+   */
+  coordinationState: CoordinationToolState;
   cleanup: () => void;
 }
 
@@ -80,6 +94,16 @@ export async function buildMcpMessageHandler(
     sessionId: null,
     channelStore,
   };
+  // AL-16: the server always constructs an empty coordination state so
+  // the tool surface is stable. A running autonomous-loop session
+  // populates `coordinator` + `alias` when it boots the Coordinator
+  // alongside the RepoAdminPool; outside an autonomous run both fields
+  // stay null and `coordination_send` returns a structured
+  // "coordinator-not-configured" error rather than throwing.
+  const coordinationState: CoordinationToolState = {
+    alias: null,
+    coordinator: null,
+  };
 
   // Auto-register this session
   const agentProvider = (process.env.RELAY_PROVIDER ?? "unknown") as "claude" | "codex" | "unknown";
@@ -110,11 +134,25 @@ export async function buildMcpMessageHandler(
   };
 
   const handler: McpMessageHandler = (message) =>
-    handleMessage(message, workspaceRoot, artifactStore, crosslinkState, channelState);
+    handleMessage(
+      message,
+      workspaceRoot,
+      artifactStore,
+      crosslinkState,
+      channelState,
+      coordinationState
+    );
 
   return {
     handler,
-    context: { workspaceRoot, artifactStore, crosslinkState, channelState, cleanup },
+    context: {
+      workspaceRoot,
+      artifactStore,
+      crosslinkState,
+      channelState,
+      coordinationState,
+      cleanup,
+    },
   };
 }
 
@@ -140,7 +178,8 @@ async function handleMessage(
   workspaceRoot: string,
   artifactStore: LocalArtifactStore,
   crosslinkState: CrosslinkToolState,
-  channelState: ChannelToolState
+  channelState: ChannelToolState,
+  coordinationState: CoordinationToolState
 ): Promise<JsonRpcMessage | null> {
   if (!message.method) {
     return null;
@@ -177,6 +216,11 @@ async function handleMessage(
           inputSchema: unknown;
         }>),
         ...(getChannelToolDefinitions() as Array<{
+          name: string;
+          description: string;
+          inputSchema: unknown;
+        }>),
+        ...(getCoordinationToolDefinitions() as Array<{
           name: string;
           description: string;
           inputSchema: unknown;
@@ -395,7 +439,9 @@ async function handleMessage(
           ? await callCrosslinkTool(toolName, toolArgs, crosslinkState)
           : isChannelTool(toolName)
             ? await callChannelTool(toolName, toolArgs, channelState)
-            : await callTool(toolName, toolArgs, workspaceRoot, artifactStore);
+            : isCoordinationTool(toolName)
+              ? await callCoordinationTool(toolName, toolArgs, coordinationState)
+              : await callTool(toolName, toolArgs, workspaceRoot, artifactStore);
 
         return {
           jsonrpc: "2.0",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,6 +27,7 @@ import {
   isCoordinationTool,
   type CoordinationToolState,
 } from "./coordination-tools.js";
+import type { Coordinator } from "../crosslink/coordinator.js";
 import {
   allowlistForRole,
   denyToolEnvelope,
@@ -56,23 +57,52 @@ export interface McpHandlerContext {
   crosslinkState: CrosslinkToolState;
   channelState: ChannelToolState;
   /**
-   * AL-16 coordination tool state. The MCP server owns an empty
-   * `coordinator: null` by default so the `coordination_send` tool
-   * returns a structured "coordinator-not-configured" error when
-   * invoked outside an autonomous-loop run. The autonomous-loop
-   * driver hands the context a real Coordinator when it spins up.
+   * AL-16 coordination tool state. Populated from
+   * {@link McpHandlerOptions} at construction time. When the caller
+   * wires a Coordinator + alias in, `coordination_send` routes through
+   * the live bus. When either is absent, the tool surfaces a
+   * structured error envelope (never a silent drop).
    */
   coordinationState: CoordinationToolState;
   cleanup: () => void;
 }
 
 /**
+ * Optional wiring for the AL-16 coordination tool surface. When the MCP
+ * server is constructed in-process (e.g. inside the autonomous-loop
+ * driver's test harness, or in a future in-process MCP host for
+ * repo-admin sessions), the caller passes the shared {@link Coordinator}
+ * and the session's own admin alias here so `coordination_send` calls
+ * route to a live bus instead of returning `coordinator-not-configured`.
+ *
+ * When the MCP server runs as a subprocess of the Claude CLI (the
+ * default production path), the coordinator can't cross the process
+ * boundary as a direct reference — the parent relays sends through a
+ * separate IPC channel. This parameter is still populated there via an
+ * in-parent bridge so the tool surface stays unified; subprocess
+ * transports that have no bridge at all leave both fields null and the
+ * tool surfaces a structured `coordinator-not-configured` error.
+ */
+export interface McpHandlerOptions {
+  /** Per-run coordinator wired by the autonomous-loop driver. */
+  coordinator?: Coordinator | null;
+  /** Admin alias the enclosing session represents. */
+  alias?: string | null;
+}
+
+/**
  * Build the JSON-RPC message handler + supporting state for an MCP server
  * instance. Shared between the stdio and HTTP/SSE transports so both paths
  * serve the same tool surface.
+ *
+ * When `options.coordinator` + `options.alias` are both provided, the
+ * resulting handler's `coordination_send` dispatch routes through the
+ * live bus. When either is absent, the tool returns a structured error
+ * envelope identifying the missing piece — never a silent drop.
  */
 export async function buildMcpMessageHandler(
-  workspaceRoot: string
+  workspaceRoot: string,
+  options: McpHandlerOptions = {}
 ): Promise<{ handler: McpMessageHandler; context: McpHandlerContext }> {
   // AL-11 (I1 fix): if RELAY_AGENT_ROLE is set to a value we don't recognise,
   // log a one-shot warning to stderr on startup. The allowlist fall-through
@@ -94,15 +124,17 @@ export async function buildMcpMessageHandler(
     sessionId: null,
     channelStore,
   };
-  // AL-16: the server always constructs an empty coordination state so
-  // the tool surface is stable. A running autonomous-loop session
-  // populates `coordinator` + `alias` when it boots the Coordinator
-  // alongside the RepoAdminPool; outside an autonomous run both fields
-  // stay null and `coordination_send` returns a structured
-  // "coordinator-not-configured" error rather than throwing.
+  // AL-16: the server always constructs a coordination state so the
+  // tool surface is stable. When the caller supplies a Coordinator
+  // + alias (in-process path — autonomous-loop driver or integration
+  // test), `coordination_send` routes through the live bus. Otherwise
+  // both fields stay null and the tool returns a structured
+  // `coordinator-not-configured` / `session-not-repo-admin` error
+  // rather than throwing. Null-coercion below keeps the type contract
+  // explicit — `undefined` and omitted both collapse to null.
   const coordinationState: CoordinationToolState = {
-    alias: null,
-    coordinator: null,
+    alias: options.alias ?? null,
+    coordinator: options.coordinator ?? null,
   };
 
   // Auto-register this session
@@ -156,8 +188,11 @@ export async function buildMcpMessageHandler(
   };
 }
 
-export async function startMcpServer(workspaceRoot: string): Promise<void> {
-  const { handler, context } = await buildMcpMessageHandler(workspaceRoot);
+export async function startMcpServer(
+  workspaceRoot: string,
+  options: McpHandlerOptions = {}
+): Promise<void> {
+  const { handler, context } = await buildMcpMessageHandler(workspaceRoot, options);
 
   process.on("exit", context.cleanup);
   process.on("SIGTERM", () => {

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -183,6 +183,43 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     );
   }
 
+  // AL-13/16: single channel store instance shared by the router, the
+  // runner fleet, and the coordinator's decisions audit. Reusing one
+  // instance avoids redundant on-disk state checks and keeps all
+  // writes going through the same in-memory mirror.
+  const channelStore = testOverrides?.channelStore ?? new ChannelStore();
+
+  // AL-16: inter-admin coordination bus. Construct BEFORE the pool so
+  // the pool can thread the reference into each session it spawns —
+  // any in-process MCP handler built on a session's behalf then has
+  // both coordinator and alias available at construction, which is
+  // what `coordination_send` needs to route end-to-end. When the pool
+  // is disabled (AL-13 pending path) the coordinator stays null; no
+  // coordination is possible without admins to address anyway.
+  //
+  // The coordinator wraps a `pool` reference for alias-lookup on send;
+  // we forward-declare a lazily-populated proxy that the pool writes
+  // into after construction, so the ordering (coordinator-before-pool
+  // for wiring, pool-before-use for routing) holds without a circular
+  // constructor call. The proxy is a thin Pick<> view — the coordinator
+  // only calls `getSession` / `listSessions` on it.
+  let poolRef: RepoAdminPool | null = null;
+  const poolView: Pick<RepoAdminPool, "getSession" | "listSessions"> = {
+    getSession(alias: string) {
+      return poolRef?.getSession(alias) ?? null;
+    },
+    listSessions() {
+      return poolRef?.listSessions() ?? [];
+    },
+  };
+  const coordinator = poolEnabled
+    ? new Coordinator({
+        pool: poolView,
+        channelStore,
+        channelId: channel.channelId,
+      })
+    : null;
+
   const pool = poolEnabled
     ? new RepoAdminPool({
         channel,
@@ -191,8 +228,13 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         lifecycle,
         spawner: testOverrides?.repoAdminSpawner,
         rootDir: testOverrides?.rootDir,
+        // AL-16: hand the shared bus to the pool so every session it
+        // constructs receives the reference and can pass it into its
+        // MCP handler at construction time.
+        coordinator,
       })
     : null;
+  poolRef = pool;
 
   if (pool) {
     try {
@@ -205,25 +247,6 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
       );
     }
   }
-
-  // AL-13/16: single channel store instance shared by the router, the
-  // runner fleet, and the coordinator's decisions audit. Reusing one
-  // instance avoids redundant on-disk state checks and keeps all
-  // writes going through the same in-memory mirror.
-  const channelStore = testOverrides?.channelStore ?? new ChannelStore();
-
-  // AL-16: inter-admin coordination bus. Lifetime matches the pool —
-  // constructed after the pool boots so `getSession` / `listSessions`
-  // resolve, closed in the finally block below. When the pool is
-  // disabled (AL-13 pending path) the coordinator stays null; no
-  // coordination is possible without admins to address anyway.
-  const coordinator = pool
-    ? new Coordinator({
-        pool,
-        channelStore,
-        channelId: channel.channelId,
-      })
-    : null;
 
   // AL-13: drain the channel's ticket board through the router exactly
   // once. AL-14 adds a second pass (gated by RELAY_AL14_WORKER_DRAIN)
@@ -339,6 +362,25 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     }
   }
 
+  // AL-16: close the coordinator BEFORE stopping the pool. Order
+  // matters — once `pool.stop()` starts, each session unwinds and
+  // `getSession(to)` begins returning null, so a late-arriving
+  // `coordination_send` would resolve with `no-such-admin` (generic,
+  // confusing post-mortem) instead of the cleaner `coordinator-closed`
+  // the close path produces. Closing first guarantees the in-flight
+  // race resolves on the close rail.
+  if (coordinator) {
+    try {
+      await coordinator.close();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] coordinator close failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
   // Terminal lifecycle transition triggers the pool's auto-stop, but also
   // await it here so teardown happens before the CLI returns.
   if (pool) {
@@ -347,23 +389,6 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     } catch (err) {
       console.warn(
         `[autonomous-loop] repo-admin pool stop failed: ${
-          err instanceof Error ? err.message : String(err)
-        }`
-      );
-    }
-  }
-
-  // AL-16: drain coordination subscribers and reject any in-flight
-  // sends after pool teardown — the pool-by-alias lookups the
-  // coordinator relies on will start returning null as sessions
-  // unwind, so closing here means a late send resolves with a clean
-  // `coordinator-closed` reason rather than a generic "no-such-admin".
-  if (coordinator) {
-    try {
-      await coordinator.close();
-    } catch (err) {
-      console.warn(
-        `[autonomous-loop] coordinator close failed: ${
           err instanceof Error ? err.message : String(err)
         }`
       );

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -2,6 +2,7 @@ import type { SessionLifecycle } from "../lifecycle/session-lifecycle.js";
 import type { TokenTracker } from "../budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import { ChannelStore } from "../channels/channel-store.js";
+import { Coordinator } from "../crosslink/coordinator.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
 import type { RepoAdminProcessSpawner } from "./repo-admin-session.js";
 import { TicketRouter } from "./ticket-router.js";
@@ -205,6 +206,25 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     }
   }
 
+  // AL-13/16: single channel store instance shared by the router, the
+  // runner fleet, and the coordinator's decisions audit. Reusing one
+  // instance avoids redundant on-disk state checks and keeps all
+  // writes going through the same in-memory mirror.
+  const channelStore = testOverrides?.channelStore ?? new ChannelStore();
+
+  // AL-16: inter-admin coordination bus. Lifetime matches the pool —
+  // constructed after the pool boots so `getSession` / `listSessions`
+  // resolve, closed in the finally block below. When the pool is
+  // disabled (AL-13 pending path) the coordinator stays null; no
+  // coordination is possible without admins to address anyway.
+  const coordinator = pool
+    ? new Coordinator({
+        pool,
+        channelStore,
+        channelId: channel.channelId,
+      })
+    : null;
+
   // AL-13: drain the channel's ticket board through the router exactly
   // once. AL-14 adds a second pass (gated by RELAY_AL14_WORKER_DRAIN)
   // that drains each admin's queue via TicketRunner — spawn a worker
@@ -216,7 +236,6 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     terminalReason = drainEnabled ? "al-16-pending" : "al-14-pending";
     const runners: TicketRunner[] = [];
     try {
-      const channelStore = testOverrides?.channelStore ?? new ChannelStore();
       const router = new TicketRouter({ pool, channel, channelStore });
       const boardTickets = await channelStore.readChannelTickets(channel.channelId);
       for (const ticket of boardTickets) {
@@ -328,6 +347,23 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     } catch (err) {
       console.warn(
         `[autonomous-loop] repo-admin pool stop failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  // AL-16: drain coordination subscribers and reject any in-flight
+  // sends after pool teardown — the pool-by-alias lookups the
+  // coordinator relies on will start returning null as sessions
+  // unwind, so closing here means a late send resolves with a clean
+  // `coordinator-closed` reason rather than a generic "no-such-admin".
+  if (coordinator) {
+    try {
+      await coordinator.close();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] coordinator close failed: ${
           err instanceof Error ? err.message : String(err)
         }`
       );

--- a/src/orchestrator/repo-admin-pool.ts
+++ b/src/orchestrator/repo-admin-pool.ts
@@ -54,6 +54,7 @@ import { join } from "node:path";
 
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import type { SessionLifecycle, LifecycleState } from "../lifecycle/session-lifecycle.js";
+import type { Coordinator } from "../crosslink/coordinator.js";
 import { getRelayDir } from "../cli/paths.js";
 
 import {
@@ -203,6 +204,16 @@ export interface RepoAdminPoolOptions {
    * ignores SIGTERM).
    */
   sessionStopGraceMs?: number;
+  /**
+   * AL-16: shared coordination bus for this run. Threaded into every
+   * {@link RepoAdminSession} the pool constructs so an in-process MCP
+   * handler built on the session's behalf can route `coordination_send`
+   * through the live bus. Null / omitted in dev-mode runs where no
+   * autonomous-loop driver is coordinating cross-repo work; in that
+   * case each session's MCP surface reports `coordinator-not-configured`
+   * on send (structured error, never a silent drop).
+   */
+  coordinator?: Coordinator | null;
 }
 
 interface InternalSessionRecord {
@@ -233,6 +244,7 @@ export class RepoAdminPool {
   private readonly clearTimer: (handle: NodeJS.Timeout | number) => void;
   private readonly clock: () => number;
   private readonly sessionStopGraceMs?: number;
+  private readonly coordinator: Coordinator | null;
 
   private readonly sessions = new Map<string, InternalSessionRecord>();
   private readonly emitter = new EventEmitter();
@@ -256,6 +268,7 @@ export class RepoAdminPool {
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
     this.clock = options.clock ?? Date.now;
     this.sessionStopGraceMs = options.sessionStopGraceMs;
+    this.coordinator = options.coordinator ?? null;
   }
 
   /**
@@ -416,6 +429,11 @@ export class RepoAdminPool {
       spawner: this.spawner,
       buildSessionId: this.buildSessionId,
       stopGraceMs: this.sessionStopGraceMs,
+      // AL-16: forward the shared bus so the session carries the
+      // reference through its lifecycle. An MCP handler built on the
+      // session's behalf (in-process path) uses it + session.alias to
+      // populate coordination state at construction.
+      coordinator: this.coordinator,
     };
     const session = new RepoAdminSession(sessionOpts);
 

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -55,6 +55,7 @@ import {
 import { REPO_ADMIN_ROLE } from "../agents/repo-admin.js";
 import { getDisallowedBuiltinsForRole } from "../mcp/role-allowlist.js";
 import { TokenTracker, type ThresholdEvent } from "../budget/token-tracker.js";
+import type { Coordinator } from "../crosslink/coordinator.js";
 import {
   buildCycleDecision,
   type CycleDecisionInput,
@@ -231,6 +232,21 @@ export interface RepoAdminSessionOptions {
    * Defaults to `() => new Date().toISOString()`.
    */
   cycleClock?: () => string;
+  /**
+   * AL-16: shared cross-admin coordination bus for this run. When
+   * supplied, the session carries the reference so an in-process MCP
+   * server constructed on its behalf can route `coordination_send`
+   * through the live bus. The session itself does NOT use the
+   * coordinator directly — it only threads it through to whoever
+   * constructs the MCP handler (the autonomous-loop driver, or a
+   * bridge subprocess in the out-of-process path).
+   *
+   * When omitted, the session runs with no coordinator reference and
+   * any MCP surface built against it surfaces `coordinator-not-
+   * configured` on `coordination_send`. That's the correct dev-mode
+   * behaviour — coordination is an autonomous-loop concern.
+   */
+  coordinator?: Coordinator | null;
 }
 
 /**
@@ -312,6 +328,14 @@ export class RepoAdminSession {
   private readonly emitter = new EventEmitter();
 
   /**
+   * AL-16: shared coordination bus for this run. Set at construction
+   * time by the pool; null when the session is booted outside an
+   * autonomous run. Consumed by any MCP handler constructed on this
+   * session's behalf — see {@link RepoAdminSession.coordinator}.
+   */
+  private readonly _coordinator: Coordinator | null;
+
+  /**
    * Monotonically increasing counter of spawn attempts for THIS session.
    * The pool uses it in conjunction with its own rapid-restart book-
    * keeping to decide when to give up.
@@ -371,6 +395,7 @@ export class RepoAdminSession {
     this.stopGraceMs = options.stopGraceMs ?? STOP_GRACE_MS;
     this.cycleConfig = options.cycle ?? null;
     this.cycleClock = options.cycleClock ?? (() => new Date().toISOString());
+    this._coordinator = options.coordinator ?? null;
 
     // AL-15: the session's own token tracker. A caller that supplies one
     // (tests, or a future aggregator) owns its lifetime; otherwise we
@@ -439,6 +464,19 @@ export class RepoAdminSession {
    */
   get tracker(): TokenTracker {
     return this.tokenTracker;
+  }
+
+  /**
+   * AL-16: the shared coordination bus for this run, or null when the
+   * session is running outside an autonomous-loop. An in-process MCP
+   * handler constructed on this session's behalf passes this +
+   * {@link RepoAdminSession.alias} into `buildMcpMessageHandler` so
+   * `coordination_send` routes to the live bus. Read-only on purpose:
+   * the session never swaps coordinators mid-life; restart / cycle
+   * reuses the same reference.
+   */
+  get coordinator(): Coordinator | null {
+    return this._coordinator;
   }
 
   /**

--- a/test/agents/repo-admin.test.ts
+++ b/test/agents/repo-admin.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   REPO_ADMIN_ALLOWED_TOOLS,
+  REPO_ADMIN_COORDINATION_POLICY_MARKER,
   REPO_ADMIN_MEMORY_POLICY_MARKER,
   REPO_ADMIN_ROLE,
   REPO_ADMIN_SPECIALTY,
@@ -156,6 +157,19 @@ describe("repo-admin role — system prompt", () => {
     expect(prompt).toContain("cache only the active working set");
     expect(prompt).toMatch(/re-read the board/i);
     expect(prompt).toMatch(/Don't rely on chat history/i);
+  });
+
+  it("encodes the AL-16 typed-coordination policy by substring match", () => {
+    // Pin the exact marker the role module exports so a future copy edit
+    // can't silently drop the typed-coordination guidance — without this
+    // assertion, an agent would quietly fall back to free-text handoffs
+    // on the channel feed. Mirrors the memory-policy marker test above.
+    expect(prompt).toContain(REPO_ADMIN_COORDINATION_POLICY_MARKER);
+    // Plus the three typed shapes the prompt names so a partial drop
+    // (marker present but shape guidance gone) also trips.
+    expect(prompt).toContain("blocked-on-repo");
+    expect(prompt).toContain("repo-ready");
+    expect(prompt).toContain("merge-order-proposal");
   });
 
   it("tells repo-admin to propose work instead of reaching for denied tools", () => {

--- a/test/agents/repo-admin.test.ts
+++ b/test/agents/repo-admin.test.ts
@@ -53,6 +53,7 @@ describe("repo-admin role — allowlist exactness", () => {
         "channel_get", // read decisions + feed + run links in one call
         "channel_post", // append-only feed updates (propose a spawn, announce a decision)
         "channel_task_board", // read the ticket board
+        "coordination_send", // AL-16: typed inter-repo coordination messages
         "harness_get_run_detail", // read-only run state
         "harness_list_runs", // read-only run index
         "harness_running_tasks", // cross-workspace running-task view

--- a/test/crosslink/coordination-tools.test.ts
+++ b/test/crosslink/coordination-tools.test.ts
@@ -1,0 +1,198 @@
+/**
+ * AL-16 MCP tool (`coordination_send`) contract tests.
+ *
+ * Focuses on the thin dispatcher surface: it delegates to the
+ * Coordinator, but the tool owns the "session is not repo-admin" /
+ * "coordinator not wired" / "malformed args" envelopes. AC4 requires a
+ * malformed payload to surface a structured error, never silently drop.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import { Coordinator } from "../../src/crosslink/coordinator.js";
+import {
+  COORDINATION_SEND_TOOL,
+  callCoordinationTool,
+  getCoordinationToolDefinitions,
+  isCoordinationTool,
+  type CoordinationToolState,
+} from "../../src/mcp/coordination-tools.js";
+
+function makeFakePool(aliases: string[]) {
+  const sessions = new Map<string, { alias: string }>();
+  for (const alias of aliases) sessions.set(alias, { alias });
+  return {
+    getSession(alias: string) {
+      return (
+        (sessions.get(alias) as unknown as ReturnType<
+          InstanceType<
+            typeof import("../../src/orchestrator/repo-admin-pool.js").RepoAdminPool
+          >["getSession"]
+        >) ?? null
+      );
+    },
+    listSessions() {
+      return Array.from(sessions.values()) as unknown as ReturnType<
+        InstanceType<
+          typeof import("../../src/orchestrator/repo-admin-pool.js").RepoAdminPool
+        >["listSessions"]
+      >;
+    },
+  };
+}
+
+async function withToolState(
+  aliases: string[],
+  body: (state: CoordinationToolState, ctx: { dir: string; channelId: string }) => Promise<void>
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "al-16-tool-"));
+  const channelStore = new ChannelStore(dir);
+  try {
+    const channel = await channelStore.createChannel({
+      name: "#al-16-tool",
+      description: "al-16 tool tests",
+    });
+    const coordinator = new Coordinator({
+      pool: makeFakePool(aliases),
+      channelStore,
+      channelId: channel.channelId,
+    });
+    try {
+      await body({ alias: aliases[0] ?? null, coordinator }, { dir, channelId: channel.channelId });
+    } finally {
+      await coordinator.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("coordination_send MCP tool", () => {
+  it("identifies itself via isCoordinationTool", () => {
+    expect(isCoordinationTool(COORDINATION_SEND_TOOL)).toBe(true);
+    expect(isCoordinationTool("coordination_send")).toBe(true);
+    expect(isCoordinationTool("crosslink_send")).toBe(false);
+    expect(isCoordinationTool("harness_status")).toBe(false);
+  });
+
+  it("exposes a tool definition with the expected name + schema basics", () => {
+    const defs = getCoordinationToolDefinitions() as Array<{
+      name: string;
+      description: string;
+      inputSchema: { required: string[]; properties: { to: unknown; payload: unknown } };
+    }>;
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe("coordination_send");
+    expect(defs[0].inputSchema.required).toEqual(["to", "payload"]);
+  });
+
+  it("returns session-not-repo-admin when alias is null", async () => {
+    const state: CoordinationToolState = { alias: null, coordinator: null };
+    const result = (await callCoordinationTool(
+      "coordination_send",
+      { to: "frontend", payload: { kind: "repo-ready" } },
+      state
+    )) as { ok: false; error: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("session-not-repo-admin");
+  });
+
+  it("returns coordinator-not-configured when the coordinator is absent", async () => {
+    const state: CoordinationToolState = { alias: "backend", coordinator: null };
+    const result = (await callCoordinationTool(
+      "coordination_send",
+      { to: "frontend", payload: { kind: "repo-ready" } },
+      state
+    )) as { ok: false; error: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("coordinator-not-configured");
+  });
+
+  it("returns malformed when the payload fails validation (AC4)", async () => {
+    await withToolState(["backend", "frontend"], async (state) => {
+      const result = (await callCoordinationTool(
+        "coordination_send",
+        {
+          to: "frontend",
+          payload: {
+            kind: "blocked-on-repo",
+            // missing every field beyond `kind`
+          },
+        },
+        state
+      )) as { ok: false; reason: string };
+      expect(result.ok).toBe(false);
+      // The tool delegates to Coordinator.send; the `reason` from the
+      // SendErr envelope is what the repo-admin system prompt pattern-
+      // matches on. AC4: structured, never a silent drop.
+      expect(result.reason).toBe("malformed");
+    });
+  });
+
+  it("returns malformed when `to` is missing", async () => {
+    await withToolState(["backend", "frontend"], async (state) => {
+      const result = (await callCoordinationTool(
+        "coordination_send",
+        { payload: { kind: "repo-ready" } },
+        state
+      )) as { ok: false; error: string };
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("malformed");
+    });
+  });
+
+  it("returns malformed when `payload` is not an object", async () => {
+    await withToolState(["backend", "frontend"], async (state) => {
+      const result = (await callCoordinationTool(
+        "coordination_send",
+        { to: "frontend", payload: "blocked-on-repo" },
+        state
+      )) as { ok: false; error: string };
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("malformed");
+    });
+  });
+
+  it("routes a valid payload successfully and returns an SendOk envelope", async () => {
+    await withToolState(["backend", "frontend"], async (state) => {
+      // Our helper sets alias = aliases[0] = "backend", so send
+      // FROM backend TO frontend.
+      const result = (await callCoordinationTool(
+        "coordination_send",
+        {
+          to: "frontend",
+          payload: {
+            kind: "blocked-on-repo",
+            requester: "backend",
+            blocker: "frontend",
+            ticketId: "AL-X",
+            dependsOnTicketId: "AL-Y",
+            reason: "consumer update first",
+            requestedAt: "2026-04-21T12:00:00.000Z",
+          },
+        },
+        state
+      )) as { ok: true; kind: string; from: string; to: string };
+      expect(result.ok).toBe(true);
+      expect(result.kind).toBe("blocked-on-repo");
+      expect(result.from).toBe("backend");
+      expect(result.to).toBe("frontend");
+    });
+  });
+
+  it("returns an unknown-tool envelope for wrong tool names", async () => {
+    await withToolState(["backend"], async (state) => {
+      const result = (await callCoordinationTool("coordination_discover", {}, state)) as {
+        ok: false;
+        error: string;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("unknown-tool");
+    });
+  });
+});

--- a/test/crosslink/coordinator.test.ts
+++ b/test/crosslink/coordinator.test.ts
@@ -1,0 +1,367 @@
+/**
+ * AL-16 Coordinator unit tests.
+ *
+ * Drives the bus with a fake pool (aliases → `{}` placeholders) and an
+ * injected channel store, then asserts on the externally-observable
+ * contract: validation, routing, block graph, audit mirror, waitFor,
+ * and the end-to-end "A blocked on B, B announces ready" scenario.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import { Coordinator } from "../../src/crosslink/coordinator.js";
+import type { CoordinationMessage, CoordinationMessageKind } from "../../src/crosslink/messages.js";
+
+/**
+ * Fake pool: the coordinator only consults `getSession` / `listSessions`
+ * to check that an alias is registered, so a simple Map<alias, {}>
+ * suffices. Returning a non-null object for known aliases is enough —
+ * the coordinator never reaches into the session.
+ */
+function makeFakePool(aliases: string[]) {
+  const sessions = new Map<string, { alias: string }>();
+  for (const alias of aliases) sessions.set(alias, { alias });
+  // Types match what Coordinator's `Pick<RepoAdminPool, ...>` needs.
+  const pool = {
+    getSession(alias: string) {
+      return (
+        (sessions.get(alias) as unknown as ReturnType<
+          InstanceType<
+            typeof import("../../src/orchestrator/repo-admin-pool.js").RepoAdminPool
+          >["getSession"]
+        >) ?? null
+      );
+    },
+    listSessions() {
+      return Array.from(sessions.values()) as unknown as ReturnType<
+        InstanceType<
+          typeof import("../../src/orchestrator/repo-admin-pool.js").RepoAdminPool
+        >["listSessions"]
+      >;
+    },
+  };
+  return pool;
+}
+
+async function withCoordinator(
+  aliases: string[],
+  body: (ctx: {
+    coordinator: Coordinator;
+    channelId: string;
+    channelStore: ChannelStore;
+    dir: string;
+  }) => Promise<void>
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "al-16-coord-"));
+  const channelStore = new ChannelStore(dir);
+  try {
+    const channel = await channelStore.createChannel({
+      name: "#al-16",
+      description: "al-16 coordinator tests",
+    });
+    const coordinator = new Coordinator({
+      pool: makeFakePool(aliases),
+      channelStore,
+      channelId: channel.channelId,
+    });
+    try {
+      await body({ coordinator, channelId: channel.channelId, channelStore, dir });
+    } finally {
+      await coordinator.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function blockedOnRepo(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    kind: "blocked-on-repo",
+    requester: "backend",
+    blocker: "frontend",
+    ticketId: "AL-X",
+    dependsOnTicketId: "AL-Y",
+    reason: "cross-repo handoff",
+    requestedAt: "2026-04-21T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function repoReady(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    kind: "repo-ready",
+    alias: "frontend",
+    ticketId: "AL-Y",
+    prUrl: "https://github.com/o/r/pull/1",
+    announcedAt: "2026-04-21T12:10:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Coordinator.send", () => {
+  it("routes a valid repo-ready payload to a subscribed listener", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      const received: CoordinationMessage[] = [];
+      const unsubscribe = coordinator.onMessage("backend", (msg) => {
+        received.push(msg);
+      });
+      try {
+        const result = await coordinator.send("frontend", "backend", repoReady());
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.kind).toBe("repo-ready");
+          expect(result.from).toBe("frontend");
+          expect(result.to).toBe("backend");
+        }
+        expect(received).toHaveLength(1);
+        expect(received[0].kind).toBe("repo-ready");
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("rejects a malformed payload with a structured error (AC4)", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      const result = await coordinator.send("frontend", "backend", {
+        kind: "repo-ready",
+        // missing alias, ticketId, prUrl, announcedAt
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("malformed");
+        expect(result.detail.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  it("rejects a send to an unknown admin alias", async () => {
+    await withCoordinator(["backend"], async ({ coordinator }) => {
+      const result = await coordinator.send("backend", "ghost", repoReady({ alias: "ghost" }));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("no-such-admin");
+      }
+    });
+  });
+
+  it("rejects self-addressed sends", async () => {
+    await withCoordinator(["backend"], async ({ coordinator }) => {
+      const result = await coordinator.send("backend", "backend", repoReady({ alias: "backend" }));
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("self-addressed");
+    });
+  });
+
+  it("rejects a blocked-on-repo whose requester doesn't match the from alias", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      // Backend is the actual sender, but requester claims "frontend".
+      const result = await coordinator.send(
+        "backend",
+        "frontend",
+        blockedOnRepo({ requester: "frontend" })
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("malformed");
+    });
+  });
+
+  it("rejects a blocked-on-repo whose blocker doesn't match the to alias", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      const result = await coordinator.send(
+        "backend",
+        "frontend",
+        blockedOnRepo({ blocker: "other" })
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("malformed");
+    });
+  });
+
+  it("rejects a blocked-on-repo that would close a cycle (AC2 deadlock prevention)", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      // A (backend) blocks on B (frontend).
+      const first = await coordinator.send(
+        "backend",
+        "frontend",
+        blockedOnRepo({ requester: "backend", blocker: "frontend" })
+      );
+      expect(first.ok).toBe(true);
+
+      // B (frontend) tries to block on A (backend) — closes the cycle.
+      const second = await coordinator.send(
+        "frontend",
+        "backend",
+        blockedOnRepo({
+          requester: "frontend",
+          blocker: "backend",
+          ticketId: "AL-Z",
+          dependsOnTicketId: "AL-W",
+        })
+      );
+      expect(second.ok).toBe(false);
+      if (!second.ok) expect(second.reason).toBe("would-form-cycle");
+
+      // The cycle-rejected edge was NOT added to the graph.
+      const openBlocks = coordinator.listOpenBlocks();
+      expect(openBlocks).toHaveLength(1);
+      expect(openBlocks[0].requester).toBe("backend");
+    });
+  });
+
+  it("clears a block edge when repo-ready announces completion of the depended-on ticket", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      await coordinator.send("backend", "frontend", blockedOnRepo());
+      expect(coordinator.listOpenBlocks()).toHaveLength(1);
+
+      // Frontend announces ready for AL-Y — the dependsOnTicketId.
+      const ready = await coordinator.send(
+        "frontend",
+        "backend",
+        repoReady({ alias: "frontend", ticketId: "AL-Y" })
+      );
+      expect(ready.ok).toBe(true);
+      expect(coordinator.listOpenBlocks()).toHaveLength(0);
+    });
+  });
+
+  it("records a coordination_message decision on every successful send (audit trail)", async () => {
+    await withCoordinator(
+      ["backend", "frontend"],
+      async ({ coordinator, channelId, channelStore }) => {
+        await coordinator.send("frontend", "backend", repoReady());
+        const decisions = await channelStore.listDecisions(channelId);
+        const coord = decisions.filter((d) => d.type === "coordination_message");
+        expect(coord).toHaveLength(1);
+        expect(coord[0].metadata?.from).toBe("frontend");
+        expect(coord[0].metadata?.to).toBe("backend");
+        const payload = coord[0].metadata?.payload as { kind: CoordinationMessageKind };
+        expect(payload.kind).toBe("repo-ready");
+      }
+    );
+  });
+
+  it("rejects sends after close()", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      await coordinator.close();
+      const result = await coordinator.send("frontend", "backend", repoReady());
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("coordinator-closed");
+    });
+  });
+});
+
+describe("Coordinator.waitFor", () => {
+  it("resolves when a matching message arrives", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      const waiter = coordinator.waitFor(
+        "backend",
+        (msg) => msg.kind === "repo-ready" && msg.ticketId === "AL-Y",
+        { timeoutMs: 1_000, label: "test-ac3" }
+      );
+      // Await the send so the coordinator's audit write completes
+      // before the enclosing `withCoordinator` unwinds the tmp dir —
+      // otherwise the decisions-file write races the rm -rf.
+      const send = coordinator.send("frontend", "backend", repoReady());
+      const [msg, sendResult] = await Promise.all([waiter, send]);
+      expect(msg.kind).toBe("repo-ready");
+      expect(sendResult.ok).toBe(true);
+    });
+  });
+
+  it("times out if no matching message arrives", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      await expect(
+        coordinator.waitFor("backend", () => false, { timeoutMs: 15, label: "tiny" })
+      ).rejects.toThrow(/wait-timeout/);
+    });
+  });
+
+  it("models the AC3 end-to-end: A blocks on B, B completes, A unblocks without deadlock", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      // A (backend) tells B (frontend) it is blocked on AL-Y.
+      const block = await coordinator.send(
+        "backend",
+        "frontend",
+        blockedOnRepo({ requester: "backend", blocker: "frontend" })
+      );
+      expect(block.ok).toBe(true);
+
+      // Backend waits for a repo-ready from frontend for AL-Y.
+      const wait = coordinator.waitFor(
+        "backend",
+        (msg) => msg.kind === "repo-ready" && msg.alias === "frontend" && msg.ticketId === "AL-Y",
+        { timeoutMs: 1_000, label: "ac3" }
+      );
+
+      // Frontend completes AL-Y and announces.
+      const ready = await coordinator.send(
+        "frontend",
+        "backend",
+        repoReady({ alias: "frontend", ticketId: "AL-Y" })
+      );
+      expect(ready.ok).toBe(true);
+
+      const resolved = await wait;
+      expect(resolved.kind).toBe("repo-ready");
+      if (resolved.kind === "repo-ready") {
+        expect(resolved.ticketId).toBe("AL-Y");
+      }
+
+      // Block graph is empty — the ready cleared it.
+      expect(coordinator.listOpenBlocks()).toHaveLength(0);
+    });
+  });
+});
+
+describe("Coordinator.onMessage", () => {
+  let cleanupFns: Array<() => Promise<void> | void> = [];
+
+  beforeEach(() => {
+    cleanupFns = [];
+  });
+
+  afterEach(async () => {
+    for (const fn of cleanupFns) await fn();
+  });
+
+  it("multiple subscribers for the same alias all receive the message", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      const seenByA: CoordinationMessage[] = [];
+      const seenByB: CoordinationMessage[] = [];
+      const offA = coordinator.onMessage("backend", (m) => {
+        seenByA.push(m);
+      });
+      const offB = coordinator.onMessage("backend", (m) => {
+        seenByB.push(m);
+      });
+      try {
+        await coordinator.send("frontend", "backend", repoReady());
+        expect(seenByA).toHaveLength(1);
+        expect(seenByB).toHaveLength(1);
+      } finally {
+        offA();
+        offB();
+      }
+    });
+  });
+
+  it("a subscriber that throws does not wedge other subscribers", async () => {
+    await withCoordinator(["backend", "frontend"], async ({ coordinator }) => {
+      const seen: CoordinationMessage[] = [];
+      coordinator.onMessage("backend", () => {
+        throw new Error("boom");
+      });
+      coordinator.onMessage("backend", (m) => {
+        seen.push(m);
+      });
+      await coordinator.send("frontend", "backend", repoReady());
+      expect(seen).toHaveLength(1);
+    });
+  });
+});

--- a/test/crosslink/messages.test.ts
+++ b/test/crosslink/messages.test.ts
@@ -1,0 +1,176 @@
+/**
+ * AL-16 message-shape validation.
+ *
+ * Covers the three accepted payload shapes and the malformed-case
+ * surface. These tests sit at the schema boundary — higher layers
+ * (coordinator, MCP tool) re-use `parseCoordinationMessage` so the
+ * shape checks only need to live here.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BlockedOnRepoSchema,
+  COORDINATION_MESSAGE_KINDS,
+  CoordinationMessageSchema,
+  MergeOrderProposalSchema,
+  RepoReadySchema,
+  parseCoordinationMessage,
+} from "../../src/crosslink/messages.js";
+
+describe("AL-16 coordination message schemas", () => {
+  it("accepts a valid blocked-on-repo payload", () => {
+    const raw = {
+      kind: "blocked-on-repo",
+      requester: "backend",
+      blocker: "frontend",
+      ticketId: "AL-X",
+      dependsOnTicketId: "AL-Y",
+      reason: "backend API change lands after frontend consumer update",
+      requestedAt: "2026-04-21T12:00:00.000Z",
+    };
+    const result = parseCoordinationMessage(raw);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.message.kind).toBe("blocked-on-repo");
+
+    // Direct schema parse should match too.
+    expect(BlockedOnRepoSchema.parse(raw)).toMatchObject(raw);
+    expect(CoordinationMessageSchema.parse(raw)).toMatchObject(raw);
+  });
+
+  it("accepts a valid repo-ready payload (PR open, no mergedAt)", () => {
+    const raw = {
+      kind: "repo-ready",
+      alias: "frontend",
+      ticketId: "AL-Y",
+      prUrl: "https://github.com/jcast90/relay/pull/123",
+      announcedAt: "2026-04-21T12:05:00.000Z",
+    };
+    const result = parseCoordinationMessage(raw);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message.kind).toBe("repo-ready");
+      if (result.message.kind === "repo-ready") {
+        expect(result.message.mergedAt).toBeUndefined();
+      }
+    }
+    expect(RepoReadySchema.parse(raw)).toMatchObject(raw);
+  });
+
+  it("accepts a valid repo-ready payload with mergedAt", () => {
+    const raw = {
+      kind: "repo-ready",
+      alias: "frontend",
+      ticketId: "AL-Y",
+      prUrl: "https://github.com/jcast90/relay/pull/123",
+      mergedAt: "2026-04-21T12:10:00.000Z",
+      announcedAt: "2026-04-21T12:10:01.000Z",
+    };
+    const result = parseCoordinationMessage(raw);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid merge-order-proposal payload", () => {
+    const raw = {
+      kind: "merge-order-proposal",
+      proposer: "backend",
+      sequence: [
+        {
+          alias: "frontend",
+          ticketId: "AL-Y",
+          prUrl: "https://github.com/o/r/pull/1",
+        },
+        {
+          alias: "backend",
+          ticketId: "AL-X",
+          prUrl: "https://github.com/o/r/pull/2",
+        },
+      ],
+      rationale: "frontend consumer must land before backend API swap",
+      proposedAt: "2026-04-21T12:15:00.000Z",
+    };
+    const result = parseCoordinationMessage(raw);
+    expect(result.ok).toBe(true);
+    if (result.ok && result.message.kind === "merge-order-proposal") {
+      expect(result.message.sequence).toHaveLength(2);
+    }
+    expect(MergeOrderProposalSchema.parse(raw)).toMatchObject(raw);
+  });
+
+  it("rejects a payload with an unknown kind", () => {
+    const result = parseCoordinationMessage({ kind: "bogus", foo: "bar" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // zod's discriminated union reports the invalid discriminator at
+      // the `kind` path — assert we surface a useful error rather than
+      // a generic "invalid union".
+      expect(result.error.toLowerCase()).toContain("kind");
+    }
+  });
+
+  it("rejects a blocked-on-repo missing required fields", () => {
+    const result = parseCoordinationMessage({
+      kind: "blocked-on-repo",
+      requester: "backend",
+      // missing blocker, ticketId, dependsOnTicketId, reason, requestedAt
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("blocker");
+    }
+  });
+
+  it("rejects a repo-ready payload with an invalid prUrl", () => {
+    const result = parseCoordinationMessage({
+      kind: "repo-ready",
+      alias: "frontend",
+      ticketId: "AL-Y",
+      prUrl: "not-a-url",
+      announcedAt: "2026-04-21T12:05:00.000Z",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("prUrl");
+    }
+  });
+
+  it("rejects a merge-order-proposal with an empty sequence", () => {
+    const result = parseCoordinationMessage({
+      kind: "merge-order-proposal",
+      proposer: "backend",
+      sequence: [],
+      rationale: "empty",
+      proposedAt: "2026-04-21T12:15:00.000Z",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("sequence");
+    }
+  });
+
+  it("rejects a payload that isn't an object", () => {
+    expect(parseCoordinationMessage(null).ok).toBe(false);
+    expect(parseCoordinationMessage("blocked-on-repo").ok).toBe(false);
+    expect(parseCoordinationMessage(42).ok).toBe(false);
+  });
+
+  it("rejects extra (unknown) fields via .strict()", () => {
+    const result = parseCoordinationMessage({
+      kind: "repo-ready",
+      alias: "frontend",
+      ticketId: "AL-Y",
+      prUrl: "https://github.com/o/r/pull/1",
+      announcedAt: "2026-04-21T12:05:00.000Z",
+      extraField: "drive-by",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("exports the full list of supported kinds", () => {
+    expect(COORDINATION_MESSAGE_KINDS).toEqual([
+      "blocked-on-repo",
+      "repo-ready",
+      "merge-order-proposal",
+    ]);
+  });
+});

--- a/test/mcp/coordination-integration.test.ts
+++ b/test/mcp/coordination-integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * AL-16 full-MCP-path integration test for `coordination_send`.
+ *
+ * Unit tests in `test/crosslink/coordination-tools.test.ts` exercise the
+ * dispatcher in isolation — they build a `CoordinationToolState` by
+ * hand and call `callCoordinationTool` directly. That path validates
+ * the dispatcher's contract, but it skips the thing a real repo-admin
+ * session exercises: the JSON-RPC message handler returned by
+ * `buildMcpMessageHandler`, including the `tools/call` routing, the
+ * per-role allowlist check, and the envelope shape the Claude CLI
+ * sees on the wire.
+ *
+ * This test drives that full path:
+ *   1. Construct a Coordinator wired to a fake pool ({A, B}).
+ *   2. Build TWO MCP handlers — one representing admin A's session
+ *      (alias="backend") and one representing admin B's (alias=
+ *      "frontend"), both pointing at the same Coordinator.
+ *   3. Subscribe directly to the coordinator's `onMessage("frontend")`
+ *      stream to observe the fan-out (the real B session would have
+ *      its own listener wired up the same way).
+ *   4. Issue a `tools/call coordination_send` JSON-RPC request against
+ *      handler A.
+ *   5. Assert: the response envelope is `{ok: true, ...}`, the
+ *      coordinator fanned the message out to B's subscriber, and the
+ *      decisions board has a `coordination_message` audit entry.
+ *
+ * This is the regression guard for B2 (PR #110 review): before the
+ * fix, every MCP server constructed its `coordinationState` with
+ * `coordinator: null` and `alias: null`, so `coordination_send`
+ * always returned `coordinator-not-configured`. The tool was
+ * unreachable end-to-end. Adding an assertion on the
+ * `{ok: true, kind: "repo-ready", ...}` envelope locks in the wiring.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CoordinationMessage } from "../../src/crosslink/messages.js";
+import type { RepoAdminPool } from "../../src/orchestrator/repo-admin-pool.js";
+
+// Pin storage to a per-test tmp FileHarnessStore — the MCP handler
+// auto-registers a crosslink session during construction and must not
+// touch real ~/.relay. Mirrors the pattern in role-allowlist.test.ts.
+// NB: top-level value imports from `src/` are deferred to after this
+// mock registration because `vi.mock` is hoisted and any module that
+// transitively imports `storage/factory.js` must see the mocked
+// version (the real `ChannelStore`, `Coordinator`, etc. all do).
+const storeRoots: string[] = [];
+vi.mock("../../src/storage/factory.js", async () => {
+  const { FileHarnessStore } = await import("../../src/storage/file-store.js");
+  const root = await mkdtemp(join(tmpdir(), "al16-mcp-integ-hs-"));
+  storeRoots.push(root);
+  const store = new FileHarnessStore(root);
+  return {
+    getHarnessStore: () => store,
+    buildHarnessStore: () => store,
+  };
+});
+
+interface ToolsCallResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
+}
+
+/**
+ * Tiny pool-shaped stand-in. The Coordinator only calls `getSession` /
+ * `listSessions` on its pool reference, so a Map<alias, {}> is enough.
+ * We cast through `unknown` to satisfy the coordinator's
+ * `Pick<RepoAdminPool, ...>` type without depending on the real pool
+ * machinery (which requires a lifecycle + spawner).
+ */
+function makeFakePool(aliases: string[]): Pick<RepoAdminPool, "getSession" | "listSessions"> {
+  const sessions = new Map<string, { alias: string }>();
+  for (const alias of aliases) sessions.set(alias, { alias });
+  return {
+    getSession(alias: string) {
+      return (sessions.get(alias) as unknown as ReturnType<RepoAdminPool["getSession"]>) ?? null;
+    },
+    listSessions() {
+      return Array.from(sessions.values()) as unknown as ReturnType<RepoAdminPool["listSessions"]>;
+    },
+  };
+}
+
+describe("MCP `coordination_send` full-path integration (AL-16 B2 guard)", () => {
+  let tmpHome: string;
+  let workspaceA: string;
+  let workspaceB: string;
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_ROLE = process.env.RELAY_AGENT_ROLE;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "al16-home-"));
+    workspaceA = await mkdtemp(join(tmpdir(), "al16-ws-a-"));
+    workspaceB = await mkdtemp(join(tmpdir(), "al16-ws-b-"));
+    process.env.HOME = tmpHome;
+    // Repo-admin role so the tool surface + allowlist exercise the
+    // same code path a real session would.
+    process.env.RELAY_AGENT_ROLE = "repo-admin";
+    const { __resetRelayDirCacheForTests } = await import("../../src/cli/paths.js");
+    __resetRelayDirCacheForTests();
+  });
+
+  afterEach(async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(workspaceA, { recursive: true, force: true });
+    await rm(workspaceB, { recursive: true, force: true });
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_ROLE === undefined) delete process.env.RELAY_AGENT_ROLE;
+    else process.env.RELAY_AGENT_ROLE = ORIGINAL_ROLE;
+    const { __resetRelayDirCacheForTests } = await import("../../src/cli/paths.js");
+    __resetRelayDirCacheForTests();
+    while (storeRoots.length > 0) {
+      const r = storeRoots.pop();
+      if (r) await rm(r, { recursive: true, force: true });
+    }
+  });
+
+  it("routes a valid send through the JSON-RPC handler to the target admin's listener", async () => {
+    const coordDir = await mkdtemp(join(tmpdir(), "al16-coord-"));
+    try {
+      const { ChannelStore } = await import("../../src/channels/channel-store.js");
+      const { Coordinator } = await import("../../src/crosslink/coordinator.js");
+      const channelStore = new ChannelStore(coordDir);
+      const channel = await channelStore.createChannel({
+        name: "#al-16-integ",
+        description: "al-16 full MCP path",
+      });
+      const coordinator = new Coordinator({
+        pool: makeFakePool(["backend", "frontend"]),
+        channelStore,
+        channelId: channel.channelId,
+      });
+
+      try {
+        const { buildMcpMessageHandler } = await import("../../src/mcp/server.js");
+        // Admin A's handler — alias "backend". Injecting the shared
+        // coordinator + its own alias is what B2 fixes: before the
+        // wiring, this state was { alias: null, coordinator: null }.
+        const handlerA = await buildMcpMessageHandler(workspaceA, {
+          coordinator,
+          alias: "backend",
+        });
+
+        // Subscribe to the frontend mailbox the same way admin B's
+        // session wiring will — the coordinator fans out to every
+        // listener for that alias, so a simple in-process listener
+        // proves the routing path. A real B session would wire this
+        // up inside its own repo-admin-session / MCP handler.
+        const seen: CoordinationMessage[] = [];
+        const unsubscribe = coordinator.onMessage("frontend", (msg) => {
+          seen.push(msg);
+        });
+
+        try {
+          // Drive `tools/call coordination_send` through the JSON-RPC
+          // surface — same entrypoint the Claude CLI's MCP client uses.
+          const response = await handlerA.handler({
+            jsonrpc: "2.0",
+            id: 42,
+            method: "tools/call",
+            params: {
+              name: "coordination_send",
+              arguments: {
+                to: "frontend",
+                payload: {
+                  kind: "repo-ready",
+                  alias: "backend",
+                  ticketId: "AL-42",
+                  prUrl: "https://github.com/o/r/pull/42",
+                  announcedAt: "2026-04-21T12:00:00.000Z",
+                },
+              },
+            },
+          });
+
+          const result = response?.result as ToolsCallResult;
+          expect(result.isError).toBe(false);
+          const envelope = JSON.parse(result.content[0].text) as {
+            ok: boolean;
+            kind?: string;
+            from?: string;
+            to?: string;
+            error?: string;
+            reason?: string;
+          };
+          // BEFORE THE FIX this was
+          // `{ ok: false, error: "coordinator-not-configured" }`.
+          expect(envelope.ok).toBe(true);
+          expect(envelope.kind).toBe("repo-ready");
+          expect(envelope.from).toBe("backend");
+          expect(envelope.to).toBe("frontend");
+
+          // Fan-out: the target admin's listener fired. Not just a
+          // dispatcher return — a real cross-admin delivery.
+          expect(seen).toHaveLength(1);
+          expect(seen[0].kind).toBe("repo-ready");
+          if (seen[0].kind === "repo-ready") {
+            expect(seen[0].ticketId).toBe("AL-42");
+          }
+
+          // Audit: the routed message is mirrored to the decisions
+          // board so a post-mortem can reconstruct the handoff.
+          const decisions = await channelStore.listDecisions(channel.channelId);
+          const coord = decisions.filter((d) => d.type === "coordination_message");
+          expect(coord).toHaveLength(1);
+          expect(coord[0].metadata?.from).toBe("backend");
+          expect(coord[0].metadata?.to).toBe("frontend");
+        } finally {
+          unsubscribe();
+          handlerA.context.cleanup();
+        }
+      } finally {
+        await coordinator.close();
+      }
+    } finally {
+      await rm(coordDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns `coordinator-not-configured` when options omit the coordinator (regression guard)", async () => {
+    // Without options, the handler's coordination state stays null —
+    // matching the subprocess MCP path that has no in-process
+    // coordinator reference. The tool must surface a structured error
+    // envelope, not a silent success.
+    const { buildMcpMessageHandler } = await import("../../src/mcp/server.js");
+    const built = await buildMcpMessageHandler(workspaceA);
+    try {
+      const response = await built.handler({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "coordination_send",
+          arguments: {
+            to: "frontend",
+            payload: { kind: "repo-ready" },
+          },
+        },
+      });
+
+      const result = response?.result as ToolsCallResult;
+      // Dispatcher returns `{ok:false}`; the MCP server wraps the
+      // result with `isError: false` (tool-call succeeded, just the
+      // business logic rejected) — we only care about the payload.
+      const envelope = JSON.parse(result.content[0].text) as {
+        ok: boolean;
+        error?: string;
+      };
+      expect(envelope.ok).toBe(false);
+      // Either "session-not-repo-admin" (alias=null in options)
+      // or "coordinator-not-configured" (alias passed but no
+      // coordinator) is acceptable — both are structured errors, and
+      // which one fires first is a dispatcher-ordering detail. The
+      // key assertion is "structured error, not silent success".
+      expect(["session-not-repo-admin", "coordinator-not-configured"]).toContain(envelope.error);
+    } finally {
+      built.context.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Closes #91

## Summary
- Defines three typed inter-repo coordination shapes (`BlockedOnRepo`, `RepoReady`, `MergeOrderProposal`) in `src/crosslink/messages.ts` with strict zod schemas + a discriminated union; malformed payloads resolve to structured errors, never silent drops (AC4).
- Adds `src/crosslink/coordinator.ts` — a per-run message bus that routes validated messages between admin aliases, tracks the block graph and rejects cycles (AC2), records every send as a `coordination_message` decision for audit, and exposes `waitFor()` so an admin can pause until a specific shape lands.
- Wires a new `coordination_send` MCP tool (`src/mcp/coordination-tools.ts`) gated to the repo-admin allowlist; the autonomous-loop driver constructs a `Coordinator` alongside the `RepoAdminPool` and tears it down in the CLI exit path.
- Extends the repo-admin system prompt with a Cross-repo coordination section documenting WHEN to use each shape and forbidding free-text handoffs.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm -C gui build`
- [x] `cargo check -p harness-data -p relay-gui`
- [x] `pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'` — 725 passed, 23 skipped
- [x] `pnpm dlx prettier --check 'src/**/*.ts' 'test/**/*.ts' '*.md' 'docs/**/*.md' 'agent_docs/**/*.md'`
- [x] Schema validation: each kind parses; missing / bad / non-object / unknown-field payloads all fail (AC4)
- [x] Send + receive: listener fires with validated payload
- [x] Unknown target → `{ok: false, reason: "no-such-admin"}`
- [x] Decisions audit: every successful send produces a `coordination_message` entry
- [x] Deadlock prevention: A blocks on B, B blocks on A → second rejected `would-form-cycle` (AC2)
- [x] AC3 integration: A sends `blocked-on-repo` to B; B sends `repo-ready` to A; A's `waitFor` resolves, no deadlock
- [x] Malformed via MCP tool → structured `reason: "malformed"` envelope (AC4)
- [x] `coordination_send` only resolves when session is repo-admin AND Coordinator is wired; otherwise structured error

## Scope / notes
- `coordination_send` input schema required fields are `to` + `payload`; `payload.kind` is the discriminator and must be one of `blocked-on-repo | repo-ready | merge-order-proposal`. Flag if a different shape is expected.
- Coordinator is a message bus + audit trail only — it does NOT enforce merge order or approvals (AL-5 / AL-7 / AL-8 territory).
- No changes to `ticket-scheduler.ts` / `dispatch.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)