### PR TITLE
fix: audit agent invoker timeout + adopt XS/S/M/L/XL effort band

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -1923,6 +1923,7 @@ mod tests {
             status: "approved".into(),
             decided_at: Some("2026-01-02T00:00:00Z".into()),
             feedback: None,
+            auto_approved_by: None,
         }];
         rewrite_approval_queue(session, &records).expect("write ok");
         let reloaded = load_approval_queue(session);

--- a/scripts/push-tickets-to-github.ts
+++ b/scripts/push-tickets-to-github.ts
@@ -33,7 +33,22 @@ import { homedir } from "node:os";
 import { ChannelStore } from "../src/channels/channel-store.js";
 import type { TicketDefinition } from "../src/domain/ticket.js";
 
-type Effort = "S" | "M" | "L";
+// Effort band: XS/S/M/L/XL to match AL-6's audit-agent schema
+// (`AuditEffortEstimateSchema`) and the widened type in
+// `scripts/seed-autonomous-loop-tickets.ts`. The GH project's Effort
+// single-select field may only carry S/M/L options on older projects
+// — `discoverFields` below appends XS + XL lazily (BLUE / PURPLE) so
+// `setSingleSelectField` has an option id to reference regardless of
+// the field's seeded state. Existing tickets already tagged S/M/L
+// are untouched.
+type Effort = "XS" | "S" | "M" | "L" | "XL";
+const EFFORT_OPTION_COLORS: Record<Effort, string> = {
+  XS: "BLUE",
+  S: "GREEN",
+  M: "YELLOW",
+  L: "ORANGE",
+  XL: "PURPLE",
+};
 
 type Args = {
   channel: string;
@@ -77,7 +92,15 @@ type ProjectFields = {
   relayId: { id: string };
   effort: {
     id: string;
-    options: { S: string; M: string; L: string };
+    // Options map is partial: `discoverFields` creates missing
+    // XS/S/M/L/XL options lazily, but `setSingleSelectField` only looks
+    // up the effort the ticket actually carries. A missing lookup
+    // triggers an append via `addEffortOption` below.
+    options: Partial<Record<Effort, string>>;
+    // Full option list in GitHub's on-project shape, used as the base
+    // for `updateProjectV2Field` when appending a new option (same
+    // wholesale-replace contract as the Repo field).
+    optionDefs: Array<{ id: string; name: string; color: string; description: string }>;
   };
   dependsOn: { id: string };
   // Two-axis routing fields. Created by this script on first run if
@@ -127,7 +150,9 @@ function gh(args: string[], input?: string): string {
 }
 
 function parseEffort(title: string): Effort | null {
-  const m = title.match(/^\[([SML])\]/);
+  // Match XS/XL first (longer) before the single-letter variants so
+  // `[XS]` doesn't fall through to a speculative S match.
+  const m = title.match(/^\[(XS|XL|S|M|L)\]/);
   return (m?.[1] as Effort) ?? null;
 }
 
@@ -489,17 +514,31 @@ function discoverFields(
   if (!effortField) {
     throw new Error(`Project is missing required single-select field "${EFFORT_FIELD_NAME}"`);
   }
-  const effortOptionId = (label: "S" | "M" | "L"): string => {
-    const opt = effortField.options.find((o) => o.name === label);
-    if (!opt) {
-      throw new Error(
-        `"${EFFORT_FIELD_NAME}" field missing expected option "${label}" (have: ${effortField.options
-          .map((o) => o.name)
-          .join(", ")})`
-      );
+  // Effort options are discovered opportunistically: whatever the
+  // project currently has is the starting set. Missing XS/XL options
+  // are appended on-demand by `addEffortOption` when a ticket needs
+  // one — we don't force-create them at discovery time so projects
+  // that genuinely only want S/M/L stay lean.
+  const effortOptionsMap: Partial<Record<Effort, string>> = {};
+  for (const opt of effortField.options) {
+    if (
+      opt.name === "XS" ||
+      opt.name === "XL" ||
+      opt.name === "S" ||
+      opt.name === "M" ||
+      opt.name === "L"
+    ) {
+      effortOptionsMap[opt.name as Effort] = opt.id;
     }
-    return opt.id;
-  };
+  }
+  const effortOptionDefs: ProjectFields["effort"]["optionDefs"] = effortField.options.map(
+    (o, i) => ({
+      id: o.id,
+      name: o.name,
+      color: (o.color ?? "").toUpperCase() || pickOptionColor(i),
+      description: o.description ?? "",
+    })
+  );
 
   const dependsOnField = findText(DEPENDS_ON_FIELD_NAME);
   if (!dependsOnField) {
@@ -573,11 +612,8 @@ function discoverFields(
     relayId: { id: relayIdField.id },
     effort: {
       id: effortField.id,
-      options: {
-        S: effortOptionId("S"),
-        M: effortOptionId("M"),
-        L: effortOptionId("L"),
-      },
+      options: effortOptionsMap,
+      optionDefs: effortOptionDefs,
     },
     dependsOn: { id: dependsOnField.id },
     repoFieldId: repo.id,
@@ -658,6 +694,88 @@ function addRepoOption(projectId: string, fields: ProjectFields, alias: string):
   const created = fields.repoOptions.get(alias);
   if (!created) {
     throw new Error(`updateProjectV2Field returned no option id for ${alias}: ${out}`);
+  }
+  return created;
+}
+
+/**
+ * Add a new effort option (XS / XL) to the existing `Effort` single-
+ * select field. Same wholesale-replace contract as `addRepoOption`:
+ * every existing option is passed back with its `id` so GitHub
+ * preserves it, plus the new option (no id yet) gets appended with a
+ * deterministic palette slot (BLUE for XS, PURPLE for XL — matches the
+ * colour guidance in the AL-6 follow-up spec).
+ */
+function addEffortOption(projectId: string, fields: ProjectFields, effort: Effort): string {
+  const next = [
+    ...fields.effort.optionDefs.map((o) => ({
+      id: o.id,
+      name: o.name,
+      color: o.color || pickOptionColor(0),
+      description: o.description ?? "",
+    })),
+    {
+      name: effort,
+      color: EFFORT_OPTION_COLORS[effort],
+      description: `Effort size: ${effort}`,
+    },
+  ];
+  const query = `mutation AppendEffortOption($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  updateProjectV2Field(input: {
+    fieldId: $fieldId
+    singleSelectOptions: $options
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        options { id name color description }
+      }
+    }
+  }
+}`;
+  const payload = JSON.stringify({
+    query,
+    variables: { fieldId: fields.effort.id, options: next },
+  });
+  const out = gh(["api", "graphql", "--input", "-"], payload);
+  const parsed = JSON.parse(out) as {
+    data?: {
+      updateProjectV2Field?: {
+        projectV2Field?: { options?: Array<{ id: string; name: string; color?: string }> };
+      };
+    };
+    errors?: Array<{ message: string }>;
+  };
+  if (parsed.errors?.length) {
+    throw new Error(
+      `updateProjectV2Field failed — likely can't append Effort options via API on this project: ` +
+        parsed.errors.map((e) => e.message).join("; ") +
+        `. Add the '${effort}' option manually via the project UI and re-run.`
+    );
+  }
+  const options = parsed.data?.updateProjectV2Field?.projectV2Field?.options ?? [];
+  // Refresh the local cache so the loop doesn't re-append the same
+  // option for a subsequent ticket of the same size.
+  fields.effort.optionDefs.length = 0;
+  const isEffort = (name: string): name is Effort =>
+    name === "XS" || name === "S" || name === "M" || name === "L" || name === "XL";
+  for (const key of Object.keys(fields.effort.options) as Effort[]) {
+    delete fields.effort.options[key];
+  }
+  for (const [i, opt] of options.entries()) {
+    if (isEffort(opt.name)) {
+      fields.effort.options[opt.name] = opt.id;
+    }
+    fields.effort.optionDefs.push({
+      id: opt.id,
+      name: opt.name,
+      color: (opt.color ?? "").toUpperCase() || pickOptionColor(i),
+      description: "",
+    });
+  }
+  const created = fields.effort.options[effort];
+  if (!created) {
+    throw new Error(`updateProjectV2Field returned no option id for effort ${effort}: ${out}`);
   }
   return created;
 }
@@ -887,12 +1005,16 @@ async function main(): Promise<void> {
         setTextField(args.projectId, itemId, fields.relayId.id, t.id);
       }
       if (effort && current.effortOptionName !== effort) {
-        setSingleSelectField(
-          args.projectId,
-          itemId,
-          fields.effort.id,
-          fields.effort.options[effort]
-        );
+        // If the project's Effort field hasn't been seeded with this
+        // size yet (e.g. XS / XL on an older project that only had
+        // S/M/L), lazily append it before setting. `addEffortOption`
+        // refreshes `fields.effort.options` so follow-up tickets with
+        // the same size hit the cache.
+        let effortOptionId = fields.effort.options[effort];
+        if (!effortOptionId) {
+          effortOptionId = addEffortOption(args.projectId, fields, effort);
+        }
+        setSingleSelectField(args.projectId, itemId, fields.effort.id, effortOptionId);
       }
       const depsText = t.dependsOn.length > 0 ? t.dependsOn.join(", ") : "";
       if (depsText && current.dependsOnText !== depsText) {

--- a/scripts/seed-autonomous-loop-tickets.ts
+++ b/scripts/seed-autonomous-loop-tickets.ts
@@ -30,7 +30,13 @@ import { join } from "node:path";
 const REPO = process.env.RELAY_REPO ?? process.cwd();
 const CHANNEL_NAME = "autonomous-loop";
 
-type Effort = "S" | "M" | "L";
+// Effort band: widened to XS/S/M/L/XL to match AL-6's audit-agent
+// schema (`AuditEffortEstimateSchema`). Existing plan entries below
+// still use S/M/L; the widened type just unblocks the full band for
+// future plan additions and keeps every Effort surface in the repo
+// consistent. See `scripts/push-tickets-to-github.ts` for the GH
+// project-field side of the same widening.
+type Effort = "XS" | "S" | "M" | "L" | "XL";
 
 interface PlanItem {
   id: string;

--- a/src/orchestrator/audit-agent.ts
+++ b/src/orchestrator/audit-agent.ts
@@ -155,7 +155,8 @@ export type AuditSkipReason =
   | "budget_headroom_too_low"
   | "ledger_had_failures"
   | "ledger_empty"
-  | "agent_error";
+  | "agent_error"
+  | "agent_timeout";
 
 export interface RunPostCompletionAuditOptions {
   /** Channel the session is running against. */
@@ -172,6 +173,15 @@ export interface RunPostCompletionAuditOptions {
   budgetHeadroomPct: number;
   /** LLM invocation callback. See {@link AuditInvoker}. */
   invokeAudit: AuditInvoker;
+  /**
+   * Hard ceiling on how long the invoker is allowed to run before the
+   * audit gives up. A hung CLI child would otherwise wedge the post-drain
+   * teardown path indefinitely; this race guarantees the caller gets a
+   * result within `auditTimeoutMs + ε`. Defaults to
+   * {@link DEFAULT_AUDIT_TIMEOUT_MS} (5 minutes) which is the envelope an
+   * interactive operator can absorb without noticing.
+   */
+  auditTimeoutMs?: number;
 }
 
 /**
@@ -180,6 +190,15 @@ export interface RunPostCompletionAuditOptions {
  * configurable per-channel) has a single site to revisit.
  */
 export const AUDIT_MIN_HEADROOM_PCT = 15;
+
+/**
+ * Default timeout for the audit invoker. 5 minutes is generous relative
+ * to a healthy Claude/Codex round-trip (seconds) but short enough that a
+ * wedged child process does not block the autonomous-loop's teardown
+ * past the point an operator would notice. Exported so tests can
+ * reference the number without duplicating it.
+ */
+export const DEFAULT_AUDIT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * Prompt template. Intentionally a JSDoc constant rather than a separate
@@ -310,7 +329,14 @@ function isLedgerAllGreen(tickets: readonly TicketLedgerEntry[]): boolean {
 export async function runPostCompletionAudit(
   opts: RunPostCompletionAuditOptions
 ): Promise<AuditRunResult> {
-  const { channel, run, channelStore, budgetHeadroomPct, invokeAudit } = opts;
+  const {
+    channel,
+    run,
+    channelStore,
+    budgetHeadroomPct,
+    invokeAudit,
+    auditTimeoutMs = DEFAULT_AUDIT_TIMEOUT_MS,
+  } = opts;
 
   if (budgetHeadroomPct < AUDIT_MIN_HEADROOM_PCT) {
     return { kind: "skipped", reason: "budget_headroom_too_low" };
@@ -325,13 +351,34 @@ export async function runPostCompletionAudit(
 
   const prompt = renderAuditPrompt(channel, run);
   let rawResponse: string;
+  // Race the invoker against a wall-clock timeout. A hung CLI child
+  // would otherwise keep the post-drain path blocked forever; on
+  // timeout we return a distinct `agent_timeout` skip reason so the
+  // caller's metadata can differentiate "invoker threw" from "invoker
+  // never returned". The sentinel symbol is local so the timeout
+  // branch cannot be impersonated by a well-crafted invoker return.
+  const TIMEOUT_SENTINEL: unique symbol = Symbol("audit-agent-timeout");
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeoutP = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), auditTimeoutMs);
+    // Don't let this timer prevent process exit — the race winner
+    // clears it on success, but belt-and-braces keep teardown clean.
+    if (typeof timeoutHandle.unref === "function") timeoutHandle.unref();
+  });
   try {
-    rawResponse = await invokeAudit(prompt);
+    const raced = await Promise.race([invokeAudit(prompt), timeoutP]);
+    if (raced === TIMEOUT_SENTINEL) {
+      console.warn(`[audit-agent] invoker timed out after ${auditTimeoutMs}ms`);
+      return { kind: "skipped", reason: "agent_timeout" };
+    }
+    rawResponse = raced;
   } catch (err) {
     console.warn(
       `[audit-agent] invoker threw: ${err instanceof Error ? err.message : String(err)}`
     );
     return { kind: "skipped", reason: "agent_error" };
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   let parsed: unknown;

--- a/test/orchestrator/audit-agent.test.ts
+++ b/test/orchestrator/audit-agent.test.ts
@@ -36,6 +36,7 @@ import { SessionLifecycle } from "../../src/lifecycle/session-lifecycle.js";
 import { TokenTracker } from "../../src/budget/token-tracker.js";
 import {
   AUDIT_MIN_HEADROOM_PCT,
+  DEFAULT_AUDIT_TIMEOUT_MS,
   runPostCompletionAudit,
   type AuditInvoker,
   type AuditResponse,
@@ -242,6 +243,45 @@ describe("runPostCompletionAudit — gating", () => {
       invokeAudit: invoker,
     });
     expect(result).toEqual({ kind: "skipped", reason: "agent_error" });
+    warnSpy.mockRestore();
+  });
+
+  it("returns agent_timeout when invoker hangs past auditTimeoutMs", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Invoker that never resolves — a stand-in for a wedged CLI child.
+    // Using an unresolved Promise rather than a long `setTimeout` keeps
+    // the test time-independent: the race inside the audit agent is what
+    // resolves the result, not the invoker's own timer.
+    const hangingInvoker: AuditInvoker = () => new Promise<string>(() => {});
+
+    const start = Date.now();
+    const result = await runPostCompletionAudit({
+      channel,
+      channelStore,
+      run: {
+        sessionId: "s-1",
+        tickets: [makeTicket("t-1", "primary", "completed")],
+        decisions: [],
+        recentCommits: [],
+      },
+      budgetHeadroomPct: 50,
+      invokeAudit: hangingInvoker,
+      // Short timeout so the test finishes quickly. The production
+      // default is 5 min; we're asserting the race itself, not the
+      // specific duration.
+      auditTimeoutMs: 50,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result).toEqual({ kind: "skipped", reason: "agent_timeout" });
+    // Generous upper bound: timeout + slack for macro task scheduling
+    // on a loaded CI box. Sanity-check only — if this trips it means
+    // the race isn't actually racing.
+    expect(elapsed).toBeLessThan(2_000);
+    // Make sure the production default is still the advertised 5
+    // minutes; a silent drop to a smaller number would be a regression
+    // callers rely on as the upper envelope.
+    expect(DEFAULT_AUDIT_TIMEOUT_MS).toBe(5 * 60 * 1000);
     warnSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

Two small follow-up fixes bundled together:

### Fix 1 — AL-6 audit invoker timeout

`runPostCompletionAudit` previously awaited `invokeAudit(prompt)` without a timeout. A hung CLI child would wedge the post-drain teardown path forever. Now the invoker is raced against a `setTimeout`:

- New `DEFAULT_AUDIT_TIMEOUT_MS = 5 * 60 * 1000` (5 min) export
- New optional `auditTimeoutMs` on `RunPostCompletionAuditOptions`
- On timeout: returns `{kind: "skipped", reason: "agent_timeout"}` — a **new** `AuditSkipReason` variant, distinct from `agent_error`, so decision metadata can tell "invoker threw" from "invoker never returned"
- Unit test asserts a never-resolving invoker with `auditTimeoutMs: 50` resolves within 2s to `agent_timeout` without throwing. Also sanity-checks that `DEFAULT_AUDIT_TIMEOUT_MS === 5 * 60 * 1000` so a silent drop to a smaller number registers as a regression.

### Fix 2 — XS/S/M/L/XL effort-band canonicalization

`AuditEffortEstimateSchema` in `audit-agent.ts` already accepts `XS/S/M/L/XL`. The seeder scripts and GH-project push script were pinned to `S/M/L`. Fix widens everything so the whole repo agrees on the XS–XL band:

- `scripts/seed-autonomous-loop-tickets.ts` — widen `type Effort = "XS" | "S" | "M" | "L" | "XL"`. Existing plan entries stay S/M/L (untouched).
- `scripts/push-tickets-to-github.ts` —
  - Widen `type Effort` + `parseEffort` regex now matches `[XS]`/`[XL]` (long variants first so `[XS]` doesn't fall through to a speculative S match).
  - `ProjectFields.effort.options` is now `Partial<Record<Effort, string>>` plus a full `optionDefs` list (mirrors the existing `repoOptions` + `repoOptionDefs` pattern used for the `Target Repo` field introduced in AL-17).
  - New `addEffortOption` helper: lazily appends XS/XL (BLUE / PURPLE respectively — matches the spec's colour guidance) to the project's Effort single-select field on first push, via the same `updateProjectV2Field` wholesale-replace pattern `addRepoOption` already uses. Safe to re-run against an already-migrated project.
  - Push loop: if a ticket's effort isn't yet an option on the field, `addEffortOption` creates it, refreshes the cache, then the usual `setSingleSelectField` call proceeds.
- `src/orchestrator/audit-agent.ts` — schema already XS-XL, no change beyond the timeout work.
- `src/approvals/queue.ts` — `CreateTicketPayload` carries no effort field today; no change needed.

## Notes on the GH project migration

The spec gave two options for adding XS + XL to Project #3's Effort field:

1. A one-off GraphQL mutation run manually as part of the test plan.
2. Extend the push script to auto-create missing options on push.

**I went with option 2** — the `addEffortOption` helper mirrors `addRepoOption`, which already works against Project #3, so running `tsx scripts/push-tickets-to-github.ts --channel <id>` on any existing board will add XS + XL on first encounter. No manual GraphQL required. If that append fails on this specific project (e.g. permission quirks), the error message instructs the operator to add the missing option via the project UI and re-run — same fallback the existing `addRepoOption` uses.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 811 passed, 23 skipped (23 are live-network `describe.skip` blocks). Audit-agent suite now 10 tests (was 9).
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean
- [ ] First real push against Project #3 will add XS + XL to the Effort single-select field (via `addEffortOption`). Not run from source in this PR — it happens on the next `push-tickets-to-github.ts` invocation that encounters an XS or XL ticket.

## Acceptance criteria

- [x] `runPostCompletionAudit` resolves within `auditTimeoutMs + slack` when the invoker hangs.
- [x] `skipped/agent_timeout` distinguishable from `skipped/agent_error` in decision metadata (new enum variant).
- [x] Effort schema XS/S/M/L/XL everywhere the type is declared (audit-agent already XS-XL; both in-scope scripts widened).
- [x] Push script creates XS + XL options on the GH project Effort field when absent (via `addEffortOption`).
- [x] Existing tickets with effort S/M/L unaffected (field type widened, regex additive, push loop falls through `setSingleSelectField` as before for already-seeded options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)