### PR TITLE
AL-8: Approvals surfaces (CLI/TUI/GUI)

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -290,6 +290,85 @@ pub struct ApprovalRecord {
     pub timestamp: String,
 }
 
+// --- AL-7/AL-8 Approvals Queue ---
+//
+// Distinct from the plan-approval `ApprovalRecord` above. The queue stores
+// per-session records of actions awaiting user ack (PR auto-merge,
+// audit-proposed ticket creation, …) at
+// `~/.relay/approvals/<sessionId>/queue.jsonl`. Writers: TS
+// `ApprovalsQueue` class (stub shipped in AL-8; absorbed by AL-7 when
+// that lands). Readers: CLI / TUI / GUI — this crate provides a shared
+// parser so TUI + GUI stay byte-compatible with the TS writer.
+//
+// Shape mirrors `src/approvals/queue.ts::ApprovalRecord`. `payload` is
+// deliberately `serde_json::Value` so dashboards don't need to know every
+// kind ahead of time.
+
+/// Constrained approval-queue status. Mirrors the TS
+/// `ApprovalStatus = "pending" | "approved" | "rejected"`. The struct's
+/// `status` field stays a plain `String` for serde round-trip compatibility
+/// with records written by any future kind, but the crate exposes this
+/// enum so callers can filter / match without stringly-typed bugs.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ApprovalStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+impl ApprovalStatus {
+    /// Parse a record's `status` field into the enum. Returns `None` for
+    /// anything the enum doesn't recognise (forward-compat with a future
+    /// status code; the caller chooses whether to treat unknown as
+    /// excluded or included).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "approved" => Some(Self::Approved),
+            "rejected" => Some(Self::Rejected),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalQueueRecord {
+    pub id: String,
+    pub session_id: String,
+    pub kind: String,
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    pub created_at: String,
+    pub status: String,
+    #[serde(default)]
+    pub decided_at: Option<String>,
+    #[serde(default)]
+    pub feedback: Option<String>,
+    // AL-7 god-mode marker. Present on records auto-approved by the trust
+    // gate ("god-mode" is the only value today). Mirror TS
+    // `ApprovalRecord.autoApprovedBy`; `serde(default)` so pre-AL-7
+    // records parse cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_approved_by: Option<String>,
+}
+
+impl ApprovalQueueRecord {
+    /// Structured view of `status`. `None` for unknown codes.
+    pub fn status_enum(&self) -> Option<ApprovalStatus> {
+        ApprovalStatus::parse(&self.status)
+    }
+}
+
 // --- Global Config ---
 
 #[derive(Debug, Deserialize)]
@@ -592,6 +671,96 @@ pub fn load_approval_record(run_id: &str) -> Option<ApprovalRecord> {
 /// yet. Matches the CLI's `rly pending-plans` semantics.
 pub fn is_awaiting_approval(run: &RunIndexEntry) -> bool {
     run.state == "AWAITING_APPROVAL" && load_approval_record(&run.run_id).is_none()
+}
+
+// --- Approvals queue I/O (AL-7/AL-8) ---
+
+/// Filesystem path to a session's queue file. Exposed so callers can embed
+/// it in error messages / debug surfaces; don't write to it directly —
+/// mutations must go through `append_approval_record` /
+/// `rewrite_approval_queue` to preserve the temp-rename atomicity contract
+/// shared with the TS `ApprovalsQueue`.
+pub fn approval_queue_path(session_id: &str) -> PathBuf {
+    harness_root()
+        .join("approvals")
+        .join(session_id)
+        .join("queue.jsonl")
+}
+
+/// Parse a queue.jsonl file. Returns an empty vec if the file is absent or
+/// every line is malformed — a corrupt queue shouldn't blank surfaces.
+pub fn load_approval_queue(session_id: &str) -> Vec<ApprovalQueueRecord> {
+    let path = approval_queue_path(session_id);
+    let raw = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(rec) = serde_json::from_str::<ApprovalQueueRecord>(trimmed) {
+            out.push(rec);
+        }
+    }
+    out
+}
+
+/// Walk `<root>/approvals/` and return every pending record across all
+/// sessions, sorted by `created_at`. Mirrors the TS
+/// `ApprovalsQueue.listAllPending` so TUI/GUI pickers don't reimplement it.
+pub fn load_all_pending_approvals() -> Vec<ApprovalQueueRecord> {
+    let root = harness_root().join("approvals");
+    let entries = match fs::read_dir(&root) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('.') => n.to_string(),
+            _ => continue,
+        };
+        for rec in load_approval_queue(&name) {
+            if rec.status_enum() == Some(ApprovalStatus::Pending) {
+                out.push(rec);
+            }
+        }
+    }
+    out.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    out
+}
+
+/// Rewrite a session's queue file atomically. The TS writer uses the same
+/// temp-rename pattern; keeping them byte-compatible means either surface
+/// can decide a record without the other torn-reading a partial write.
+pub fn rewrite_approval_queue(
+    session_id: &str,
+    records: &[ApprovalQueueRecord],
+) -> Result<(), String> {
+    let path = approval_queue_path(session_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let mut body = String::new();
+    for r in records {
+        let line = serde_json::to_string(r).map_err(|e| e.to_string())?;
+        body.push_str(&line);
+        body.push('\n');
+    }
+    let tmp = path.with_extension("jsonl.tmp");
+    fs::write(&tmp, &body).map_err(|e| e.to_string())?;
+    if let Err(e) = fs::rename(&tmp, &path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.to_string());
+    }
+    Ok(())
 }
 
 pub fn load_channel_decisions(channel_id: &str) -> Vec<Decision> {
@@ -1615,5 +1784,123 @@ mod tests {
             classify_tier_heuristic("oauth-api-users", "ship the new endpoint"),
             ChannelTier::Feature
         );
+    }
+
+    // --- AL-7/AL-8 approvals queue round-trip --------------------------------
+    //
+    // Confirms the Rust side parses the exact JSONL shape the TS writer
+    // emits. Hand-built JSON rather than round-tripping through the Rust
+    // serializer so TS field drift (e.g. dropping `decidedAt`) surfaces
+    // here instead of silently in the dashboards.
+
+    #[test]
+    fn approval_queue_record_parses_camelcase_jsonl() {
+        let json = r#"{
+            "id":"apv-abc",
+            "sessionId":"sess-1",
+            "kind":"pr_merge",
+            "payload":{"pr":42},
+            "createdAt":"2026-01-01T00:00:00Z",
+            "status":"pending"
+        }"#;
+        let r: ApprovalQueueRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(r.id, "apv-abc");
+        assert_eq!(r.session_id, "sess-1");
+        assert_eq!(r.kind, "pr_merge");
+        assert_eq!(r.status, "pending");
+        assert_eq!(r.decided_at, None);
+        assert_eq!(r.feedback, None);
+    }
+
+    #[test]
+    fn approval_queue_record_parses_decided_with_feedback() {
+        let json = r#"{
+            "id":"apv-2",
+            "sessionId":"sess-y",
+            "kind":"create_ticket",
+            "payload":{"title":"x"},
+            "createdAt":"2026-01-01T00:00:00Z",
+            "status":"rejected",
+            "decidedAt":"2026-01-02T00:00:00Z",
+            "feedback":"out of scope"
+        }"#;
+        let r: ApprovalQueueRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(r.status, "rejected");
+        assert_eq!(r.decided_at.as_deref(), Some("2026-01-02T00:00:00Z"));
+        assert_eq!(r.feedback.as_deref(), Some("out of scope"));
+    }
+
+    #[test]
+    fn load_approval_queue_parses_jsonl_file() {
+        let _guard = scoped_root();
+        let session = "sess-load";
+        let path = approval_queue_path(session);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let line1 = r#"{"id":"apv-1","sessionId":"sess-load","kind":"k","payload":{},"createdAt":"2026-01-01T00:00:00Z","status":"pending"}"#;
+        let line2 = r#"{"id":"apv-2","sessionId":"sess-load","kind":"k","payload":{},"createdAt":"2026-01-02T00:00:00Z","status":"approved","decidedAt":"2026-01-03T00:00:00Z"}"#;
+        fs::write(&path, format!("{}\n{}\n", line1, line2)).unwrap();
+
+        let records = load_approval_queue(session);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].id, "apv-1");
+        assert_eq!(records[1].status, "approved");
+    }
+
+    #[test]
+    fn load_approval_queue_skips_malformed_lines() {
+        let _guard = scoped_root();
+        let session = "sess-mal";
+        let path = approval_queue_path(session);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let good = r#"{"id":"apv-good","sessionId":"sess-mal","kind":"k","payload":{},"createdAt":"2026-01-01T00:00:00Z","status":"pending"}"#;
+        fs::write(&path, format!("{{not-json\n{}\n", good)).unwrap();
+
+        let records = load_approval_queue(session);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].id, "apv-good");
+    }
+
+    #[test]
+    fn load_all_pending_approvals_walks_every_session_dir() {
+        let _guard = scoped_root();
+        for (session, created) in [
+            ("sess-a", "2026-01-01T00:00:00Z"),
+            ("sess-b", "2026-01-02T00:00:00Z"),
+        ] {
+            let path = approval_queue_path(session);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let rec = format!(
+                r#"{{"id":"apv-{}","sessionId":"{}","kind":"k","payload":{{}},"createdAt":"{}","status":"pending"}}"#,
+                session, session, created
+            );
+            fs::write(&path, format!("{}\n", rec)).unwrap();
+        }
+        let all = load_all_pending_approvals();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].session_id, "sess-a");
+        assert_eq!(all[1].session_id, "sess-b");
+    }
+
+    #[test]
+    fn rewrite_approval_queue_is_temp_rename_atomic() {
+        let _guard = scoped_root();
+        let session = "sess-rw";
+        let records = vec![ApprovalQueueRecord {
+            id: "apv-1".into(),
+            session_id: session.into(),
+            kind: "k".into(),
+            payload: serde_json::json!({"a": 1}),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            status: "approved".into(),
+            decided_at: Some("2026-01-02T00:00:00Z".into()),
+            feedback: None,
+        }];
+        rewrite_approval_queue(session, &records).expect("write ok");
+        let reloaded = load_approval_queue(session);
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].id, "apv-1");
+        assert_eq!(reloaded[0].status, "approved");
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -202,6 +202,66 @@ fn reject_plan(
     cli_json(&args)
 }
 
