### PR TITLE
AL-6: Post-completion audit agent

### DIFF
--- a/src/orchestrator/audit-agent.ts
+++ b/src/orchestrator/audit-agent.ts
@@ -1,0 +1,394 @@
+/**
+ * AL-6: post-completion audit agent (proposals only).
+ *
+ * After the autonomous driver drains its last ticket, the audit agent
+ * looks at what just shipped — the ticket ledger, the run's decisions,
+ * the recent git log — and proposes the next 3–5 tickets the operator
+ * should tackle, ranked by user value. Each proposal is persisted as an
+ * `audit_proposal` decision entry on the channel so the TUI/GUI can
+ * surface it. Auto-creation of Linear / GitHub issues is deferred until
+ * god mode (AL-7): today the audit is advisory only.
+ *
+ * ## Gating
+ *
+ * Two hard gates before the audit fires:
+ *
+ *   1. **Ledger is all-green.** Every ticket on the board must be in
+ *      `completed` or `verifying` status. A single `failed` / `blocked`
+ *      / `retry` entry aborts silently — the operator's attention belongs
+ *      on the failure, not on a speculative next-ticket list.
+ *   2. **Budget headroom >= 15%.** Passed in by the caller as the
+ *      post-drain percentage remaining. The audit call itself consumes
+ *      tokens; we refuse to eat headroom the operator might have earmarked
+ *      for a retry or follow-up ticket.
+ *
+ * Both gates produce a "skip" result with an explicit reason so the caller
+ * can log it. Neither throws — the post-drain path must remain clean.
+ *
+ * ## Single-fire per session
+ *
+ * The driver calls this function exactly once per autonomous session, in
+ * the post-drain window before the lifecycle transitions to `killed`.
+ * This module does not itself track "already fired" — that invariant
+ * belongs to the caller's control flow (one call, then the function
+ * returns). Callers that fear re-entry can wrap with an `idempotent`
+ * guard, but today the autonomous-loop shape makes re-entry impossible.
+ *
+ * ## Output contract
+ *
+ * On success, writes one `audit_proposal` decision per proposed ticket.
+ * The decision entry shape:
+ *
+ *   - `type: "audit_proposal"`
+ *   - `title: <proposal title>`
+ *   - `description: <one-paragraph pitch>`
+ *   - `rationale: <why this ticket, now>`
+ *   - `metadata: { title, dependencies, effortEstimate, sessionId }`
+ *
+ * The redundant `title` in metadata exists because the Rust reader
+ * (`crates/harness-data/src/lib.rs`) treats `metadata` as a flat
+ * `Record<string, string>`, and downstream TUI/GUI filters key off
+ * metadata rather than reparsing the decision. Cost is one extra string;
+ * benefit is that dashboards do not have to know the decision-schema
+ * gymnastics.
+ *
+ * ## Why no real agent spawn in the default export
+ *
+ * The production wiring hands in an `invokeAudit` callback that the
+ * autonomous loop constructs from the agent factory (Claude/Codex CLI
+ * child process, short-lived). Tests inject a scripted callback. Keeping
+ * that boundary sharp means this module stays free of CLI subprocess
+ * concerns: its job is gating, prompt building, zod validation of the
+ * agent's JSON, and decision-board writes.
+ */
+
+import { z } from "zod";
+
+import type { ChannelStore } from "../channels/channel-store.js";
+import type { Channel } from "../domain/channel.js";
+import type { Decision } from "../domain/decision.js";
+import type { TicketLedgerEntry } from "../domain/ticket.js";
+
+/**
+ * Effort band the audit agent tags each proposal with. Aligned with the
+ * GH-issue size labels the project board already uses so the operator can
+ * drop a proposal straight onto the board without relabelling.
+ */
+export const AuditEffortEstimateSchema = z.enum(["XS", "S", "M", "L", "XL"]);
+export type AuditEffortEstimate = z.infer<typeof AuditEffortEstimateSchema>;
+
+/**
+ * Shape of one proposal returned by the audit agent. The schema is
+ * enforced by zod before any decision is written — a malformed proposal
+ * is logged and skipped rather than poisoning the board.
+ *
+ * `dependencies` is a free-form list of ticket IDs or proposal titles the
+ * agent thinks this proposal depends on. We keep it loose (strings) rather
+ * than typed-reference because the agent is reasoning over open-ended
+ * inputs (in-flight tickets, hypothetical future work) and a rigid
+ * reference type would force it to invent IDs.
+ */
+export const AuditProposalSchema = z.object({
+  title: z.string().min(1).max(120),
+  rationale: z.string().min(1),
+  dependencies: z.array(z.string()).default([]),
+  effortEstimate: AuditEffortEstimateSchema,
+});
+export type AuditProposal = z.infer<typeof AuditProposalSchema>;
+
+/**
+ * Agent-returned envelope. A 3..5 count is enforced so an agent that
+ * returns 0 / 1 / 20 does not slip through with nothing-or-noise.
+ */
+export const AuditResponseSchema = z.object({
+  proposals: z.array(AuditProposalSchema).min(3).max(5),
+});
+export type AuditResponse = z.infer<typeof AuditResponseSchema>;
+
+/**
+ * Context the audit agent sees. Built by the caller from the current
+ * run's state. Kept small — the agent is reasoning over "what just
+ * shipped", not over the full session history, so deep run-replay data
+ * is intentionally excluded.
+ */
+export interface AuditRunContext {
+  sessionId: string;
+  /** Ticket ledger the driver just finished draining. */
+  tickets: readonly TicketLedgerEntry[];
+  /**
+   * Decisions already on the board — coordination messages, session-
+   * start audit, any prior `audit_proposal` entries. The agent uses
+   * these to avoid proposing what the operator explicitly decided
+   * against or what was already proposed.
+   */
+  decisions: readonly Decision[];
+  /**
+   * Recent git log lines (subject line only). Caller is responsible
+   * for shelling out — audit-agent stays free of shell-exec concerns.
+   * An empty array is fine; the prompt tolerates a missing git view.
+   */
+  recentCommits: readonly string[];
+}
+
+/**
+ * Callback that actually invokes the underlying LLM / CLI agent. The
+ * production binding constructs a short-lived Claude/Codex child via
+ * the agent factory; tests inject a scripted function.
+ *
+ * Contract: given the fully-rendered prompt, return a string that
+ * parses as JSON matching {@link AuditResponseSchema}. Rejecting with
+ * any error is treated as a skip (no decisions written, reason
+ * `agent_error`) rather than letting the driver's teardown throw.
+ */
+export type AuditInvoker = (prompt: string) => Promise<string>;
+
+/**
+ * Result summary returned to the caller so the autonomous-loop's
+ * shutdown log has something to print.
+ */
+export type AuditRunResult =
+  | { kind: "fired"; proposalsWritten: number }
+  | { kind: "skipped"; reason: AuditSkipReason }
+  | { kind: "invalid"; issues: z.ZodIssue[] };
+
+export type AuditSkipReason =
+  | "budget_headroom_too_low"
+  | "ledger_had_failures"
+  | "ledger_empty"
+  | "agent_error";
+
+export interface RunPostCompletionAuditOptions {
+  /** Channel the session is running against. */
+  channel: Channel;
+  /** Run context (ticket ledger + decisions + recent commits). */
+  run: AuditRunContext;
+  /** Channel store — used to write `audit_proposal` decisions. */
+  channelStore: Pick<ChannelStore, "recordDecision">;
+  /**
+   * Post-drain budget headroom, 0..100. Gate: audit fires only when
+   * >= 15. Callers that do not have a tracker (e.g. non-autonomous
+   * flows) should not call this function at all.
+   */
+  budgetHeadroomPct: number;
+  /** LLM invocation callback. See {@link AuditInvoker}. */
+  invokeAudit: AuditInvoker;
+}
+
+/**
+ * Hard-coded budget-headroom gate. Exported so tests can reference it
+ * without duplicating the number, and so a future knob (e.g. making it
+ * configurable per-channel) has a single site to revisit.
+ */
+export const AUDIT_MIN_HEADROOM_PCT = 15;
+
+/**
+ * Prompt template. Intentionally a JSDoc constant rather than a separate
+ * file — the task spec's "stubs tolerated" section pins this choice so
+ * the prompt stays versioned with the code that emits it. Placeholders
+ * are replaced at render time.
+ *
+ * The prompt asks for strict JSON so the response path is a single
+ * JSON.parse + zod validation; no free-form markdown stripping.
+ */
+const AUDIT_PROMPT_TEMPLATE = `You are Relay's post-completion audit agent. A run just finished
+draining its ticket board; every ticket landed green. Your job is to
+propose the NEXT 3 to 5 tickets the operator should tackle, prioritised
+by user value.
+
+## Context
+
+Session: {{sessionId}}
+Channel: {{channelName}} ({{channelId}})
+
+### Tickets just completed
+{{ticketSummary}}
+
+### Decisions on the board
+{{decisionsSummary}}
+
+### Recent commits
+{{commitsSummary}}
+
+## Output
+
+Respond with STRICT JSON matching this shape — no markdown fences, no
+commentary, nothing outside the braces:
+
+{
+  "proposals": [
+    {
+      "title": "short ticket title",
+      "rationale": "why this ticket now, one to three sentences",
+      "dependencies": ["ticket title or id this depends on, if any"],
+      "effortEstimate": "XS" | "S" | "M" | "L" | "XL"
+    }
+  ]
+}
+
+Rules:
+ - Between 3 and 5 proposals.
+ - Prioritise by user-visible impact, not internal refactors.
+ - Rationale must reference concrete evidence from the context above.
+ - Do NOT propose anything that duplicates an existing decision on the
+   board.
+`;
+
+/**
+ * Render the prompt template with the current run context. Kept out of
+ * the main function so tests can exercise the substitution logic in
+ * isolation and so the template itself is tweakable without changing
+ * call-site code.
+ */
+export function renderAuditPrompt(channel: Channel, run: AuditRunContext): string {
+  const ticketSummary =
+    run.tickets.length === 0
+      ? "(no tickets — this should have been gated before reaching the prompt)"
+      : run.tickets
+          .map(
+            (t) =>
+              `- [${t.status}] ${t.ticketId}: ${t.title}` +
+              (t.assignedAlias ? ` (repo: ${t.assignedAlias})` : "")
+          )
+          .join("\n");
+
+  const decisionsSummary =
+    run.decisions.length === 0
+      ? "(no prior decisions)"
+      : run.decisions
+          .slice(-20)
+          .map((d) => `- [${d.type ?? "general"}] ${d.title}`)
+          .join("\n");
+
+  const commitsSummary =
+    run.recentCommits.length === 0
+      ? "(no recent commits captured)"
+      : run.recentCommits
+          .slice(0, 20)
+          .map((c) => `- ${c}`)
+          .join("\n");
+
+  return AUDIT_PROMPT_TEMPLATE.replace("{{sessionId}}", run.sessionId)
+    .replace("{{channelName}}", channel.name)
+    .replace("{{channelId}}", channel.channelId)
+    .replace("{{ticketSummary}}", ticketSummary)
+    .replace("{{decisionsSummary}}", decisionsSummary)
+    .replace("{{commitsSummary}}", commitsSummary);
+}
+
+/**
+ * Extract a JSON object from the raw agent response. Tolerates surrounding
+ * whitespace and a single pair of markdown fences (triple backticks) — but
+ * not free-form prose around the object. The prompt asks for strict JSON;
+ * this is a safety net, not a license for the agent to ramble.
+ */
+function extractJson(raw: string): string {
+  const trimmed = raw.trim();
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/m.exec(trimmed);
+  if (fenced) return fenced[1].trim();
+  return trimmed;
+}
+
+/**
+ * Does the ledger count as "all green"? Every ticket must be in a
+ * terminal-green state (`completed`) or a post-spawn PR-opened state
+ * (`verifying`). `failed`, `blocked`, `retry` are all red; so is a
+ * `pending` / `ready` / `executing` ticket that somehow made it past
+ * the drain. An empty ledger is ALSO red — nothing happened this run,
+ * so there is no basis for a proposal.
+ */
+function isLedgerAllGreen(tickets: readonly TicketLedgerEntry[]): boolean {
+  if (tickets.length === 0) return false;
+  return tickets.every((t) => t.status === "completed" || t.status === "verifying");
+}
+
+/**
+ * Entry point called by the autonomous-loop driver (AL-4 or,
+ * pre-AL-4, `autonomous-loop.ts` directly). Gates, prompts, validates,
+ * writes decisions. Never throws — the post-drain path must exit
+ * cleanly regardless of audit outcome.
+ */
+export async function runPostCompletionAudit(
+  opts: RunPostCompletionAuditOptions
+): Promise<AuditRunResult> {
+  const { channel, run, channelStore, budgetHeadroomPct, invokeAudit } = opts;
+
+  if (budgetHeadroomPct < AUDIT_MIN_HEADROOM_PCT) {
+    return { kind: "skipped", reason: "budget_headroom_too_low" };
+  }
+
+  if (run.tickets.length === 0) {
+    return { kind: "skipped", reason: "ledger_empty" };
+  }
+  if (!isLedgerAllGreen(run.tickets)) {
+    return { kind: "skipped", reason: "ledger_had_failures" };
+  }
+
+  const prompt = renderAuditPrompt(channel, run);
+  let rawResponse: string;
+  try {
+    rawResponse = await invokeAudit(prompt);
+  } catch (err) {
+    console.warn(
+      `[audit-agent] invoker threw: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { kind: "skipped", reason: "agent_error" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extractJson(rawResponse));
+  } catch (err) {
+    console.warn(
+      `[audit-agent] response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return {
+      kind: "invalid",
+      issues: [
+        {
+          code: "custom",
+          path: [],
+          message: `Non-JSON response: ${String(err).slice(0, 200)}`,
+        } as z.ZodIssue,
+      ],
+    };
+  }
+
+  const validation = AuditResponseSchema.safeParse(parsed);
+  if (!validation.success) {
+    console.warn(`[audit-agent] response failed zod validation: ${validation.error.message}`);
+    return { kind: "invalid", issues: validation.error.issues };
+  }
+
+  let written = 0;
+  for (const proposal of validation.data.proposals) {
+    try {
+      await channelStore.recordDecision(channel.channelId, {
+        runId: null,
+        ticketId: null,
+        title: proposal.title,
+        description: proposal.rationale,
+        rationale: proposal.rationale,
+        alternatives: [],
+        decidedBy: "audit-agent",
+        decidedByName: "Audit Agent (AL-6)",
+        linkedArtifacts: [],
+        type: "audit_proposal",
+        metadata: {
+          title: proposal.title,
+          dependencies: proposal.dependencies,
+          effortEstimate: proposal.effortEstimate,
+          sessionId: run.sessionId,
+        },
+      });
+      written += 1;
+    } catch (err) {
+      console.warn(
+        `[audit-agent] failed to persist proposal "${proposal.title}": ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  return { kind: "fired", proposalsWritten: written };
+}

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -3,6 +3,7 @@ import type { TokenTracker } from "../budget/token-tracker.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import { ChannelStore } from "../channels/channel-store.js";
 import { Coordinator } from "../crosslink/coordinator.js";
+import { runPostCompletionAudit, type AuditInvoker, type AuditRunResult } from "./audit-agent.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
 import type { RepoAdminProcessSpawner } from "./repo-admin-session.js";
 import { TicketRouter } from "./ticket-router.js";
@@ -92,7 +93,57 @@ export interface StartAutonomousSessionOptions {
      * used instead of the real home dir for session/admin logs.
      */
     rootDir?: string;
+    /**
+     * AL-6: replace the audit agent's LLM invoker with a deterministic
+     * scripted function. Tests use this to return pre-shaped JSON so the
+     * gating + decision-write path runs end-to-end without a real CLI
+     * spawn. Production leaves this unset; `runPostCompletionAudit` is
+     * never reached in pre-AL-4 shapes (the driver stub skips it) so the
+     * production default is "no invoker, no audit" until AL-4 wires in a
+     * factory-built agent.
+     */
+    auditInvoker?: AuditInvoker;
   };
+  /**
+   * AL-6 seam: invoked exactly once when the driver reaches "all
+   * tickets done" — after the last ticket finishes draining and before
+   * the lifecycle transitions to its terminal state. AL-4's real driver
+   * is expected to populate this; until AL-4 ships, the default
+   * behaviour (defined below) is to directly invoke
+   * {@link runPostCompletionAudit} against the channel's ledger. Callers
+   * that want to suppress the audit entirely can pass a no-op.
+   *
+   * The hook runs synchronously inside the loop's post-drain block: a
+   * throw here is caught and warned, never rethrown, because the
+   * autonomous loop's shutdown path must be robust to third-party
+   * failures.
+   */
+  onAllTicketsComplete?: (ctx: AllTicketsCompleteContext) => Promise<void>;
+}
+
+/**
+ * Context handed to the {@link StartAutonomousSessionOptions.onAllTicketsComplete}
+ * seam. Everything the seam needs to run AL-6's
+ * {@link runPostCompletionAudit} is on this object; no "reach into the
+ * loop's internals" required.
+ */
+export interface AllTicketsCompleteContext {
+  channel: Channel;
+  channelStore: ChannelStore;
+  sessionId: string;
+  tracker: TokenTracker;
+  /**
+   * Post-drain budget headroom percentage (0..100). Pre-computed so the
+   * seam implementation doesn't have to care whether the tracker has
+   * replayed its JSONL yet.
+   */
+  budgetHeadroomPct: number;
+  /**
+   * Audit invoker threaded through from `testOverrides.auditInvoker`, if
+   * any. Production is `undefined` — AL-4's real driver is expected to
+   * build one from the agent factory.
+   */
+  auditInvoker?: AuditInvoker;
 }
 
 /**
@@ -342,6 +393,47 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         )
       );
     }
+
+    // AL-6: post-completion audit hook. Fires exactly once per session,
+    // in the window between "last ticket drained" and "terminal lifecycle
+    // transition". Gated internally on budget headroom + ledger health
+    // (see `runPostCompletionAudit`). The `onAllTicketsComplete` seam is
+    // exposed so AL-4's richer driver — which knows about retries,
+    // stop-on-failure flags, etc. — can decide when "all tickets done"
+    // truly holds; the default implementation treats "drain finished"
+    // as the signal, which is correct for the current AL-14 single-pass
+    // shape.
+    //
+    // Only fires when the worker drain was enabled. In drain-disabled
+    // mode no tickets actually ran (AL-13 pending), so auditing what
+    // "just completed" is meaningless and would write stale proposals
+    // from a stale board.
+    if (drainEnabled) {
+      const headroomPct = Math.max(0, 100 - tracker.pct);
+      const auditCtx: AllTicketsCompleteContext = {
+        channel,
+        channelStore,
+        sessionId,
+        tracker,
+        budgetHeadroomPct: headroomPct,
+        auditInvoker: testOverrides?.auditInvoker,
+      };
+      try {
+        if (opts.onAllTicketsComplete) {
+          await opts.onAllTicketsComplete(auditCtx);
+        } else {
+          await defaultOnAllTicketsComplete(auditCtx);
+        }
+      } catch (err) {
+        // A misbehaving hook must NOT keep the loop from tearing down
+        // its pool / lifecycle / tracker. Warn and continue.
+        console.warn(
+          `[autonomous-loop] onAllTicketsComplete hook failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
   }
 
   // Only transition if we're still in a non-terminal state. A concurrent
@@ -412,6 +504,58 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   } catch (err) {
     console.warn(
       `[autonomous-loop] tracker close failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/**
+ * AL-6: default implementation of the `onAllTicketsComplete` seam.
+ * Reads the channel's current ticket ledger + decisions, then hands them
+ * to {@link runPostCompletionAudit}. Logs the outcome so an operator can
+ * tell from the autonomous-loop's final output whether the audit fired,
+ * was gated off, or produced an invalid response.
+ *
+ * Auto-audit is disabled when no `auditInvoker` is supplied — i.e. the
+ * production default until AL-4 wires the agent factory into this seam.
+ * Tests explicitly pass an invoker via `testOverrides.auditInvoker`.
+ */
+async function defaultOnAllTicketsComplete(ctx: AllTicketsCompleteContext): Promise<void> {
+  if (!ctx.auditInvoker) {
+    // No invoker, no audit. Keeping this silent by default — the
+    // autonomous-loop's pre-audit log already told the operator that
+    // AL-4 is not yet wired; shouting "audit skipped (no invoker)" on
+    // every successful run would just add noise.
+    return;
+  }
+
+  const tickets = await ctx.channelStore.readChannelTickets(ctx.channel.channelId);
+  const decisions = await ctx.channelStore.listDecisions(ctx.channel.channelId);
+
+  const result: AuditRunResult = await runPostCompletionAudit({
+    channel: ctx.channel,
+    channelStore: ctx.channelStore,
+    run: {
+      sessionId: ctx.sessionId,
+      tickets,
+      decisions,
+      // Recent git log capture is deferred to AL-4's richer driver,
+      // which knows which repos the run touched. The audit prompt
+      // tolerates an empty array, so skipping here produces no noise.
+      recentCommits: [],
+    },
+    budgetHeadroomPct: ctx.budgetHeadroomPct,
+    invokeAudit: ctx.auditInvoker,
+  });
+
+  if (result.kind === "fired") {
+    console.log(
+      `[autonomous-loop] audit-agent fired — ${result.proposalsWritten} proposal(s) written.`
+    );
+  } else if (result.kind === "skipped") {
+    console.log(`[autonomous-loop] audit-agent skipped (${result.reason}).`);
+  } else {
+    console.warn(
+      `[autonomous-loop] audit-agent returned invalid response (${result.issues.length} issue(s)).`
     );
   }
 }

--- a/test/orchestrator/audit-agent.test.ts
+++ b/test/orchestrator/audit-agent.test.ts
@@ -1,0 +1,691 @@
+/**
+ * AL-6 — post-completion audit agent unit + integration tests.
+ *
+ * Covers:
+ *  1. Unit: gating — budget headroom < 15% skips silently with the
+ *     `budget_headroom_too_low` reason and NEVER invokes the agent.
+ *  2. Unit: gating — ledger with any failure skips silently with
+ *     `ledger_had_failures` (no agent invocation, no decision writes).
+ *  3. Unit: invalid agent response → `invalid` result, no decision
+ *     writes, warning logged (zod rejection).
+ *  4. Unit: agent invoker throws → `skipped / agent_error`, no writes.
+ *  5. Integration (AC4): 2-ticket green board drives the autonomous
+ *     loop's drain pass; audit fires; >=1 `audit_proposal` decision
+ *     entry lands on the board with the expected metadata shape.
+ *
+ * The integration test reuses the AL-14 drain fixture shape (fake admin
+ * spawner + fake worker spawner) so no real `claude` binary, no real git,
+ * no real subprocess fires. The audit invoker is a scripted function that
+ * returns a pre-shaped JSON payload — the focus of AL-6 is the gating +
+ * decision-write contract, not the LLM-call plumbing (which sits behind
+ * the `invokeAudit` seam and is exercised by the CLI-agent tests already).
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import type { SandboxRef } from "../../src/execution/sandbox.js";
+import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
+import { TokenTracker } from "../../src/budget/token-tracker.js";
+import {
+  AUDIT_MIN_HEADROOM_PCT,
+  runPostCompletionAudit,
+  type AuditInvoker,
+  type AuditResponse,
+} from "../../src/orchestrator/audit-agent.js";
+import {
+  RELAY_AL14_WORKER_DRAIN,
+  startAutonomousSession,
+} from "../../src/orchestrator/autonomous-loop.js";
+import { RELAY_REPO_ADMIN_POOL_ENABLED } from "../../src/orchestrator/repo-admin-pool.js";
+import type {
+  RepoAdminProcessSpawner,
+  RepoAdminSpawnArgs,
+} from "../../src/orchestrator/repo-admin-session.js";
+import type {
+  WorkerExitEvent,
+  WorkerHandle,
+  WorkerSpawner,
+} from "../../src/orchestrator/worker-spawner.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+// --- Shared helpers ----------------------------------------------------------
+
+function makeTicket(
+  id: string,
+  alias: string,
+  status: "completed" | "verifying"
+): TicketLedgerEntry {
+  return {
+    ticketId: id,
+    title: `Ticket ${id}`,
+    specialty: "general",
+    status,
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: status === "completed" ? "passed" : "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 1,
+    startedAt: "2026-04-21T00:00:00.000Z",
+    completedAt: status === "completed" ? "2026-04-21T00:05:00.000Z" : null,
+    updatedAt: "2026-04-21T00:05:00.000Z",
+    runId: null,
+    assignedAlias: alias,
+  };
+}
+
+const VALID_RESPONSE: AuditResponse = {
+  proposals: [
+    {
+      title: "Add TUI keybinding for audit-proposal acceptance",
+      rationale:
+        "Operators just reviewed audit proposals inline; a one-key accept path closes the feedback loop.",
+      dependencies: [],
+      effortEstimate: "S",
+    },
+    {
+      title: "Persist audit proposals to Linear on god-mode opt-in",
+      rationale:
+        "Once AL-7 lands god mode, the proposals should create Linear tickets automatically instead of manual triage.",
+      dependencies: ["AL-7 trust-mode flag"],
+      effortEstimate: "M",
+    },
+    {
+      title: "Surface audit proposals in the GUI decisions tab",
+      rationale:
+        "Proposals live on the decisions board already; the GUI filter just needs an `audit_proposal` chip.",
+      dependencies: [],
+      effortEstimate: "XS",
+    },
+  ],
+};
+
+function makeValidInvoker(response: AuditResponse = VALID_RESPONSE): AuditInvoker {
+  return async () => JSON.stringify(response);
+}
+
+// --- Unit tests --------------------------------------------------------------
+
+describe("runPostCompletionAudit — gating", () => {
+  let root: string;
+  let channelStore: ChannelStore;
+  let channel: Channel;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "al-6-audit-unit-"));
+    const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+    channelStore = new ChannelStore(join(root, "channels"), harnessStore);
+    channel = await channelStore.createChannel({
+      name: "al-6-unit",
+      description: "audit-agent unit tests",
+      workspaceIds: ["ws-1"],
+      repoAssignments: [{ alias: "primary", workspaceId: "ws-1", repoPath: "/tmp/fake" }],
+    });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("skips silently when budget headroom is below 15%", async () => {
+    const invoker = vi.fn<AuditInvoker>();
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: {
+        sessionId: "s-1",
+        tickets: [makeTicket("t-1", "primary", "completed")],
+        decisions: [],
+        recentCommits: [],
+      },
+      budgetHeadroomPct: AUDIT_MIN_HEADROOM_PCT - 1, // 14
+      invokeAudit: invoker,
+    });
+
+    expect(result).toEqual({ kind: "skipped", reason: "budget_headroom_too_low" });
+    expect(invoker).not.toHaveBeenCalled();
+    const decisions = await channelStore.listDecisions(channel.channelId);
+    expect(decisions.filter((d) => d.type === "audit_proposal")).toHaveLength(0);
+  });
+
+  it("skips when ledger has a failed ticket", async () => {
+    const invoker = vi.fn<AuditInvoker>();
+    const tickets = [
+      makeTicket("t-1", "primary", "completed"),
+      { ...makeTicket("t-2", "primary", "completed"), status: "failed" as const },
+    ];
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: { sessionId: "s-1", tickets, decisions: [], recentCommits: [] },
+      budgetHeadroomPct: 50,
+      invokeAudit: invoker,
+    });
+
+    expect(result).toEqual({ kind: "skipped", reason: "ledger_had_failures" });
+    expect(invoker).not.toHaveBeenCalled();
+  });
+
+  it("skips when ledger is empty", async () => {
+    const invoker = vi.fn<AuditInvoker>();
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: { sessionId: "s-1", tickets: [], decisions: [], recentCommits: [] },
+      budgetHeadroomPct: 80,
+      invokeAudit: invoker,
+    });
+    expect(result).toEqual({ kind: "skipped", reason: "ledger_empty" });
+    expect(invoker).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid when agent response fails zod validation", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const invoker: AuditInvoker = async () =>
+      JSON.stringify({
+        proposals: [
+          {
+            title: "Only one proposal",
+            rationale: "This fails the min(3) gate.",
+            dependencies: [],
+            effortEstimate: "S",
+          },
+        ],
+      });
+
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: {
+        sessionId: "s-1",
+        tickets: [makeTicket("t-1", "primary", "completed")],
+        decisions: [],
+        recentCommits: [],
+      },
+      budgetHeadroomPct: 50,
+      invokeAudit: invoker,
+    });
+
+    expect(result.kind).toBe("invalid");
+    // No decisions written on invalid responses.
+    const decisions = await channelStore.listDecisions(channel.channelId);
+    expect(decisions.filter((d) => d.type === "audit_proposal")).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it("returns agent_error when invoker throws", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const invoker: AuditInvoker = async () => {
+      throw new Error("network down");
+    };
+
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: {
+        sessionId: "s-1",
+        tickets: [makeTicket("t-1", "primary", "completed")],
+        decisions: [],
+        recentCommits: [],
+      },
+      budgetHeadroomPct: 50,
+      invokeAudit: invoker,
+    });
+    expect(result).toEqual({ kind: "skipped", reason: "agent_error" });
+    warnSpy.mockRestore();
+  });
+
+  it("tolerates a fenced ```json code block in the agent response", async () => {
+    const fenced = "```json\n" + JSON.stringify(VALID_RESPONSE) + "\n```";
+    const invoker: AuditInvoker = async () => fenced;
+
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: {
+        sessionId: "s-1",
+        tickets: [makeTicket("t-1", "primary", "completed")],
+        decisions: [],
+        recentCommits: [],
+      },
+      budgetHeadroomPct: 50,
+      invokeAudit: invoker,
+    });
+    expect(result.kind).toBe("fired");
+    if (result.kind === "fired") {
+      expect(result.proposalsWritten).toBe(3);
+    }
+  });
+
+  it("writes one audit_proposal decision per proposal with the expected metadata shape", async () => {
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: {
+        sessionId: "sess-abc",
+        tickets: [
+          makeTicket("t-1", "primary", "completed"),
+          makeTicket("t-2", "primary", "verifying"),
+        ],
+        decisions: [],
+        recentCommits: ["abc123 feat: ship the thing"],
+      },
+      budgetHeadroomPct: 40,
+      invokeAudit: makeValidInvoker(),
+    });
+
+    expect(result).toEqual({ kind: "fired", proposalsWritten: 3 });
+
+    const proposals = (await channelStore.listDecisions(channel.channelId)).filter(
+      (d) => d.type === "audit_proposal"
+    );
+    expect(proposals).toHaveLength(3);
+    for (let i = 0; i < proposals.length; i++) {
+      const d = proposals[i];
+      expect(d.type).toBe("audit_proposal");
+      expect(d.decidedBy).toBe("audit-agent");
+      expect(d.metadata).toBeDefined();
+      expect(d.metadata?.title).toBeDefined();
+      expect(d.metadata?.effortEstimate).toBeDefined();
+      expect(d.metadata?.sessionId).toBe("sess-abc");
+      expect(Array.isArray(d.metadata?.dependencies)).toBe(true);
+    }
+  });
+});
+
+// --- Integration: autonomous-loop drives the audit seam ----------------------
+
+// Reused AL-14 drain-fixture fakes. Minimal copies so this test stays hermetic
+// from the autonomous-loop-drain.test.ts file — if one breaks, the other
+// shouldn't cascade.
+type StdListener = (chunk: string) => void;
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeAdminChild extends SpawnedProcess {
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  spawnArgs: RepoAdminSpawnArgs;
+}
+
+function makeFakeAdminChild(args: RepoAdminSpawnArgs): FakeAdminChild {
+  const exitListeners: ExitListener[] = [];
+  return {
+    pid: 30_000 + Math.floor(Math.random() * 1000),
+    spawnArgs: args,
+    onStdout(_l: StdListener) {},
+    onStderr(_l: StdListener) {},
+    onExit(l: ExitListener) {
+      exitListeners.push(l);
+    },
+    onError(_l: ErrorListener) {},
+    kill() {
+      for (const l of exitListeners) l(0, "SIGTERM");
+      return true;
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+  };
+}
+
+class FakeAdminSpawner implements RepoAdminProcessSpawner {
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    return makeFakeAdminChild(args);
+  }
+}
+
+class FakeWorkerHandle implements WorkerHandle {
+  readonly ticketId: string;
+  readonly sessionId: string;
+  readonly specialty = "general" as const;
+  readonly worktreePath: string;
+  readonly sandboxRef: SandboxRef;
+  private _state: "running" | "completed" | "failed" | "stopped" = "running";
+  private _prUrl: string | null = null;
+  private listeners: Array<(evt: WorkerExitEvent) => void> = [];
+  private finalEvent: WorkerExitEvent | null = null;
+
+  constructor(ticketId: string, sessionId: string, worktreePath: string, sandboxRef: SandboxRef) {
+    this.ticketId = ticketId;
+    this.sessionId = sessionId;
+    this.worktreePath = worktreePath;
+    this.sandboxRef = sandboxRef;
+  }
+  get state(): "running" | "completed" | "failed" | "stopped" {
+    return this._state;
+  }
+  get detectedPrUrl(): string | null {
+    return this._prUrl;
+  }
+  onExit(listener: (evt: WorkerExitEvent) => void): () => void {
+    if (this.finalEvent) {
+      const evt = this.finalEvent;
+      queueMicrotask(() => listener(evt));
+      return () => {};
+    }
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+  stop = vi.fn(async (): Promise<void> => {
+    if (this._state === "running") {
+      this.fire({ exitCode: null });
+    }
+  });
+  fire(args: { exitCode: number | null; prUrl?: string | null }): void {
+    if (this.finalEvent) return;
+    this._prUrl = args.prUrl ?? null;
+    const evt: WorkerExitEvent = {
+      exitCode: args.exitCode,
+      signal: null,
+      reason:
+        args.exitCode === 0
+          ? "completed"
+          : args.exitCode === null
+            ? "stopped"
+            : `exit ${args.exitCode}`,
+      stdoutTail: "",
+      stderrTail: "",
+      detectedPrUrl: args.prUrl ?? null,
+    };
+    if (args.exitCode === 0) this._state = "completed";
+    else if (args.exitCode === null) this._state = "stopped";
+    else this._state = "failed";
+    this.finalEvent = evt;
+    const listeners = this.listeners.slice();
+    this.listeners = [];
+    for (const l of listeners) l(evt);
+  }
+}
+
+class FakeWorkerSpawner {
+  readonly spawnedByAlias = new Map<string, FakeWorkerHandle[]>();
+  private counter = 0;
+  private onSpawnListeners: Array<
+    (args: { alias: string; ticketId: string; handle: FakeWorkerHandle }) => void
+  > = [];
+
+  onSpawn(cb: (args: { alias: string; ticketId: string; handle: FakeWorkerHandle }) => void): void {
+    this.onSpawnListeners.push(cb);
+  }
+
+  spawn = vi.fn(
+    async (opts: {
+      ticket: TicketLedgerEntry;
+      repoAssignment: RepoAssignment;
+      channel: Channel;
+    }) => {
+      this.counter += 1;
+      const runId = `fake-run-${this.counter}`;
+      const ticketId = opts.ticket.ticketId;
+      const alias = opts.repoAssignment.alias;
+      const worktreePath = `/tmp/fake-worktree/${alias}/${runId}/${ticketId}`;
+      const sandboxRef: SandboxRef = {
+        id: `sb-${runId}-${ticketId}`,
+        workdir: { kind: "local", path: worktreePath },
+        meta: {
+          branch: `sandbox/${runId}/${ticketId}`,
+          base: "main",
+          runId,
+          ticketId,
+          repoRoot: opts.repoAssignment.repoPath,
+        },
+      };
+      const handle = new FakeWorkerHandle(
+        ticketId,
+        `worker-sess-${this.counter}`,
+        worktreePath,
+        sandboxRef
+      );
+      const list = this.spawnedByAlias.get(alias) ?? [];
+      list.push(handle);
+      this.spawnedByAlias.set(alias, list);
+      for (const cb of this.onSpawnListeners) cb({ alias, ticketId, handle });
+      return { handle, worktreePath, sandboxRef };
+    }
+  );
+
+  destroyWorktree = vi.fn(async (_ref: SandboxRef) => {});
+
+  handles(alias: string): FakeWorkerHandle[] {
+    return this.spawnedByAlias.get(alias) ?? [];
+  }
+}
+
+async function waitUntil(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitUntil timed out");
+    }
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+describe("audit-agent integration — autonomous-loop onAllTicketsComplete seam", () => {
+  let cleanupFns: Array<() => Promise<void>> = [];
+  let originalPoolFlag: string | undefined;
+  let originalDrainFlag: string | undefined;
+
+  beforeEach(() => {
+    cleanupFns = [];
+    originalPoolFlag = process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    originalDrainFlag = process.env[RELAY_AL14_WORKER_DRAIN];
+    process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = "1";
+    process.env[RELAY_AL14_WORKER_DRAIN] = "1";
+  });
+
+  afterEach(async () => {
+    for (const fn of cleanupFns) await fn();
+    if (originalPoolFlag === undefined) delete process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    else process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = originalPoolFlag;
+    if (originalDrainFlag === undefined) delete process.env[RELAY_AL14_WORKER_DRAIN];
+    else process.env[RELAY_AL14_WORKER_DRAIN] = originalDrainFlag;
+  });
+
+  it("fires the audit agent after a 2-ticket board drains green and writes >=1 audit_proposal decision", async () => {
+    // Fixture: 1 admin, 2 tickets, both complete cleanly.
+    const root = await mkdtemp(join(tmpdir(), "al-6-audit-int-"));
+    const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+    const channelStore = new ChannelStore(join(root, "channels"), harnessStore);
+
+    const assignments: RepoAssignment[] = [
+      { alias: "primary", workspaceId: "ws-primary", repoPath: "/tmp/fake-primary" },
+    ];
+    const persisted = await channelStore.createChannel({
+      name: "al-6-int",
+      description: "al-6 integration",
+      workspaceIds: ["ws-primary"],
+      repoAssignments: assignments,
+    });
+    const channel: Channel = { ...persisted, repoAssignments: assignments, fullAccess: false };
+
+    const tickets: TicketLedgerEntry[] = [
+      {
+        ticketId: "al-6-int-1",
+        title: "t-1",
+        specialty: "general",
+        status: "ready",
+        dependsOn: [],
+        assignedAgentId: null,
+        assignedAgentName: null,
+        crosslinkSessionId: null,
+        verification: "pending",
+        lastClassification: null,
+        chosenNextAction: null,
+        attempt: 0,
+        startedAt: null,
+        completedAt: null,
+        updatedAt: "2026-04-21T00:00:00.000Z",
+        runId: null,
+        assignedAlias: "primary",
+      },
+      {
+        ticketId: "al-6-int-2",
+        title: "t-2",
+        specialty: "general",
+        status: "ready",
+        dependsOn: [],
+        assignedAgentId: null,
+        assignedAgentName: null,
+        crosslinkSessionId: null,
+        verification: "pending",
+        lastClassification: null,
+        chosenNextAction: null,
+        attempt: 0,
+        startedAt: null,
+        completedAt: null,
+        updatedAt: "2026-04-21T00:00:00.000Z",
+        runId: null,
+        assignedAlias: "primary",
+      },
+    ];
+    await channelStore.writeChannelTickets(channel.channelId, tickets);
+
+    const sessionId = `auto-al-6-${Date.now()}`;
+    const lifecycle = new SessionLifecycle(sessionId, { rootDir: root });
+    await lifecycle.transition("dispatching", "autonomous-session-started");
+    const tracker = new TokenTracker(sessionId, 100_000, { rootDir: root });
+
+    const adminSpawner = new FakeAdminSpawner();
+    const workerSpawner = new FakeWorkerSpawner();
+    const auditInvoker: AuditInvoker = vi.fn(async () => JSON.stringify(VALID_RESPONSE));
+
+    cleanupFns.push(async () => {
+      await tracker.close().catch(() => {});
+      await lifecycle.close().catch(() => {});
+      await rm(root, { recursive: true, force: true });
+    });
+
+    // Silence expected info noise — the loop logs its phases + the audit
+    // outcome. We only want to fail on unexpected warn() calls coming from
+    // the runner/coordinator.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    const driverP = startAutonomousSession({
+      sessionId,
+      channel,
+      tracker,
+      lifecycle,
+      trust: "supervised",
+      allowedRepos: assignments,
+      testOverrides: {
+        channelStore,
+        repoAdminSpawner: adminSpawner,
+        workerSpawner: workerSpawner as unknown as WorkerSpawner,
+        rootDir: root,
+        auditInvoker,
+      },
+    });
+
+    // Drive the drain: each ticket spawns → complete with PR URL → next
+    // ticket spawns → complete. After the second completion the loop's
+    // post-drain block fires onAllTicketsComplete → audit-agent.
+    await waitUntil(() => workerSpawner.handles("primary").length >= 1);
+    workerSpawner
+      .handles("primary")[0]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/1" });
+    await waitUntil(() => workerSpawner.handles("primary").length >= 2);
+    workerSpawner
+      .handles("primary")[1]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/2" });
+
+    await driverP;
+
+    // AC1: audit fired exactly once — the invoker recorded exactly one call.
+    expect(auditInvoker).toHaveBeenCalledTimes(1);
+
+    // AC3: each proposal writes a decision entry with the audit_proposal
+    // type + the metadata shape the spec calls out.
+    const decisions = await channelStore.listDecisions(channel.channelId);
+    const proposals = decisions.filter((d) => d.type === "audit_proposal");
+    expect(proposals.length).toBeGreaterThanOrEqual(1);
+    expect(proposals.length).toBe(VALID_RESPONSE.proposals.length);
+    for (const d of proposals) {
+      expect(d.decidedBy).toBe("audit-agent");
+      expect(d.metadata?.title).toBeDefined();
+      expect(d.metadata?.effortEstimate).toBeDefined();
+      expect(d.metadata?.sessionId).toBe(sessionId);
+      expect(Array.isArray(d.metadata?.dependencies)).toBe(true);
+    }
+  }, 10_000);
+
+  it("does NOT fire audit when worker drain is disabled (AL-13 pending path)", async () => {
+    // Drain flag off = no tickets execute, no audit should be triggered.
+    process.env[RELAY_AL14_WORKER_DRAIN] = "0";
+
+    const root = await mkdtemp(join(tmpdir(), "al-6-audit-int-drain-off-"));
+    const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+    const channelStore = new ChannelStore(join(root, "channels"), harnessStore);
+
+    const assignments: RepoAssignment[] = [
+      { alias: "primary", workspaceId: "ws-primary", repoPath: "/tmp/fake-primary" },
+    ];
+    const persisted = await channelStore.createChannel({
+      name: "al-6-int-drain-off",
+      description: "drain off",
+      workspaceIds: ["ws-primary"],
+      repoAssignments: assignments,
+    });
+    const channel: Channel = { ...persisted, repoAssignments: assignments, fullAccess: false };
+    await channelStore.writeChannelTickets(channel.channelId, []);
+
+    const sessionId = `auto-al-6-off-${Date.now()}`;
+    const lifecycle = new SessionLifecycle(sessionId, { rootDir: root });
+    await lifecycle.transition("dispatching", "autonomous-session-started");
+    const tracker = new TokenTracker(sessionId, 100_000, { rootDir: root });
+
+    const adminSpawner = new FakeAdminSpawner();
+    const workerSpawner = new FakeWorkerSpawner();
+    const auditInvoker: AuditInvoker = vi.fn(async () => JSON.stringify(VALID_RESPONSE));
+
+    cleanupFns.push(async () => {
+      await tracker.close().catch(() => {});
+      await lifecycle.close().catch(() => {});
+      await rm(root, { recursive: true, force: true });
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    await startAutonomousSession({
+      sessionId,
+      channel,
+      tracker,
+      lifecycle,
+      trust: "supervised",
+      allowedRepos: assignments,
+      testOverrides: {
+        channelStore,
+        repoAdminSpawner: adminSpawner,
+        workerSpawner: workerSpawner as unknown as WorkerSpawner,
+        rootDir: root,
+        auditInvoker,
+      },
+    });
+
+    expect(auditInvoker).not.toHaveBeenCalled();
+    const decisions = await channelStore.listDecisions(channel.channelId);
+    expect(decisions.filter((d) => d.type === "audit_proposal")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #81

## Summary

Post-completion audit agent (proposals only). After the autonomous driver finishes draining a ticket board, the audit agent reads the ledger + decisions + recent commits and proposes the next 3–5 tickets to tackle, ranked by user value. Each proposal is persisted as an `audit_proposal` decision entry on the channel. Auto-ticket-creation is deferred to AL-7 god mode.

## Gating

Fires exactly once per session, only when:
- budget headroom is >= 15% (single source of truth: `AUDIT_MIN_HEADROOM_PCT`)
- ledger is all-green (every ticket in `completed` or `verifying`)

Silent-skip with an explicit reason (`budget_headroom_too_low`, `ledger_had_failures`, `ledger_empty`, `agent_error`) on either gate miss. Agent responses are zod-validated; invalid shapes log and skip rather than poison the board. Invoker throws resolve to `agent_error` so the post-drain teardown stays clean.

## Integration seam

`startAutonomousSession` gains an `onAllTicketsComplete` hook so AL-4's richer driver can plug in when it lands. The default implementation reads ledger + decisions from the channel store and calls `runPostCompletionAudit`. Production is no-op until an `auditInvoker` is wired via `testOverrides.auditInvoker` — AL-6 intentionally doesn't own the CLI-agent factory binding; AL-4 or a follow-up ticket will.

AL-4 isn't merged yet, so per the task brief we also wire the audit directly into the `autonomous-loop.ts` post-drain block (drain-enabled mode only).

## Decision shape

```
type: "audit_proposal"
title: <proposal title>
description / rationale: <why this ticket now>
metadata: { title, dependencies, effortEstimate, sessionId }
```

The redundant `title` in metadata matches the TUI/GUI's flat-metadata convention.

## Stubs tolerated (per task brief)

- Prompt template is a JSDoc constant (`AUDIT_PROMPT_TEMPLATE`) in `audit-agent.ts`, not a separate file.
- God-mode auto-ticket-creation is not wired — deferred to AL-7.
- Real LLM invocation is behind the `AuditInvoker` seam; production binding to the agent factory is future work.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 760 tests (737 passed, 23 skipped), no regressions
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean
- [x] AC1: audit fires exactly once per session (integration test asserts `invoker` called once)
- [x] AC2: skips silently when headroom < 15% or ledger had failures (4 unit tests)
- [x] AC3: each proposal writes a decision entry with the required metadata shape (unit + integration assertions)
- [x] AC4: 2-ticket green board integration test — audit fires, >=1 `audit_proposal` decision entry created

## Files

- `src/orchestrator/audit-agent.ts` (new): gating, prompt render, zod validation, decision writes
- `src/orchestrator/autonomous-loop.ts`: adds `onAllTicketsComplete` seam + default invocation
- `test/orchestrator/audit-agent.test.ts` (new): 9 tests covering gating, validation, integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)