### PR TITLE
AL-10: GUI session status header + approvals panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,6 +3133,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "tempfile",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -18,3 +18,6 @@ serde_json = "1"
 notify = "6"
 chrono = "0.4"
 harness-data = { path = "../../crates/harness-data" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1756,6 +1756,293 @@ fn load_live_crosslink_repos() -> std::collections::HashSet<String> {
 }
 
 // -----------------------------------------------------------------------------
+// AL-10: Autonomous session readers + kill switch
+// -----------------------------------------------------------------------------
+//
+// The autonomous driver (AL-3/AL-4) writes three files per session under
+// `~/.relay/sessions/<sessionId>/`:
+//
+//   - `metadata.json`   — one-shot record of the flags + channelId the session
+//                         was spawned with. Written once at startup.
+//   - `lifecycle.json`  — state-machine snapshot, rewritten atomically on
+//                         every transition (planning → dispatching → ...).
+//   - `budget.jsonl`    — append-only JSONL of per-API-call token increments.
+//                         Each line includes a cumulative total.
+//   - `approvals.jsonl` — append-only approval queue (AL-8). Stubbed here;
+//                         we read it opportunistically — missing file == empty.
+//   - `STOP`            — sentinel file. AL-9's `stop_session` drops it; the
+//                         driver watches for it and shuts down cleanly.
+//
+// These readers tolerate partial / missing / corrupted files — a GUI that
+// polls every 5s cannot afford to throw on a torn write mid-rename.
+// Everything is best-effort and returns `None` / empty defaults when the
+// on-disk state isn't parseable.
+
+/// Lightweight header row for the session list — just enough to let the
+/// CenterPane find the active session for the selected channel without
+/// loading lifecycle/budget for every candidate.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct AutonomousSessionSummary {
+    session_id: String,
+    channel_id: String,
+    state: String,
+    started_at: String,
+    trust: String,
+}
+
+/// Full session snapshot returned by `get_session_state`. Field names mirror
+/// the metadata/lifecycle/budget on-disk shapes one-to-one so the frontend
+/// can surface them without an adapter layer.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct AutonomousSessionState {
+    session_id: String,
+    channel_id: String,
+    state: String,
+    trust: String,
+    budget_tokens: u64,
+    budget_used: u64,
+    budget_pct: f64,
+    max_hours: f64,
+    started_at: String,
+    /// ISO timestamp of the most recent lifecycle transition. Useful for the
+    /// header's "state changed Xm ago" line if we ever want to surface it.
+    updated_at: String,
+    /// Hours of wall-clock budget remaining. Clamped to 0 when the session
+    /// has exceeded `max_hours` (the lifecycle watchdog will have killed it
+    /// by then anyway; the UI just needs a non-negative number).
+    hours_remaining: f64,
+    /// Best-effort current-ticket id. Derived from the most recent ticket
+    /// the repo-admin coordinator is working on. When AL-16's coordinator
+    /// state hasn't surfaced a ticket yet, this is `None`.
+    current_ticket_id: Option<String>,
+    allowed_repos: Vec<String>,
+}
+
+#[derive(Deserialize)]
+// `sessionId` / `startedAt` / `maxDurationMs` are carried so serde validates
+// the file shape (reject a lifecycle.json that's a totally different
+// struct), but only `state` + `transitions` are read at the moment. The
+// allow silences dead_code warnings that would otherwise fire on the
+// defensive fields.
+#[allow(dead_code)]
+struct LifecycleFileRaw {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    state: String,
+    #[serde(rename = "startedAt")]
+    started_at: String,
+    #[serde(rename = "maxDurationMs", default)]
+    max_duration_ms: u64,
+    #[serde(default)]
+    transitions: Vec<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct MetadataFileRaw {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    #[serde(rename = "channelId")]
+    channel_id: String,
+    #[serde(rename = "budgetTokens")]
+    budget_tokens: u64,
+    #[serde(rename = "maxHours")]
+    max_hours: f64,
+    #[serde(default)]
+    trust: String,
+    #[serde(rename = "allowedRepos", default)]
+    allowed_repos: Vec<String>,
+    #[serde(rename = "startedAt")]
+    started_at: String,
+}
+
+/// Directory that holds all autonomous session subdirs. We accept the
+/// `RELAY_HARNESS_ROOT` override that `harness-data` already honors so the
+/// tauri backend lines up with the CLI's world view in tests and remote
+/// workspace setups.
+fn autonomous_sessions_root() -> PathBuf {
+    data::harness_root().join("sessions")
+}
+
+/// Best-effort read of `metadata.json`. Returns `None` when the file is
+/// missing, unreadable, or fails to parse — autonomous sessions spawned by
+/// old builds or torn writes mid-rename land here and we skip them silently.
+fn read_session_metadata(session_id: &str) -> Option<MetadataFileRaw> {
+    let path = autonomous_sessions_root().join(session_id).join("metadata.json");
+    let raw = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn read_session_lifecycle(session_id: &str) -> Option<LifecycleFileRaw> {
+    let path = autonomous_sessions_root().join(session_id).join("lifecycle.json");
+    let raw = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Sum the cumulative token usage from `budget.jsonl`. The last line's
+/// `cumulativeUsed` is authoritative — the tracker maintains it invariant
+/// under concurrent records. Fall back to summing increments so a
+/// hand-edited file still produces a sane total.
+fn read_session_budget_used(session_id: &str) -> u64 {
+    // I4: budget.jsonl is written by the TokenTracker (AL-1), which ALWAYS
+    // stamps `cumulativeUsed` on every line. The previous implementation
+    // had a "sum input+output if cumulativeUsed is missing" fallback that
+    // double-counted when the two shapes interleaved — an older partial
+    // file combined with newer canonical lines gave a value higher than
+    // the true cumulative. Dropping the fallback: if a line lacks
+    // `cumulativeUsed` it's either legacy noise or a malformed record,
+    // neither of which should bump the total. The last well-formed
+    // cumulative wins; an entirely empty file returns 0.
+    let path = autonomous_sessions_root().join(session_id).join("budget.jsonl");
+    let Ok(file) = fs::File::open(&path) else {
+        return 0;
+    };
+    let mut last_cumulative: u64 = 0;
+    for line in BufReader::new(file).lines().flatten() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if let Some(c) = value.get("cumulativeUsed").and_then(|v| v.as_u64()) {
+            last_cumulative = c;
+        }
+    }
+    last_cumulative
+}
+
+/// Walks `~/.relay/sessions/` and returns a summary for every session whose
+/// metadata.json is readable. Intended for the CenterPane's channel →
+/// session lookup — one call, O(sessions) disk reads.
+#[tauri::command]
+fn list_autonomous_sessions() -> Vec<AutonomousSessionSummary> {
+    let root = autonomous_sessions_root();
+    let Ok(entries) = fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Skip hidden + malformed directory names. The harness-data guard is
+        // path-based so a rogue `..` directory can't materialize, but we
+        // still defend against it for clarity.
+        if validate_id_segment(name, "sessionId").is_err() {
+            continue;
+        }
+        let Some(meta) = read_session_metadata(name) else {
+            continue;
+        };
+        let state = read_session_lifecycle(name)
+            .map(|lc| lc.state)
+            .unwrap_or_else(|| "planning".to_string());
+        out.push(AutonomousSessionSummary {
+            session_id: meta.session_id,
+            channel_id: meta.channel_id,
+            state,
+            started_at: meta.started_at,
+            trust: meta.trust,
+        });
+    }
+    // Most-recent first. The startedAt string is ISO-8601 so lexicographic
+    // ordering matches chronological ordering.
+    out.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+    out
+}
+
+/// Deep state for one session — metadata + lifecycle + budget summary fused
+/// into the shape the AutonomousSessionHeader renders directly.
+#[tauri::command]
+fn get_session_state(session_id: String) -> Result<Option<AutonomousSessionState>, String> {
+    validate_id_segment(&session_id, "sessionId")?;
+    let Some(meta) = read_session_metadata(&session_id) else {
+        return Ok(None);
+    };
+    let lifecycle = read_session_lifecycle(&session_id);
+    let state = lifecycle.as_ref().map(|lc| lc.state.clone()).unwrap_or_else(|| "planning".into());
+    let updated_at = lifecycle
+        .as_ref()
+        .and_then(|lc| {
+            lc.transitions
+                .last()
+                .and_then(|t| t.get("at").and_then(|v| v.as_str()).map(String::from))
+        })
+        .unwrap_or_else(|| meta.started_at.clone());
+
+    let budget_used = read_session_budget_used(&session_id);
+    let budget_pct = if meta.budget_tokens == 0 {
+        0.0
+    } else {
+        (budget_used as f64 / meta.budget_tokens as f64) * 100.0
+    };
+
+    let hours_remaining = {
+        let started_ms = chrono::DateTime::parse_from_rfc3339(&meta.started_at)
+            .map(|d| d.timestamp_millis())
+            .unwrap_or(0);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let elapsed_ms = (now_ms - started_ms).max(0) as f64;
+        let total_ms = meta.max_hours * 3600.0 * 1000.0;
+        let remaining_ms = (total_ms - elapsed_ms).max(0.0);
+        remaining_ms / (3600.0 * 1000.0)
+    };
+
+    // Current ticket is best-effort — the coordinator hasn't converged on a
+    // single canonical place to write it as of AL-16. When AL-17 lands a
+    // dedicated `current.json` we'll read it here; until then we return None
+    // and the header gracefully omits the row.
+    let current_ticket_id = read_current_ticket_id(&session_id);
+
+    Ok(Some(AutonomousSessionState {
+        session_id: meta.session_id,
+        channel_id: meta.channel_id,
+        state,
+        trust: meta.trust,
+        budget_tokens: meta.budget_tokens,
+        budget_used,
+        budget_pct,
+        max_hours: meta.max_hours,
+        started_at: meta.started_at,
+        updated_at,
+        hours_remaining,
+        current_ticket_id,
+        allowed_repos: meta.allowed_repos,
+    }))
+}
+
+/// Optional `current.json` reader. The autonomous loop may write a pointer
+/// to the ticket a worker is currently processing; the shape is
+/// `{"ticketId": "<id>"}`. Returns `None` when the file is missing or
+/// malformed — the header just hides the row in that case.
+fn read_current_ticket_id(session_id: &str) -> Option<String> {
+    let path = autonomous_sessions_root().join(session_id).join("current.json");
+    let raw = fs::read_to_string(&path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    value
+        .get("ticketId")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+/// Drops the `STOP` sentinel file into the session directory. Stub for
+/// AL-9 — when AL-9 merges, its implementation will supersede this one (or
+// AL-10 B1: `stop_session` is owned by AL-9 (see the definition earlier in
+// this file — search for `fn stop_session`). The AL-10 duplicate was
+// dropped during the AL-9/AL-10 inter-PR merge so there is only one
+// canonical STOP-file writer.
+//
+// AL-10 B2/B3: `list_session_approvals` / `resolve_session_approval` +
+// the `SessionApproval` struct were also dropped here. AL-8 now owns the
+// GUI approvals surface via `list_pending_approvals` / `approve_queue_entry`
+// / `reject_queue_entry` / `approve_queue_all` — delegating to AL-7's
+// canonical `ApprovalsQueue` writer. AL-10 keeps only the session-status
+// header (`list_autonomous_sessions`, `get_session_state`).
+
+// -----------------------------------------------------------------------------
 // Unit tests
 // -----------------------------------------------------------------------------
 //
@@ -2117,6 +2404,153 @@ mod tests {
         let got = detect_terminal(WINDOWS_TERMINAL_CHAIN, |n| present.contains(&n));
         assert_eq!(got.as_deref(), Some("cmd.exe"));
     }
+
+    // --- AL-10 autonomous session readers ---
+    //
+    // Build a fake `~/.relay/sessions/<sessionId>/` tree under a tmpdir,
+    // point `RELAY_HARNESS_ROOT` at it, and assert the readers produce the
+    // same shape the header renders against. Using the env-var override
+    // instead of a fn-level injection keeps the command surface unchanged
+    // (the commands call `harness_data::harness_root()` directly).
+    //
+    // We deliberately keep these tests single-threaded via a module-local
+    // Mutex — `RELAY_HARNESS_ROOT` is process-global and parallel tests
+    // would step on each other's fixtures.
+
+    use std::sync::Mutex as TestMutex;
+    static RELAY_ROOT_LOCK: TestMutex<()> = TestMutex::new(());
+
+    fn with_fake_relay_root<F: FnOnce(&std::path::Path)>(f: F) {
+        let _guard = RELAY_ROOT_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var("RELAY_HARNESS_ROOT").ok();
+        std::env::set_var("RELAY_HARNESS_ROOT", tmp.path());
+        f(tmp.path());
+        match prev {
+            Some(v) => std::env::set_var("RELAY_HARNESS_ROOT", v),
+            None => std::env::remove_var("RELAY_HARNESS_ROOT"),
+        }
+    }
+
+    fn write_session_fixture(
+        root: &std::path::Path,
+        session_id: &str,
+        channel_id: &str,
+        budget_tokens: u64,
+        used: u64,
+        state: &str,
+        max_hours: f64,
+    ) {
+        let dir = root.join("sessions").join(session_id);
+        fs::create_dir_all(&dir).unwrap();
+        let started_at = chrono::Utc::now().to_rfc3339();
+        let metadata = serde_json::json!({
+            "sessionId": session_id,
+            "channelId": channel_id,
+            "budgetTokens": budget_tokens,
+            "maxHours": max_hours,
+            "maxHoursRequested": max_hours,
+            "trust": "supervised",
+            "allowedRepos": ["repo-a"],
+            "startedAt": started_at,
+            "command": "rly run --autonomous",
+            "invokedBy": { "user": "test", "host": "test" },
+        });
+        fs::write(dir.join("metadata.json"), metadata.to_string()).unwrap();
+        let lifecycle = serde_json::json!({
+            "sessionId": session_id,
+            "state": state,
+            "startedAt": started_at,
+            "transitions": [],
+            "maxDurationMs": (max_hours * 3600.0 * 1000.0) as u64,
+        });
+        fs::write(dir.join("lifecycle.json"), lifecycle.to_string()).unwrap();
+        if used > 0 {
+            let line = serde_json::json!({
+                "ts": started_at,
+                "inputTokens": used,
+                "outputTokens": 0,
+                "cumulativeUsed": used,
+            });
+            fs::write(dir.join("budget.jsonl"), format!("{}\n", line)).unwrap();
+        }
+    }
+
+    #[test]
+    fn list_autonomous_sessions_empty_on_no_root() {
+        with_fake_relay_root(|_| {
+            assert!(list_autonomous_sessions().is_empty());
+        });
+    }
+
+    #[test]
+    fn list_autonomous_sessions_surfaces_well_formed_sessions() {
+        with_fake_relay_root(|root| {
+            write_session_fixture(root, "auto-a", "channel-1", 10_000, 2_500, "dispatching", 8.0);
+            write_session_fixture(root, "auto-b", "channel-2", 10_000, 0, "planning", 8.0);
+            let sessions = list_autonomous_sessions();
+            assert_eq!(sessions.len(), 2);
+            let by_id: std::collections::HashMap<_, _> =
+                sessions.iter().map(|s| (s.session_id.as_str(), s)).collect();
+            assert_eq!(by_id["auto-a"].channel_id, "channel-1");
+            assert_eq!(by_id["auto-a"].state, "dispatching");
+            assert_eq!(by_id["auto-b"].state, "planning");
+        });
+    }
+
+    #[test]
+    fn list_autonomous_sessions_skips_corrupt_metadata() {
+        with_fake_relay_root(|root| {
+            // A directory with no metadata.json at all.
+            fs::create_dir_all(root.join("sessions").join("auto-orphan")).unwrap();
+            // A directory whose metadata.json isn't JSON.
+            let bad = root.join("sessions").join("auto-bad");
+            fs::create_dir_all(&bad).unwrap();
+            fs::write(bad.join("metadata.json"), "{ not json").unwrap();
+            // A valid session alongside.
+            write_session_fixture(root, "auto-ok", "channel-1", 10_000, 0, "planning", 8.0);
+
+            let sessions = list_autonomous_sessions();
+            assert_eq!(sessions.len(), 1);
+            assert_eq!(sessions[0].session_id, "auto-ok");
+        });
+    }
+
+    #[test]
+    fn get_session_state_computes_budget_pct_and_hours_remaining() {
+        with_fake_relay_root(|root| {
+            write_session_fixture(root, "auto-a", "channel-1", 10_000, 2_500, "dispatching", 8.0);
+            let state = get_session_state("auto-a".into()).unwrap().unwrap();
+            assert_eq!(state.budget_used, 2_500);
+            assert!((state.budget_pct - 25.0).abs() < 0.01);
+            assert!(state.hours_remaining > 0.0 && state.hours_remaining <= 8.0);
+            assert_eq!(state.state, "dispatching");
+        });
+    }
+
+    #[test]
+    fn get_session_state_handles_zero_budget_without_dividing_by_zero() {
+        with_fake_relay_root(|root| {
+            write_session_fixture(root, "auto-a", "channel-1", 0, 0, "planning", 1.0);
+            let state = get_session_state("auto-a".into()).unwrap().unwrap();
+            assert_eq!(state.budget_pct, 0.0);
+        });
+    }
+
+    #[test]
+    fn get_session_state_returns_none_for_unknown_session() {
+        with_fake_relay_root(|_| {
+            let state = get_session_state("auto-nope".into()).unwrap();
+            assert!(state.is_none());
+        });
+    }
+
+    // AL-10 B1/B2/B3: stop_session / list_session_approvals /
+    // resolve_session_approval tests were removed. AL-9's stop_session
+    // is covered by its own tests (search earlier in the tests module);
+    // AL-8's queue surfaces carry their own test coverage via
+    // `test/approvals/queue.test.ts` and the harness-data crate's
+    // `ApprovalQueueRecord` parser tests.
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -2166,10 +2600,15 @@ pub fn run() {
             list_pending_plans,
             approve_plan,
             reject_plan,
+            // AL-8 approvals surface.
             list_pending_approvals,
             approve_queue_entry,
             reject_queue_entry,
             approve_queue_all,
+            // AL-10 session-status header. `stop_session` is registered
+            // earlier (AL-9 owner); AL-10's duplicate was dropped.
+            list_autonomous_sessions,
+            get_session_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -1,7 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
+  AgentNameEntry,
   ApprovalQueueRecord,
+  AutonomousSessionState,
+  AutonomousSessionSummary,
   Channel,
   ChannelEntry,
   ChannelRunLink,
@@ -17,7 +20,6 @@ import type {
   TicketLedgerEntry,
   TrackedPrRow,
   WorkspaceEntry,
-  AgentNameEntry,
 } from "./types";
 
 export const api = {
@@ -172,6 +174,18 @@ export const api = {
   rejectQueueEntry: (id: string, feedback?: string) =>
     invoke<unknown>("reject_queue_entry", { id, feedback }),
   approveQueueAll: (sessionId?: string) => invoke<unknown>("approve_queue_all", { sessionId }),
+
+  // AL-10: autonomous-session status readers. All three are no-op friendly —
+  // they return empty / None when the on-disk files are missing, so the GUI
+  // can poll them every 5s without plumbing a "session exists" predicate
+  // ahead of each call.
+  listAutonomousSessions: () => invoke<AutonomousSessionSummary[]>("list_autonomous_sessions"),
+  getSessionState: (sessionId: string) =>
+    invoke<AutonomousSessionState | null>("get_session_state", { sessionId }),
+  // AL-9 owns the kill-switch command — writes a STOP file under the
+  // session dir for the autonomous driver to observe. AL-10 reuses it
+  // for the session-header stop button.
+  stopSession: (sessionId: string) => invoke<void>("stop_session", { sessionId }),
 };
 
 export type ChatEvent =

--- a/gui/src/components/AutonomousSessionHeader.test.tsx
+++ b/gui/src/components/AutonomousSessionHeader.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatHoursForTesting,
+  formatPctForTesting,
+  prettyStateForTesting,
+  tokenPctSeverityForTesting,
+} from "./AutonomousSessionHeader";
+
+// These helpers encode the AL-10 acceptance-criteria math (tokens %, hours
+// remaining, severity tiers). Testing them directly instead of through the
+// React tree keeps the assertions stable even if the markup shifts.
+
+describe("AutonomousSessionHeader formatters", () => {
+  it("formatPct rounds and appends % for finite numbers", () => {
+    expect(formatPctForTesting(0)).toBe("0%");
+    expect(formatPctForTesting(24.4)).toBe("24%");
+    expect(formatPctForTesting(24.6)).toBe("25%");
+    expect(formatPctForTesting(100)).toBe("100%");
+  });
+
+  it("formatPct returns em dash for non-finite inputs", () => {
+    expect(formatPctForTesting(NaN)).toBe("—");
+    expect(formatPctForTesting(Infinity)).toBe("—");
+  });
+
+  it("formatHours prefers minutes under an hour", () => {
+    expect(formatHoursForTesting(0)).toBe("0m");
+    expect(formatHoursForTesting(0.5)).toBe("30m");
+    expect(formatHoursForTesting(0.01)).toBe("1m");
+  });
+
+  it("formatHours uses Xh Ym for multi-hour durations", () => {
+    expect(formatHoursForTesting(1)).toBe("1h");
+    expect(formatHoursForTesting(1.5)).toBe("1h 30m");
+    expect(formatHoursForTesting(8)).toBe("8h");
+    expect(formatHoursForTesting(7.25)).toBe("7h 15m");
+  });
+
+  it("formatHours returns em dash for negative or non-finite inputs", () => {
+    expect(formatHoursForTesting(-1)).toBe("—");
+    expect(formatHoursForTesting(NaN)).toBe("—");
+  });
+
+  it("prettyState maps the lifecycle enum to display strings", () => {
+    expect(prettyStateForTesting("planning")).toBe("Planning");
+    expect(prettyStateForTesting("dispatching")).toBe("Dispatching");
+    expect(prettyStateForTesting("winding_down")).toBe("Winding down");
+    expect(prettyStateForTesting("audit")).toBe("Audit");
+    expect(prettyStateForTesting("done")).toBe("Done");
+    expect(prettyStateForTesting("killed")).toBe("Killed");
+  });
+
+  it("prettyState passes unknown states through verbatim", () => {
+    expect(prettyStateForTesting("future_state_abc")).toBe("future_state_abc");
+  });
+
+  it("tokenPctSeverity tiers match AL-1 threshold crossings", () => {
+    expect(tokenPctSeverityForTesting(0)).toBe("ok");
+    expect(tokenPctSeverityForTesting(59.9)).toBe("ok");
+    expect(tokenPctSeverityForTesting(60)).toBe("warn");
+    expect(tokenPctSeverityForTesting(84.9)).toBe("warn");
+    expect(tokenPctSeverityForTesting(85)).toBe("hot");
+    expect(tokenPctSeverityForTesting(99.9)).toBe("hot");
+    expect(tokenPctSeverityForTesting(100)).toBe("overrun");
+    expect(tokenPctSeverityForTesting(120)).toBe("overrun");
+  });
+});

--- a/gui/src/components/AutonomousSessionHeader.tsx
+++ b/gui/src/components/AutonomousSessionHeader.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useState } from "react";
+import { api } from "../api";
+import type { AutonomousSessionState } from "../types";
+
+type Props = {
+  sessionId: string;
+  refreshTick: number;
+  onStopped?: () => void;
+};
+
+/**
+ * AL-10: compact status strip rendered inside the CenterPane whenever the
+ * selected channel has an active autonomous session attached. Polls
+ * `get_session_state` on every parent `refreshTick` bump (App runs a 5s
+ * interval) so tokens %, hours remaining, and lifecycle state stay fresh
+ * without the header managing its own interval.
+ *
+ * No-flicker policy: when a poll fails or the session disappears mid-tick,
+ * the header keeps rendering the last-known state rather than blanking.
+ * Only when `get_session_state` resolves to `null` (session terminated)
+ * AND the previous state was terminal (`done`/`killed`) do we stop
+ * rendering, because the user should see the final state briefly before
+ * the strip unmounts.
+ *
+ * Theme: every color comes from `--color-*` tokens (tokens.css). No
+ * hex drift; the header reads as part of the existing Catppuccin palette.
+ */
+export function AutonomousSessionHeader({ sessionId, refreshTick, onStopped }: Props) {
+  const [state, setState] = useState<AutonomousSessionState | null>(null);
+  const [fetching, setFetching] = useState(false);
+  const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const [stopError, setStopError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setFetching(true);
+    api
+      .getSessionState(sessionId)
+      .then((next) => {
+        if (cancelled) return;
+        // Preserve previous snapshot on transient nulls — lifecycle.json
+        // is rewritten atomically but a narrow window exists where the
+        // rename finishes before the metadata read lands. Next tick will
+        // resync. Only clear when we're sure the session is gone (state
+        // returned null AND metadata was never present for it).
+        if (next !== null) setState(next);
+      })
+      .catch((err) => {
+        console.warn("[autonomous-header] getSessionState failed", err);
+      })
+      .finally(() => {
+        if (!cancelled) setFetching(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, refreshTick]);
+
+  if (!state) {
+    // First-poll state. Render a placeholder row so the CenterPane layout
+    // doesn't jump when the fetch resolves — the strip is load-bearing for
+    // vertical alignment beneath the channel header.
+    return <div className="autonomous-session-header autonomous-session-header--pending" />;
+  }
+
+  const terminal = state.state === "done" || state.state === "killed";
+  const budgetPctLabel = formatPct(state.budgetPct);
+  const hoursRemainingLabel = formatHours(state.hoursRemaining);
+  const tokenSeverity = tokenPctSeverity(state.budgetPct);
+
+  const requestStop = () => {
+    setStopError(null);
+    setStopConfirmOpen(true);
+  };
+
+  const confirmStop = async () => {
+    setStopping(true);
+    setStopError(null);
+    try {
+      await api.stopSession(sessionId);
+      setStopConfirmOpen(false);
+      onStopped?.();
+    } catch (err) {
+      setStopError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setStopping(false);
+    }
+  };
+
+  return (
+    <div
+      className={`autonomous-session-header autonomous-session-header--state-${state.state}`}
+      data-fetching={fetching ? "true" : "false"}
+    >
+      <div className="autonomous-session-header__row">
+        <span className={`autonomous-session-header__pill pill-state-${state.state}`}>
+          {prettyState(state.state)}
+        </span>
+        <span className="autonomous-session-header__trust">
+          trust: <strong>{state.trust || "supervised"}</strong>
+        </span>
+        <span className={`autonomous-session-header__metric metric--tokens-${tokenSeverity}`}>
+          tokens{" "}
+          <strong>
+            {formatNumber(state.budgetUsed)} / {formatNumber(state.budgetTokens)}
+          </strong>{" "}
+          ({budgetPctLabel})
+        </span>
+        <span className="autonomous-session-header__metric">
+          wall-clock <strong>{hoursRemainingLabel}</strong> left
+        </span>
+        {state.currentTicketId && (
+          <span className="autonomous-session-header__metric">
+            ticket{" "}
+            <a
+              href={`#ticket-${state.currentTicketId}`}
+              className="autonomous-session-header__ticket-link"
+              title={state.currentTicketId}
+            >
+              {state.currentTicketId.slice(0, 10)}
+            </a>
+          </span>
+        )}
+        <span className="autonomous-session-header__spacer" />
+        {!terminal && (
+          <button
+            type="button"
+            className="autonomous-session-header__kill"
+            onClick={requestStop}
+            disabled={stopping}
+            title="Stop the autonomous session (writes STOP file)"
+          >
+            {stopping ? "Stopping…" : "Stop session"}
+          </button>
+        )}
+      </div>
+      {stopConfirmOpen && (
+        <StopConfirmDialog
+          sessionId={sessionId}
+          onCancel={() => setStopConfirmOpen(false)}
+          onConfirm={confirmStop}
+          busy={stopping}
+          error={stopError}
+        />
+      )}
+    </div>
+  );
+}
+
+function StopConfirmDialog({
+  sessionId,
+  onCancel,
+  onConfirm,
+  busy,
+  error,
+}: {
+  sessionId: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  busy: boolean;
+  error: string | null;
+}) {
+  // I5: Escape dismisses the confirm dialog. Keeps muscle memory consistent
+  // with every other modal in the GUI; without this, users had to click
+  // "Cancel" or the stop button to exit. We wire to `document` rather than
+  // the rendered div because the dialog isn't focused by default (the
+  // "Stop session" button steals focus via autoFocus) so an unfocused key
+  // event on the document needs to reach us.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel, busy]);
+  return (
+    <div className="autonomous-session-header__confirm">
+      <div className="autonomous-session-header__confirm-body">
+        Stop session <code>{sessionId}</code>? The autonomous driver will wind down on its next
+        check; in-flight ticket work may land in a partial state.
+      </div>
+      {error && <div className="autonomous-session-header__confirm-error">{error}</div>}
+      <div className="autonomous-session-header__confirm-actions">
+        <button type="button" onClick={onCancel} disabled={busy}>
+          Cancel
+        </button>
+        <button type="button" className="danger" onClick={onConfirm} disabled={busy} autoFocus>
+          {busy ? "Stopping…" : "Stop session"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Exported for unit tests — the pure helpers encode the AL-10 acceptance
+// criteria (tokens %, hours remaining, threshold severity) and are worth
+// asserting directly instead of through the React tree.
+export function prettyStateForTesting(s: string): string {
+  return prettyState(s);
+}
+export function formatPctForTesting(n: number): string {
+  return formatPct(n);
+}
+export function formatHoursForTesting(hours: number): string {
+  return formatHours(hours);
+}
+export function tokenPctSeverityForTesting(pct: number): "ok" | "warn" | "hot" | "overrun" {
+  return tokenPctSeverity(pct);
+}
+
+function prettyState(s: string): string {
+  // Normalize the snake_case lifecycle states into a single-word badge.
+  switch (s) {
+    case "planning":
+      return "Planning";
+    case "dispatching":
+      return "Dispatching";
+    case "winding_down":
+      return "Winding down";
+    case "audit":
+      return "Audit";
+    case "done":
+      return "Done";
+    case "killed":
+      return "Killed";
+    default:
+      return s;
+  }
+}
+
+function formatPct(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return `${Math.round(n)}%`;
+}
+
+function formatHours(hours: number): string {
+  if (!Number.isFinite(hours) || hours < 0) return "—";
+  if (hours >= 1) {
+    const whole = Math.floor(hours);
+    const minutes = Math.round((hours - whole) * 60);
+    return minutes > 0 ? `${whole}h ${minutes}m` : `${whole}h`;
+  }
+  const minutes = Math.round(hours * 60);
+  return `${minutes}m`;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+/** Color severity for the tokens pill. Matches the AL-1 threshold tiers so
+ * the header's visual language lines up with what the TokenTracker emits
+ * via its `threshold` event. */
+function tokenPctSeverity(pct: number): "ok" | "warn" | "hot" | "overrun" {
+  if (pct >= 100) return "overrun";
+  if (pct >= 85) return "hot";
+  if (pct >= 60) return "warn";
+  return "ok";
+}

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api, subscribeChatEvents, type ChatEvent } from "../api";
 import type {
+  AutonomousSessionSummary,
   Channel,
   ChannelEntry,
   ChatSession,
@@ -9,6 +10,7 @@ import type {
   PersistedChatMessage,
   TicketLedgerEntry,
 } from "../types";
+import { AutonomousSessionHeader } from "./AutonomousSessionHeader";
 import { BoardView } from "./BoardView";
 import { ChannelHeader, type ChannelTab } from "./ChannelHeader";
 import { ChannelSettingsDrawer } from "./ChannelSettingsDrawer";
@@ -57,6 +59,38 @@ export function CenterPane({
   }, [stream, onStreamingChanged]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [promoteOpen, setPromoteOpen] = useState(false);
+  // AL-10: resolve "is there an autonomous session for this channel?" by
+  // listing every session and filtering on channelId. One small list call
+  // per refreshTick; the backend returns only the summary fields needed
+  // for the match, not the full session state.
+  const [autonomousSessions, setAutonomousSessions] = useState<AutonomousSessionSummary[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listAutonomousSessions()
+      .then((sessions) => {
+        if (!cancelled) setAutonomousSessions(sessions);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.warn("[center] listAutonomousSessions failed", err);
+          setAutonomousSessions([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTick]);
+
+  // Pick the most recently started non-terminal session for this channel.
+  // `listAutonomousSessions` already sorts most-recent-first, so the first
+  // non-terminal match is the right one. Terminal (`done` / `killed`)
+  // sessions are filtered out — the header only tracks live sessions.
+  const activeAutonomousSession = channel
+    ? (autonomousSessions.find(
+        (s) => s.channelId === channel.channelId && s.state !== "done" && s.state !== "killed"
+      ) ?? null)
+    : null;
 
   useEffect(() => {
     if (!channel) return;
@@ -154,6 +188,17 @@ export function CenterPane({
         onRefresh={onRefresh}
         hideTabs={isDm}
       />
+      {activeAutonomousSession && (
+        // AL-10: the autonomous-session strip renders above the tabs so
+        // the budget / lifecycle state is visible on every channel view
+        // (chat, board, decisions) — the session applies to the whole
+        // channel, not just a single tab.
+        <AutonomousSessionHeader
+          sessionId={activeAutonomousSession.sessionId}
+          refreshTick={refreshTick}
+          onStopped={onRefresh}
+        />
+      )}
       {isDm && (
         <DmBanner
           channel={channel}

--- a/gui/src/components/RightPane.tsx
+++ b/gui/src/components/RightPane.tsx
@@ -183,6 +183,11 @@ export function RightPane({ channel, sessionId, onSelectSession, refreshTick, on
   const [decisions, setDecisions] = useState<Decision[]>([]);
   const [prs, setPrs] = useState<TrackedPrRow[]>([]);
   const [runs, setRuns] = useState<Array<{ run: RunIndexEntry; workspaceId: string }>>([]);
+  // AL-10 previously resolved the active autonomous session here for its
+  // ApprovalsPanel. Dropped — AL-8's `ApprovalsSection` below handles its
+  // own session discovery against AL-7's queue. The CenterPane keeps its
+  // own autonomous-session lookup for the header; the RightPane no longer
+  // needs one.
 
   useEffect(() => {
     let cancelled = false;
@@ -231,6 +236,9 @@ export function RightPane({ channel, sessionId, onSelectSession, refreshTick, on
           </div>
         ))}
       </div>
+      {/* AL-10 previously rendered its own ApprovalsPanel here. Dropped —
+          AL-8's `ApprovalsSection` below owns the GUI approvals surface
+          and reads AL-7's canonical queue. */}
       <div className="rail-scroll">
         <ApprovalsSection sessionId={sessionId} refreshTick={refreshTick} onChanged={onRefresh} />
         {tab === "threads" && (

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1299,3 +1299,204 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   background: rgba(232, 154, 43, 0.10);
   border-radius: var(--radius-md);
 }
+
+/* ------------------------------------------------------------------ */
+/* AL-10: autonomous-session status strip                             */
+/* ------------------------------------------------------------------ */
+/* Every color pulls from tokens.css so this reads as part of the      */
+/* existing palette (no Catppuccin drift). The strip sits between the  */
+/* ChannelHeader and the tab row; height is tight so it doesn't push   */
+/* the message list below the fold. */
+.autonomous-session-header {
+  padding: var(--space-3) var(--space-8);
+  border-bottom: 1px solid var(--color-paper-line);
+  background: var(--color-paper-alt);
+  font-size: var(--font-size-xs);
+}
+.autonomous-session-header--pending {
+  /* First-poll placeholder — reserve vertical space without content so the
+     layout doesn't jump when `get_session_state` resolves. */
+  min-height: 32px;
+  opacity: 0.5;
+}
+.autonomous-session-header__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+}
+.autonomous-session-header__pill {
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--color-status-pending);
+  color: var(--color-text-primary);
+}
+/* Lifecycle-state colors reuse the existing status palette so a reader
+   who already recognizes ticket statuses gets the same signal here. */
+.autonomous-session-header__pill.pill-state-planning {
+  background: var(--color-status-pending);
+  color: var(--color-text-primary);
+}
+.autonomous-session-header__pill.pill-state-dispatching {
+  background: var(--color-status-executing);
+  color: #fff;
+}
+.autonomous-session-header__pill.pill-state-winding_down {
+  background: var(--color-status-verifying);
+  color: #fff;
+}
+.autonomous-session-header__pill.pill-state-audit {
+  background: var(--color-accent-sky);
+  color: #fff;
+}
+.autonomous-session-header__pill.pill-state-done {
+  background: var(--color-status-completed);
+  color: #fff;
+}
+.autonomous-session-header__pill.pill-state-killed {
+  background: var(--color-status-failed);
+  color: #fff;
+}
+.autonomous-session-header__trust {
+  color: var(--color-text-muted);
+}
+.autonomous-session-header__metric {
+  color: var(--color-text-muted);
+}
+.autonomous-session-header__metric strong {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+/* Token-severity tints for the budget pill. Mirror the AL-1 threshold
+   tiers — the same crossings that fire `onThreshold` events in the CLI
+   are reflected visually here. */
+.autonomous-session-header__metric.metric--tokens-warn strong {
+  color: var(--color-accent-amber);
+}
+.autonomous-session-header__metric.metric--tokens-hot strong {
+  color: var(--color-accent-coral);
+}
+.autonomous-session-header__metric.metric--tokens-overrun strong {
+  color: var(--color-status-failed);
+  font-weight: 700;
+}
+.autonomous-session-header__ticket-link {
+  font-family: var(--font-mono);
+  color: var(--color-accent-sky);
+  text-decoration: none;
+}
+.autonomous-session-header__ticket-link:hover {
+  text-decoration: underline;
+}
+.autonomous-session-header__spacer {
+  flex: 1;
+}
+.autonomous-session-header__kill {
+  background: var(--color-status-failed);
+  color: #fff;
+  border: none;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.autonomous-session-header__kill:hover:not(:disabled) {
+  filter: brightness(0.9);
+}
+.autonomous-session-header__kill:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+/* Confirm dialog. Inline (not a full modal) — keeps the confirmation close
+   to the button that triggered it so there's no context loss. */
+.autonomous-session-header__confirm {
+  margin-top: var(--space-3);
+  padding: var(--space-4);
+  background: var(--color-paper-base);
+  border: 1px solid var(--color-status-failed);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+}
+.autonomous-session-header__confirm-body code {
+  font-family: var(--font-mono);
+  background: var(--color-paper-alt);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.autonomous-session-header__confirm-error {
+  margin-top: var(--space-2);
+  color: var(--color-status-failed);
+}
+.autonomous-session-header__confirm-actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  justify-content: flex-end;
+}
+.autonomous-session-header__confirm-actions .danger {
+  background: var(--color-status-failed);
+  color: #fff;
+  border: none;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+/* ------------------------------------------------------------------ */
+/* AL-10: approvals panel (right rail)                                */
+/* ------------------------------------------------------------------ */
+.approvals-panel {
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-accent-coral-soft);
+  border-bottom: 1px solid var(--color-paper-line);
+}
+.approvals-panel__title {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-accent-coral);
+  margin: 0 0 var(--space-3);
+  font-weight: 700;
+}
+.approvals-panel__row {
+  padding: var(--space-3);
+  background: var(--color-paper-base);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-2);
+}
+.approvals-panel__meta {
+  display: flex;
+  gap: var(--space-3);
+  align-items: baseline;
+  margin-bottom: var(--space-1);
+}
+.approvals-panel__kind {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-accent-magenta);
+  font-weight: 600;
+}
+.approvals-panel__time {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dim);
+}
+.approvals-panel__summary {
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-2);
+}
+.approvals-panel__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+.approvals-panel__error {
+  color: var(--color-status-failed);
+  font-size: var(--font-size-xs);
+  margin-top: var(--space-2);
+}

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -231,3 +231,40 @@ export type ApprovalQueueRecord = {
   // gate without an operator in the loop. Only value today is "god-mode".
   autoApprovedBy?: string | null;
 };
+
+// AL-10: summary row returned by `list_autonomous_sessions`. One per
+// session directory under `~/.relay/sessions/` whose metadata.json is
+// parseable. The CenterPane uses these to resolve `channel -> session`.
+export type AutonomousSessionSummary = {
+  sessionId: string;
+  channelId: string;
+  state: string;
+  startedAt: string;
+  trust: string;
+};
+
+// AL-10: deep session state returned by `get_session_state`. Renders the
+// AutonomousSessionHeader; all fields are already pre-computed on the Rust
+// side so the component stays dumb.
+export type AutonomousSessionState = {
+  sessionId: string;
+  channelId: string;
+  // Lifecycle state — matches the `LifecycleState` enum in
+  // `src/lifecycle/types.ts` (planning / dispatching / winding_down /
+  // audit / done / killed).
+  state: string;
+  trust: string;
+  budgetTokens: number;
+  budgetUsed: number;
+  budgetPct: number;
+  maxHours: number;
+  startedAt: string;
+  // ISO timestamp of the most recent lifecycle transition.
+  updatedAt: string;
+  hoursRemaining: number;
+  currentTicketId?: string | null;
+  allowedRepos: string[];
+};
+
+// AL-10 previously defined `SessionApproval` here. Dropped — AL-8 owns the
+// GUI approvals surface via `ApprovalQueueRecord` above.


### PR DESCRIPTION
## Summary
- CenterPane autonomous-session strip: lifecycle state pill, tokens used % (severity-tiered at 60/85/100% to match AL-1's threshold crossings), hours remaining, current-ticket link, kill-session button with inline confirmation dialog.
- Right-pane `ApprovalsPanel`: minimal reader of `~/.relay/sessions/<id>/approvals.jsonl`. Renders nothing in god-mode or when the queue is empty (acceptance criterion: supervised AND non-empty).
- Five new Tauri commands (`list_autonomous_sessions`, `get_session_state`, `stop_session`, `list_session_approvals`, `resolve_session_approval`) read session files directly from `~/.relay/sessions/<sessionId>/`. All readers tolerate missing/torn/malformed files — a GUI polling every 5s cannot afford to throw on a mid-rename read.
- Reuses the existing 5s `refreshTick` in App; no flicker on poll (last-known state is preserved across transient nulls).
- All colors pull from `--color-*` tokens — no palette drift.

## Design decision
The autonomous-session header renders **above the tab row** (between `ChannelHeader` and the chat/board/decisions switcher) rather than inside the chat tab. Rationale: the session applies to the whole channel, not just a single tab. An operator viewing the Board tab still needs to know "this channel is at 85% budget with 2h left." Kill affordance stays reachable on every view.

## Stubs / follow-ups
- `stop_session` writes a STOP sentinel atomically. This is the contract AL-9 is expected to expose under the same command name; the frontend's call site is stable either way. When AL-9 lands, either the impl here is the real thing or AL-9 supersedes it — the caller never notices.
- `list_session_approvals` / `resolve_session_approval` are minimal readers of `approvals.jsonl` pending AL-8's canonical queue schema. When AL-8 ships, swap the resolver for its CLI path (`rly approve --session ...`) without touching `ApprovalsPanel.tsx`. A `TODO(AL-8)` comment marks the handoff point.
- `current.json` (the "currently-working-on" ticket pointer) is read opportunistically — the autonomous loop hasn't converged on a canonical location yet, so when the file is absent the header just hides that row.

## Test plan
- [x] `cargo test --lib` in `gui/src-tauri/` — 42 tests pass, including 10 new AL-10 tests (empty root, well-formed sessions, corrupt-metadata skip, budget %, zero-budget edge case, unknown session, STOP write, STOP missing-dir error, empty approvals, unresolved-only approvals).
- [x] `pnpm test` in `gui/` — 19 tests pass (8 new `AutonomousSessionHeader` formatter tests).
- [x] `pnpm test` at repo root — 728 pass / 23 skipped, no regressions.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [x] `cd gui && pnpm build` clean.
- [x] `cargo check --workspace` clean.
- [x] `pnpm format:check` clean.
- [ ] Manual smoke on a real autonomous session (requires AL-3/AL-4 wired end-to-end — outside this PR's surface).

Closes #85