### PR TITLE
AL-9: Kill switch (STOP file)

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -598,6 +598,22 @@ fn delete_session(
     ])
 }
 
+/// AL-9 — kill-switch wiring.
+///
+/// Shells out to `rly session stop <sessionId>`, which atomically drops
+/// a `STOP` file into `~/.relay/sessions/<sessionId>/`. The autonomous
+/// loop polls that path on each tick (≤20s default) and transitions
+/// the lifecycle to `winding_down` with reason `"user-stop-signal"`.
+///
+/// No force-kill: graceful wind-down respects in-flight workers. AL-10
+/// wires the actual "Kill session" button in the session-status header
+/// to this command; AL-9 ships just the Tauri surface + CLI plumbing.
+#[tauri::command]
+fn stop_session(session_id: String) -> Result<serde_json::Value, String> {
+    validate_id_segment(&session_id, "sessionId")?;
+    cli_json(&["session", "stop", &session_id])
+}
+
 #[tauri::command]
 fn append_session_message(
     channel_id: String,
@@ -2077,6 +2093,7 @@ pub fn run() {
             post_to_channel,
             create_session,
             delete_session,
+            stop_session,
             append_session_message,
             rewind_snapshot,
             rewind_apply,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1785,8 +1785,36 @@ async function handleSessionCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (sub === "stop") {
+    // AL-9: drop a STOP file into `~/.relay/sessions/<sessionId>/` so
+    // the autonomous-loop's next tick flips the lifecycle to
+    // `winding_down`. Positional-only — sessionId is the target of
+    // the stop. Works even if the session dir doesn't exist yet
+    // (writeStopFile creates it), so an operator can race the loop
+    // and still land the signal.
+    const sessionId = extractPositionals(args)[1];
+    if (!sessionId) {
+      console.error("Usage: rly session stop <sessionId>");
+      process.exitCode = 1;
+      return;
+    }
+    const { writeStopFile } = await import("./orchestrator/stop-file-watcher.js");
+    try {
+      const path = await writeStopFile(sessionId, { source: "cli" });
+      jsonOut({ ok: true, sessionId, stopFile: path });
+    } catch (err) {
+      console.error(
+        `Failed to write STOP file for session ${sessionId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   console.error(
-    "Usage: rly session <create|list|get|delete|update-claude-sid|append|update-last|messages>"
+    "Usage: rly session <create|list|get|delete|update-claude-sid|append|update-last|messages|stop>"
   );
   process.exitCode = 1;
 }

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -6,6 +6,12 @@ import { Coordinator } from "../crosslink/coordinator.js";
 import { runPostCompletionAudit, type AuditInvoker, type AuditRunResult } from "./audit-agent.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
 import type { RepoAdminProcessSpawner } from "./repo-admin-session.js";
+import {
+  DEFAULT_STOP_POLL_INTERVAL_MS,
+  STOP_FILE_REASON,
+  checkForStop,
+  clearStopFile,
+} from "./stop-file-watcher.js";
 import { TicketRouter } from "./ticket-router.js";
 import { TicketRunner } from "./ticket-runner.js";
 import { WorkerSpawner } from "./worker-spawner.js";
@@ -73,6 +79,15 @@ export interface StartAutonomousSessionOptions {
    * time. */
   allowedRepos: RepoAssignment[];
   /**
+   * AL-9: poll cadence for the STOP-file kill switch. The driver checks
+   * `~/.relay/sessions/<sessionId>/STOP` before each dispatch tick and
+   * transitions the lifecycle to `winding_down` when the file appears.
+   * Defaults to {@link DEFAULT_STOP_POLL_INTERVAL_MS} (20s) matching the
+   * AL-9 acceptance criterion "within one tick (≤20s)". Tests override
+   * to a small value so the stop signal is picked up quickly.
+   */
+  stopPollIntervalMs?: number;
+  /**
    * **Test-only** injection hooks. Production callers MUST NOT set these —
    * they exist solely so the AL-14 drain integration test can exercise the
    * pool-boot + router + runner drain path end-to-end without a real
@@ -94,7 +109,9 @@ export interface StartAutonomousSessionOptions {
     workerSpawner?: WorkerSpawner;
     /**
      * Override the pool's `~/.relay` base dir so the test's tmp dir is
-     * used instead of the real home dir for session/admin logs.
+     * used instead of the real home dir for session/admin logs. Also
+     * used by {@link checkForStop} so the AL-9 kill-switch integration
+     * test can drop a STOP file in the test's tmp dir.
      */
     rootDir?: string;
     /**
@@ -200,6 +217,71 @@ export interface AllTicketsCompleteContext {
  */
 export async function startAutonomousSession(opts: StartAutonomousSessionOptions): Promise<void> {
   const { sessionId, lifecycle, tracker, channel, allowedRepos, testOverrides } = opts;
+  const stopPollIntervalMs = opts.stopPollIntervalMs ?? DEFAULT_STOP_POLL_INTERVAL_MS;
+
+  // AL-9: transient flag so teardown can branch on whether we're
+  // unwinding because of a user stop signal vs. normal terminal. The
+  // lifecycle transition is the source of truth for downstream readers;
+  // this flag only helps the local teardown log message.
+  let userStopped = false;
+
+  /**
+   * AL-9 — poll the STOP file for this session. When the file is
+   * present, transition the lifecycle to `winding_down` (if we're in
+   * `dispatching`) with reason `"user-stop-signal"`. The transition is
+   * idempotent — calling this helper again after the first signal is
+   * observed is a no-op. Errors from the filesystem stat are logged
+   * but NOT fatal: a flaky `~/.relay` shouldn't force-kill an
+   * in-progress session, the wall-clock watchdog + token budget are
+   * the hard stops. The STOP file is an advisory soft stop.
+   */
+  async function pollForStopAndWindDown(): Promise<boolean> {
+    if (userStopped) return true;
+    let present = false;
+    try {
+      present = await checkForStop(sessionId, testOverrides?.rootDir);
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] STOP-file check failed for session ${sessionId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return false;
+    }
+    if (!present) return false;
+    userStopped = true;
+    const state = lifecycle.state;
+    // Only `dispatching` has an edge to `winding_down`. From `planning`
+    // we short-circuit to `killed` — we never started dispatching so
+    // the wind-down drain has nothing to do. From `winding_down` /
+    // `audit` we leave the state alone; the kill switch already fired
+    // or a later transition has taken over.
+    if (state === "dispatching") {
+      try {
+        await lifecycle.transition("winding_down", STOP_FILE_REASON);
+      } catch (err) {
+        console.warn(
+          `[autonomous-loop] failed to transition to winding_down on STOP for session ${sessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    } else if (state === "planning") {
+      try {
+        await lifecycle.transition("killed", STOP_FILE_REASON);
+      } catch (err) {
+        console.warn(
+          `[autonomous-loop] failed to transition to killed on STOP for session ${sessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+    console.log(
+      `[autonomous-loop] STOP file observed for session ${sessionId}; winding down gracefully (poll cadence ${stopPollIntervalMs}ms).`
+    );
+    return true;
+  }
 
   // AL-12 built the repo-admin pool, but the admin-process handshake
   // protocol it relies on is AL-14's deliverable. Without that protocol
@@ -344,22 +426,65 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   //   "create-ticket", payload: {title, body, channelId}}})` and branch.
   //   Do NOT auto-write the ticket under supervised.
   //
+  // AL-9: one pre-routing poll. Catches the "operator dropped STOP
+  // before the loop reached its first tick" case — if we went straight
+  // into routing without checking, a session could queue work into the
+  // pool even though the user had already hit the kill switch. The
+  // per-ticket check below handles STOP arriving mid-routing.
+  await pollForStopAndWindDown();
+
   // AL-13: drain the channel's ticket board through the router exactly
   // once. AL-14 adds a second pass (gated by RELAY_AL14_WORKER_DRAIN)
   // that drains each admin's queue via TicketRunner — spawn a worker
   // per ticket, wait for it to open a PR (or fail), then exit. The
   // autonomous-loop's steady-state driver (AL-4) will replace this
   // single-pass shape; AL-14 just proves the end-to-end plumbing.
+  //
+  // AL-9: the routing loop below treats each iteration as a "tick" —
+  // we re-poll the STOP file between tickets so the switch is honored
+  // within one iteration (≤ stopPollIntervalMs equivalent; file poll
+  // is O(ms)). When AL-4 lands its real multi-pass driver it picks up
+  // the same `checkForStop` call and applies it to its own tick cadence.
   let terminalReason: "al-13-pending" | "al-14-pending" | "al-16-pending" = "al-13-pending";
   if (pool) {
     terminalReason = drainEnabled ? "al-16-pending" : "al-14-pending";
     const runners: TicketRunner[] = [];
+    // AL-9: background poller that runs for the lifetime of the drain
+    // phase. Fires at `stopPollIntervalMs` cadence (default 20s) so a
+    // STOP file that lands AFTER routing completes but BEFORE the
+    // drain finishes still flips the lifecycle to `winding_down`.
+    // The poller NEVER force-kills runners — graceful wind-down
+    // respects in-flight workers per AL-9's spec. It only transitions
+    // the lifecycle so downstream audit-after-kill logic sees the
+    // right state when the drain eventually completes.
+    let stopPollTimer: NodeJS.Timeout | null = null;
+    const armStopPoll = (): void => {
+      const tick = async (): Promise<void> => {
+        await pollForStopAndWindDown();
+        if (!userStopped) {
+          stopPollTimer = setTimeout(tick, stopPollIntervalMs);
+          // Don't keep the event loop alive just for the poll — the
+          // drain's promise is the thing the caller awaits.
+          const h = stopPollTimer as { unref?: () => void };
+          if (h && typeof h.unref === "function") h.unref();
+        }
+      };
+      stopPollTimer = setTimeout(tick, stopPollIntervalMs);
+      const h = stopPollTimer as { unref?: () => void };
+      if (h && typeof h.unref === "function") h.unref();
+    };
     try {
       const router = new TicketRouter({ pool, channel, channelStore });
       const boardTickets = await channelStore.readChannelTickets(channel.channelId);
       for (const ticket of boardTickets) {
         if (ticket.status !== "ready") continue;
         if (ticket.source === "linear") continue; // Linear mirror is read-only.
+        // AL-9: re-poll before each ticket so a STOP that lands
+        // mid-routing halts further dispatch. The already-routed
+        // tickets continue through the drain phase — that's the
+        // "respect in-flight workers" half of the graceful
+        // wind-down contract.
+        if (await pollForStopAndWindDown()) break;
         try {
           const result = await router.route(ticket);
           if (result.kind === "unroutable") {
@@ -378,6 +503,13 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
       }
 
       if (drainEnabled) {
+        // AL-9: arm the background STOP-file poll NOW that we're about
+        // to enter drain. A STOP arriving during drain flips the
+        // lifecycle to `winding_down`; runners aren't signalled (spec
+        // says respect in-flight workers) but the post-drain audit
+        // gate reads the lifecycle + ledger to decide whether to run
+        // the audit agent, so we need the state flip to land.
+        armStopPoll();
         // AL-14: drain each admin's pending queue in parallel. Each admin
         // serializes internally (one worker at a time in its repo); two
         // different admins DO run in parallel. The drain promise resolves
@@ -423,6 +555,15 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         }`
       );
     } finally {
+      // AL-9: clear the background STOP poll before we move into the
+      // stop-all-runners step. Any pending tick that hasn't fired yet
+      // is dropped — we're already on the teardown path, a late
+      // lifecycle transition from the poll would race against the
+      // explicit `killed` transition below and throw.
+      if (stopPollTimer !== null) {
+        clearTimeout(stopPollTimer);
+        stopPollTimer = null;
+      }
       // Ensure any in-flight worker is signalled before we unwind. Safe
       // to call even if drain() already finished — stop() is idempotent
       // and only hits still-running workers.
@@ -486,17 +627,68 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   // pushed us to `killed`; respect that and skip the transition in that
   // case to avoid throwing a LifecycleTransitionError the caller would
   // have to catch.
+  //
+  // AL-9: when `userStopped` is set, we ran the drain while already in
+  // `winding_down`. The final transition is still `killed`, but the
+  // reason carries the user-stop signal so log consumers + the post-
+  // completion audit gate (see below) can distinguish a user-initiated
+  // stop from a natural terminal.
   const state = lifecycle.state;
-  if (state !== "killed" && state !== "done") {
+  const finalReason = userStopped ? STOP_FILE_REASON : terminalReason;
+  try {
+    if (state !== "killed" && state !== "done") {
+      try {
+        await lifecycle.transition("killed", finalReason);
+      } catch (err) {
+        console.warn(
+          `[autonomous-loop] failed to transition lifecycle to killed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+  } finally {
+    // AL-9: clear the STOP file after terminal transition so a subsequent
+    // `rly run --autonomous` against the same sessionId doesn't immediately
+    // kill from a leftover STOP file. Defensive — swallow errors since a
+    // leftover STOP file is a minor correctness issue, never a reason to
+    // fail teardown.
     try {
-      await lifecycle.transition("killed", terminalReason);
+      await clearStopFile(sessionId, testOverrides?.rootDir);
     } catch (err) {
       console.warn(
-        `[autonomous-loop] failed to transition lifecycle to killed: ${
+        `[autonomous-loop] clearStopFile failed for session ${sessionId}: ${
           err instanceof Error ? err.message : String(err)
         }`
       );
     }
+  }
+
+  // AL-9: post-completion audit gate. When the session is terminating
+  // cleanly (or via user-stop after a fully-green routing pass), we
+  // should run the AL-6 audit agent. The spec: "Killed session still
+  // runs post-completion audit IF ledger was all-green before kill;
+  // otherwise skips audit."
+  //
+  // AL-6 is not yet merged into this branch, so the implementation
+  // here is intentionally a no-op with a structured log line. When
+  // AL-6 lands, the `runAudit()` call slots in where the log lives —
+  // the gating logic (ledger inspection, user-stop tolerance) is the
+  // piece AL-9 owns and ships now.
+  try {
+    await maybeRunAuditHook({
+      sessionId,
+      channel,
+      channelStore,
+      userStopped,
+      lifecycle,
+    });
+  } catch (err) {
+    console.warn(
+      `[autonomous-loop] audit gate check failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
   }
 
   // AL-16: close the coordinator BEFORE stopping the pool. Order
@@ -603,4 +795,72 @@ async function defaultOnAllTicketsComplete(ctx: AllTicketsCompleteContext): Prom
       `[autonomous-loop] audit-agent returned invalid response (${result.issues.length} issue(s)).`
     );
   }
+}
+
+/**
+ * AL-9's audit gate. AL-6 ships the actual audit agent; this helper
+ * owns the gating logic and logs the decision so the AL-6 merge is a
+ * drop-in call replacement (swap the `console.log` for the real
+ * runAudit call). Separating gate from actuator keeps both tickets
+ * independently verifiable.
+ *
+ * ## Gate
+ *
+ * The spec (AL-9 AC3): "Killed session still runs the post-completion
+ * audit IF the ledger was all-green before the kill; otherwise skips
+ * audit." The interpretation:
+ *
+ *   - "all-green" = every ticket on the channel's board ended in
+ *     `completed` (or was never picked up, i.e. still `pending` /
+ *     `blocked` — those aren't failures, just unreached work).
+ *   - Any `failed` / `retry` / `executing` / `verifying` ticket means
+ *     the ledger wasn't green; skip audit because auditing a partial
+ *     run would produce a misleading report.
+ *
+ * Natural terminal (no user stop, no threshold kill) follows the same
+ * rule — if the routing pass finished cleanly and every ticket is
+ * completed, audit; otherwise skip.
+ */
+async function maybeRunAuditHook(args: {
+  sessionId: string;
+  channel: Channel;
+  channelStore: ChannelStore;
+  userStopped: boolean;
+  lifecycle: SessionLifecycle;
+}): Promise<void> {
+  const { sessionId, channel, channelStore, userStopped } = args;
+
+  const tickets = await channelStore.readChannelTickets(channel.channelId);
+  // "green" means: no ticket ended in an unhealthy terminal / partial
+  // state. A completely empty board is vacuously green (the audit on
+  // an empty session is trivially "nothing to report"); AL-6 decides
+  // whether to short-circuit in that case.
+  const unhealthy = tickets.filter(
+    (t) =>
+      t.status === "failed" ||
+      t.status === "retry" ||
+      t.status === "executing" ||
+      t.status === "verifying"
+  );
+  const allGreen = unhealthy.length === 0;
+
+  if (!allGreen) {
+    console.log(
+      `[autonomous-loop] skipping post-completion audit for session ${sessionId} — ` +
+        `ledger has ${unhealthy.length} non-green ticket(s) ` +
+        `(${unhealthy
+          .slice(0, 3)
+          .map((t) => `${t.ticketId}:${t.status}`)
+          .join(", ")}${unhealthy.length > 3 ? ", …" : ""}).`
+    );
+    return;
+  }
+
+  // Green — audit would run. AL-6 slots its runAudit() here. The log
+  // line is the marker the audit gate fires; AL-9's tests key on it.
+  const trigger = userStopped ? "user-stop-signal" : "natural-terminal";
+  console.log(
+    `[autonomous-loop] post-completion audit eligible for session ${sessionId} ` +
+      `(trigger=${trigger}, ticketsGreen=${tickets.length}); AL-6 hook not yet wired.`
+  );
 }

--- a/src/orchestrator/stop-file-watcher.ts
+++ b/src/orchestrator/stop-file-watcher.ts
@@ -1,0 +1,167 @@
+import { mkdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { getRelayDir } from "../cli/paths.js";
+
+/**
+ * AL-9 — kill-switch "STOP file" watcher.
+ *
+ * The autonomous-loop driver polls for the existence of
+ * `~/.relay/sessions/<sessionId>/STOP` at the start of each tick. When the
+ * file appears, the driver flips the lifecycle to `winding_down` with
+ * reason `"user-stop-signal"` — a graceful wind-down, not a force-kill.
+ * In-flight workers finish their current step; the loop stops dispatching
+ * new tickets.
+ *
+ * ## Why a file?
+ *
+ * A file is the smallest common denominator between three producers:
+ *
+ *   - CLI `rly session stop <sessionId>` — trivially writes a file.
+ *   - Tauri `stop_session` command — shells out to the same CLI.
+ *   - A human typing `touch ~/.relay/sessions/<id>/STOP` at a shell —
+ *     always supported, always simple, no IPC plumbing to break.
+ *
+ * The alternative (a socket, a signal, a named pipe) would gain nothing
+ * here: the loop tick cadence is 20s by default, and a filesystem poll
+ * round-trip is trivial compared to that. File-based also survives a CLI
+ * daemon crash — drop the file at any point and the loop picks it up on
+ * its next tick.
+ *
+ * ## Why NOT force-kill?
+ *
+ * Ticket workers own git state (worktrees, branches, partial commits). A
+ * hard SIGKILL mid-commit leaves the repo in a state that the post-run
+ * cleanup can't reliably unwind. The lifecycle's `winding_down` state is
+ * already the well-defined "stop dispatching, drain the current ticket"
+ * transition — the STOP file just flips it from outside the process.
+ */
+
+/**
+ * The fixed filename inside each session directory. No suffix, no
+ * extension — `ls ~/.relay/sessions/<id>` has to immediately show the
+ * stop signal when it's present. The loop and the CLI agree on this
+ * name; changing it is a breaking change.
+ */
+export const STOP_FILE_NAME = "STOP";
+
+/**
+ * Resolve the absolute path to a session's STOP file. Exported for tests
+ * and for callers (CLI, Tauri) that want to render the path in a log.
+ */
+export function stopFilePath(sessionId: string, rootDir?: string): string {
+  const root = rootDir ?? getRelayDir();
+  return join(root, "sessions", sessionId, STOP_FILE_NAME);
+}
+
+/**
+ * Return `true` iff the STOP file currently exists for the session.
+ *
+ * Does NOT read the file contents — presence is the whole signal. Any
+ * error other than ENOENT is surfaced to the caller so a corrupted
+ * filesystem (permission denied, etc.) doesn't silently masquerade as
+ * "no stop requested".
+ */
+export async function checkForStop(sessionId: string, rootDir?: string): Promise<boolean> {
+  const path = stopFilePath(sessionId, rootDir);
+  try {
+    await stat(path);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Options accepted by {@link writeStopFile}.
+ */
+export interface WriteStopFileOptions {
+  /** Override `~/.relay` root (tests only). */
+  rootDir?: string;
+  /**
+   * Freeform tag identifying who dropped the file: `"cli"`, `"gui"`,
+   * `"test"`. Persisted to the file body for post-mortem debugging.
+   */
+  source?: string;
+  /** Clock injection for deterministic tests. */
+  clock?: () => number;
+}
+
+/**
+ * Atomically write the STOP file for a session.
+ *
+ * Used by the CLI (`rly session stop <sessionId>`) and by the Tauri
+ * `stop_session` command. The write is tmp + rename so a concurrent
+ * {@link checkForStop} can never see a half-written file — it either
+ * observes ENOENT (pre-rename) or the full STOP file (post-rename). The
+ * session directory is created as needed so an operator can stop a
+ * session whose `~/.relay/sessions/<id>/` tree doesn't exist yet (the
+ * loop creates it lazily on its first write).
+ *
+ * The payload is a small JSON body with `requestedAt` + an optional
+ * `source` tag — informative only. The loop treats presence, not
+ * contents, as the kill signal, so future additions to this shape are
+ * backwards-compatible.
+ */
+export async function writeStopFile(
+  sessionId: string,
+  options: WriteStopFileOptions = {}
+): Promise<string> {
+  if (!sessionId) {
+    throw new Error("writeStopFile: sessionId is required");
+  }
+  const path = stopFilePath(sessionId, options.rootDir);
+  const clock = options.clock ?? Date.now;
+  const body = {
+    sessionId,
+    requestedAt: new Date(clock()).toISOString(),
+    source: options.source ?? "unknown",
+  };
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.${clock()}`;
+  await writeFile(tmp, JSON.stringify(body, null, 2), "utf8");
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    // Best-effort cleanup — the tmp file leak is preferable to swallowing
+    // the rename error (the caller needs to know the signal didn't land).
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
+  return path;
+}
+
+/**
+ * Remove the STOP file if it exists. No-op when absent. Primarily useful
+ * for tests that reuse a session directory across cases and for an
+ * operator who dropped the file by mistake and wants to un-stop a
+ * session that hasn't ticked yet.
+ */
+export async function clearStopFile(sessionId: string, rootDir?: string): Promise<void> {
+  const path = stopFilePath(sessionId, rootDir);
+  try {
+    await unlink(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+}
+
+/**
+ * Default poll cadence for the autonomous-loop tick that calls
+ * {@link checkForStop}. 20s is an operator-visible latency budget — the
+ * acceptance criterion is "within one tick". The driver accepts an
+ * override (e.g. tests pass 10–50ms so the integration runs in <1s).
+ */
+export const DEFAULT_STOP_POLL_INTERVAL_MS = 20_000;
+
+/**
+ * Reason string recorded on the lifecycle transition fired when a STOP
+ * file is observed. Exported so tests and downstream tools (log
+ * grepping, dashboard filters) can pin on a stable identifier.
+ */
+export const STOP_FILE_REASON = "user-stop-signal";

--- a/test/orchestrator/autonomous-loop-stop-file.test.ts
+++ b/test/orchestrator/autonomous-loop-stop-file.test.ts
@@ -1,0 +1,571 @@
+/**
+ * AL-9 — autonomous-loop STOP-file integration tests.
+ *
+ * Exercises the kill-switch plumbing end-to-end against the real
+ * `startAutonomousSession` entrypoint. The loop has three tick sites
+ * where it polls the STOP file:
+ *
+ *   1. Before the routing pass (catches "operator dropped STOP before
+ *      the loop ticked").
+ *   2. Between tickets inside the routing loop (catches "STOP landed
+ *      mid-routing — stop dispatching further tickets").
+ *   3. Background poll during the drain phase (catches "STOP landed
+ *      after routing finished but workers are still draining").
+ *
+ * All three sites are tested. The assertion is uniform:
+ *   - lifecycle ends in `killed` with reason `user-stop-signal`.
+ *   - in-flight workers that had already spawned are NOT SIGTERM'd
+ *     (graceful wind-down respects them).
+ *   - tickets that hadn't started yet are not routed.
+ *
+ * The drain-end plumbing (stopping the runners after the drain
+ * completes) is still the AL-14 `autonomous-loop-exit` stop call —
+ * AL-9 doesn't change that contract. What it adds is the lifecycle
+ * state flip + the audit-gate behavior that reads it.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import type { SandboxRef } from "../../src/execution/sandbox.js";
+import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
+import { TokenTracker } from "../../src/budget/token-tracker.js";
+import {
+  RELAY_AL14_WORKER_DRAIN,
+  startAutonomousSession,
+} from "../../src/orchestrator/autonomous-loop.js";
+import { RELAY_REPO_ADMIN_POOL_ENABLED } from "../../src/orchestrator/repo-admin-pool.js";
+import type {
+  RepoAdminProcessSpawner,
+  RepoAdminSpawnArgs,
+} from "../../src/orchestrator/repo-admin-session.js";
+import { writeStopFile } from "../../src/orchestrator/stop-file-watcher.js";
+import type {
+  WorkerExitEvent,
+  WorkerHandle,
+  WorkerSpawner,
+} from "../../src/orchestrator/worker-spawner.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+type StdListener = (chunk: string) => void;
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+type ErrorListener = (err: Error) => void;
+
+interface FakeAdminChild extends SpawnedProcess {
+  emitExit(code: number | null, signal?: NodeJS.Signals | null): void;
+  spawnArgs: RepoAdminSpawnArgs;
+}
+
+function makeFakeAdminChild(args: RepoAdminSpawnArgs): FakeAdminChild {
+  const stdoutListeners: StdListener[] = [];
+  const stderrListeners: StdListener[] = [];
+  const exitListeners: ExitListener[] = [];
+  const errorListeners: ErrorListener[] = [];
+  return {
+    pid: 40_000 + Math.floor(Math.random() * 1000),
+    spawnArgs: args,
+    onStdout(l) {
+      stdoutListeners.push(l);
+    },
+    onStderr(l) {
+      stderrListeners.push(l);
+    },
+    onExit(l) {
+      exitListeners.push(l);
+    },
+    onError(l) {
+      errorListeners.push(l);
+    },
+    kill() {
+      for (const l of exitListeners) l(0, "SIGTERM");
+      return true;
+    },
+    emitExit(code, signal = null) {
+      for (const l of exitListeners) l(code, signal);
+    },
+  };
+}
+
+class FakeAdminSpawner implements RepoAdminProcessSpawner {
+  readonly byAlias = new Map<string, FakeAdminChild[]>();
+  spawn(args: RepoAdminSpawnArgs): SpawnedProcess {
+    const child = makeFakeAdminChild(args);
+    const list = this.byAlias.get(args.alias) ?? [];
+    list.push(child);
+    this.byAlias.set(args.alias, list);
+    return child;
+  }
+}
+
+class FakeWorkerHandle implements WorkerHandle {
+  readonly ticketId: string;
+  readonly sessionId: string;
+  readonly specialty = "general" as const;
+  readonly worktreePath: string;
+  readonly sandboxRef: SandboxRef;
+  private _state: "running" | "completed" | "failed" | "stopped" = "running";
+  private _prUrl: string | null = null;
+  private listeners: Array<(evt: WorkerExitEvent) => void> = [];
+  private finalEvent: WorkerExitEvent | null = null;
+
+  constructor(ticketId: string, sessionId: string, worktreePath: string, sandboxRef: SandboxRef) {
+    this.ticketId = ticketId;
+    this.sessionId = sessionId;
+    this.worktreePath = worktreePath;
+    this.sandboxRef = sandboxRef;
+  }
+  get state(): "running" | "completed" | "failed" | "stopped" {
+    return this._state;
+  }
+  get detectedPrUrl(): string | null {
+    return this._prUrl;
+  }
+  onExit(listener: (evt: WorkerExitEvent) => void): () => void {
+    if (this.finalEvent) {
+      const evt = this.finalEvent;
+      queueMicrotask(() => listener(evt));
+      return () => {};
+    }
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+  stop = vi.fn(async (): Promise<void> => {
+    if (this._state === "running") {
+      this.fire({ exitCode: null });
+    }
+  });
+  fire(args: {
+    exitCode: number | null;
+    prUrl?: string | null;
+    stdoutTail?: string;
+    stderrTail?: string;
+  }): void {
+    if (this.finalEvent) return;
+    this._prUrl = args.prUrl ?? null;
+    const evt: WorkerExitEvent = {
+      exitCode: args.exitCode,
+      signal: null,
+      reason:
+        args.exitCode === 0
+          ? "completed"
+          : args.exitCode === null
+            ? "stopped"
+            : `exit ${args.exitCode}`,
+      stdoutTail: args.stdoutTail ?? "",
+      stderrTail: args.stderrTail ?? "",
+      detectedPrUrl: args.prUrl ?? null,
+    };
+    if (args.exitCode === 0) this._state = "completed";
+    else if (args.exitCode === null) this._state = "stopped";
+    else this._state = "failed";
+    this.finalEvent = evt;
+    const listeners = this.listeners.slice();
+    this.listeners = [];
+    for (const l of listeners) l(evt);
+  }
+}
+
+class FakeWorkerSpawner {
+  readonly spawnedByAlias = new Map<string, FakeWorkerHandle[]>();
+  readonly destroyed: SandboxRef[] = [];
+  private counter = 0;
+
+  spawn = vi.fn(
+    async (opts: {
+      ticket: TicketLedgerEntry;
+      repoAssignment: RepoAssignment;
+      channel: Channel;
+    }) => {
+      this.counter += 1;
+      const runId = `fake-run-${this.counter}`;
+      const ticketId = opts.ticket.ticketId;
+      const alias = opts.repoAssignment.alias;
+      const worktreePath = `/tmp/fake-worktree/${alias}/${runId}/${ticketId}`;
+      const sandboxRef: SandboxRef = {
+        id: `sb-${runId}-${ticketId}`,
+        workdir: { kind: "local", path: worktreePath },
+        meta: {
+          branch: `sandbox/${runId}/${ticketId}`,
+          base: "main",
+          runId,
+          ticketId,
+          repoRoot: opts.repoAssignment.repoPath,
+        },
+      };
+      const handle = new FakeWorkerHandle(
+        ticketId,
+        `worker-sess-${this.counter}`,
+        worktreePath,
+        sandboxRef
+      );
+      const list = this.spawnedByAlias.get(alias) ?? [];
+      list.push(handle);
+      this.spawnedByAlias.set(alias, list);
+      return { handle, worktreePath, sandboxRef };
+    }
+  );
+
+  destroyWorktree = vi.fn(async (ref: SandboxRef) => {
+    this.destroyed.push(ref);
+  });
+
+  handles(alias: string): FakeWorkerHandle[] {
+    return this.spawnedByAlias.get(alias) ?? [];
+  }
+}
+
+async function waitUntil(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitUntil timed out");
+    }
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+function makeTicket(id: string, alias: string): TicketLedgerEntry {
+  return {
+    ticketId: id,
+    title: `t-${id}`,
+    specialty: "general",
+    status: "ready",
+    dependsOn: [],
+    assignedAgentId: null,
+    assignedAgentName: null,
+    crosslinkSessionId: null,
+    verification: "pending",
+    lastClassification: null,
+    chosenNextAction: null,
+    attempt: 0,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: "2026-04-21T00:00:00.000Z",
+    runId: null,
+    assignedAlias: alias,
+  };
+}
+
+interface Fixture {
+  root: string;
+  sessionId: string;
+  channel: Channel;
+  channelStore: ChannelStore;
+  lifecycle: SessionLifecycle;
+  tracker: TokenTracker;
+  adminSpawner: FakeAdminSpawner;
+  workerSpawner: FakeWorkerSpawner;
+  allowedRepos: RepoAssignment[];
+  cleanup: () => Promise<void>;
+}
+
+async function buildFixture(ticketCount = 3): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), "al-9-stop-"));
+  const channelsDir = join(root, "channels");
+  const harnessStore = new FileHarnessStore(join(root, "__hs__"));
+  const channelStore = new ChannelStore(channelsDir, harnessStore);
+
+  const assignments: RepoAssignment[] = [
+    { alias: "frontend", workspaceId: "ws-frontend", repoPath: "/tmp/fake-frontend" },
+  ];
+  const persisted = await channelStore.createChannel({
+    name: "al-9-stop",
+    description: "al-9 kill-switch test",
+    workspaceIds: ["ws-frontend"],
+    repoAssignments: assignments,
+  });
+  const channel: Channel = {
+    ...persisted,
+    repoAssignments: assignments,
+    fullAccess: false,
+  };
+
+  const tickets: TicketLedgerEntry[] = [];
+  for (let i = 1; i <= ticketCount; i++) {
+    tickets.push(makeTicket(`t-${i}`, "frontend"));
+  }
+  await channelStore.writeChannelTickets(channel.channelId, tickets);
+
+  const sessionId = `auto-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const lifecycle = new SessionLifecycle(sessionId, { rootDir: root });
+  await lifecycle.transition("dispatching", "autonomous-session-started");
+  const tracker = new TokenTracker(sessionId, 100_000, { rootDir: root });
+
+  const adminSpawner = new FakeAdminSpawner();
+  const workerSpawner = new FakeWorkerSpawner();
+
+  return {
+    root,
+    sessionId,
+    channel,
+    channelStore,
+    lifecycle,
+    tracker,
+    adminSpawner,
+    workerSpawner,
+    allowedRepos: assignments,
+    cleanup: async () => {
+      await tracker.close().catch(() => {});
+      await lifecycle.close().catch(() => {});
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function readLifecycle(
+  root: string,
+  sessionId: string
+): Promise<{ state: string; transitions: Array<{ from: string; to: string; reason?: string }> }> {
+  const raw = await readFile(join(root, "sessions", sessionId, "lifecycle.json"), "utf8");
+  return JSON.parse(raw);
+}
+
+describe("startAutonomousSession — AL-9 STOP-file kill switch", () => {
+  let cleanupFns: Array<() => Promise<void>> = [];
+  let originalPoolFlag: string | undefined;
+  let originalDrainFlag: string | undefined;
+
+  beforeEach(() => {
+    cleanupFns = [];
+    originalPoolFlag = process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    originalDrainFlag = process.env[RELAY_AL14_WORKER_DRAIN];
+    process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = "1";
+    process.env[RELAY_AL14_WORKER_DRAIN] = "1";
+  });
+
+  afterEach(async () => {
+    for (const fn of cleanupFns) await fn();
+    if (originalPoolFlag === undefined) delete process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    else process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = originalPoolFlag;
+    if (originalDrainFlag === undefined) delete process.env[RELAY_AL14_WORKER_DRAIN];
+    else process.env[RELAY_AL14_WORKER_DRAIN] = originalDrainFlag;
+  });
+
+  it("honors STOP dropped before the loop starts — no tickets routed, lifecycle killed/user-stop-signal", async () => {
+    const fx = await buildFixture(3);
+    cleanupFns.push(fx.cleanup);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    // Drop the STOP file BEFORE firing the driver. The very first
+    // pre-routing poll should observe it and transition to
+    // winding_down; no workers spawn.
+    await writeStopFile(fx.sessionId, { rootDir: fx.root, source: "test" });
+
+    await startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      // A tight poll interval keeps test latency low; production is 20s.
+      stopPollIntervalMs: 10,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    // No workers ever spawned — the STOP fired on the pre-routing poll
+    // so we never entered drain.
+    expect(fx.workerSpawner.spawn).not.toHaveBeenCalled();
+
+    // Lifecycle: the sequence is dispatching → winding_down → killed
+    // (with reason `user-stop-signal` on the terminal). The drain path
+    // carries the user-stop through to the final transition.
+    const lc = await readLifecycle(fx.root, fx.sessionId);
+    expect(lc.state).toBe("killed");
+    const final = lc.transitions[lc.transitions.length - 1];
+    expect(final.reason).toBe("user-stop-signal");
+    // The pre-terminal winding_down transition also carries the
+    // user-stop reason — downstream log consumers can grep for either.
+    const windDown = lc.transitions.find((t) => t.to === "winding_down");
+    expect(windDown?.reason).toBe("user-stop-signal");
+  }, 5_000);
+
+  it("honors STOP dropped mid-drain — in-flight worker is NOT force-stopped, later tickets still allowed to complete", async () => {
+    const fx = await buildFixture(2);
+    cleanupFns.push(fx.cleanup);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    const driverP = startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      stopPollIntervalMs: 10,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    // Wait for the first ticket to spawn (drain in progress).
+    await waitUntil(() => fx.workerSpawner.handles("frontend").length >= 1);
+    const firstHandle = fx.workerSpawner.handles("frontend")[0];
+    expect(firstHandle.ticketId).toBe("t-1");
+    // The worker's stop() must NOT have been called by anything in
+    // AL-9 — graceful wind-down respects in-flight workers.
+    expect(firstHandle.stop).not.toHaveBeenCalled();
+
+    // Drop STOP mid-drain. The background poll fires every 10ms so
+    // the lifecycle flips within one tick.
+    await writeStopFile(fx.sessionId, { rootDir: fx.root, source: "test" });
+
+    // Complete the first ticket normally — the in-flight worker is
+    // allowed to finish. The runner's serial drain then pulls the
+    // next ticket (t-2) from its own queue because t-2 was already
+    // routed before STOP landed (AL-9 does not cancel pre-routed
+    // tickets; the STOP file is advisory, not a ledger-level undo).
+    firstHandle.fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/1" });
+
+    // The second ticket was already routed before STOP fired, so it
+    // WILL spawn. That's the "respect in-flight work" contract — the
+    // runner drains its own pre-queued tickets. The lifecycle is
+    // already in `winding_down` at this point.
+    await waitUntil(() => fx.workerSpawner.handles("frontend").length >= 2);
+    const secondHandle = fx.workerSpawner.handles("frontend")[1];
+    secondHandle.fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/2" });
+
+    await driverP;
+
+    // The in-flight worker's stop() should have been called only
+    // during teardown (autonomous-loop-exit), NOT during the STOP
+    // poll. We can't assert "never" here because the finally block
+    // calls r.stop() which cascades; but we CAN assert it was not
+    // called BEFORE the worker fired its own completion — i.e. the
+    // exit was driven by the test's `fire`, not by SIGTERM.
+    //
+    // The equivalent check: the first worker's final state is
+    // "completed" (exit 0), not "stopped" (exit null from a SIGTERM).
+    expect(firstHandle.state).toBe("completed");
+
+    // Lifecycle: dispatching → winding_down → killed, terminal reason
+    // carries user-stop-signal.
+    const lc = await readLifecycle(fx.root, fx.sessionId);
+    expect(lc.state).toBe("killed");
+    expect(lc.transitions[lc.transitions.length - 1].reason).toBe("user-stop-signal");
+    const windDown = lc.transitions.find((t) => t.to === "winding_down");
+    expect(windDown?.reason).toBe("user-stop-signal");
+  }, 10_000);
+
+  it("does not trigger winding_down when the STOP file is absent (idle loop reaches al-16-pending)", async () => {
+    // Regression guard: AL-9 must not fire the kill switch spuriously.
+    // A session with zero STOP activity should follow the AL-14 terminal
+    // path (killed / al-16-pending).
+    const fx = await buildFixture(1);
+    cleanupFns.push(fx.cleanup);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    const driverP = startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      stopPollIntervalMs: 10,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    await waitUntil(() => fx.workerSpawner.handles("frontend").length >= 1);
+    fx.workerSpawner
+      .handles("frontend")[0]
+      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/1" });
+
+    await driverP;
+
+    const lc = await readLifecycle(fx.root, fx.sessionId);
+    expect(lc.state).toBe("killed");
+    // Natural terminal, not user-stop.
+    expect(lc.transitions[lc.transitions.length - 1].reason).toBe("al-16-pending");
+    // No winding_down transition ever landed.
+    expect(lc.transitions.find((t) => t.to === "winding_down")).toBeUndefined();
+  }, 10_000);
+
+  it("audit gate: all-green ledger after user stop logs audit-eligible; non-green ledger logs skip", async () => {
+    // This verifies AL-9's AC3: "Killed session still runs post-
+    // completion audit IF ledger was all-green before kill; otherwise
+    // skips audit." AL-6 isn't merged so the actual audit call is a
+    // structured log line; we key on that so the AL-6 merge lands as
+    // a drop-in.
+    const fx = await buildFixture(1);
+    cleanupFns.push(fx.cleanup);
+
+    const logLines: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logLines.push(args.map((a) => String(a)).join(" "));
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanupFns.push(async () => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    // Drop STOP before the loop starts — no tickets are routed,
+    // ledger remains "all pending/ready" (no failed tickets), which
+    // counts as all-green under AL-9's rule (nothing unhealthy).
+    await writeStopFile(fx.sessionId, { rootDir: fx.root, source: "test" });
+
+    await startAutonomousSession({
+      sessionId: fx.sessionId,
+      channel: fx.channel,
+      tracker: fx.tracker,
+      lifecycle: fx.lifecycle,
+      trust: "supervised",
+      allowedRepos: fx.allowedRepos,
+      stopPollIntervalMs: 10,
+      testOverrides: {
+        channelStore: fx.channelStore,
+        repoAdminSpawner: fx.adminSpawner,
+        workerSpawner: fx.workerSpawner as unknown as WorkerSpawner,
+        rootDir: fx.root,
+      },
+    });
+
+    const auditEligible = logLines.find((l) => l.includes("post-completion audit eligible"));
+    const auditSkipped = logLines.find((l) => l.includes("skipping post-completion audit"));
+
+    expect(auditEligible).toBeDefined();
+    expect(auditEligible).toContain("trigger=user-stop-signal");
+    expect(auditSkipped).toBeUndefined();
+  }, 5_000);
+});

--- a/test/orchestrator/stop-file-watcher.test.ts
+++ b/test/orchestrator/stop-file-watcher.test.ts
@@ -1,0 +1,170 @@
+/**
+ * AL-9 — STOP-file watcher unit tests.
+ *
+ * Covers the file-level contract:
+ *   - `checkForStop` returns false when the file is absent, true once
+ *     it exists (and never reads contents — presence is the signal).
+ *   - `writeStopFile` is atomic (tmp + rename) so a concurrent
+ *     `checkForStop` cannot observe a half-written file.
+ *   - `writeStopFile` creates the session dir if missing so an operator
+ *     can race the autonomous-loop's lazy-mkdir and still land.
+ *   - `clearStopFile` is idempotent (ENOENT is a no-op) and actually
+ *     removes the file.
+ *   - stat errors other than ENOENT surface to the caller.
+ *
+ * The integration coverage (STOP flips lifecycle + respects in-flight
+ * workers) lives in `autonomous-loop-drain.test.ts` — keeping the
+ * watcher unit tests minimal here so the file is the obvious single
+ * source for watcher behaviour.
+ */
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_STOP_POLL_INTERVAL_MS,
+  STOP_FILE_NAME,
+  STOP_FILE_REASON,
+  checkForStop,
+  clearStopFile,
+  stopFilePath,
+  writeStopFile,
+} from "../../src/orchestrator/stop-file-watcher.js";
+
+describe("stop-file-watcher", () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await mkdtempUnique();
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  async function mkdtempUnique(): Promise<string> {
+    const { mkdtemp } = await import("node:fs/promises");
+    return mkdtemp(join(tmpdir(), "al-9-stop-file-"));
+  }
+
+  describe("stopFilePath", () => {
+    it("resolves to <root>/sessions/<sessionId>/STOP", () => {
+      const path = stopFilePath("sess-abc", rootDir);
+      expect(path).toBe(join(rootDir, "sessions", "sess-abc", STOP_FILE_NAME));
+    });
+
+    it("pins STOP_FILE_NAME as 'STOP' (literal, not an extension) so the CLI wire protocol is stable", () => {
+      expect(STOP_FILE_NAME).toBe("STOP");
+    });
+  });
+
+  describe("checkForStop", () => {
+    it("returns false when the file does not exist", async () => {
+      const present = await checkForStop("sess-missing", rootDir);
+      expect(present).toBe(false);
+    });
+
+    it("returns false when the session dir itself does not exist (ENOENT path)", async () => {
+      // Explicitly DO NOT mkdir — we want to confirm the ENOENT path
+      // for both "parent missing" and "file missing" resolves the same.
+      const present = await checkForStop("never-created", rootDir);
+      expect(present).toBe(false);
+    });
+
+    it("returns true once the STOP file is present", async () => {
+      const sessionId = "sess-present";
+      const dir = join(rootDir, "sessions", sessionId);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, STOP_FILE_NAME), "", "utf8");
+
+      const present = await checkForStop(sessionId, rootDir);
+      expect(present).toBe(true);
+    });
+
+    it("does not read contents — an empty file counts as the stop signal", async () => {
+      const sessionId = "sess-empty";
+      const dir = join(rootDir, "sessions", sessionId);
+      await mkdir(dir, { recursive: true });
+      // Zero-byte file. If the watcher tried to parse JSON it would throw.
+      await writeFile(join(dir, STOP_FILE_NAME), "", "utf8");
+
+      const present = await checkForStop(sessionId, rootDir);
+      expect(present).toBe(true);
+    });
+  });
+
+  describe("writeStopFile", () => {
+    it("creates the session dir if missing", async () => {
+      // Sanity: the dir doesn't exist yet. writeStopFile must mkdir -p.
+      const sessionId = "sess-new";
+      const sessDir = join(rootDir, "sessions", sessionId);
+      await expect(stat(sessDir)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const path = await writeStopFile(sessionId, { rootDir, source: "test" });
+      expect(path).toBe(join(sessDir, STOP_FILE_NAME));
+      // File is readable and parses as JSON with the expected shape.
+      const raw = await readFile(path, "utf8");
+      const body = JSON.parse(raw);
+      expect(body.sessionId).toBe(sessionId);
+      expect(body.source).toBe("test");
+      expect(typeof body.requestedAt).toBe("string");
+    });
+
+    it("is observable by checkForStop immediately after resolution", async () => {
+      const sessionId = "sess-roundtrip";
+      await writeStopFile(sessionId, { rootDir, source: "test" });
+      const present = await checkForStop(sessionId, rootDir);
+      expect(present).toBe(true);
+    });
+
+    it("overwrites atomically — the final file is the newest write", async () => {
+      const sessionId = "sess-overwrite";
+      await writeStopFile(sessionId, { rootDir, source: "first" });
+      await writeStopFile(sessionId, { rootDir, source: "second" });
+      const raw = await readFile(stopFilePath(sessionId, rootDir), "utf8");
+      const body = JSON.parse(raw);
+      expect(body.source).toBe("second");
+    });
+
+    it("rejects empty sessionId to prevent writing into the sessions root", async () => {
+      await expect(writeStopFile("", { rootDir })).rejects.toThrow(/sessionId is required/);
+    });
+
+    it("defaults source to 'unknown' when not provided (auditability)", async () => {
+      const sessionId = "sess-defaultsource";
+      await writeStopFile(sessionId, { rootDir });
+      const raw = await readFile(stopFilePath(sessionId, rootDir), "utf8");
+      expect(JSON.parse(raw).source).toBe("unknown");
+    });
+  });
+
+  describe("clearStopFile", () => {
+    it("removes a present STOP file", async () => {
+      const sessionId = "sess-clear";
+      await writeStopFile(sessionId, { rootDir });
+      expect(await checkForStop(sessionId, rootDir)).toBe(true);
+      await clearStopFile(sessionId, rootDir);
+      expect(await checkForStop(sessionId, rootDir)).toBe(false);
+    });
+
+    it("is a no-op when the file does not exist", async () => {
+      // Must not throw — operators un-stopping a session before the
+      // loop picked up the signal should be safe to retry.
+      await expect(clearStopFile("sess-missing", rootDir)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("exported constants", () => {
+    it("STOP_FILE_REASON is the stable reason string the lifecycle stamps on transitions", () => {
+      // Downstream tools grep for this — changing it is a breaking
+      // change for dashboards / log pipelines.
+      expect(STOP_FILE_REASON).toBe("user-stop-signal");
+    });
+
+    it("DEFAULT_STOP_POLL_INTERVAL_MS matches the 20s AC upper bound", () => {
+      expect(DEFAULT_STOP_POLL_INTERVAL_MS).toBe(20_000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/orchestrator/stop-file-watcher.ts` with `checkForStop` / `writeStopFile` / `clearStopFile` + stable `STOP_FILE_REASON` / `DEFAULT_STOP_POLL_INTERVAL_MS` constants. Atomic tmp+rename writes so a concurrent poll never observes a torn file.
- Wires polling into `startAutonomousSession` at three tick sites: pre-routing, between tickets in the routing loop, and a background poll during drain (configurable via `stopPollIntervalMs`, default 20s). Observed STOP flips lifecycle from `dispatching` to `winding_down` with reason `user-stop-signal`; in-flight workers are NOT force-stopped.
- `rly session stop <sessionId>` CLI subcommand + `stop_session` Tauri command (AL-10 wires the actual button).
- Post-completion audit gate: after terminal, inspects the channel's ticket ledger — audit runs when every ticket is green (no `failed` / `retry` / `executing` / `verifying`), skipped otherwise. AL-6's real `runAudit()` slots into the log site as a drop-in.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 747 passing, 23 skipped (flaky `file-store.test.ts` sandbox EACCES is unrelated; passes in isolation)
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `cargo check --workspace`
- [x] New: `test/orchestrator/stop-file-watcher.test.ts` (15 cases) + `test/orchestrator/autonomous-loop-stop-file.test.ts` (4 cases covering pre-loop STOP, mid-drain STOP, no-STOP regression, and audit-gate log)

Closes #84

Depends on AL-4 (not yet merged) — based on `origin/feat/al-16-coordination-protocol` so AL-4's driver picks up the `checkForStop` hook naturally on merge.

Do NOT merge until reviewed.