### PR TITLE
fix(0.5.1): Sidebar Threads + Running polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.1
+
+### Patch Changes
+
+- Tidewater polish:
+  - Sidebar **Threads** count now excludes archived channels and DM-kind channels — was inflating with historical DMs and retired channels. Only active, channel-kind entries count as threads.
+  - Sidebar **Running** row re-scoped from a counter (which always capped at 1 in a single-center-pane shell) to a presence signal — pulse dot when a stream is live, dimmed when idle.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -3123,7 +3123,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/harness-data/Cargo.toml
+++ b/crates/harness-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-data"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-gui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-gui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -74,13 +74,15 @@ fn list_sessions(channel_id: String) -> Result<Vec<data::ChatSession>, String> {
     Ok(data::load_sessions(&channel_id))
 }
 
-/// Aggregate session counts across all active channels for the Sidebar's
-/// Threads row. One call instead of N `list_sessions` round-trips.
+/// Aggregate session counts for the Sidebar's Threads row. Counts only
+/// active, channel-kind entries — archived channels and DMs don't belong
+/// in a "threads across channels" metric. One call instead of N.
 #[tauri::command]
 fn list_session_counts() -> std::collections::HashMap<String, usize> {
-    let channels = data::load_channels_with_status(true);
+    let channels = data::load_channels_with_status(false);
     channels
         .into_iter()
+        .filter(|c| c.kind.as_deref() != Some("dm"))
         .map(|c| {
             let count = data::load_sessions(&c.channel_id).len();
             (c.channel_id, count)

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -275,7 +275,7 @@ function ActivityBlock({
     <section className="sidebar-section">
       <NavRow label="Activity" sigil="◔" count={activeCount} />
       <NavRow label="Threads" sigil="☰" count={threadCount} />
-      <NavRow label="Running" sigil="▶" count={runningStreams} />
+      <RunningRow active={runningStreams > 0} />
     </section>
   );
 }
@@ -286,6 +286,31 @@ function NavRow({ label, sigil, count }: { label: string; sigil: string; count: 
       <span className="ch-sigil">{sigil}</span>
       <span className="ch-name">{label}</span>
       {count > 0 && <span className="ch-badge">{count}</span>}
+    </div>
+  );
+}
+
+// Running is a presence signal, not a counter — the shell only ever has
+// one center pane, so "N streams" would cap at 1 and read as noise. Pulse
+// dot when a stream is live; dim when idle.
+function RunningRow({ active }: { active: boolean }) {
+  return (
+    <div className="sidebar-item" style={{ cursor: "default", opacity: active ? 1 : 0.6 }}>
+      <span className="ch-sigil">▶</span>
+      <span className="ch-name">Running</span>
+      {active && (
+        <span
+          aria-label="agent streaming"
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: "var(--color-accent-amber)",
+            animation: "var(--anim-pulse)",
+            display: "inline-block",
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jcast90/relay",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
   "license": "MIT",
   "private": false,

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-tui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Small polish. Threads count filters to active channel-kind only; Running row becomes a pulse presence signal instead of a counter that always caps at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)