### PR TITLE
AL-7: Approvals queue + trust-mode gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.1
+
+### Patch Changes
+
+- Tidewater polish:
+  - Sidebar **Threads** count now excludes archived channels and DM-kind channels — was inflating with historical DMs and retired channels. Only active, channel-kind entries count as threads.
+  - Sidebar **Running** row re-scoped from a counter (which always capped at 1 in a single-center-pane shell) to a presence signal — pulse dot when a stream is live, dimmed when idle.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -3123,7 +3123,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/harness-data/Cargo.toml
+++ b/crates/harness-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-data"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-gui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-gui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -74,13 +74,15 @@ fn list_sessions(channel_id: String) -> Result<Vec<data::ChatSession>, String> {
     Ok(data::load_sessions(&channel_id))
 }
 
-/// Aggregate session counts across all active channels for the Sidebar's
-/// Threads row. One call instead of N `list_sessions` round-trips.
+/// Aggregate session counts for the Sidebar's Threads row. Counts only
+/// active, channel-kind entries — archived channels and DMs don't belong
+/// in a "threads across channels" metric. One call instead of N.
 #[tauri::command]
 fn list_session_counts() -> std::collections::HashMap<String, usize> {
-    let channels = data::load_channels_with_status(true);
+    let channels = data::load_channels_with_status(false);
     channels
         .into_iter()
+        .filter(|c| c.kind.as_deref() != Some("dm"))
         .map(|c| {
             let count = data::load_sessions(&c.channel_id).len();
             (c.channel_id, count)

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -275,7 +275,7 @@ function ActivityBlock({
     <section className="sidebar-section">
       <NavRow label="Activity" sigil="◔" count={activeCount} />
       <NavRow label="Threads" sigil="☰" count={threadCount} />
-      <NavRow label="Running" sigil="▶" count={runningStreams} />
+      <RunningRow active={runningStreams > 0} />
     </section>
   );
 }
@@ -286,6 +286,31 @@ function NavRow({ label, sigil, count }: { label: string; sigil: string; count: 
       <span className="ch-sigil">{sigil}</span>
       <span className="ch-name">{label}</span>
       {count > 0 && <span className="ch-badge">{count}</span>}
+    </div>
+  );
+}
+
+// Running is a presence signal, not a counter — the shell only ever has
+// one center pane, so "N streams" would cap at 1 and read as noise. Pulse
+// dot when a stream is live; dim when idle.
+function RunningRow({ active }: { active: boolean }) {
+  return (
+    <div className="sidebar-item" style={{ cursor: "default", opacity: active ? 1 : 0.6 }}>
+      <span className="ch-sigil">▶</span>
+      <span className="ch-name">Running</span>
+      {active && (
+        <span
+          aria-label="agent streaming"
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: "var(--color-accent-amber)",
+            animation: "var(--anim-pulse)",
+            display: "inline-block",
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jcast90/relay",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
   "license": "MIT",
   "private": false,

--- a/src/approvals/index.ts
+++ b/src/approvals/index.ts
@@ -1,0 +1,21 @@
+export {
+  ApprovalsQueue,
+  type ApprovalKind,
+  type ApprovalPayload,
+  type ApprovalRecord,
+  type ApprovalStatus,
+  type ApprovalsQueueOptions,
+  type CreateTicketPayload,
+  type EnqueueInput,
+  type ListOptions,
+  type MergePrPayload,
+} from "./queue.js";
+
+export {
+  decide,
+  isGodAutomergeEnabled,
+  RELAY_AL7_GOD_AUTOMERGE,
+  type Action,
+  type Decision,
+  type DecideInput,
+} from "./trust-gate.js";

--- a/src/approvals/index.ts
+++ b/src/approvals/index.ts
@@ -6,6 +6,7 @@ export {
   type ApprovalStatus,
   type ApprovalsQueueOptions,
   type CreateTicketPayload,
+  type EnqueueAutoApprovedInput,
   type EnqueueInput,
   type ListOptions,
   type MergePrPayload,

--- a/src/approvals/queue.ts
+++ b/src/approvals/queue.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from "node:crypto";
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getRelayDir } from "../cli/paths.js";
+
+/**
+ * Kinds of ack-requiring actions AL-7 queues under supervised trust mode.
+ *
+ * The queue is deliberately typed on a small closed set rather than an open
+ * string: every new kind requires a corresponding CLI surface in AL-8 and a
+ * schema decision here, so adding one should be a visible code change, not a
+ * caller-supplied string.
+ *
+ *  - `merge-pr`: produced by AL-5's PR-review-complete hook. Payload carries
+ *    the PR URL + review summary so an operator can approve/reject without
+ *    re-running the review.
+ *  - `create-ticket`: produced by AL-6's audit-proposal hook. Payload carries
+ *    the proposed ticket body that would otherwise be written directly into
+ *    the channel ticket board under god mode.
+ */
+export type ApprovalKind = "merge-pr" | "create-ticket";
+
+/**
+ * Approval lifecycle states. Queue records start `pending`; the CLI surface
+ * in AL-8 transitions them to `approved` or `rejected`. No other transitions
+ * are legal — once a record leaves `pending` it is terminal and the
+ * consumer (AL-4 driver / future workers) must treat it as immutable.
+ */
+export type ApprovalStatus = "pending" | "approved" | "rejected";
+
+/**
+ * Payload for a queued PR auto-merge proposal. Shape matches what the AL-5
+ * PR-reviewer produces at review-complete time. Optional fields exist so
+ * AL-5's integration point can evolve without breaking AL-7 tests — the
+ * minimum contract is `prUrl`.
+ */
+export interface MergePrPayload {
+  /** Canonical PR URL (e.g. `https://github.com/foo/bar/pull/42`). */
+  prUrl: string;
+  /** Optional one-paragraph review summary from the reviewer agent. Rendered
+   * as the approval card body in AL-8. */
+  reviewSummary?: string;
+  /** Optional run id the review came from, for cross-referencing the feed. */
+  runId?: string;
+}
+
+/**
+ * Payload for a queued audit-agent ticket proposal. Mirrors the minimum
+ * subset of a ticket board row the audit agent (AL-6) produces when it
+ * suggests a new remediation ticket. Approval in AL-8 writes the ticket to
+ * the channel board; rejection discards it. Required fields are kept to
+ * just `title` + `body` so AL-6's eventual integration point is not
+ * pre-constrained.
+ */
+export interface CreateTicketPayload {
+  /** Ticket title — human-readable, one line. */
+  title: string;
+  /** Ticket body — markdown, free-form. */
+  body: string;
+  /** Optional channel id the audit agent thinks the ticket belongs on. When
+   * absent, AL-8 prompts the operator to choose. */
+  channelId?: string;
+  /** Optional rationale string from the audit agent. */
+  rationale?: string;
+}
+
+/** Union of all payload variants, discriminated by the record's `kind`. */
+export type ApprovalPayload =
+  | { kind: "merge-pr"; payload: MergePrPayload }
+  | { kind: "create-ticket"; payload: CreateTicketPayload };
+
+/**
+ * On-disk record shape written to `~/.relay/approvals/<sessionId>/queue.jsonl`.
+ * One JSON object per line, appended atomically (`appendFile` with a
+ * <PIPE_BUF JSON payload is atomic on POSIX).
+ *
+ * Decision state is mutated by reading the file, filtering to the target id,
+ * and writing a follow-up "decision" record — the file is NOT a log of
+ * immutable appends, it's a stack of records keyed by id where the newest
+ * record for a given id wins. `list()` collapses duplicates to the latest
+ * entry per id. This keeps atomicity cheap (every mutation is still a
+ * single append) while preserving the linear-history shape the AL-8 CLI
+ * will render.
+ */
+export interface ApprovalRecord {
+  /** Stable id. UUID v4. */
+  id: string;
+  /** Autonomous-session id the record belongs to. Partitions the queue
+   * file path — one `queue.jsonl` per session. */
+  sessionId: string;
+  /** Action kind — see {@link ApprovalKind}. */
+  kind: ApprovalKind;
+  /** Action payload, discriminated by {@link ApprovalKind}. */
+  payload: MergePrPayload | CreateTicketPayload;
+  /** ISO-8601 timestamp the record was enqueued. */
+  createdAt: string;
+  /** Current lifecycle state. */
+  status: ApprovalStatus;
+  /** ISO-8601 timestamp of the most recent `approve()` / `reject()` call.
+   * Absent while `status === "pending"`. */
+  decidedAt?: string;
+  /** Free-form operator feedback supplied on `reject()`. */
+  feedback?: string;
+}
+
+/** Input to {@link ApprovalsQueue.enqueue}. The queue owns `id`, `createdAt`,
+ * and `status` — callers supply the session + action. */
+export interface EnqueueInput {
+  sessionId: string;
+  kind: ApprovalKind;
+  payload: MergePrPayload | CreateTicketPayload;
+}
+
+/** Filter options for {@link ApprovalsQueue.list}. */
+export interface ListOptions {
+  /** When set, return only records with this status. */
+  status?: ApprovalStatus;
+}
+
+/** Options for {@link ApprovalsQueue}. Tests inject `rootDir` + `clock` +
+ * `idFactory` so on-disk state + timestamps + record ids are deterministic. */
+export interface ApprovalsQueueOptions {
+  /** Override `~/.relay`. Defaults to {@link getRelayDir}. */
+  rootDir?: string;
+  /** Clock injection. Defaults to `Date.now`. */
+  clock?: () => number;
+  /** Id factory. Defaults to `crypto.randomUUID`. */
+  idFactory?: () => string;
+}
+
+/**
+ * File-backed approvals queue. One queue file per autonomous session lives
+ * at `~/.relay/approvals/<sessionId>/queue.jsonl`.
+ *
+ * Concurrency model:
+ *   - `enqueue` appends one line (atomic on POSIX for a single <PIPE_BUF
+ *     write). Multiple `enqueue` calls from the same process never
+ *     interleave bytes.
+ *   - `approve` / `reject` append a *new* record with the same `id` and
+ *     an updated `status` / `decidedAt` / `feedback`. `list` collapses to
+ *     the newest entry per id. This makes every mutation a single atomic
+ *     append — no read-modify-write races — at the cost of a log that
+ *     grows linearly with decision count. For AL-7's scale (human-rate
+ *     approvals, tens per session) this is cheap and the simplicity is
+ *     worth more than compaction.
+ *   - Crashes mid-write leave at worst a truncated trailing line, which
+ *     `list` tolerates by skipping unparseable lines with a warning.
+ *
+ * The queue file is append-only in the file-system sense (no in-place
+ * mutation), matching the repo-wide convention from
+ * `channel-store.postEntry` / `feed.jsonl`. Callers must NOT rewrite the
+ * file; they must go through `enqueue` / `approve` / `reject`.
+ */
+export class ApprovalsQueue {
+  private readonly rootDir: string;
+  private readonly clock: () => number;
+  private readonly idFactory: () => string;
+
+  constructor(options: ApprovalsQueueOptions = {}) {
+    this.rootDir = options.rootDir ?? getRelayDir();
+    this.clock = options.clock ?? Date.now;
+    this.idFactory = options.idFactory ?? randomUUID;
+  }
+
+  /**
+   * Compute the queue-file path for a session. Exposed primarily for tests
+   * and the AL-8 CLI — internal callers go through the other methods.
+   */
+  queuePath(sessionId: string): string {
+    return join(this.rootDir, "approvals", sessionId, "queue.jsonl");
+  }
+
+  /**
+   * Append a new pending approval. Returns the full record (id + timestamps
+   * + status) so the caller can thread the id into the channel feed / audit
+   * decision entry without a second read of the queue file.
+   */
+  async enqueue(input: EnqueueInput): Promise<ApprovalRecord> {
+    const record: ApprovalRecord = {
+      id: this.idFactory(),
+      sessionId: input.sessionId,
+      kind: input.kind,
+      payload: input.payload,
+      createdAt: new Date(this.clock()).toISOString(),
+      status: "pending",
+    };
+
+    const path = this.queuePath(input.sessionId);
+    await mkdir(join(this.rootDir, "approvals", input.sessionId), { recursive: true });
+    // `appendFile` with a single <PIPE_BUF line is atomic on POSIX — no
+    // interleave with concurrent appenders from the same process. Matches
+    // the pattern from `src/budget/token-tracker.ts` and
+    // `src/channels/channel-store.ts`.
+    await appendFile(path, JSON.stringify(record) + "\n", "utf8");
+    return record;
+  }
+
+  /**
+   * Return every record for `sessionId`, newest-wins collapse per id,
+   * filtered by `options.status` when provided.
+   *
+   * Missing queue file -> empty array (the session simply has no queued
+   * approvals yet). Unparseable trailing lines are skipped — they can
+   * only happen if a concurrent writer crashed mid-append, in which case
+   * the partial record is indistinguishable from "never written" and
+   * swallowing it is safe.
+   */
+  async list(sessionId: string, options: ListOptions = {}): Promise<ApprovalRecord[]> {
+    const path = this.queuePath(sessionId);
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return [];
+      throw err;
+    }
+
+    const byId = new Map<string, ApprovalRecord>();
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      if (!line) continue;
+      let parsed: ApprovalRecord;
+      try {
+        parsed = JSON.parse(line) as ApprovalRecord;
+      } catch {
+        // Torn write from a crashed concurrent appender. Skip; the record
+        // effectively never existed.
+        continue;
+      }
+      // Newest wins: subsequent writes for the same id (approve/reject)
+      // replace the earlier pending record in the collapsed view.
+      byId.set(parsed.id, parsed);
+    }
+
+    const collapsed = Array.from(byId.values());
+    // Preserve insertion order from the file, which matches enqueue order
+    // (Map retains insertion order in ES2015+). Callers who want a
+    // different sort can do it themselves; the queue does not impose one.
+    const filtered = options.status
+      ? collapsed.filter((r) => r.status === options.status)
+      : collapsed;
+    return filtered;
+  }
+
+  /**
+   * Mark a pending record approved. Throws when the id is unknown, matches
+   * a different session, or the record is already in a terminal state — an
+   * operator approving an already-approved record is almost certainly a
+   * bug in the calling UI / double-click, and silently succeeding would
+   * mask it.
+   */
+  async approve(sessionId: string, id: string): Promise<ApprovalRecord> {
+    return this.decide(sessionId, id, "approved");
+  }
+
+  /**
+   * Mark a pending record rejected. `feedback` is optional but recommended —
+   * it lets the proposing agent (AL-5 / AL-6) refine its next output.
+   * Throws on the same failure modes as {@link approve}.
+   */
+  async reject(sessionId: string, id: string, feedback?: string): Promise<ApprovalRecord> {
+    return this.decide(sessionId, id, "rejected", feedback);
+  }
+
+  private async decide(
+    sessionId: string,
+    id: string,
+    status: "approved" | "rejected",
+    feedback?: string
+  ): Promise<ApprovalRecord> {
+    const existing = await this.list(sessionId);
+    const current = existing.find((r) => r.id === id);
+    if (!current) {
+      throw new Error(`approvals queue: no record with id "${id}" on session "${sessionId}"`);
+    }
+    if (current.sessionId !== sessionId) {
+      // Defence-in-depth: list() already filters on the session-scoped file
+      // path, so a mismatch here means someone hand-edited the JSONL.
+      throw new Error(
+        `approvals queue: record "${id}" belongs to session "${current.sessionId}", not "${sessionId}"`
+      );
+    }
+    if (current.status !== "pending") {
+      throw new Error(
+        `approvals queue: record "${id}" is already ${current.status}; decisions are terminal`
+      );
+    }
+
+    const updated: ApprovalRecord = {
+      ...current,
+      status,
+      decidedAt: new Date(this.clock()).toISOString(),
+      ...(feedback !== undefined ? { feedback } : {}),
+    };
+
+    const path = this.queuePath(sessionId);
+    await appendFile(path, JSON.stringify(updated) + "\n", "utf8");
+    return updated;
+  }
+
+  /**
+   * Rewrite the queue file in collapsed form — only the newest record per
+   * id. Not called by {@link enqueue} / {@link approve} / {@link reject};
+   * exposed so operators / AL-8 can compact a long-running session's
+   * queue offline without touching live state.
+   *
+   * Write is atomic (tmp + rename) so a crash mid-compact leaves the
+   * original file intact.
+   */
+  async compact(sessionId: string): Promise<number> {
+    const records = await this.list(sessionId);
+    const path = this.queuePath(sessionId);
+    await mkdir(join(this.rootDir, "approvals", sessionId), { recursive: true });
+    const tmp = `${path}.tmp.${process.pid}.${this.clock()}`;
+    const body = records.map((r) => JSON.stringify(r)).join("\n") + (records.length ? "\n" : "");
+    await writeFile(tmp, body, "utf8");
+    await rename(tmp, path);
+    return records.length;
+  }
+}

--- a/src/approvals/queue.ts
+++ b/src/approvals/queue.ts
@@ -102,6 +102,13 @@ export interface ApprovalRecord {
   decidedAt?: string;
   /** Free-form operator feedback supplied on `reject()`. */
   feedback?: string;
+  /** Marker set when the record bypassed human review. Today the only value
+   * is `"god-mode"`: the record was auto-approved by
+   * {@link "./trust-gate".decide} because the session runs in
+   * `--trust god` with `RELAY_AL7_GOD_AUTOMERGE=1`. Present so the AL-8
+   * review UI can flag auto-approvals visually and so audit tooling can
+   * distinguish "an operator explicitly approved" from "god mode ran". */
+  autoApprovedBy?: "god-mode";
 }
 
 /** Input to {@link ApprovalsQueue.enqueue}. The queue owns `id`, `createdAt`,
@@ -110,6 +117,21 @@ export interface EnqueueInput {
   sessionId: string;
   kind: ApprovalKind;
   payload: MergePrPayload | CreateTicketPayload;
+}
+
+/**
+ * Input to {@link ApprovalsQueue.enqueueAutoApproved}. Separate from
+ * {@link EnqueueInput} because the caller is `trust-gate.decide`'s god-mode
+ * branch — there is no human in the loop, so we write the record in a
+ * terminal `approved` state with an `autoApprovedBy` marker instead of
+ * letting it sit `pending`.
+ */
+export interface EnqueueAutoApprovedInput {
+  sessionId: string;
+  kind: ApprovalKind;
+  payload: MergePrPayload | CreateTicketPayload;
+  /** Who / what auto-approved. Today only `"god-mode"` is defined. */
+  autoApprovedBy: "god-mode";
 }
 
 /** Filter options for {@link ApprovalsQueue.list}. */
@@ -130,27 +152,70 @@ export interface ApprovalsQueueOptions {
 }
 
 /**
+ * Regex guarding every public queue method that takes a `sessionId`. The
+ * session id is spliced directly into a filesystem path
+ * (`~/.relay/approvals/<sessionId>/queue.jsonl`), so we reject anything
+ * that would let a caller escape `rootDir` (`../`, absolute paths, null
+ * bytes, or any character that could be interpreted as a path separator
+ * on the platforms we support). The generator in
+ * `src/orchestrator/autonomous-loop.ts` only produces UUID-shaped ids, so
+ * this is conservative by design.
+ */
+const VALID_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+
+function assertValidSessionId(sessionId: string): void {
+  if (typeof sessionId !== "string" || !VALID_SESSION_ID.test(sessionId)) {
+    throw new Error(
+      `approvals queue: invalid sessionId ${JSON.stringify(sessionId)}; ` +
+        `expected /^[A-Za-z0-9_-]+$/`
+    );
+  }
+}
+
+/**
  * File-backed approvals queue. One queue file per autonomous session lives
  * at `~/.relay/approvals/<sessionId>/queue.jsonl`.
  *
  * Concurrency model:
- *   - `enqueue` appends one line (atomic on POSIX for a single <PIPE_BUF
- *     write). Multiple `enqueue` calls from the same process never
- *     interleave bytes.
+ *   - `enqueue` appends one line. Within a single process, sequential
+ *     awaits serialize naturally and a single `appendFile` call with a
+ *     small line is effectively best-effort atomic on a local filesystem.
+ *     The original POSIX-`O_APPEND` guarantee applies to pipes up to
+ *     `PIPE_BUF`, not regular files on every filesystem we care about
+ *     (network mounts, Windows, some FUSE overlays) — two CLI / TUI / GUI
+ *     appenders CAN interleave bytes on those. The recovery path is in
+ *     `list`: unparseable (torn / interleaved) lines are skipped, so a
+ *     cross-process interleave at worst loses the malformed record, not
+ *     the whole file. Callers that need stronger guarantees against a
+ *     known-busy session should call {@link ApprovalsQueue.compact}
+ *     during quiescent windows to collapse the JSONL to a canonical form.
  *   - `approve` / `reject` append a *new* record with the same `id` and
  *     an updated `status` / `decidedAt` / `feedback`. `list` collapses to
- *     the newest entry per id. This makes every mutation a single atomic
- *     append — no read-modify-write races — at the cost of a log that
- *     grows linearly with decision count. For AL-7's scale (human-rate
+ *     the newest entry per id. This makes every mutation a single append —
+ *     no read-modify-write races — at the cost of a log that grows
+ *     linearly with decision count. For AL-7's scale (human-rate
  *     approvals, tens per session) this is cheap and the simplicity is
  *     worth more than compaction.
- *   - Crashes mid-write leave at worst a truncated trailing line, which
- *     `list` tolerates by skipping unparseable lines with a warning.
+ *   - Crashes mid-write leave at worst a truncated or interleaved line,
+ *     which `list` tolerates by skipping unparseable records. Two valid
+ *     records with a torn record between them are both recovered; the
+ *     half-record is silently dropped (see the "torn-write between two
+ *     valid records" test in `test/approvals/queue.test.ts`).
+ *
+ * Trade-off: we deliberately did NOT adopt `proper-lockfile` or a
+ * hand-rolled advisory lock here. The skip-unparseable recovery covers
+ * the realistic failure modes (same-process sequential-await serializes
+ * already; cross-process interleaving only corrupts the interleaved
+ * record, not its neighbours), and introducing a lockfile dep for this
+ * one writer would create its own failure modes (stale locks blocking a
+ * session after a crashed CLI / TUI process). If a future AL-8 surface
+ * starts writing high-frequency batched state from multiple processes,
+ * revisit this.
  *
  * The queue file is append-only in the file-system sense (no in-place
  * mutation), matching the repo-wide convention from
  * `channel-store.postEntry` / `feed.jsonl`. Callers must NOT rewrite the
- * file; they must go through `enqueue` / `approve` / `reject`.
+ * file; they must go through `enqueue` / `approve` / `reject` / `compact`.
  */
 export class ApprovalsQueue {
   private readonly rootDir: string;
@@ -166,8 +231,13 @@ export class ApprovalsQueue {
   /**
    * Compute the queue-file path for a session. Exposed primarily for tests
    * and the AL-8 CLI — internal callers go through the other methods.
+   *
+   * The `sessionId` is validated against {@link VALID_SESSION_ID} before the
+   * path is built, so a caller that hand-crafts a `../` string can't escape
+   * `rootDir`.
    */
   queuePath(sessionId: string): string {
+    assertValidSessionId(sessionId);
     return join(this.rootDir, "approvals", sessionId, "queue.jsonl");
   }
 
@@ -177,6 +247,7 @@ export class ApprovalsQueue {
    * decision entry without a second read of the queue file.
    */
   async enqueue(input: EnqueueInput): Promise<ApprovalRecord> {
+    assertValidSessionId(input.sessionId);
     const record: ApprovalRecord = {
       id: this.idFactory(),
       sessionId: input.sessionId,
@@ -188,10 +259,42 @@ export class ApprovalsQueue {
 
     const path = this.queuePath(input.sessionId);
     await mkdir(join(this.rootDir, "approvals", input.sessionId), { recursive: true });
-    // `appendFile` with a single <PIPE_BUF line is atomic on POSIX — no
-    // interleave with concurrent appenders from the same process. Matches
-    // the pattern from `src/budget/token-tracker.ts` and
-    // `src/channels/channel-store.ts`.
+    // Single-line append. Sequential awaits inside a single process
+    // serialize naturally; cross-process interleaving is tolerated by
+    // `list()`'s skip-unparseable recovery path. See the class docstring
+    // for the concurrency trade-off.
+    await appendFile(path, JSON.stringify(record) + "\n", "utf8");
+    return record;
+  }
+
+  /**
+   * Append a record that is born in a terminal `approved` state with an
+   * `autoApprovedBy` marker. Used by {@link "./trust-gate".decide}'s
+   * god-mode execute path so every god-mode execution still leaves a
+   * persistent audit trail — without this, a stale
+   * `RELAY_AL7_GOD_AUTOMERGE=1` would merge PRs with no queue evidence.
+   *
+   * `createdAt` and `decidedAt` are stamped identically (both from
+   * `clock()` at call time): the record was created + decided in the same
+   * instant by the gate. `feedback` is intentionally left absent — god-mode
+   * approvals have no operator-supplied reason.
+   */
+  async enqueueAutoApproved(input: EnqueueAutoApprovedInput): Promise<ApprovalRecord> {
+    assertValidSessionId(input.sessionId);
+    const stamp = new Date(this.clock()).toISOString();
+    const record: ApprovalRecord = {
+      id: this.idFactory(),
+      sessionId: input.sessionId,
+      kind: input.kind,
+      payload: input.payload,
+      createdAt: stamp,
+      status: "approved",
+      decidedAt: stamp,
+      autoApprovedBy: input.autoApprovedBy,
+    };
+
+    const path = this.queuePath(input.sessionId);
+    await mkdir(join(this.rootDir, "approvals", input.sessionId), { recursive: true });
     await appendFile(path, JSON.stringify(record) + "\n", "utf8");
     return record;
   }
@@ -305,10 +408,22 @@ export class ApprovalsQueue {
    * exposed so operators / AL-8 can compact a long-running session's
    * queue offline without touching live state.
    *
-   * Write is atomic (tmp + rename) so a crash mid-compact leaves the
-   * original file intact.
+   * Write is file-level atomic (tmp + rename) so a crash mid-compact
+   * leaves the original file intact.
+   *
+   * Concurrency caveat: `compact` does a read-then-rename. A concurrent
+   * `enqueue` / `approve` / `reject` that lands AFTER {@link list} has
+   * read but BEFORE `rename` overwrites the file will be silently
+   * dropped. This class deliberately does not take a file lock (see the
+   * class-level concurrency docstring). Callers MUST only compact during
+   * quiescent windows — the intended call site is session shutdown (all
+   * writers stopped) or an explicit AL-8 "compact" CLI command the
+   * operator runs against an idle session. Do NOT call `compact` from
+   * inside a live driver loop while other agents may still be queuing
+   * approvals.
    */
   async compact(sessionId: string): Promise<number> {
+    assertValidSessionId(sessionId);
     const records = await this.list(sessionId);
     const path = this.queuePath(sessionId);
     await mkdir(join(this.rootDir, "approvals", sessionId), { recursive: true });

--- a/src/approvals/trust-gate.ts
+++ b/src/approvals/trust-gate.ts
@@ -1,0 +1,123 @@
+import type { TrustMode } from "../cli/run-autonomous.js";
+import type {
+  ApprovalRecord,
+  ApprovalsQueue,
+  CreateTicketPayload,
+  MergePrPayload,
+} from "./queue.js";
+
+/**
+ * Env var gating the god-mode auto-merge / auto-create path. AL-7 requires
+ * that god mode's bypass-the-queue behaviour sit behind a separate flag from
+ * the `--trust god` CLI switch so an operator who explicitly asked for god
+ * mode still has to opt into the destructive side-effects. Until this flag
+ * is flipped, god mode falls back to the queue path (same as supervised)
+ * and the decision is surfaced for a human ack.
+ *
+ * This two-level gate — `trust === "god"` AND `RELAY_AL7_GOD_AUTOMERGE=1` —
+ * is the minimum viable guard against a stale `god` flag in a session file
+ * accidentally merging PRs after the codebase has moved on. Both must be
+ * true for auto-execute to fire.
+ *
+ * Recognised true-ish values: `"1"`, `"true"`, `"yes"`, `"on"`
+ * (case-insensitive). Anything else is treated as off.
+ */
+export const RELAY_AL7_GOD_AUTOMERGE = "RELAY_AL7_GOD_AUTOMERGE";
+
+/**
+ * Parse {@link RELAY_AL7_GOD_AUTOMERGE} into a bool. Separate function so
+ * tests can inject a stub env without mutating `process.env`.
+ */
+export function isGodAutomergeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[RELAY_AL7_GOD_AUTOMERGE];
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+/**
+ * Discriminated-union shape describing an ack-requiring action. Callers
+ * (AL-5's PR-reviewer, AL-6's audit agent) construct one of these and hand
+ * it to {@link decide} along with the session's trust mode. The shape
+ * deliberately mirrors the `queue.ts` payload variants so the trust gate
+ * is a thin wrapper and the queue's schema stays the single source of
+ * truth for what each action kind carries.
+ */
+export type Action =
+  | { kind: "merge-pr"; payload: MergePrPayload }
+  | { kind: "create-ticket"; payload: CreateTicketPayload };
+
+/**
+ * Result of {@link decide}. Two shapes:
+ *
+ *  - `{kind: "execute"}` — caller runs the action immediately (god mode +
+ *    `RELAY_AL7_GOD_AUTOMERGE` on). The gate performs no side effect; it
+ *    only authorises the caller to do so.
+ *  - `{kind: "enqueue", approvalId, record}` — caller must NOT execute.
+ *    The gate has already written a pending record to the approvals queue
+ *    for `sessionId`; AL-8's CLI surface (or a future human review UI)
+ *    will transition it to `approved` / `rejected`. The caller's duty is
+ *    to surface the approval id back to the session feed so an operator
+ *    can find it.
+ */
+export type Decision =
+  | { kind: "execute" }
+  | { kind: "enqueue"; approvalId: string; record: ApprovalRecord };
+
+/**
+ * Input for {@link decide}. `trust` is threaded explicitly — AL-7 forbids
+ * implicit globals so every ack-requiring call site has to pass the mode
+ * through. Passing `"god"` is necessary but not sufficient for execute;
+ * see {@link RELAY_AL7_GOD_AUTOMERGE}.
+ */
+export interface DecideInput {
+  sessionId: string;
+  trust: TrustMode;
+  action: Action;
+  /** Injected queue. Required — the gate never constructs one itself so
+   * the caller owns `~/.relay/` root resolution. */
+  queue: ApprovalsQueue;
+  /** Injectable env for testing the god flag path. Defaults to
+   * `process.env`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Trust-mode gate. Given an ack-requiring action and the session's trust
+ * mode, returns either "execute now" or "enqueue for human ack."
+ *
+ * Decision matrix:
+ *
+ *   | trust mode  | RELAY_AL7_GOD_AUTOMERGE | result                 |
+ *   |-------------|-------------------------|------------------------|
+ *   | supervised  | (any)                   | enqueue                |
+ *   | god         | off                     | enqueue (safety fall-back) |
+ *   | god         | on                      | execute                |
+ *
+ * Supervised NEVER auto-merges / auto-tickets under any env setting —
+ * that's the whole point of the mode. The env flag only unlocks god mode's
+ * fast path; flipping the flag without the `--trust god` CLI switch is a
+ * no-op.
+ *
+ * Side effects: on the enqueue branch this function writes one record to
+ * the session's queue file via `queue.enqueue`. On the execute branch it
+ * performs NO side effects — the caller is responsible for executing the
+ * action (merging the PR / writing the ticket).
+ */
+export async function decide(input: DecideInput): Promise<Decision> {
+  const env = input.env ?? process.env;
+  const automergeEnabled = isGodAutomergeEnabled(env);
+
+  if (input.trust === "god" && automergeEnabled) {
+    return { kind: "execute" };
+  }
+
+  // Supervised or god-with-flag-off: enqueue.
+  const record = await input.queue.enqueue({
+    sessionId: input.sessionId,
+    kind: input.action.kind,
+    payload: input.action.payload,
+  });
+
+  return { kind: "enqueue", approvalId: record.id, record };
+}

--- a/src/approvals/trust-gate.ts
+++ b/src/approvals/trust-gate.ts
@@ -50,9 +50,14 @@ export type Action =
 /**
  * Result of {@link decide}. Two shapes:
  *
- *  - `{kind: "execute"}` — caller runs the action immediately (god mode +
- *    `RELAY_AL7_GOD_AUTOMERGE` on). The gate performs no side effect; it
- *    only authorises the caller to do so.
+ *  - `{kind: "execute", auditRecordId, record}` — caller runs the action
+ *    immediately (god mode + `RELAY_AL7_GOD_AUTOMERGE` on). The gate has
+ *    already written an auto-approved audit record to the session's queue
+ *    with `autoApprovedBy: "god-mode"`, so every god-mode execution
+ *    leaves a persistent trail even if the caller never re-reads it.
+ *    `auditRecordId` is the id of that record so the caller can correlate
+ *    the executed action (merge URL, created ticket id) back to the audit
+ *    entry in the feed.
  *  - `{kind: "enqueue", approvalId, record}` — caller must NOT execute.
  *    The gate has already written a pending record to the approvals queue
  *    for `sessionId`; AL-8's CLI surface (or a future human review UI)
@@ -61,7 +66,7 @@ export type Action =
  *    can find it.
  */
 export type Decision =
-  | { kind: "execute" }
+  | { kind: "execute"; auditRecordId: string; record: ApprovalRecord }
   | { kind: "enqueue"; approvalId: string; record: ApprovalRecord };
 
 /**
@@ -88,28 +93,40 @@ export interface DecideInput {
  *
  * Decision matrix:
  *
- *   | trust mode  | RELAY_AL7_GOD_AUTOMERGE | result                 |
- *   |-------------|-------------------------|------------------------|
- *   | supervised  | (any)                   | enqueue                |
- *   | god         | off                     | enqueue (safety fall-back) |
- *   | god         | on                      | execute                |
+ *   | trust mode  | RELAY_AL7_GOD_AUTOMERGE | result                          |
+ *   |-------------|-------------------------|---------------------------------|
+ *   | supervised  | (any)                   | enqueue (pending)               |
+ *   | god         | off                     | enqueue (pending, safety fall-back) |
+ *   | god         | on                      | execute (+ auto-approved audit record) |
  *
  * Supervised NEVER auto-merges / auto-tickets under any env setting —
  * that's the whole point of the mode. The env flag only unlocks god mode's
  * fast path; flipping the flag without the `--trust god` CLI switch is a
  * no-op.
  *
- * Side effects: on the enqueue branch this function writes one record to
- * the session's queue file via `queue.enqueue`. On the execute branch it
- * performs NO side effects — the caller is responsible for executing the
- * action (merging the PR / writing the ticket).
+ * Side effects:
+ *   - enqueue branch: writes one pending record to the session's queue
+ *     file via `queue.enqueue`.
+ *   - execute branch: writes one auto-approved audit record to the same
+ *     queue via `queue.enqueueAutoApproved` (status `"approved"`,
+ *     `autoApprovedBy: "god-mode"`, `decidedAt` stamped by the queue's
+ *     clock). The caller still owns the actual side effect (merge / ticket
+ *     write); the audit record is the durable trail that the side effect
+ *     was authorised, so a stale `RELAY_AL7_GOD_AUTOMERGE=1` can never
+ *     merge a PR with zero persistent evidence.
  */
 export async function decide(input: DecideInput): Promise<Decision> {
   const env = input.env ?? process.env;
   const automergeEnabled = isGodAutomergeEnabled(env);
 
   if (input.trust === "god" && automergeEnabled) {
-    return { kind: "execute" };
+    const record = await input.queue.enqueueAutoApproved({
+      sessionId: input.sessionId,
+      kind: input.action.kind,
+      payload: input.action.payload,
+      autoApprovedBy: "god-mode",
+    });
+    return { kind: "execute", auditRecordId: record.id, record };
   }
 
   // Supervised or god-with-flag-off: enqueue.

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -256,11 +256,35 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   // land their driver hooks, each of their ack-requiring outputs must be
   // threaded through `decide({trust: opts.trust, ...})` from
   // `src/approvals/trust-gate.ts`. Under `supervised` the decision writes
-  // a record to `~/.relay/approvals/<sessionId>/queue.jsonl`; under `god`
-  // with `RELAY_AL7_GOD_AUTOMERGE=1` it returns `{kind: "execute"}` and
-  // the caller performs the merge / ticket write directly. AL-7 itself
-  // only produces + consumes the queue file; AL-8 owns the approve / reject
-  // CLI surface.
+  // a pending record to `~/.relay/approvals/<sessionId>/queue.jsonl`;
+  // under `god` with `RELAY_AL7_GOD_AUTOMERGE=1` it writes an auto-approved
+  // record (tagged `autoApprovedBy: "god-mode"`) AND returns
+  // `{kind: "execute", auditRecordId, record}` so the caller performs the
+  // merge / ticket write directly while the audit trail is already on
+  // disk. AL-7 itself only produces + consumes the queue file; AL-8 owns
+  // the approve / reject CLI surface.
+  //
+  // Concrete instantiation hint for AL-5 / AL-6 implementers — construct
+  // the queue once at the start of the driver loop and thread the same
+  // instance into every `decide()` call:
+  //
+  //   import { ApprovalsQueue, decide } from "../approvals/index.js";
+  //   import { getRelayDir } from "../cli/paths.js";
+  //
+  //   const approvalsQueue = opts.approvalsQueue
+  //     ?? new ApprovalsQueue({ rootDir: getRelayDir() });
+  //
+  //   // at PR-review-complete:
+  //   const outcome = await decide({
+  //     sessionId,
+  //     trust: opts.trust,
+  //     queue: approvalsQueue,
+  //     action: { kind: "merge-pr", payload: { prUrl, reviewSummary } },
+  //   });
+  //   if (outcome.kind === "execute") { /* perform the merge */ }
+  //
+  // The `opts.approvalsQueue` fallback exists so the AL-4 driver test can
+  // inject a tmp-dir-backed queue without touching `~/.relay/`.
   //
   // TODO(AL-5): at PR-review-complete, call `decide({..., action: {kind:
   //   "merge-pr", payload: {prUrl, reviewSummary}}})` and branch on the

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -58,9 +58,13 @@ export interface StartAutonomousSessionOptions {
   /** Lifecycle state machine. Caller has already transitioned it into
    * `dispatching`; AL-4's driver owns subsequent transitions. */
   lifecycle: SessionLifecycle;
-  /** Trust mode as selected on the CLI. The stub records it but never acts
-   * on it. AL-5 / AL-7 gate the real behaviour difference between
-   * `supervised` and `god`. */
+  /** Trust mode as selected on the CLI. AL-7 supplies the trust-mode gate
+   * (`src/approvals/trust-gate.ts`) that every ack-requiring call site (PR
+   * auto-merge from AL-5, audit-proposed ticket from AL-6) threads this
+   * value into. Under `supervised`, ack-requiring actions are written to
+   * `~/.relay/approvals/<sessionId>/queue.jsonl`; under `god` with
+   * `RELAY_AL7_GOD_AUTOMERGE=1`, they execute directly. See
+   * {@link "../approvals/trust-gate".decide}. */
   trust: "supervised" | "god";
   /** Repo assignments the session is allowed to dispatch work into. Either
    * the subset selected by `--allow-repo` or — when the flag is absent —
@@ -248,6 +252,23 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     }
   }
 
+  // AL-7 integration anchor. When AL-5 (PR reviewer) and AL-6 (audit agent)
+  // land their driver hooks, each of their ack-requiring outputs must be
+  // threaded through `decide({trust: opts.trust, ...})` from
+  // `src/approvals/trust-gate.ts`. Under `supervised` the decision writes
+  // a record to `~/.relay/approvals/<sessionId>/queue.jsonl`; under `god`
+  // with `RELAY_AL7_GOD_AUTOMERGE=1` it returns `{kind: "execute"}` and
+  // the caller performs the merge / ticket write directly. AL-7 itself
+  // only produces + consumes the queue file; AL-8 owns the approve / reject
+  // CLI surface.
+  //
+  // TODO(AL-5): at PR-review-complete, call `decide({..., action: {kind:
+  //   "merge-pr", payload: {prUrl, reviewSummary}}})` and branch on the
+  //   return. Do NOT auto-merge under supervised.
+  // TODO(AL-6): at audit-proposal time, call `decide({..., action: {kind:
+  //   "create-ticket", payload: {title, body, channelId}}})` and branch.
+  //   Do NOT auto-write the ticket under supervised.
+  //
   // AL-13: drain the channel's ticket board through the router exactly
   // once. AL-14 adds a second pass (gated by RELAY_AL14_WORKER_DRAIN)
   // that drains each admin's queue via TicketRunner — spawn a worker

--- a/test/approvals/queue.test.ts
+++ b/test/approvals/queue.test.ts
@@ -1,0 +1,297 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ApprovalsQueue, type ApprovalRecord } from "../../src/approvals/queue.js";
+
+describe("ApprovalsQueue", () => {
+  let root: string;
+  let now: number;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-approvals-"));
+    now = Date.parse("2026-01-01T00:00:00.000Z");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  function makeQueue(opts?: { ids?: string[] }) {
+    const ids = opts?.ids ?? ["id-1", "id-2", "id-3", "id-4", "id-5"];
+    let i = 0;
+    return new ApprovalsQueue({
+      rootDir: root,
+      clock: () => now,
+      idFactory: () => ids[i++] ?? `id-fallback-${i}`,
+    });
+  }
+
+  describe("enqueue", () => {
+    it("writes a pending record under ~/.relay/approvals/<sessionId>/queue.jsonl", async () => {
+      const queue = makeQueue();
+      const record = await queue.enqueue({
+        sessionId: "sess-1",
+        kind: "merge-pr",
+        payload: { prUrl: "https://github.com/foo/bar/pull/42" },
+      });
+
+      expect(record.id).toBe("id-1");
+      expect(record.status).toBe("pending");
+      expect(record.sessionId).toBe("sess-1");
+      expect(record.kind).toBe("merge-pr");
+      expect(record.createdAt).toBe("2026-01-01T00:00:00.000Z");
+      expect(record.decidedAt).toBeUndefined();
+
+      const path = join(root, "approvals", "sess-1", "queue.jsonl");
+      const raw = await readFile(path, "utf8");
+      expect(raw.trim().split("\n")).toHaveLength(1);
+      expect(JSON.parse(raw.trim())).toEqual(record);
+    });
+
+    it("scopes queue files per session — two sessions never share a file", async () => {
+      const queue = makeQueue();
+      await queue.enqueue({
+        sessionId: "sess-a",
+        kind: "merge-pr",
+        payload: { prUrl: "https://example/pr/1" },
+      });
+      await queue.enqueue({
+        sessionId: "sess-b",
+        kind: "create-ticket",
+        payload: { title: "t", body: "b" },
+      });
+
+      const listA = await queue.list("sess-a");
+      const listB = await queue.list("sess-b");
+      expect(listA).toHaveLength(1);
+      expect(listB).toHaveLength(1);
+      expect(listA[0]!.kind).toBe("merge-pr");
+      expect(listB[0]!.kind).toBe("create-ticket");
+
+      // Files are separate on disk.
+      await stat(join(root, "approvals", "sess-a", "queue.jsonl"));
+      await stat(join(root, "approvals", "sess-b", "queue.jsonl"));
+    });
+
+    it("atomic-appends: two enqueue calls produce two JSONL lines, both parseable", async () => {
+      const queue = makeQueue();
+      await queue.enqueue({
+        sessionId: "sess-1",
+        kind: "merge-pr",
+        payload: { prUrl: "u-1" },
+      });
+      await queue.enqueue({
+        sessionId: "sess-1",
+        kind: "create-ticket",
+        payload: { title: "a", body: "b" },
+      });
+
+      const raw = await readFile(join(root, "approvals", "sess-1", "queue.jsonl"), "utf8");
+      const lines = raw.trim().split("\n");
+      expect(lines).toHaveLength(2);
+      const parsed = lines.map((l) => JSON.parse(l) as ApprovalRecord);
+      expect(parsed[0]!.id).toBe("id-1");
+      expect(parsed[1]!.id).toBe("id-2");
+    });
+
+    it("returns the full record including the payload shape", async () => {
+      const queue = makeQueue();
+      const record = await queue.enqueue({
+        sessionId: "sess-1",
+        kind: "create-ticket",
+        payload: {
+          title: "Fix flaky test",
+          body: "The audit agent noticed the retry loop swallows the real error.",
+          channelId: "ch-1",
+          rationale: "observed 3 times in the last run",
+        },
+      });
+      expect(record.payload).toEqual({
+        title: "Fix flaky test",
+        body: "The audit agent noticed the retry loop swallows the real error.",
+        channelId: "ch-1",
+        rationale: "observed 3 times in the last run",
+      });
+    });
+  });
+
+  describe("list", () => {
+    it("returns [] when no queue file exists yet", async () => {
+      const queue = makeQueue();
+      const records = await queue.list("never-seen");
+      expect(records).toEqual([]);
+    });
+
+    it("filters by status when provided", async () => {
+      const queue = makeQueue();
+      const a = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u1" },
+      });
+      await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u2" },
+      });
+      await queue.approve("s", a.id);
+
+      const pending = await queue.list("s", { status: "pending" });
+      const approved = await queue.list("s", { status: "approved" });
+      expect(pending).toHaveLength(1);
+      expect(pending[0]!.payload).toEqual({ prUrl: "u2" });
+      expect(approved).toHaveLength(1);
+      expect(approved[0]!.id).toBe(a.id);
+    });
+
+    it("collapses duplicate ids keeping the newest record per id", async () => {
+      const queue = makeQueue();
+      const rec = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      await queue.reject("s", rec.id, "not ready");
+
+      const all = await queue.list("s");
+      expect(all).toHaveLength(1);
+      expect(all[0]!.status).toBe("rejected");
+      expect(all[0]!.feedback).toBe("not ready");
+
+      // Raw file has two lines — collapse happens in `list`, not on disk.
+      const raw = await readFile(join(root, "approvals", "s", "queue.jsonl"), "utf8");
+      expect(raw.trim().split("\n")).toHaveLength(2);
+    });
+
+    it("skips unparseable (torn) trailing lines", async () => {
+      const queue = makeQueue();
+      await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      // Simulate a crash mid-append by concatenating a half-written line.
+      const path = join(root, "approvals", "s", "queue.jsonl");
+      const raw = await readFile(path, "utf8");
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(path, raw + '{"id":"half', "utf8");
+
+      const records = await queue.list("s");
+      expect(records).toHaveLength(1);
+      expect(records[0]!.status).toBe("pending");
+    });
+  });
+
+  describe("approve / reject state transitions", () => {
+    it("approve flips pending -> approved + stamps decidedAt", async () => {
+      const queue = makeQueue();
+      const rec = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      expect(rec.status).toBe("pending");
+
+      now = Date.parse("2026-01-01T00:05:00.000Z");
+      const approved = await queue.approve("s", rec.id);
+      expect(approved.status).toBe("approved");
+      expect(approved.decidedAt).toBe("2026-01-01T00:05:00.000Z");
+      expect(approved.id).toBe(rec.id);
+
+      const list = await queue.list("s");
+      expect(list).toHaveLength(1);
+      expect(list[0]!.status).toBe("approved");
+    });
+
+    it("reject flips pending -> rejected + preserves optional feedback", async () => {
+      const queue = makeQueue();
+      const rec = await queue.enqueue({
+        sessionId: "s",
+        kind: "create-ticket",
+        payload: { title: "t", body: "b" },
+      });
+      const rejected = await queue.reject("s", rec.id, "out of scope");
+      expect(rejected.status).toBe("rejected");
+      expect(rejected.feedback).toBe("out of scope");
+
+      const rejectedNoFeedback = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      const r2 = await queue.reject("s", rejectedNoFeedback.id);
+      expect(r2.status).toBe("rejected");
+      expect(r2.feedback).toBeUndefined();
+    });
+
+    it("throws on unknown id", async () => {
+      const queue = makeQueue();
+      await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      await expect(queue.approve("s", "nope")).rejects.toThrow(/no record with id "nope"/);
+      await expect(queue.reject("s", "nope")).rejects.toThrow(/no record with id "nope"/);
+    });
+
+    it("refuses to re-decide a terminal record", async () => {
+      const queue = makeQueue();
+      const rec = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      await queue.approve("s", rec.id);
+      await expect(queue.approve("s", rec.id)).rejects.toThrow(/already approved/);
+      await expect(queue.reject("s", rec.id)).rejects.toThrow(/already approved/);
+    });
+
+    it("rejected records are also terminal", async () => {
+      const queue = makeQueue();
+      const rec = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u" },
+      });
+      await queue.reject("s", rec.id, "nope");
+      await expect(queue.approve("s", rec.id)).rejects.toThrow(/already rejected/);
+    });
+  });
+
+  describe("compact", () => {
+    it("rewrites the queue file in collapsed form and keeps list() stable", async () => {
+      const queue = makeQueue();
+      const a = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u1" },
+      });
+      const b = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u2" },
+      });
+      await queue.approve("s", a.id);
+      await queue.reject("s", b.id, "x");
+
+      const beforeRaw = await readFile(join(root, "approvals", "s", "queue.jsonl"), "utf8");
+      expect(beforeRaw.trim().split("\n")).toHaveLength(4);
+
+      const count = await queue.compact("s");
+      expect(count).toBe(2);
+
+      const afterRaw = await readFile(join(root, "approvals", "s", "queue.jsonl"), "utf8");
+      expect(afterRaw.trim().split("\n")).toHaveLength(2);
+
+      const list = await queue.list("s");
+      expect(list.map((r) => [r.id, r.status])).toEqual([
+        [a.id, "approved"],
+        [b.id, "rejected"],
+      ]);
+    });
+  });
+});

--- a/test/approvals/queue.test.ts
+++ b/test/approvals/queue.test.ts
@@ -183,6 +183,48 @@ describe("ApprovalsQueue", () => {
       expect(records).toHaveLength(1);
       expect(records[0]!.status).toBe("pending");
     });
+
+    it("recovers both neighbours when a torn record sits BETWEEN two valid ones", async () => {
+      // The realistic cross-process failure mode: appender A writes valid1,
+      // appender B crashes mid-write (no trailing newline), appender C then
+      // writes valid2 on a new line. The skip-unparseable path must recover
+      // valid1 + valid2 and silently drop the half-record in the middle.
+      const queue = makeQueue();
+      const rec1 = await queue.enqueue({
+        sessionId: "s",
+        kind: "merge-pr",
+        payload: { prUrl: "u1" },
+      });
+      const rec2 = await queue.enqueue({
+        sessionId: "s",
+        kind: "create-ticket",
+        payload: { title: "t2", body: "b2" },
+      });
+
+      // Splice a half-written record between the two valid lines, no
+      // trailing newline on the half-record itself — mimicking a crash
+      // after the appender started the line but before flush.
+      const path = join(root, "approvals", "s", "queue.jsonl");
+      const raw = await readFile(path, "utf8");
+      const lines = raw.split("\n").filter((l) => l.length > 0);
+      expect(lines).toHaveLength(2);
+      const corrupted = `${lines[0]}\n{"id":"half-record","session`;
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(path, `${corrupted}\n${lines[1]}\n`, "utf8");
+
+      const records = await queue.list("s");
+      expect(records).toHaveLength(2);
+      const ids = records.map((r) => r.id).sort();
+      expect(ids).toEqual([rec1.id, rec2.id].sort());
+      // The half-record is silently skipped — it's not surfaced as an
+      // error and it doesn't shadow either neighbour.
+      expect(
+        records.find((r) => r.payload && "prUrl" in r.payload && r.payload.prUrl === "u1")
+      ).toBeDefined();
+      expect(
+        records.find((r) => r.payload && "title" in r.payload && r.payload.title === "t2")
+      ).toBeDefined();
+    });
   });
 
   describe("approve / reject state transitions", () => {
@@ -259,6 +301,112 @@ describe("ApprovalsQueue", () => {
       });
       await queue.reject("s", rec.id, "nope");
       await expect(queue.approve("s", rec.id)).rejects.toThrow(/already rejected/);
+    });
+  });
+
+  describe("sessionId validation (path-traversal guard)", () => {
+    // The sessionId is spliced directly into a filesystem path, so every
+    // public entry point has to reject values that could escape rootDir.
+    // We test the surface rather than the regex: if a future tightening
+    // adds new invalid characters, these assertions still pass.
+    const BAD_IDS = ["../escape", "..", "a/b", "a\\b", "abc def", "", ".", "-/-", "\u0000", "a\nb"];
+
+    it("enqueue rejects traversal / path-separator ids", async () => {
+      const queue = makeQueue();
+      for (const bad of BAD_IDS) {
+        await expect(
+          queue.enqueue({ sessionId: bad, kind: "merge-pr", payload: { prUrl: "u" } })
+        ).rejects.toThrow(/invalid sessionId/);
+      }
+    });
+
+    it("enqueueAutoApproved rejects traversal / path-separator ids", async () => {
+      const queue = makeQueue();
+      for (const bad of BAD_IDS) {
+        await expect(
+          queue.enqueueAutoApproved({
+            sessionId: bad,
+            kind: "merge-pr",
+            payload: { prUrl: "u" },
+            autoApprovedBy: "god-mode",
+          })
+        ).rejects.toThrow(/invalid sessionId/);
+      }
+    });
+
+    it("list rejects traversal / path-separator ids", async () => {
+      const queue = makeQueue();
+      for (const bad of BAD_IDS) {
+        await expect(queue.list(bad)).rejects.toThrow(/invalid sessionId/);
+      }
+    });
+
+    it("approve / reject reject traversal / path-separator ids", async () => {
+      const queue = makeQueue();
+      for (const bad of BAD_IDS) {
+        await expect(queue.approve(bad, "any")).rejects.toThrow(/invalid sessionId/);
+        await expect(queue.reject(bad, "any")).rejects.toThrow(/invalid sessionId/);
+      }
+    });
+
+    it("compact rejects traversal / path-separator ids", async () => {
+      const queue = makeQueue();
+      for (const bad of BAD_IDS) {
+        await expect(queue.compact(bad)).rejects.toThrow(/invalid sessionId/);
+      }
+    });
+
+    it("queuePath rejects traversal / path-separator ids", () => {
+      const queue = makeQueue();
+      for (const bad of BAD_IDS) {
+        expect(() => queue.queuePath(bad)).toThrow(/invalid sessionId/);
+      }
+    });
+
+    it("accepts plain UUID-shaped ids and typical test fixture ids", () => {
+      const queue = makeQueue();
+      for (const good of [
+        "sess-1",
+        "sess_1",
+        "0af84ca0-1234-5678-9abc-def012345678",
+        "abc",
+        "ABC123",
+      ]) {
+        expect(() => queue.queuePath(good)).not.toThrow();
+      }
+    });
+  });
+
+  describe("enqueueAutoApproved", () => {
+    it("writes a terminal approved record tagged autoApprovedBy", async () => {
+      const queue = makeQueue();
+      const record = await queue.enqueueAutoApproved({
+        sessionId: "sess-1",
+        kind: "merge-pr",
+        payload: { prUrl: "https://github.com/foo/bar/pull/99" },
+        autoApprovedBy: "god-mode",
+      });
+
+      expect(record.status).toBe("approved");
+      expect(record.autoApprovedBy).toBe("god-mode");
+      expect(record.createdAt).toBe("2026-01-01T00:00:00.000Z");
+      expect(record.decidedAt).toBe("2026-01-01T00:00:00.000Z");
+
+      const list = await queue.list("sess-1");
+      expect(list).toHaveLength(1);
+      expect(list[0]!).toEqual(record);
+    });
+
+    it("subsequent approve / reject on an auto-approved record is rejected as terminal", async () => {
+      const queue = makeQueue();
+      const rec = await queue.enqueueAutoApproved({
+        sessionId: "sess-1",
+        kind: "create-ticket",
+        payload: { title: "t", body: "b" },
+        autoApprovedBy: "god-mode",
+      });
+      await expect(queue.approve("sess-1", rec.id)).rejects.toThrow(/already approved/);
+      await expect(queue.reject("sess-1", rec.id)).rejects.toThrow(/already approved/);
     });
   });
 

--- a/test/approvals/trust-gate.test.ts
+++ b/test/approvals/trust-gate.test.ts
@@ -1,0 +1,212 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ApprovalsQueue } from "../../src/approvals/queue.js";
+import {
+  RELAY_AL7_GOD_AUTOMERGE,
+  decide,
+  isGodAutomergeEnabled,
+} from "../../src/approvals/trust-gate.js";
+
+describe("trust-gate.decide", () => {
+  let root: string;
+  let queue: ApprovalsQueue;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-trust-gate-"));
+    let i = 0;
+    queue = new ApprovalsQueue({
+      rootDir: root,
+      clock: () => Date.parse("2026-01-01T00:00:00.000Z"),
+      idFactory: () => `id-${++i}`,
+    });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe("supervised trust mode", () => {
+    it("enqueues a merge-pr action and never auto-executes", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "supervised",
+        queue,
+        env: {},
+        action: {
+          kind: "merge-pr",
+          payload: { prUrl: "https://github.com/foo/bar/pull/42", reviewSummary: "LGTM" },
+        },
+      });
+
+      expect(result.kind).toBe("enqueue");
+      if (result.kind !== "enqueue") throw new Error("unreachable");
+      expect(result.approvalId).toBe("id-1");
+      expect(result.record.status).toBe("pending");
+      expect(result.record.kind).toBe("merge-pr");
+      expect(result.record.payload).toEqual({
+        prUrl: "https://github.com/foo/bar/pull/42",
+        reviewSummary: "LGTM",
+      });
+
+      const list = await queue.list("sess-1");
+      expect(list).toHaveLength(1);
+      expect(list[0]!.status).toBe("pending");
+    });
+
+    it("enqueues a create-ticket action and never auto-executes", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "supervised",
+        queue,
+        env: {},
+        action: {
+          kind: "create-ticket",
+          payload: {
+            title: "Fix flaky test",
+            body: "retry loop swallows the real error",
+            channelId: "ch-1",
+          },
+        },
+      });
+
+      expect(result.kind).toBe("enqueue");
+      const list = await queue.list("sess-1");
+      expect(list[0]!.kind).toBe("create-ticket");
+      expect(list[0]!.payload).toMatchObject({ title: "Fix flaky test", channelId: "ch-1" });
+    });
+
+    it("ignores RELAY_AL7_GOD_AUTOMERGE — supervised NEVER auto-executes", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "supervised",
+        queue,
+        env: { [RELAY_AL7_GOD_AUTOMERGE]: "1" },
+        action: {
+          kind: "merge-pr",
+          payload: { prUrl: "u" },
+        },
+      });
+      expect(result.kind).toBe("enqueue");
+    });
+  });
+
+  describe("god trust mode", () => {
+    it("enqueues when RELAY_AL7_GOD_AUTOMERGE is unset (safety fall-back)", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "god",
+        queue,
+        env: {},
+        action: {
+          kind: "merge-pr",
+          payload: { prUrl: "u" },
+        },
+      });
+
+      expect(result.kind).toBe("enqueue");
+      const list = await queue.list("sess-1");
+      expect(list).toHaveLength(1);
+    });
+
+    it("executes when RELAY_AL7_GOD_AUTOMERGE=1", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "god",
+        queue,
+        env: { [RELAY_AL7_GOD_AUTOMERGE]: "1" },
+        action: {
+          kind: "merge-pr",
+          payload: { prUrl: "u" },
+        },
+      });
+
+      expect(result.kind).toBe("execute");
+      // Execute branch performs NO side effects; queue stays empty.
+      const list = await queue.list("sess-1");
+      expect(list).toEqual([]);
+    });
+
+    it("executes for create-ticket actions too", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "god",
+        queue,
+        env: { [RELAY_AL7_GOD_AUTOMERGE]: "true" },
+        action: {
+          kind: "create-ticket",
+          payload: { title: "t", body: "b" },
+        },
+      });
+      expect(result.kind).toBe("execute");
+    });
+
+    it("treats typos / empty strings as off, not on", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "god",
+        queue,
+        env: { [RELAY_AL7_GOD_AUTOMERGE]: "yeah-maybe" },
+        action: {
+          kind: "merge-pr",
+          payload: { prUrl: "u" },
+        },
+      });
+      expect(result.kind).toBe("enqueue");
+    });
+  });
+
+  describe("approve / reject state transitions downstream", () => {
+    it("queued supervised record flows through approve without re-entering the gate", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "supervised",
+        queue,
+        env: {},
+        action: { kind: "merge-pr", payload: { prUrl: "u" } },
+      });
+      if (result.kind !== "enqueue") throw new Error("unreachable");
+
+      const approved = await queue.approve("sess-1", result.approvalId);
+      expect(approved.status).toBe("approved");
+
+      const pending = await queue.list("sess-1", { status: "pending" });
+      expect(pending).toEqual([]);
+    });
+
+    it("queued supervised record flows through reject with feedback", async () => {
+      const result = await decide({
+        sessionId: "sess-1",
+        trust: "supervised",
+        queue,
+        env: {},
+        action: { kind: "create-ticket", payload: { title: "t", body: "b" } },
+      });
+      if (result.kind !== "enqueue") throw new Error("unreachable");
+
+      const rejected = await queue.reject("sess-1", result.approvalId, "duplicate");
+      expect(rejected.status).toBe("rejected");
+      expect(rejected.feedback).toBe("duplicate");
+    });
+  });
+});
+
+describe("isGodAutomergeEnabled", () => {
+  it("recognises true-ish values case-insensitively", () => {
+    for (const v of ["1", "true", "yes", "on", "TRUE", "Yes", "ON"]) {
+      expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: v })).toBe(true);
+    }
+  });
+
+  it("treats anything else (including unset / empty / typos) as false", () => {
+    expect(isGodAutomergeEnabled({})).toBe(false);
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "" })).toBe(false);
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "0" })).toBe(false);
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "false" })).toBe(false);
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "no" })).toBe(false);
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "enabled?" })).toBe(false);
+  });
+});

--- a/test/approvals/trust-gate.test.ts
+++ b/test/approvals/trust-gate.test.ts
@@ -112,7 +112,7 @@ describe("trust-gate.decide", () => {
       expect(list).toHaveLength(1);
     });
 
-    it("executes when RELAY_AL7_GOD_AUTOMERGE=1", async () => {
+    it("executes when RELAY_AL7_GOD_AUTOMERGE=1 and writes an auto-approved audit record", async () => {
       const result = await decide({
         sessionId: "sess-1",
         trust: "god",
@@ -125,12 +125,23 @@ describe("trust-gate.decide", () => {
       });
 
       expect(result.kind).toBe("execute");
-      // Execute branch performs NO side effects; queue stays empty.
+      if (result.kind !== "execute") throw new Error("unreachable");
+      // Execute branch writes an audit record so god-mode executions are
+      // not invisible — the record is born approved + tagged "god-mode".
+      expect(result.auditRecordId).toBe("id-1");
+      expect(result.record.status).toBe("approved");
+      expect(result.record.autoApprovedBy).toBe("god-mode");
+      expect(result.record.decidedAt).toBe("2026-01-01T00:00:00.000Z");
+
       const list = await queue.list("sess-1");
-      expect(list).toEqual([]);
+      expect(list).toHaveLength(1);
+      expect(list[0]!.id).toBe(result.auditRecordId);
+      expect(list[0]!.status).toBe("approved");
+      expect(list[0]!.autoApprovedBy).toBe("god-mode");
+      expect(list[0]!.kind).toBe("merge-pr");
     });
 
-    it("executes for create-ticket actions too", async () => {
+    it("executes for create-ticket actions too and also writes an audit record", async () => {
       const result = await decide({
         sessionId: "sess-1",
         trust: "god",
@@ -142,6 +153,12 @@ describe("trust-gate.decide", () => {
         },
       });
       expect(result.kind).toBe("execute");
+      if (result.kind !== "execute") throw new Error("unreachable");
+      expect(result.record.autoApprovedBy).toBe("god-mode");
+      expect(result.record.kind).toBe("create-ticket");
+      const list = await queue.list("sess-1");
+      expect(list).toHaveLength(1);
+      expect(list[0]!.autoApprovedBy).toBe("god-mode");
     });
 
     it("treats typos / empty strings as off, not on", async () => {
@@ -201,6 +218,14 @@ describe("isGodAutomergeEnabled", () => {
     }
   });
 
+  it("trims surrounding whitespace before matching true-ish values", () => {
+    // Env files / shell quirks sometimes leave padding on `RELAY_AL7_GOD_AUTOMERGE=" 1 "`.
+    // The parser trims before comparing, so these must still parse as true.
+    for (const v of [" 1 ", "\ttrue\n", "  yes", "on\r\n", " TRUE\t"]) {
+      expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: v })).toBe(true);
+    }
+  });
+
   it("treats anything else (including unset / empty / typos) as false", () => {
     expect(isGodAutomergeEnabled({})).toBe(false);
     expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "" })).toBe(false);
@@ -208,5 +233,8 @@ describe("isGodAutomergeEnabled", () => {
     expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "false" })).toBe(false);
     expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "no" })).toBe(false);
     expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "enabled?" })).toBe(false);
+    // Whitespace around a false-ish value stays false.
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "  " })).toBe(false);
+    expect(isGodAutomergeEnabled({ [RELAY_AL7_GOD_AUTOMERGE]: "\t0\n" })).toBe(false);
   });
 });

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-tui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Closes #82

## Summary

- `ApprovalsQueue` (`src/approvals/queue.ts`): file-backed per-session queue at `~/.relay/approvals/<sessionId>/queue.jsonl` with `enqueue` / `list` / `approve` / `reject` / `compact`. Atomic single-line appends (matches `token-tracker.ts` / `channel-store.ts` conventions); newest-wins collapse keeps every state transition a single append — no read-modify-write races.
- `decide` (`src/approvals/trust-gate.ts`): trust mode threaded explicitly per call — no implicit globals. Supervised NEVER auto-executes regardless of env. God mode falls back to the queue too unless `RELAY_AL7_GOD_AUTOMERGE=1` (two-level gate against stale `--trust god` flags in long-lived session files).
- `autonomous-loop.ts`: trust-mode docstring points at the gate; TODO anchors at the driver-loop body so AL-5 (`merge-pr` payload from PR-review-complete) and AL-6 (`create-ticket` payload from audit-proposal) merge naturally into the hook.

Acceptance criteria
- queue.jsonl records carry `{id, sessionId, kind, payload, createdAt, status, decidedAt?, feedback?}`, atomic-appended.
- Every ack-requiring call site threads `trust` explicitly via `decide({..., trust})`.
- Supervised never auto-merges / auto-creates; god mode's direct-execute path requires `RELAY_AL7_GOD_AUTOMERGE`.
- 25 tests — both modes, approve / reject transitions, terminal-record guard, torn-write tolerance, session scoping, env-flag parsing.

## Stubs tolerated
- AL-8 (CLI / TUI / GUI surfaces) is next. AL-7 produces + consumes the file; approve / reject happen via CLI in AL-8.
- AL-5 / AL-6 hooks aren't in this branch yet — TODO anchors mark the integration sites in `autonomous-loop.ts` so they hook in on merge.

## Dependency note
Based on `origin/feat/al-16-coordination-protocol` (AL-5 + AL-6 not yet merged). Rebase on merge of deps.

## Test plan
- [x] `pnpm test` — 753 passed, 23 skipped
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [ ] Re-run after AL-5 / AL-6 land and rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)