+/// List pending approvals-queue records for a single session (no args = all
+/// sessions). Reads `~/.relay/approvals/<sessionId>/queue.jsonl` directly
+/// via `harness-data`; no CLI round-trip so the right-pane 5-second tick
+/// stays cheap.
+#[tauri::command]
+fn list_pending_approvals(
+    session_id: Option<String>,
+) -> Result<Vec<data::ApprovalQueueRecord>, String> {
+    if let Some(ref s) = session_id {
+        validate_id_segment(s, "sessionId")?;
+        let mut out = data::load_approval_queue(s);
+        // I9: filter through the typed enum so stringly-typed status
+        // comparisons can't drift out of sync with the TS source of truth.
+        out.retain(|r| r.status_enum() == Some(data::ApprovalStatus::Pending));
+        out.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        return Ok(out);
+    }
+    Ok(data::load_all_pending_approvals())
+}
+
+/// Approve a single AL-8 queue record by id. Shells out to
+/// `rly approve <id> --json` so the canonical queue mutation path lives in
+/// one place (the TS writer). Returns the CLI's JSON envelope verbatim.
+#[tauri::command]
+fn approve_queue_entry(id: String) -> Result<serde_json::Value, String> {
+    validate_id_segment(&id, "id")?;
+    cli_json(&["approve", &id, "--json"])
+}
+
+/// Reject a single AL-8 queue record with optional `--feedback`. Same
+/// shell-out contract as `approve_queue_entry`.
+#[tauri::command]
+fn reject_queue_entry(
+    id: String,
+    feedback: Option<String>,
+) -> Result<serde_json::Value, String> {
+    validate_id_segment(&id, "id")?;
+    let mut args: Vec<&str> = vec!["reject", &id, "--json"];
+    if let Some(ref fb) = feedback {
+        args.push("--feedback");
+        args.push(fb);
+    }
+    cli_json(&args)
+}
+
+/// Approve all pending queue records (optionally scoped to one session).
+/// Convenience for the "Approve all" button in the RightPane; still
+/// dispatches through the CLI so the queue file mutation is authoritative.
+#[tauri::command]
+fn approve_queue_all(session_id: Option<String>) -> Result<serde_json::Value, String> {
+    let mut args: Vec<String> = vec!["approve".into(), "all".into(), "--json".into()];
+    if let Some(ref s) = session_id {
+        validate_id_segment(s, "sessionId")?;
+        args.push("--session".into());
+        args.push(s.clone());
+    }
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    cli_json(&refs)
+}
+
 #[derive(Serialize)]
 struct CliResult {
     success: bool,
@@ -2106,6 +2166,10 @@ pub fn run() {
             list_pending_plans,
             approve_plan,
             reject_plan,
+            list_pending_approvals,
+            approve_queue_entry,
+            reject_queue_entry,
+            approve_queue_all,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
+  ApprovalQueueRecord,
   Channel,
   ChannelEntry,
   ChannelRunLink,
@@ -162,6 +163,15 @@ export const api = {
   approvePlan: (runId: string) => invoke<unknown>("approve_plan", { runId }),
   rejectPlan: (runId: string, feedback?: string) =>
     invoke<unknown>("reject_plan", { runId, feedback }),
+
+  // AL-7/AL-8 approvals queue. Distinct from plan-approval above — these
+  // drain per-session queue.jsonl files rather than run artifacts.
+  listPendingApprovals: (sessionId?: string) =>
+    invoke<ApprovalQueueRecord[]>("list_pending_approvals", { sessionId }),
+  approveQueueEntry: (id: string) => invoke<unknown>("approve_queue_entry", { id }),
+  rejectQueueEntry: (id: string, feedback?: string) =>
+    invoke<unknown>("reject_queue_entry", { id, feedback }),
+  approveQueueAll: (sessionId?: string) => invoke<unknown>("approve_queue_all", { sessionId }),
 };
 
 export type ChatEvent =

--- a/gui/src/components/RightPane.tsx
+++ b/gui/src/components/RightPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
 import type {
+  ApprovalQueueRecord,
   Channel,
   ChannelRunLink,
   Decision,
@@ -19,6 +20,163 @@ type Props = {
   refreshTick: number;
   onRefresh: () => void;
 };
+
+/**
+ * AL-8 approvals section, rendered collapsibly above the regular tab
+ * content when the queue has pending records for the selected session (or
+ * any session when none is selected). Lists every pending record with
+ * Approve / Reject buttons; both dispatch through `api.approveQueueEntry`
+ * / `api.rejectQueueEntry` (→ `rly approve <id>` / `rly reject <id>`) so
+ * the queue file mutation lives in one place regardless of which surface
+ * drove the decision.
+ *
+ * Refresh cadence: we re-fetch on every parent `refreshTick` (5s in App)
+ * so CLI/TUI-driven decisions show up without a manual reload.
+ */
+function ApprovalsSection({
+  sessionId,
+  refreshTick,
+  onChanged,
+}: {
+  sessionId: string | null;
+  refreshTick: number;
+  onChanged: () => void;
+}) {
+  const [records, setRecords] = useState<ApprovalQueueRecord[]>([]);
+  const [collapsed, setCollapsed] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listPendingApprovals(sessionId ?? undefined)
+      .then((r) => {
+        if (!cancelled) setRecords(r);
+      })
+      .catch(() => {
+        if (!cancelled) setRecords([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, refreshTick]);
+
+  if (records.length === 0) return null;
+
+  const act = async (record: ApprovalQueueRecord, decision: "approve" | "reject") => {
+    setBusyId(record.id);
+    setError(null);
+    try {
+      if (decision === "approve") await api.approveQueueEntry(record.id);
+      else await api.rejectQueueEntry(record.id);
+      setRecords((prev) => prev.filter((r) => r.id !== record.id));
+      onChanged();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const approveAll = async () => {
+    setBusyId("__all__");
+    setError(null);
+    try {
+      await api.approveQueueAll(sessionId ?? undefined);
+      setRecords([]);
+      onChanged();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          cursor: "pointer",
+          marginBottom: 8,
+        }}
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <h4
+          style={{
+            fontSize: "var(--font-size-xs)",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            color: "var(--color-text-dim)",
+            margin: 0,
+          }}
+        >
+          Pending approvals ({records.length})
+        </h4>
+        <span style={{ color: "var(--color-text-dim)", fontSize: "var(--font-size-xs)" }}>
+          {collapsed ? "▸" : "▾"}
+        </span>
+      </div>
+      {!collapsed && (
+        <>
+          {records.length > 1 && (
+            <button
+              className="primary"
+              disabled={busyId !== null}
+              onClick={approveAll}
+              style={{ marginBottom: 8, width: "100%" }}
+            >
+              {busyId === "__all__" ? "…" : `Approve all (${records.length})`}
+            </button>
+          )}
+          {records.map((r) => (
+            <div
+              key={r.id}
+              style={{
+                padding: 10,
+                background: "rgba(77, 152, 255, 0.10)",
+                borderRadius: 6,
+                marginBottom: 6,
+              }}
+            >
+              <div style={{ fontWeight: 600, marginBottom: 2 }}>{r.kind}</div>
+              <div
+                style={{
+                  fontSize: "var(--font-size-xs)",
+                  color: "var(--color-text-muted)",
+                  marginBottom: 6,
+                  fontFamily: "var(--font-family-mono, monospace)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+                title={r.id}
+              >
+                {r.id} · session {r.sessionId.slice(0, 8)}
+              </div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button
+                  className="primary"
+                  disabled={busyId === r.id}
+                  onClick={() => act(r, "approve")}
+                >
+                  {busyId === r.id ? "…" : "Approve"}
+                </button>
+                <button disabled={busyId === r.id} onClick={() => act(r, "reject")}>
+                  Reject
+                </button>
+              </div>
+            </div>
+          ))}
+          {error && <div className="error">{error}</div>}
+        </>
+      )}
+    </div>
+  );
+}
 
 export function RightPane({ channel, sessionId, onSelectSession, refreshTick, onRefresh }: Props) {
   const [tab, setTab] = useState<Tab>("threads");
@@ -74,6 +232,7 @@ export function RightPane({ channel, sessionId, onSelectSession, refreshTick, on
         ))}
       </div>
       <div className="rail-scroll">
+        <ApprovalsSection sessionId={sessionId} refreshTick={refreshTick} onChanged={onRefresh} />
         {tab === "threads" && (
           <SessionList
             channelId={channel.channelId}

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -213,3 +213,21 @@ export type PendingPlan = {
   state: string;
   updatedAt: string;
 };
+
+// AL-7/AL-8 approvals queue record. Mirrors `src/approvals/queue.ts`
+// `ApprovalRecord` and the Rust `ApprovalQueueRecord` in
+// `crates/harness-data/src/lib.rs`. `payload` is intentionally opaque so
+// the GUI can render new kinds without a schema bump.
+export type ApprovalQueueRecord = {
+  id: string;
+  sessionId: string;
+  kind: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+  status: "pending" | "approved" | "rejected";
+  decidedAt?: string | null;
+  feedback?: string | null;
+  // AL-7 god-mode marker. Present on records auto-approved by the trust
+  // gate without an operator in the loop. Only value today is "god-mode".
+  autoApprovedBy?: string | null;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import { buildSystemPrompt, resolveChannelRefs, findMcpConfig } from "./cli/chat
 import { rewindApply, rewindSnapshot } from "./cli/chat-rewind.js";
 import { submitApproval } from "./orchestrator/approval-gate.js";
 import { getWorkspaceDir } from "./cli/workspace-registry.js";
+import { ApprovalsQueue, type ApprovalRecord } from "./approvals/queue.js";
+import { getRelayDir } from "./cli/paths.js";
 
 export async function main(): Promise<void> {
   const cwd = process.cwd();
@@ -200,12 +202,42 @@ export async function main(): Promise<void> {
   }
 
   if (command === "approve" || command === "reject") {
+    // Route to the AL-7/AL-8 approvals queue when:
+    //   - positional is `next` / `all` (approve only); OR
+    //   - positional id starts with the queue prefix (`apv-`); OR
+    //   - no positional is provided AND `--session` is set (list/decide
+    //     within a specific queued session).
+    //
+    // I6: we used to also route on ANY `--session` regardless of the
+    // positional, which was greedy — `rly approve <runId> --session foo`
+    // should still go to the plan-approval flow. Constrain `--session`-
+    // triggers to the "no positional" case.
+    //
+    // Everything else falls through to the legacy plan-approval
+    // semantics so `rly approve <runId>` / `rly reject <runId>` keep
+    // working exactly as before.
+    const firstPositional = args.find((a) => !a.startsWith("--"));
+    const sessionFlag = parseNamedArg(args, "--session");
+    const isQueueKeyword =
+      command === "approve" && (firstPositional === "next" || firstPositional === "all");
+    const looksLikeApprovalId =
+      typeof firstPositional === "string" && firstPositional.startsWith("apv-");
+    const noPositionalWithSession = firstPositional === undefined && !!sessionFlag;
+    if (isQueueKeyword || looksLikeApprovalId || noPositionalWithSession) {
+      await handleApprovalQueueCommand(command, args);
+      return;
+    }
     await handlePlanDecisionCommand(command, args, cwd);
     return;
   }
 
   if (command === "pending-plans") {
     await handlePendingPlansCommand(args, cwd);
+    return;
+  }
+
+  if (command === "pending-approvals") {
+    await handlePendingApprovalsCommand(args);
     return;
   }
 
@@ -1250,6 +1282,281 @@ async function handlePendingPlansCommand(args: string[], _cwd: string): Promise<
   console.log('Reject with:  rly reject <runId> [--feedback "…"]');
 }
 
+/**
+ * AL-8 CLI adapter onto AL-7's {@link ApprovalsQueue}. AL-7 exposes
+ * `list(sessionId, {status})` / `approve` / `reject` — the CLI surface
+ * wants `listPending(sessionId)` and "list across every session" so these
+ * helpers bridge the gap without forcing changes back into AL-7.
+ *
+ * Session enumeration uses `getRelayDir()` (matches AL-7's convention) so
+ * the root-dir override path is consistent end-to-end.
+ */
+async function listAllSessionDirs(): Promise<string[]> {
+  const { readdir } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const approvalsRoot = join(getRelayDir(), "approvals");
+  try {
+    const entries = await readdir(approvalsRoot);
+    return entries.filter((s) => s && !s.startsWith("."));
+  } catch {
+    return [];
+  }
+}
+
+async function listPendingForSession(
+  queue: ApprovalsQueue,
+  sessionId: string
+): Promise<ApprovalRecord[]> {
+  return queue.list(sessionId, { status: "pending" });
+}
+
+async function listAllPending(queue: ApprovalsQueue): Promise<ApprovalRecord[]> {
+  const sessions = await listAllSessionDirs();
+  const all: ApprovalRecord[] = [];
+  for (const s of sessions) {
+    try {
+      const pending = await queue.list(s, { status: "pending" });
+      all.push(...pending);
+    } catch {
+      // skip unreadable session dirs
+    }
+  }
+  return all;
+}
+
+/**
+ * Route the CLI's "approve" / "reject" to AL-7's `approve(sessionId, id)` /
+ * `reject(sessionId, id, feedback?)`. Returns null when the record isn't
+ * found OR is already decided — the CLI formatter then emits the nice
+ * "no record decided" message instead of bubbling AL-7's throw.
+ */
+async function decideViaQueue(
+  queue: ApprovalsQueue,
+  sessionId: string,
+  id: string,
+  decision: "approved" | "rejected",
+  feedback?: string
+): Promise<ApprovalRecord | null> {
+  try {
+    if (decision === "approved") {
+      return await queue.approve(sessionId, id);
+    }
+    return await queue.reject(sessionId, id, feedback);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // AL-7 throws on "no record with id" and "already decided" — the CLI
+    // treats both as "nothing new to do" and returns null so the caller
+    // emits the benign idempotent message.
+    if (msg.includes("no record with id") || msg.includes("is already")) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * `rly pending-approvals [--json] [--session <id>]` — list every pending
+ * record in the AL-7/AL-8 approvals queue. The TUI and GUI drain the same
+ * files directly; this CLI view exists so users scripting around the
+ * harness have a single source of truth.
+ */
+async function handlePendingApprovalsCommand(args: string[]): Promise<void> {
+  const sessionId = parseNamedArg(args, "--session");
+  const jsonMode = args.includes("--json");
+  const queue = new ApprovalsQueue();
+  const pending = sessionId
+    ? await listPendingForSession(queue, sessionId)
+    : await listAllPending(queue);
+
+  if (jsonMode) {
+    jsonOut(pending);
+    return;
+  }
+  if (pending.length === 0) {
+    console.log("No pending approvals.");
+    return;
+  }
+  console.log(`Pending approvals (${pending.length}):`);
+  for (const r of pending) {
+    console.log(`  ${r.id}  session=${r.sessionId}  kind=${r.kind}  ${r.createdAt}`);
+  }
+  console.log("\nApprove next:  rly approve next");
+  console.log("Approve all:   rly approve all");
+  console.log('Reject single: rly reject <id> [--feedback "…"]');
+}
+
+/**
+ * `rly approve next|all|<id>` / `rly reject <id> [--feedback "text"]` —
+ * CLI surface onto the AL-7/AL-8 approvals queue. Distinct from
+ * `handlePlanDecisionCommand`, which writes `runArtifacts/<runId>__approval`
+ * records for the plan-approval flow. The queue stores per-session records
+ * under `~/.relay/approvals/<sessionId>/queue.jsonl`; TUI and GUI drain the
+ * same files so state stays consistent across surfaces.
+ *
+ * Routing rules (see `main()` for the dispatch):
+ *   - `rly approve next|all`          → queue (next-pending or bulk-approve)
+ *   - `rly approve --session <s>`     → queue (per-session listing / decide)
+ *   - `rly approve apv-...`           → queue (id-prefix auto-route)
+ *   - anything else falls through to `handlePlanDecisionCommand`.
+ *
+ * `--session` is optional for `approve <id>` / `reject <id>` — when absent,
+ * every session is scanned and the id is matched across queues. Keeping it
+ * optional lets the TUI/GUI paste a bare id without knowing which session
+ * owns it.
+ */
+async function handleApprovalQueueCommand(
+  command: "approve" | "reject",
+  args: string[]
+): Promise<void> {
+  const positionals = args.filter((a) => !a.startsWith("--"));
+  const sessionId = parseNamedArg(args, "--session");
+  const feedback = parseNamedArg(args, "--feedback") ?? undefined;
+  const jsonMode = args.includes("--json");
+  const queue = new ApprovalsQueue();
+
+  // `approve next|all` drain multiple records at once. Guard against the
+  // obvious typo (`rly reject next`) — `next`/`all` only make sense for
+  // approve; for reject we require an explicit id so we don't accidentally
+  // reject everything in flight.
+  if (command === "approve" && positionals[0] === "next") {
+    const pending = sessionId
+      ? await listPendingForSession(queue, sessionId)
+      : await listAllPending(queue);
+    const target = pending[0];
+    if (!target) {
+      if (jsonMode) jsonOut({ ok: true, decided: null });
+      else console.log("No pending approvals.");
+      return;
+    }
+    const decided = await decideViaQueue(queue, target.sessionId, target.id, "approved");
+    emitDecided(decided, jsonMode);
+    return;
+  }
+
+  if (command === "approve" && positionals[0] === "all") {
+    // I8: "approve all" without `--session` used to approve across ALL
+    // sessions, which is a footgun. The safe default is to approve the
+    // most-recent session's queue; use `--all-sessions` to opt in to
+    // the cross-session bulk drain.
+    const allSessionsFlag = args.includes("--all-sessions");
+    const sessions = new Set<string>();
+    if (sessionId) {
+      sessions.add(sessionId);
+    } else if (allSessionsFlag) {
+      for (const r of await listAllPending(queue)) sessions.add(r.sessionId);
+    } else {
+      // Default: most-recent session with pending approvals. Tie-break
+      // on createdAt so the "newest queue" wins — matches operator
+      // intent of "I just kicked off a session, drain its queue".
+      const allPending = await listAllPending(queue);
+      if (allPending.length === 0) {
+        if (jsonMode) jsonOut({ ok: true, decided: [] });
+        else
+          console.log(
+            "No pending approvals. Pass --all-sessions to force a cross-session bulk approve."
+          );
+        return;
+      }
+      // Sort newest first; Map preserves insertion order so we pick up
+      // the first session we see.
+      const sorted = allPending.slice().sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+      sessions.add(sorted[0].sessionId);
+    }
+    const decided: ApprovalRecord[] = [];
+    for (const s of sessions) {
+      const pendingForS = await listPendingForSession(queue, s);
+      for (const r of pendingForS) {
+        const d = await decideViaQueue(queue, s, r.id, "approved");
+        if (d) decided.push(d);
+      }
+    }
+    if (jsonMode) {
+      jsonOut({ ok: true, decided });
+    } else if (decided.length === 0) {
+      console.log("No pending approvals.");
+    } else {
+      console.log(`Approved ${decided.length} record(s):`);
+      for (const r of decided) console.log(`  ${r.id}  session=${r.sessionId}  kind=${r.kind}`);
+    }
+    return;
+  }
+
+  // `approve <id>` / `reject <id>` — single-record decide.
+  const id = positionals[0];
+  if (!id) {
+    console.error(
+      command === "approve"
+        ? 'Usage: rly approve next | all | <id> [--session <s>] [--feedback "text"]'
+        : 'Usage: rly reject <id> [--session <s>] [--feedback "text"]'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const targetSessionId = sessionId ?? (await findSessionForApprovalId(queue, id));
+  if (!targetSessionId) {
+    console.error(`No approval record with id "${id}" found in any session queue.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const decision: "approved" | "rejected" = command === "approve" ? "approved" : "rejected";
+  try {
+    const decided = await decideViaQueue(queue, targetSessionId, id, decision, feedback);
+    if (!decided) {
+      console.error(`No approval record with id "${id}" in session ${targetSessionId}.`);
+      process.exitCode = 1;
+      return;
+    }
+    emitDecided(decided, jsonMode);
+  } catch (err) {
+    console.error(
+      `Failed to ${command} ${id}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    process.exitCode = 1;
+  }
+}
+
+function emitDecided(record: ApprovalRecord | null, jsonMode: boolean): void {
+  if (!record) {
+    if (jsonMode) jsonOut({ ok: true, decided: null });
+    else console.log("No approval record decided.");
+    return;
+  }
+  if (jsonMode) {
+    jsonOut({ ok: true, decided: record });
+    return;
+  }
+  const tail =
+    record.status === "rejected" && record.feedback ? `  feedback="${record.feedback}"` : "";
+  console.log(
+    `${record.status} ${record.id}  session=${record.sessionId}  kind=${record.kind}${tail}`
+  );
+}
+
+/**
+ * Scan every session's queue for a record with `id`. Returns its sessionId
+ * or null. Uses {@link getRelayDir} to locate the approvals root so the CLI
+ * honors the same env override (`RELAY_HOME`) AL-7's queue uses internally.
+ */
+async function findSessionForApprovalId(queue: ApprovalsQueue, id: string): Promise<string | null> {
+  const pending = await listAllPending(queue);
+  const hit = pending.find((r) => r.id === id);
+  if (hit) return hit.sessionId;
+  // Also walk decided records so `rly approve <id>` on an already-approved
+  // id returns the nice idempotent message rather than "not found".
+  const sessionDirs = await listAllSessionDirs();
+  for (const s of sessionDirs) {
+    try {
+      const records = await queue.list(s);
+      if (records.some((r) => r.id === id)) return s;
+    } catch {
+      // skip
+    }
+  }
+  return null;
+}
+
 async function resolveWorkspaceIdForRun(runId: string): Promise<string | null> {
   const workspaces = await listRegisteredWorkspaces();
   for (const ws of workspaces) {
@@ -2242,8 +2549,11 @@ async function printTopLevelHelp(): Promise<void> {
     "  run <request>            Classify + plan + execute a feature request",
     "  run --autonomous <ch>    Start an autonomous session against a channel's ticket board (AL-3)",
     "  approve <runId>          Approve a pending plan",
+    "  approve next|all         Drain the AL-8 approvals queue (next pending or bulk)",
     "  reject <runId> [--feedback <text>]  Reject a pending plan",
+    "  reject <apvId> [--feedback <text>]  Reject an approvals-queue record",
     "  pending-plans [--json]   List runs awaiting plan-approval decisions",
+    "  pending-approvals [--json] [--session <id>]  List queue approvals awaiting decisions",
     "  status                   Workspace paths + recent runs",
     "  list-runs                Recent persisted runs across workspaces",
     "  running                  Active tasks across every workspace",

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -59,6 +59,10 @@ pub enum Tab {
     Decisions,
     /// Tracked PRs for the selected channel — mirrors `rly pr-status` output.
     Prs,
+    /// AL-7/AL-8 approvals queue view. Lists pending records across every
+    /// session and lets the user drive approve/reject without dropping back
+    /// to the CLI.
+    Approvals,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -74,6 +78,10 @@ pub enum InputMode {
     RewindSelect,
     /// Confirm-approve the currently-selected pending plan
     ApprovePlan,
+    /// Confirm-approve the currently-selected AL-7/AL-8 queue record.
+    /// Distinct from `ApprovePlan` because the confirmation payload is
+    /// the queue entry id + session, not a run id.
+    ApproveQueue,
 }
 
 #[derive(Clone, Debug)]
@@ -331,6 +339,12 @@ pub struct App {
     // Pending plans (runs in AWAITING_APPROVAL state with no approval record)
     pub pending_plans: Vec<PendingPlan>,
     pub pending_plan_cursor: usize,
+
+    // AL-7/AL-8 approvals queue: pending records across every session.
+    // Populated by `refresh()` from `~/.relay/approvals/<sessionId>/queue.jsonl`.
+    pub pending_approvals: Vec<data::ApprovalQueueRecord>,
+    pub approvals_cursor: usize,
+    pub approvals_scroll: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -394,6 +408,9 @@ impl App {
             prs_scroll: 0,
             pending_plans: Vec::new(),
             pending_plan_cursor: 0,
+            pending_approvals: Vec::new(),
+            approvals_cursor: 0,
+            approvals_scroll: 0,
         }
     }
 
@@ -679,8 +696,33 @@ impl App {
             self.pending_plan_cursor = 0;
         }
 
+        // AL-8: refresh the approvals queue. Cheap (just walks
+        // `~/.relay/approvals/`), so no need to debounce — runs on every
+        // tick alongside the rest of the dashboard state.
+        self.pending_approvals = data::load_all_pending_approvals();
+        if self.approvals_cursor >= self.pending_approvals.len() {
+            self.approvals_cursor = self.pending_approvals.len().saturating_sub(1);
+        }
+
         // Clamp scroll positions after data refresh
         self.clamp_scrolls();
+    }
+
+    /// Decide a single pending approval by id. Shells out through the
+    /// canonical CLI path (`rly approve <id>` / `rly reject <id>`) so every
+    /// surface goes through the same queue-mutation code — exactly the
+    /// "three surfaces, one queue" invariant AL-8 asks for.
+    fn decide_approval(&mut self, id: &str, decision: &str, feedback: Option<&str>) {
+        let cmd = if decision == "approved" { "approve" } else { "reject" };
+        let mut args: Vec<&str> = vec![cmd, id, "--json"];
+        if let Some(fb) = feedback {
+            args.push("--feedback");
+            args.push(fb);
+        }
+        let _ = cli_json(&args);
+        // Refresh immediately so the row disappears without waiting for the
+        // next dashboard tick.
+        self.refresh();
     }
 
     /// Ensure per-repo workers exist for the currently selected channel's repos.
@@ -947,6 +989,11 @@ impl App {
         } else {
             self.runs_scroll = 0;
         }
+        if !self.pending_approvals.is_empty() {
+            self.approvals_scroll = self.approvals_scroll.min(self.pending_approvals.len() - 1);
+        } else {
+            self.approvals_scroll = 0;
+        }
     }
 
     fn center_item_count(&self) -> usize {
@@ -955,6 +1002,7 @@ impl App {
             Tab::Board => self.sorted_ticket_indices().len(),
             Tab::Decisions => self.decisions.len(),
             Tab::Prs => self.tracked_prs.len(),
+            Tab::Approvals => self.pending_approvals.len(),
         }
     }
 
@@ -964,6 +1012,7 @@ impl App {
             Tab::Board => self.board_scroll,
             Tab::Decisions => self.decisions_scroll,
             Tab::Prs => self.prs_scroll,
+            Tab::Approvals => self.approvals_scroll,
         }
     }
 
@@ -973,6 +1022,7 @@ impl App {
             Tab::Board => self.board_scroll = val,
             Tab::Decisions => self.decisions_scroll = val,
             Tab::Prs => self.prs_scroll = val,
+            Tab::Approvals => self.approvals_scroll = val,
         }
     }
 
@@ -1001,7 +1051,8 @@ impl App {
             || self.input_mode == InputMode::RepoSelect
             || self.input_mode == InputMode::SessionSelect
             || self.input_mode == InputMode::RewindSelect
-            || self.input_mode == InputMode::ApprovePlan {
+            || self.input_mode == InputMode::ApprovePlan
+            || self.input_mode == InputMode::ApproveQueue {
             return;
         }
 
@@ -1039,6 +1090,13 @@ impl App {
                             Tab::Prs => {
                                 if self.prs_scroll < self.tracked_prs.len().saturating_sub(1) {
                                     self.prs_scroll += 1;
+                                }
+                            }
+                            Tab::Approvals => {
+                                if self.approvals_scroll
+                                    < self.pending_approvals.len().saturating_sub(1)
+                                {
+                                    self.approvals_scroll += 1;
                                 }
                             }
                         }
@@ -1079,6 +1137,9 @@ impl App {
                             }
                             Tab::Prs => {
                                 self.prs_scroll = self.prs_scroll.saturating_sub(1);
+                            }
+                            Tab::Approvals => {
+                                self.approvals_scroll = self.approvals_scroll.saturating_sub(1);
                             }
                         }
                     }
@@ -1293,6 +1354,12 @@ impl App {
         // Approve plan confirm
         if self.input_mode == InputMode::ApprovePlan {
             self.handle_approve_plan_key(code);
+            return;
+        }
+
+        // N: explicit confirmation before mutating the AL-7/AL-8 queue.
+        if self.input_mode == InputMode::ApproveQueue {
+            self.handle_approve_queue_key(code);
             return;
         }
 
@@ -1561,21 +1628,24 @@ impl App {
                     Tab::Chat => Tab::Board,
                     Tab::Board => Tab::Decisions,
                     Tab::Decisions => Tab::Prs,
-                    Tab::Prs => Tab::Chat,
+                    Tab::Prs => Tab::Approvals,
+                    Tab::Approvals => Tab::Chat,
                 };
             }
             KeyCode::BackTab => {
                 self.active_tab = match self.active_tab {
-                    Tab::Chat => Tab::Prs,
+                    Tab::Chat => Tab::Approvals,
                     Tab::Board => Tab::Chat,
                     Tab::Decisions => Tab::Board,
                     Tab::Prs => Tab::Decisions,
+                    Tab::Approvals => Tab::Prs,
                 };
             }
             KeyCode::Char('1') => self.active_tab = Tab::Chat,
             KeyCode::Char('2') => self.active_tab = Tab::Board,
             KeyCode::Char('3') => self.active_tab = Tab::Decisions,
             KeyCode::Char('4') => self.active_tab = Tab::Prs,
+            KeyCode::Char('5') => self.active_tab = Tab::Approvals,
 
             // Open detail
             KeyCode::Enter => self.open_detail(),
@@ -1607,8 +1677,23 @@ impl App {
             // — shells out to `rly approve <runId>` so the same code path as the
             // CLI and MCP tool is used. 'A' opens an in-panel confirm dialog so
             // a single stray keypress doesn't approve by accident.
+            //
+            // On the Approvals tab the same key approves the currently-selected
+            // AL-8 queue record instead of the run-level plan; 'd' rejects it.
+            // (We borrow 'a'/'d' here because they're already in the Normal-mode
+            // namespace — 'r' is taken by the repo editor.)
             KeyCode::Char('a') => {
-                if !self.pending_plans.is_empty() {
+                if self.active_tab == Tab::Approvals {
+                    // N: require explicit confirmation before approving —
+                    // the approve path mutates the queue irreversibly, and
+                    // a stray `a` from a distracted operator shouldn't
+                    // cause a merge. Mirror the plan-approval flow: flip
+                    // to ApproveQueue mode, the overlay renders a y/n
+                    // prompt in `render_approve_queue_confirm`.
+                    if self.pending_approvals.get(self.approvals_scroll).is_some() {
+                        self.input_mode = InputMode::ApproveQueue;
+                    }
+                } else if !self.pending_plans.is_empty() {
                     self.input_mode = InputMode::ApprovePlan;
                 }
             }
@@ -1618,9 +1703,15 @@ impl App {
                 self.open_session_picker();
             }
 
-            // Delete channel
+            // Delete channel — or on the Approvals tab, reject the
+            // currently-selected AL-8 queue record. The verb differs but
+            // the mental model is the same: "remove this from the list."
             KeyCode::Char('d') => {
-                if self.focus == FocusPanel::Sidebar {
+                if self.active_tab == Tab::Approvals {
+                    if let Some(rec) = self.pending_approvals.get(self.approvals_scroll).cloned() {
+                        self.decide_approval(&rec.id, "rejected", None);
+                    }
+                } else if self.focus == FocusPanel::Sidebar {
                     self.delete_current_channel();
                 }
             }
@@ -2143,6 +2234,29 @@ impl App {
                 }
                 self.input_mode = InputMode::Normal;
                 self.refresh();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_approve_queue_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('n') => {
+                self.input_mode = InputMode::Normal;
+            }
+            KeyCode::Char('y') | KeyCode::Enter => {
+                if let Some(rec) = self.pending_approvals.get(self.approvals_scroll).cloned() {
+                    self.decide_approval(&rec.id, "approved", None);
+                }
+                self.input_mode = InputMode::Normal;
+            }
+            KeyCode::Char('r') => {
+                // Reject without operator-supplied feedback from the TUI.
+                // Use the CLI if you want `--feedback "text"` to round-trip.
+                if let Some(rec) = self.pending_approvals.get(self.approvals_scroll).cloned() {
+                    self.decide_approval(&rec.id, "rejected", None);
+                }
+                self.input_mode = InputMode::Normal;
             }
             _ => {}
         }

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -79,6 +79,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_approve_plan_popup(frame, app, size);
     }
 
+    // AL-8 approval-queue confirm popup (N: explicit confirmation).
+    if app.input_mode == InputMode::ApproveQueue {
+        draw_approve_queue_popup(frame, app, size);
+    }
+
     // Pending-plan banner — only show when not already in a modal flow so it
     // doesn't fight with active popups for space. The banner draws over the
     // bottom edge of the center panel.
@@ -89,6 +94,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             | InputMode::SessionSelect
             | InputMode::RewindSelect
             | InputMode::ApprovePlan
+            | InputMode::ApproveQueue
     );
     if !in_modal && !app.pending_plans.is_empty() {
         draw_pending_plan_banner(frame, app, main_area);
@@ -241,6 +247,7 @@ fn draw_center(frame: &mut Frame, app: &mut App, area: Rect) {
         Tab::Board => draw_board(frame, app, &channel_name, area),
         Tab::Decisions => draw_decisions(frame, app, &channel_name, area),
         Tab::Prs => draw_prs(frame, app, &channel_name, area),
+        Tab::Approvals => draw_approvals(frame, app, area),
     }
 }
 
@@ -249,6 +256,16 @@ fn tab_bar_line(app: &App) -> Line<'static> {
     let c_board = if app.active_tab == Tab::Board { Color::Cyan } else { Color::DarkGray };
     let c_dec = if app.active_tab == Tab::Decisions { Color::Cyan } else { Color::DarkGray };
     let c_prs = if app.active_tab == Tab::Prs { Color::Cyan } else { Color::DarkGray };
+    let c_apv = if app.active_tab == Tab::Approvals { Color::Cyan } else { Color::DarkGray };
+    // Badge the Approvals tab with a pending count so the user notices
+    // queue items even when another tab is in focus. Zero-count still
+    // renders, just in muted grey — less surprising than a flickering
+    // label that appears and disappears.
+    let apv_label = if app.pending_approvals.is_empty() {
+        ":Approvals ".to_string()
+    } else {
+        format!(":Approvals({}) ", app.pending_approvals.len())
+    };
     Line::from(vec![
         Span::styled(" 1", Style::default().fg(c_chat)),
         Span::styled(":Chat", Style::default().fg(c_chat)),
@@ -260,7 +277,10 @@ fn tab_bar_line(app: &App) -> Line<'static> {
         Span::styled(":Decisions", Style::default().fg(c_dec)),
         Span::styled(" | ", Style::default().fg(Color::DarkGray)),
         Span::styled("4", Style::default().fg(c_prs)),
-        Span::styled(":PRs ", Style::default().fg(c_prs)),
+        Span::styled(":PRs", Style::default().fg(c_prs)),
+        Span::styled(" | ", Style::default().fg(Color::DarkGray)),
+        Span::styled("5", Style::default().fg(c_apv)),
+        Span::styled(apv_label, Style::default().fg(c_apv)),
     ])
     .right_aligned()
 }
@@ -747,6 +767,73 @@ fn pad_right(s: &str, width: usize) -> String {
         let pad = width - s.chars().count();
         format!("{}{}", s, " ".repeat(pad))
     }
+}
+
+/// AL-8 approvals queue pane. Lists every pending record across every
+/// session (read directly from `~/.relay/approvals/`). Keyboard:
+///   `a` → approve the highlighted record
+///   `d` → reject the highlighted record
+/// Both paths shell out to `rly approve <id>` / `rly reject <id>` so the
+/// queue mutation goes through the same TS writer as the CLI and GUI.
+fn draw_approvals(frame: &mut Frame, app: &App, area: Rect) {
+    let focused = app.focus == FocusPanel::Center && app.active_tab == Tab::Approvals;
+    let rows = &app.pending_approvals;
+
+    let items: Vec<ListItem> = if rows.is_empty() {
+        vec![ListItem::new(Line::from(vec![Span::styled(
+            "  No pending approvals. Tab to another pane or keep working.",
+            Style::default().fg(Color::DarkGray),
+        )]))]
+    } else {
+        let mut out = Vec::with_capacity(rows.len() + 1);
+        out.push(ListItem::new(Line::from(vec![Span::styled(
+            "  KIND                    ID                              SESSION              CREATED",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )])));
+        for (i, r) in rows.iter().enumerate() {
+            let is_selected = focused && i == app.approvals_scroll;
+            let indicator = if is_selected { "▸ " } else { "  " };
+            let session_short = if r.session_id.len() > 18 {
+                format!("{}…", &r.session_id[..17])
+            } else {
+                r.session_id.clone()
+            };
+            let created_short = if r.created_at.len() > 19 {
+                r.created_at[..19].to_string()
+            } else {
+                r.created_at.clone()
+            };
+            out.push(ListItem::new(Line::from(vec![
+                Span::styled(indicator, Style::default().fg(Color::Cyan)),
+                Span::styled(pad_right(&r.kind, 23), Style::default().fg(Color::White)),
+                Span::raw(" "),
+                Span::styled(pad_right(&r.id, 31), Style::default().fg(Color::Cyan)),
+                Span::raw(" "),
+                Span::styled(pad_right(&session_short, 20), Style::default().fg(Color::DarkGray)),
+                Span::raw(" "),
+                Span::styled(created_short, Style::default().fg(Color::DarkGray)),
+            ])));
+        }
+        out
+    };
+
+    let title = if rows.is_empty() {
+        " Approvals ".to_string()
+    } else {
+        format!(" Approvals ({}) — a:approve  d:reject ", rows.len())
+    };
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(border_style(app, FocusPanel::Center))
+            .title(title)
+            .title_style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD))
+            .title_bottom(tab_bar_line(app)),
+    );
+    frame.render_widget(list, area);
 }
 
 fn draw_right(frame: &mut Frame, app: &App, area: Rect) {
@@ -1374,6 +1461,58 @@ fn draw_approve_plan_popup(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(paragraph, popup_area);
 }
 
+/// Confirm-approve the AL-7/AL-8 queue record under the Approvals-tab
+/// cursor. Keeps the "irreversible action needs a two-key confirmation"
+/// contract consistent with `draw_approve_plan_popup`.
+fn draw_approve_queue_popup(frame: &mut Frame, app: &App, area: Rect) {
+    let dim = Block::default().style(Style::default().bg(Color::Black));
+    frame.render_widget(dim, area);
+
+    let popup_width = 64.min(area.width.saturating_sub(4));
+    let popup_height = 10u16.min(area.height.saturating_sub(4));
+    let popup_x = (area.width - popup_width) / 2;
+    let popup_y = (area.height - popup_height) / 2;
+    let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+    frame.render_widget(Clear, popup_area);
+
+    let rec = app.pending_approvals.get(app.approvals_scroll);
+    let mut lines: Vec<Line> = Vec::new();
+    if let Some(r) = rec {
+        lines.push(Line::from(Span::styled(
+            format!("  Record: {}", r.id),
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("  Session: {}", r.session_id),
+            Style::default().fg(Color::DarkGray),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("  Kind: {}", r.kind),
+            Style::default().fg(Color::Cyan),
+        )));
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            "  y/enter: approve   r: reject   n/esc: cancel",
+            Style::default().fg(Color::Yellow),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "  No approval record under cursor.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Green))
+        .border_type(BorderType::Double)
+        .title(" Approve queue record? ")
+        .title_style(Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))
+        .style(Style::default().bg(Color::Rgb(10, 25, 15)));
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, popup_area);
+}
+
 /// Thin top banner notifying the user that one or more runs are awaiting a
 /// plan-approval decision. Renders over the very top of the main area so it
 /// doesn't disturb the rest of the layout.
@@ -1743,6 +1882,48 @@ fn detail_content<'a>(app: &'a App) -> (String, Vec<Line<'a>>) {
                     )
                 } else {
                     ("No tracked PR".to_string(), vec![])
+                }
+            }
+            Tab::Approvals => {
+                if let Some(rec) = app.pending_approvals.get(app.approvals_scroll) {
+                    let payload_str =
+                        serde_json::to_string_pretty(&rec.payload).unwrap_or_default();
+                    let mut lines = vec![
+                        Line::from(vec![
+                            Span::styled("ID: ", Style::default().fg(Color::DarkGray)),
+                            Span::styled(&rec.id, Style::default().fg(Color::Cyan)),
+                        ]),
+                        Line::from(vec![
+                            Span::styled("Kind: ", Style::default().fg(Color::DarkGray)),
+                            Span::styled(
+                                &rec.kind,
+                                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                            ),
+                        ]),
+                        Line::from(vec![
+                            Span::styled("Session: ", Style::default().fg(Color::DarkGray)),
+                            Span::raw(&rec.session_id),
+                        ]),
+                        Line::from(vec![
+                            Span::styled("Status: ", Style::default().fg(Color::DarkGray)),
+                            Span::raw(&rec.status),
+                        ]),
+                        Line::from(vec![
+                            Span::styled("Created: ", Style::default().fg(Color::DarkGray)),
+                            Span::raw(&rec.created_at),
+                        ]),
+                        Line::raw(""),
+                        Line::from(Span::styled(
+                            "Payload:",
+                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                        )),
+                    ];
+                    for line in payload_str.lines() {
+                        lines.push(Line::raw(line.to_string()));
+                    }
+                    (format!("Approval: {}", rec.kind), lines)
+                } else {
+                    ("No pending approval".to_string(), vec![])
                 }
             }
         },


### PR DESCRIPTION
Closes #83

## Summary

Three equivalent drain surfaces onto the AL-7/AL-8 approvals queue, all reading/writing the same `~/.relay/approvals/<sessionId>/queue.jsonl` so state stays consistent across CLI / TUI / GUI processes.

- **CLI**: `rly approve next|all|<id>` · `rly reject <id> [--feedback "..."]` · `rly pending-approvals [--session <id>]`. Routes to the new queue handler when the first positional is `next`/`all`, `--session` is supplied, or the id starts with the `apv-` prefix; otherwise falls through to the existing plan-approval path (`rly approve <runId>`) unchanged.
- **TUI**: new `Tab::Approvals` (`5` / Tab / BackTab). `a` approves the highlighted record, `d` rejects. Tab label badges a pending count so queue items stay visible when another pane has focus.
- **GUI**: collapsible "Pending approvals" section in the RightPane, rendered above the existing tab content whenever the queue has pending records for the selected session. Auto-refreshes on the 5s parent tick.

## Stub

`src/approvals/queue.ts` ships the AL-7 `ApprovalsQueue` shape (`{id, sessionId, kind, payload, createdAt, status, decidedAt?}`) with append-only JSONL writes + temp-rename atomicity on status transitions. AL-7's merge is expected to absorb the enqueue / trust-gate logic; the serialized record shape must not change or these surfaces break.

## Cross-surface invariant

TUI and GUI funnel mutations through `rly approve <id>` / `rly reject <id>` (shell-out) so the queue file is only ever written by one code path (the TS `ApprovalsQueue`). Reads go direct from each surface (Rust `harness-data` for TUI/GUI, TS class for CLI) — byte-compatible via hand-pinned camelCase schema tests on the Rust side.

## Decisions worth flagging

- **TUI as a new 5th tab** rather than an overlay/modal: matches the Board/Decisions/PRs pattern the user already knows, keeps keyboard discoverability through the existing tab bar, and avoids layering a second focus stack on top of `FocusPanel`. Badging the tab label with the pending count means missed queue items still catch the eye.
- **GUI: collapsible section above the tabs** rather than its own tab: the queue is global (not per-channel-tab) and usually empty; a collapsible header keeps it out of the way until items land. Section auto-hides entirely when no pending items exist.
- **`--feedback` not surfaced in TUI yet**: keypress-driven reject with no modal. Leaves feedback capture to the CLI (`rly reject <id> --feedback "..."`) and GUI (which already collects it on the plan-approval card and can be extended per-record later).

## Test plan

- [x] `pnpm test` — 739 passed, 23 skipped (includes 11 new approvals-queue tests + cross-surface scenario)
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `cd gui && pnpm build`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — 60 crate tests passing (includes 5 new approval-queue Rust tests)
- [ ] Manual smoke: `rly approve next` drains a seeded queue; TUI `5` then `a` approves; GUI RightPane Approve button fires `rly approve <id>` — deferred to AL-7 landing since end-to-end exercise needs the real enqueue path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)