### PR TITLE
al-16 follow-up: cross-process MCP→Coordinator IPC bridge

### DIFF
--- a/src/crosslink/ipc-bridge.ts
+++ b/src/crosslink/ipc-bridge.ts
@@ -1,0 +1,349 @@
+/**
+ * AL-16 cross-process IPC bridge.
+ *
+ * Problem shape: the Coordinator lives in the parent Node process, but
+ * each repo-admin's MCP server runs in a child process spawned by the
+ * Claude CLI. In-process code wires a Coordinator reference into the MCP
+ * server directly; child-process MCP servers never see it.
+ *
+ * Solution: file-based message queue per alias under
+ * `~/.relay/sessions/<sessionId>/coordination/`:
+ *
+ *   - `outbox-<alias>.jsonl`: the CHILD's `coordination_send` appends when
+ *     the in-process Coordinator is unavailable. The PARENT tails these.
+ *   - `inbox-<alias>.jsonl`: the PARENT appends after a successful
+ *     `coordinator.send`. The CHILD's `coordination_receive` tool reads
+ *     from this, tracking a cursor in `inbox-cursor-<alias>.json` so
+ *     prior messages don't get redelivered.
+ *
+ * Polling model: the parent bridge scans each registered alias's outbox
+ * file on an interval (`~250ms` default), parses any new lines, and
+ * routes them via the real Coordinator. Append-only JSONL + a byte-
+ * offset cursor (not file-size-based so a torn trailing line is OK)
+ * means the parent never re-routes what it has already seen.
+ */
+
+import { EventEmitter } from "node:events";
+import { mkdir, stat, readFile, appendFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { Coordinator } from "./coordinator.js";
+import { parseCoordinationMessage, type CoordinationMessage } from "./messages.js";
+import { getOutboxPath, getInboxPath, getCoordinationDir } from "./ipc-paths.js";
+
+/** Default poll cadence for tailing outbox files. */
+export const DEFAULT_POLL_INTERVAL_MS = 250;
+
+/**
+ * Wire-format record appended to an outbox / inbox JSONL line. Both ends
+ * of the bridge produce the same shape so `parseIpcRecord` can be reused
+ * for parent-side outbox reads and child-side inbox reads.
+ */
+export interface IpcRecord {
+  id: string;
+  from: string;
+  to: string;
+  payload: Record<string, unknown>;
+  writtenAt: string;
+}
+
+export interface IpcBridgeOptions {
+  sessionId: string;
+  coordinator: Coordinator;
+  rootDir?: string;
+  /** Poll interval in ms. Defaults to {@link DEFAULT_POLL_INTERVAL_MS}. */
+  pollIntervalMs?: number;
+  /** Injected clock for deterministic tests. Defaults to `Date.now`. */
+  clock?: () => number;
+  /**
+   * Injected error sink. Bridge I/O errors land here instead of throwing
+   * so the driver doesn't crash mid-poll. Defaults to `console.warn`.
+   */
+  onError?: (message: string, error: unknown) => void;
+}
+
+export type IpcBridgeEvent =
+  | { kind: "routed"; alias: string; record: IpcRecord }
+  | { kind: "parse-failure"; alias: string; raw: string; detail: string }
+  | { kind: "route-failure"; alias: string; record: IpcRecord; detail: string };
+
+interface OutboxState {
+  alias: string;
+  path: string;
+  /** Byte offset we've already routed past. */
+  cursor: number;
+}
+
+/**
+ * Parent-side tail + route loop. Hand it a {@link Coordinator} and a set
+ * of aliases to watch; it polls each alias's outbox file and routes new
+ * messages through the live bus. Also writes the receiver's inbox file
+ * on success so the target child can pick the message up on its next
+ * `coordination_receive` call.
+ */
+export class IpcBridge extends EventEmitter {
+  private readonly sessionId: string;
+  private readonly coordinator: Coordinator;
+  private readonly rootDir: string | undefined;
+  private readonly pollIntervalMs: number;
+  private readonly clock: () => number;
+  private readonly onError: (message: string, error: unknown) => void;
+
+  private readonly outboxes = new Map<string, OutboxState>();
+  private poller: NodeJS.Timeout | null = null;
+  private stopped = false;
+  private polling = false;
+
+  constructor(opts: IpcBridgeOptions) {
+    super();
+    this.sessionId = opts.sessionId;
+    this.coordinator = opts.coordinator;
+    this.rootDir = opts.rootDir;
+    this.pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.clock = opts.clock ?? (() => Date.now());
+    this.onError =
+      opts.onError ??
+      ((message, error) => {
+        const detail = error instanceof Error ? error.message : String(error);
+        console.warn(`[ipc-bridge] ${message}: ${detail}`);
+      });
+  }
+
+  /**
+   * Add an alias to the watch set. Idempotent. Calling `registerAlias`
+   * multiple times for the same alias doesn't reset the cursor — the
+   * bridge remembers what it has already routed.
+   */
+  registerAlias(alias: string): void {
+    if (this.outboxes.has(alias)) return;
+    this.outboxes.set(alias, {
+      alias,
+      path: getOutboxPath(this.sessionId, alias, this.rootDir),
+      cursor: 0,
+    });
+  }
+
+  /** Start the poll loop. Idempotent. */
+  async start(): Promise<void> {
+    if (this.stopped) return;
+    if (this.poller) return;
+    await mkdir(getCoordinationDir(this.sessionId, this.rootDir), { recursive: true });
+    // Seed each outbox cursor to the end-of-file so pre-existing messages
+    // from a prior session don't get re-routed. The child's side is also
+    // append-only; a fresh run starts from "no new messages".
+    for (const state of this.outboxes.values()) {
+      state.cursor = await fileSize(state.path);
+    }
+    this.poller = setInterval(() => void this.drainOnce(), this.pollIntervalMs);
+    // Don't hold the event loop open if this is the only handle.
+    (this.poller as unknown as { unref?: () => void }).unref?.();
+  }
+
+  /**
+   * Graceful shutdown. Clears the timer, awaits any in-flight poll, and
+   * marks the bridge as stopped so calls to `start()` after this are no-ops.
+   */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.poller) {
+      clearInterval(this.poller);
+      this.poller = null;
+    }
+    // Settle the in-flight drain if one is running.
+    while (this.polling) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  /**
+   * One drain pass — exported for tests so they can advance the bridge
+   * without waiting on the real setInterval cadence.
+   */
+  async drainOnce(): Promise<void> {
+    if (this.stopped || this.polling) return;
+    this.polling = true;
+    try {
+      for (const state of this.outboxes.values()) {
+        await this.drainOutbox(state);
+      }
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private async drainOutbox(state: OutboxState): Promise<void> {
+    let raw: string;
+    try {
+      raw = await readFile(state.path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      this.onError(`read outbox ${state.alias}`, err);
+      return;
+    }
+    if (raw.length <= state.cursor) return;
+
+    const chunk = raw.slice(state.cursor);
+    const lines = chunk.split("\n");
+    // A trailing partial line (crash mid-write) is skipped until the next
+    // drain, when either the writer completes it or the reader sees EOF.
+    const complete = raw.endsWith("\n") ? lines.filter((l) => l.length > 0) : lines.slice(0, -1);
+    // Advance cursor past the last fully-parsed line. If the final line
+    // is partial, leave the cursor on its starting byte so we retry next
+    // tick once the writer flushes its newline.
+    let consumed = 0;
+    for (let i = 0; i < lines.length; i += 1) {
+      const isLast = i === lines.length - 1;
+      if (isLast && !raw.endsWith("\n")) break;
+      consumed += lines[i].length + 1; // +1 for '\n'
+    }
+    state.cursor += consumed;
+
+    for (const line of complete) {
+      const record = parseIpcRecord(line);
+      if (!record) {
+        this.emit("ipc-event", {
+          kind: "parse-failure",
+          alias: state.alias,
+          raw: line,
+          detail: "malformed JSON or missing required fields",
+        } satisfies IpcBridgeEvent);
+        continue;
+      }
+      await this.routeRecord(record, state.alias);
+    }
+  }
+
+  private async routeRecord(record: IpcRecord, outboxAlias: string): Promise<void> {
+    // `from` SHOULD match the outbox alias (the child writing to its own
+    // outbox). If it doesn't, the coordinator's own spoof guard catches
+    // it — we still attempt the send so the rejection is logged.
+    const result = await this.coordinator.send(record.from, record.to, record.payload);
+    if (!result.ok) {
+      this.emit("ipc-event", {
+        kind: "route-failure",
+        alias: outboxAlias,
+        record,
+        detail: result.reason,
+      } satisfies IpcBridgeEvent);
+      return;
+    }
+    // Mirror the message into the target's inbox so their next
+    // `coordination_receive` sees it. The coordinator already delivered
+    // in-process (for any in-process subscriber) but the target child
+    // process only sees the file.
+    try {
+      const inboxPath = getInboxPath(this.sessionId, record.to, this.rootDir);
+      await mkdir(dirname(inboxPath), { recursive: true });
+      await appendFile(inboxPath, JSON.stringify(record) + "\n");
+    } catch (err) {
+      this.onError(`write inbox ${record.to}`, err);
+    }
+    this.emit("ipc-event", {
+      kind: "routed",
+      alias: outboxAlias,
+      record,
+    } satisfies IpcBridgeEvent);
+  }
+}
+
+async function fileSize(path: string): Promise<number> {
+  try {
+    const s = await stat(path);
+    return s.size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+}
+
+/**
+ * Shared wire-format parser. Exported so the child's `coordination_receive`
+ * can decode inbox lines with the exact same schema the bridge emits.
+ */
+export function parseIpcRecord(line: string): IpcRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const rec = parsed as Record<string, unknown>;
+  const { id, from, to, payload, writtenAt } = rec;
+  if (typeof id !== "string" || !id) return null;
+  if (typeof from !== "string" || !from) return null;
+  if (typeof to !== "string" || !to) return null;
+  if (!payload || typeof payload !== "object") return null;
+  if (typeof writtenAt !== "string" || !writtenAt) return null;
+  // We don't zod-check the payload here — the parent's coordinator.send
+  // does that authoritatively. A malformed payload results in a
+  // route-failure event on the bridge, not a silent drop.
+  return { id, from, to, payload: payload as Record<string, unknown>, writtenAt };
+}
+
+/**
+ * Helper used by the child MCP process's fallback path when the in-
+ * process Coordinator is unavailable. Appends to the outbox JSONL.
+ * Atomic up to POSIX `PIPE_BUF` for a single-process appender; the
+ * parent's reader tolerates torn trailing lines (see {@link IpcBridge.drainOutbox}).
+ */
+export async function writeOutboxRecord(
+  sessionId: string,
+  alias: string,
+  record: IpcRecord,
+  rootDir?: string
+): Promise<void> {
+  const path = getOutboxPath(sessionId, alias, rootDir);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, JSON.stringify(record) + "\n");
+}
+
+/** Persisted cursor for child-side inbox reads. */
+export interface InboxCursor {
+  /** Byte offset in the inbox file the child has already consumed. */
+  offset: number;
+}
+
+/** Read the inbox cursor (defaulting to offset 0 when absent). */
+export async function readInboxCursor(
+  sessionId: string,
+  alias: string,
+  rootDir?: string
+): Promise<InboxCursor> {
+  const { getInboxCursorPath } = await import("./ipc-paths.js");
+  const path = getInboxCursorPath(sessionId, alias, rootDir);
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as InboxCursor;
+    if (typeof parsed?.offset === "number") return parsed;
+  } catch {
+    // fall through — cursor doesn't exist or is corrupted; start fresh.
+  }
+  return { offset: 0 };
+}
+
+/** Write the inbox cursor atomically (tmp + rename). */
+export async function writeInboxCursor(
+  sessionId: string,
+  alias: string,
+  cursor: InboxCursor,
+  rootDir?: string
+): Promise<void> {
+  const { getInboxCursorPath } = await import("./ipc-paths.js");
+  const path = getInboxCursorPath(sessionId, alias, rootDir);
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, JSON.stringify(cursor));
+  const { rename } = await import("node:fs/promises");
+  await rename(tmp, path);
+}
+
+/**
+ * Type guard so downstream consumers can narrow `unknown` coordinator
+ * payloads before handing them to `parseCoordinationMessage`. Kept here
+ * rather than on `parseCoordinationMessage` itself to avoid circular
+ * import pressure on the schemas module.
+ */
+export function isCoordinationPayload(value: unknown): value is CoordinationMessage {
+  return parseCoordinationMessage(value).ok;
+}

--- a/src/crosslink/ipc-bridge.ts
+++ b/src/crosslink/ipc-bridge.ts
@@ -214,9 +214,23 @@ export class IpcBridge extends EventEmitter {
   }
 
   private async routeRecord(record: IpcRecord, outboxAlias: string): Promise<void> {
-    // `from` SHOULD match the outbox alias (the child writing to its own
-    // outbox). If it doesn't, the coordinator's own spoof guard catches
-    // it — we still attempt the send so the rejection is logged.
+    // Spoof guard: only the child that owns `outbox-<alias>.jsonl` can
+    // write to it, so `record.from` MUST match the outbox alias. The
+    // coordinator's own guard only cross-checks `from` against the
+    // `requester`/`blocker` fields on `blocked-on-repo` — `repo-ready`
+    // and `merge-order-proposal` carry `alias`/`proposer` that aren't
+    // cross-checked against `from`. Without this bridge-level check a
+    // malicious or buggy child could route messages under any identity
+    // AND poison the decisions audit trail.
+    if (record.from !== outboxAlias) {
+      this.emit("ipc-event", {
+        kind: "route-failure",
+        alias: outboxAlias,
+        record,
+        detail: `spoof-rejected: record.from="${record.from}" does not match outbox alias "${outboxAlias}"`,
+      } satisfies IpcBridgeEvent);
+      return;
+    }
     const result = await this.coordinator.send(record.from, record.to, record.payload);
     if (!result.ok) {
       this.emit("ipc-event", {

--- a/src/crosslink/ipc-paths.ts
+++ b/src/crosslink/ipc-paths.ts
@@ -1,0 +1,43 @@
+/**
+ * AL-16 IPC bridge: canonical file paths shared by parent + child.
+ *
+ * Keep these as pure functions with no I/O so test code can compute
+ * expected paths without touching the filesystem.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function defaultRootDir(): string {
+  return process.env.RELAY_HOME ?? join(homedir(), ".relay");
+}
+
+/** Root dir for one session's IPC traffic. */
+export function getCoordinationDir(sessionId: string, rootDir?: string): string {
+  return join(rootDir ?? defaultRootDir(), "sessions", sessionId, "coordination");
+}
+
+/**
+ * File the CHILD appends to and the PARENT tails. Each line is a JSON
+ * `{id, from, to, payload, writtenAt}` record. Parent's bridge reads it,
+ * routes via the live Coordinator, and moves the receiver's cursor forward.
+ */
+export function getOutboxPath(sessionId: string, alias: string, rootDir?: string): string {
+  return join(getCoordinationDir(sessionId, rootDir), `outbox-${alias}.jsonl`);
+}
+
+/**
+ * File the PARENT appends to after a successful send and the CHILD tails
+ * via `coordination_receive`. Holds messages addressed to `alias`.
+ */
+export function getInboxPath(sessionId: string, alias: string, rootDir?: string): string {
+  return join(getCoordinationDir(sessionId, rootDir), `inbox-${alias}.jsonl`);
+}
+
+/**
+ * Per-alias cursor persisted by the CHILD so `coordination_receive`
+ * doesn't re-deliver previously-read messages on the next tool call.
+ */
+export function getInboxCursorPath(sessionId: string, alias: string, rootDir?: string): string {
+  return join(getCoordinationDir(sessionId, rootDir), `inbox-cursor-${alias}.json`);
+}

--- a/src/mcp/coordination-tools.ts
+++ b/src/mcp/coordination-tools.ts
@@ -19,14 +19,33 @@
  * lightweight state interface the MCP server threads through.
  */
 
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
 import type { Coordinator, SendResult } from "../crosslink/coordinator.js";
 import { COORDINATION_MESSAGE_KINDS } from "../crosslink/messages.js";
+import {
+  writeOutboxRecord,
+  readInboxCursor,
+  writeInboxCursor,
+  parseIpcRecord,
+  type IpcRecord,
+} from "../crosslink/ipc-bridge.js";
+import { getInboxPath } from "../crosslink/ipc-paths.js";
 
 /**
  * MCP tool name. Exported so the role allowlist and tests can pattern-
  * match without re-declaring the string.
  */
 export const COORDINATION_SEND_TOOL = "coordination_send";
+
+/**
+ * MCP tool name for the child-side inbox drain. Repo-admin sessions
+ * running as a spawned MCP child reach the Coordinator via files, not
+ * in-memory; they call this tool at the start of each work cycle to
+ * pull pending messages addressed to their alias.
+ */
+export const COORDINATION_RECEIVE_TOOL = "coordination_receive";
 
 /**
  * State the MCP server owns and threads into each tool dispatch. A
@@ -39,14 +58,36 @@ export interface CoordinationToolState {
    * running inside a repo-admin context (RELAY_AGENT_ROLE=repo-admin).
    * Absent otherwise. */
   alias: string | null;
-  /** Per-run coordinator instance. Wired by the autonomous-loop driver
-   * (AL-16 follow-up). When null, the tool surfaces a clear error. */
+  /** Per-run coordinator instance. Populated when the MCP server runs
+   * in-process (tests, some dev flows). Child-process MCP servers leave
+   * this null and the tool falls through to the file-based IPC bridge
+   * (`writeOutboxRecord` + the parent's {@link IpcBridge} tail). */
   coordinator: Coordinator | null;
+  /** Session id that scopes the IPC files under
+   * `~/.relay/sessions/<sessionId>/coordination/`. Read from
+   * `RELAY_SESSION_ID` in the real spawner path. Required for the IPC
+   * fallback; tools return a clear error when absent. */
+  sessionId: string | null;
+  /** Root dir override for IPC paths. Defaults to `~/.relay` via
+   * {@link getCoordinationDir}. Tests inject a tmpdir. */
+  rootDir?: string;
+  /** Injected clock for deterministic tests. Defaults to `Date.now`. */
+  clock?: () => number;
+  /** Injected id factory for deterministic tests. Defaults to a
+   * crypto-free counter since the id's only job is to round-trip the
+   * message through the bridge for logging. */
+  idFactory?: () => string;
 }
 
 /** True iff the tool name belongs to the AL-16 surface. */
 export function isCoordinationTool(name: string): boolean {
-  return name === COORDINATION_SEND_TOOL;
+  return name === COORDINATION_SEND_TOOL || name === COORDINATION_RECEIVE_TOOL;
+}
+
+let ipcRecordCounter = 0;
+function defaultIpcId(): string {
+  ipcRecordCounter += 1;
+  return `ipc-${process.pid}-${Date.now().toString(36)}-${ipcRecordCounter.toString(36)}`;
 }
 
 /**
@@ -65,7 +106,10 @@ export function getCoordinationToolDefinitions(): object[] {
         "merged and downstream repos may be waiting on it; 'merge-order-proposal' " +
         "to record an ordering rationale across multiple open PRs. DO NOT free-text " +
         "these coordination handoffs in the channel feed — use this tool so the " +
-        "scheduler and other admins can parse them programmatically.",
+        "scheduler and other admins can parse them programmatically. Works whether " +
+        "the MCP server is in-process (tests) or spawned as a child process " +
+        "(production) — the tool auto-falls-back to a file-based IPC bridge in the " +
+        "latter case.",
       inputSchema: {
         type: "object",
         additionalProperties: false,
@@ -91,6 +135,26 @@ export function getCoordinationToolDefinitions(): object[] {
         },
       },
     },
+    {
+      name: COORDINATION_RECEIVE_TOOL,
+      description:
+        "Pull unread cross-repo coordination messages addressed to this repo-admin. " +
+        "Call at the start of each work cycle. Returns an array of messages that " +
+        "arrived since the last call. Cursor is persisted so messages are delivered " +
+        "exactly once per session.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            description: "Maximum number of messages to return in a single call. Default 25.",
+          },
+        },
+      },
+    },
   ];
 }
 
@@ -104,14 +168,23 @@ export async function callCoordinationTool(
   args: Record<string, unknown>,
   state: CoordinationToolState
 ): Promise<unknown> {
-  if (name !== COORDINATION_SEND_TOOL) {
-    return {
-      ok: false,
-      error: "unknown-tool",
-      detail: `coordination_send dispatcher received unexpected tool name: ${name}`,
-    };
+  if (name === COORDINATION_SEND_TOOL) {
+    return await handleSend(args, state);
   }
+  if (name === COORDINATION_RECEIVE_TOOL) {
+    return await handleReceive(args, state);
+  }
+  return {
+    ok: false,
+    error: "unknown-tool",
+    detail: `coordination dispatcher received unexpected tool name: ${name}`,
+  };
+}
 
+async function handleSend(
+  args: Record<string, unknown>,
+  state: CoordinationToolState
+): Promise<unknown> {
   if (!state.alias) {
     return {
       ok: false,
@@ -119,17 +192,6 @@ export async function callCoordinationTool(
       detail:
         "coordination_send is only callable from a repo-admin session. Set " +
         "RELAY_AGENT_ROLE=repo-admin and bind the session to a repo alias.",
-    };
-  }
-
-  if (!state.coordinator) {
-    return {
-      ok: false,
-      error: "coordinator-not-configured",
-      detail:
-        "No coordinator is wired into this MCP server instance. Coordination " +
-        "messaging requires running inside an autonomous-loop session where " +
-        "the Coordinator is constructed alongside the RepoAdminPool.",
     };
   }
 
@@ -150,10 +212,133 @@ export async function callCoordinationTool(
     };
   }
 
-  const result: SendResult = await state.coordinator.send(
-    state.alias,
+  // In-process path: the parent wired a live Coordinator into state.
+  // Fastest, simplest, used by tests + any future in-process admin.
+  if (state.coordinator) {
+    const result: SendResult = await state.coordinator.send(
+      state.alias,
+      to,
+      payload as Record<string, unknown>
+    );
+    return result;
+  }
+
+  // Cross-process path: the MCP server is running as a child of Claude
+  // CLI and doesn't share a heap with the parent's Coordinator. Append
+  // to the outbox file; the parent's IpcBridge will tail + route it.
+  if (!state.sessionId) {
+    return {
+      ok: false,
+      error: "coordinator-not-configured",
+      detail:
+        "No coordinator is wired into this MCP server instance AND RELAY_SESSION_ID " +
+        "is unset, so the file-based IPC fallback can't locate its outbox. This " +
+        "normally indicates the session was not spawned by the autonomous-loop " +
+        "driver.",
+    };
+  }
+
+  const clock = state.clock ?? Date.now;
+  const id = (state.idFactory ?? defaultIpcId)();
+  const record: IpcRecord = {
+    id,
+    from: state.alias,
     to,
-    payload as Record<string, unknown>
-  );
-  return result;
+    payload: payload as Record<string, unknown>,
+    writtenAt: new Date(clock()).toISOString(),
+  };
+  try {
+    await writeOutboxRecord(state.sessionId, state.alias, record, state.rootDir);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: "ipc-write-failed",
+      detail: `outbox append failed: ${detail}`,
+    };
+  }
+  return {
+    ok: true,
+    routedVia: "ipc-file",
+    messageId: id,
+    kind: (payload as { kind?: unknown }).kind,
+    from: state.alias,
+    to,
+    detail:
+      "Message queued for the parent process's IpcBridge. It will appear in the " +
+      "target admin's inbox after the parent routes it through the live Coordinator.",
+  };
+}
+
+async function handleReceive(
+  args: Record<string, unknown>,
+  state: CoordinationToolState
+): Promise<unknown> {
+  if (!state.alias) {
+    return {
+      ok: false,
+      error: "session-not-repo-admin",
+      detail: "coordination_receive is only callable from a repo-admin session.",
+    };
+  }
+  if (!state.sessionId) {
+    return {
+      ok: false,
+      error: "coordinator-not-configured",
+      detail:
+        "RELAY_SESSION_ID is unset; the inbox path cannot be resolved. This " +
+        "normally indicates the session was not spawned by the autonomous-loop " +
+        "driver.",
+    };
+  }
+  const limitArg = args.limit;
+  const limit =
+    typeof limitArg === "number" && Number.isFinite(limitArg) && limitArg >= 1
+      ? Math.min(100, Math.floor(limitArg))
+      : 25;
+
+  const inboxPath = getInboxPath(state.sessionId, state.alias, state.rootDir);
+  let raw: string;
+  try {
+    raw = await readFile(inboxPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ok: true, messages: [], cursor: 0 };
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: "ipc-read-failed", detail };
+  }
+
+  const cursor = await readInboxCursor(state.sessionId, state.alias, state.rootDir);
+  if (raw.length <= cursor.offset) {
+    return { ok: true, messages: [], cursor: cursor.offset };
+  }
+  const chunk = raw.slice(cursor.offset);
+  // Only whole lines — a torn trailing line stays in the buffer until
+  // the parent's next append closes it with a newline.
+  const lines = chunk.split("\n");
+  const complete = raw.endsWith("\n") ? lines.filter((l) => l.length > 0) : lines.slice(0, -1);
+
+  const messages: IpcRecord[] = [];
+  for (const line of complete) {
+    if (messages.length >= limit) break;
+    const rec = parseIpcRecord(line);
+    if (rec) messages.push(rec);
+  }
+
+  // Advance cursor only past the lines we actually returned so the next
+  // call picks up where we left off if we hit the limit.
+  let advanced = 0;
+  for (let i = 0; i < messages.length; i += 1) {
+    advanced += complete[i].length + 1; // +1 for newline
+  }
+  const nextOffset = cursor.offset + advanced;
+  try {
+    await writeInboxCursor(state.sessionId, state.alias, { offset: nextOffset }, state.rootDir);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: "ipc-cursor-write-failed", detail };
+  }
+  void mkdir(dirname(inboxPath), { recursive: true }); // idempotent ensure
+  return { ok: true, messages, cursor: nextOffset };
 }

--- a/src/mcp/role-allowlist.ts
+++ b/src/mcp/role-allowlist.ts
@@ -123,6 +123,10 @@ export const REPO_ADMIN_ALLOWED_TOOLS: ReadonlySet<string> = new Set<string>([
   // barred so cross-repo handoffs stay at the foreman tier where the
   // ticket board + decisions audit live.
   "coordination_send",
+  // AL-16 IPC follow-up: drain the inbox file populated by the parent's
+  // IpcBridge. Repo-admins running as spawned MCP children call this at
+  // the start of each work cycle to pull pending cross-repo messages.
+  "coordination_receive",
 ]);
 
 /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -133,8 +133,16 @@ export async function buildMcpMessageHandler(
   // rather than throwing. Null-coercion below keeps the type contract
   // explicit — `undefined` and omitted both collapse to null.
   const coordinationState: CoordinationToolState = {
-    alias: options.alias ?? null,
+    alias: options.alias ?? process.env.RELAY_AGENT_ALIAS ?? null,
     coordinator: options.coordinator ?? null,
+    // AL-16 IPC follow-up: when this server is spawned as a child
+    // process (no in-process Coordinator ref), `coordination_send`
+    // falls back to appending the outbox file at
+    // `~/.relay/sessions/<sessionId>/coordination/`. Read the parent
+    // autonomous-session id from RELAY_SESSION_ID; absent → the tool
+    // returns a clear "coordinator-not-configured" error instead of
+    // writing to a bogus path.
+    sessionId: process.env.RELAY_SESSION_ID ?? null,
   };
 
   // Auto-register this session

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -4,6 +4,7 @@ import type { Channel, RepoAssignment } from "../domain/channel.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
 import { ChannelStore } from "../channels/channel-store.js";
 import { Coordinator } from "../crosslink/coordinator.js";
+import { IpcBridge } from "../crosslink/ipc-bridge.js";
 import type { PrMergedEvent, PrPoller } from "../integrations/pr-poller.js";
 import { runPostCompletionAudit, type AuditInvoker, type AuditRunResult } from "./audit-agent.js";
 import { RepoAdminPool, isRepoAdminPoolEnabled } from "./repo-admin-pool.js";
@@ -473,6 +474,35 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
     }
   }
 
+  // AL-16 IPC follow-up: tails each admin's outbox file and routes
+  // messages through the live Coordinator. Necessary because each
+  // repo-admin MCP server runs as a Claude-CLI child process that
+  // can't share a heap with this Coordinator instance. Tests inject
+  // rootDir via testOverrides so outbox/inbox paths land under a
+  // tmpdir instead of ~/.relay.
+  const bridge =
+    coordinator && pool
+      ? new IpcBridge({
+          sessionId,
+          coordinator,
+          rootDir: testOverrides?.rootDir,
+        })
+      : null;
+  if (bridge && pool) {
+    for (const admin of pool.listSessions()) {
+      bridge.registerAlias(admin.alias);
+    }
+    try {
+      await bridge.start();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] IPC bridge failed to start: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
   // AL-7 integration anchor. When AL-5 (PR reviewer) and AL-6 (audit agent)
   // land their driver hooks, each of their ack-requiring outputs must be
   // threaded through `decide({trust: opts.trust, ...})` from
@@ -827,6 +857,33 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
         err instanceof Error ? err.message : String(err)
       }`
     );
+  }
+
+  // AL-16 IPC: stop the bridge BEFORE closing the coordinator. In-flight
+  // messages already appended to the outbox need one last drain so they
+  // hit the coordinator while it's still live; new writes after stop()
+  // sit in the outbox until the NEXT autonomous run (which seeds its
+  // cursor past them on start, i.e. they're dropped — acceptable for a
+  // session that's already terminating).
+  if (bridge) {
+    try {
+      await bridge.drainOnce();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] final IPC drain failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+    try {
+      await bridge.stop();
+    } catch (err) {
+      console.warn(
+        `[autonomous-loop] IPC bridge stop failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   // AL-16: close the coordinator BEFORE stopping the pool. Order

--- a/src/orchestrator/repo-admin-pool.ts
+++ b/src/orchestrator/repo-admin-pool.ts
@@ -434,6 +434,10 @@ export class RepoAdminPool {
       // session's behalf (in-process path) uses it + session.alias to
       // populate coordination state at construction.
       coordinator: this.coordinator,
+      // AL-16 IPC follow-up: let the spawner set RELAY_SESSION_ID on
+      // the child so its MCP server can resolve coordination file paths
+      // when the in-process Coordinator isn't reachable.
+      autonomousSessionId: this.lifecycle.sessionId,
     };
     const session = new RepoAdminSession(sessionOpts);
 

--- a/src/orchestrator/repo-admin-session.ts
+++ b/src/orchestrator/repo-admin-session.ts
@@ -114,6 +114,14 @@ export interface RepoAdminSpawnArgs {
    * (AL-0). Passed through to `--dangerously-skip-permissions`.
    */
   fullAccess: boolean;
+  /**
+   * Parent autonomous-session id (the one that owns the coordinator +
+   * budget + lifecycle). AL-16 IPC follow-up: the child MCP server uses
+   * this as `RELAY_SESSION_ID` to resolve `~/.relay/sessions/<id>/coordination/`
+   * paths when the in-process Coordinator isn't available. Optional for
+   * back-compat with tests constructed before the IPC bridge landed.
+   */
+  autonomousSessionId?: string;
 }
 
 /**
@@ -247,6 +255,14 @@ export interface RepoAdminSessionOptions {
    * behaviour — coordination is an autonomous-loop concern.
    */
   coordinator?: Coordinator | null;
+  /**
+   * AL-16 IPC: parent autonomous-session id. Threaded into the spawned
+   * child process as `RELAY_SESSION_ID` so the child's MCP server can
+   * resolve `~/.relay/sessions/<id>/coordination/` paths when the in-
+   * process Coordinator isn't reachable. Optional for back-compat with
+   * tests that construct a standalone session.
+   */
+  autonomousSessionId?: string;
 }
 
 /**
@@ -301,7 +317,17 @@ export class ClaudeRepoAdminSpawner implements RepoAdminProcessSpawner {
       // AL-11: activates the MCP per-role allowlist inside the spawned
       // session. RELAY_* flows through the default sanitizer whitelist,
       // so no `passEnv` gymnastics needed.
-      env: { RELAY_AGENT_ROLE: REPO_ADMIN_ROLE },
+      // AL-16 IPC: RELAY_SESSION_ID + RELAY_AGENT_ALIAS let the child
+      // MCP server resolve file-based coordination paths when the
+      // in-process Coordinator isn't reachable (the common production
+      // case). Both are optional — absence just disables the IPC
+      // fallback and coordination_send/receive return a structured
+      // "coordinator-not-configured" error.
+      env: {
+        RELAY_AGENT_ROLE: REPO_ADMIN_ROLE,
+        ...(args.autonomousSessionId ? { RELAY_SESSION_ID: args.autonomousSessionId } : {}),
+        RELAY_AGENT_ALIAS: args.alias,
+      },
       // Claude CLI still needs its auth creds; mirror the pass-list used
       // by the short-lived adapter in `src/agents/cli-agents.ts`.
       passEnv: [
@@ -384,6 +410,12 @@ export class RepoAdminSession {
   private readonly unsubscribeTokenTracker: () => void;
   private readonly cycleConfig: SessionCycleConfig | null;
   private readonly cycleClock: () => string;
+  /**
+   * AL-16 IPC: parent autonomous-session id passed through to the
+   * spawner for the RELAY_SESSION_ID env var. Undefined in tests that
+   * construct a standalone session.
+   */
+  private readonly autonomousSessionId: string | undefined;
 
   constructor(options: RepoAdminSessionOptions) {
     this.alias = options.assignment.alias;
@@ -396,6 +428,7 @@ export class RepoAdminSession {
     this.cycleConfig = options.cycle ?? null;
     this.cycleClock = options.cycleClock ?? (() => new Date().toISOString());
     this._coordinator = options.coordinator ?? null;
+    this.autonomousSessionId = options.autonomousSessionId;
 
     // AL-15: the session's own token tracker. A caller that supplies one
     // (tests, or a future aggregator) owns its lifetime; otherwise we
@@ -586,6 +619,7 @@ export class RepoAdminSession {
       alias: this.alias,
       sessionId: nextId,
       fullAccess: this.fullAccess,
+      autonomousSessionId: this.autonomousSessionId,
     });
     this.child = child;
 

--- a/test/agents/repo-admin.test.ts
+++ b/test/agents/repo-admin.test.ts
@@ -54,6 +54,7 @@ describe("repo-admin role — allowlist exactness", () => {
         "channel_get", // read decisions + feed + run links in one call
         "channel_post", // append-only feed updates (propose a spawn, announce a decision)
         "channel_task_board", // read the ticket board
+        "coordination_receive", // AL-16 IPC: drain inbox file populated by the parent's IpcBridge
         "coordination_send", // AL-16: typed inter-repo coordination messages
         "harness_get_run_detail", // read-only run state
         "harness_list_runs", // read-only run index

--- a/test/crosslink/coordination-tools.test.ts
+++ b/test/crosslink/coordination-tools.test.ts
@@ -63,7 +63,10 @@ async function withToolState(
       channelId: channel.channelId,
     });
     try {
-      await body({ alias: aliases[0] ?? null, coordinator }, { dir, channelId: channel.channelId });
+      await body(
+        { alias: aliases[0] ?? null, coordinator, sessionId: null },
+        { dir, channelId: channel.channelId }
+      );
     } finally {
       await coordinator.close();
     }
@@ -86,13 +89,14 @@ describe("coordination_send MCP tool", () => {
       description: string;
       inputSchema: { required: string[]; properties: { to: unknown; payload: unknown } };
     }>;
-    expect(defs).toHaveLength(1);
+    expect(defs).toHaveLength(2);
     expect(defs[0].name).toBe("coordination_send");
     expect(defs[0].inputSchema.required).toEqual(["to", "payload"]);
+    expect(defs[1].name).toBe("coordination_receive");
   });
 
   it("returns session-not-repo-admin when alias is null", async () => {
-    const state: CoordinationToolState = { alias: null, coordinator: null };
+    const state: CoordinationToolState = { alias: null, coordinator: null, sessionId: null };
     const result = (await callCoordinationTool(
       "coordination_send",
       { to: "frontend", payload: { kind: "repo-ready" } },
@@ -103,7 +107,7 @@ describe("coordination_send MCP tool", () => {
   });
 
   it("returns coordinator-not-configured when the coordinator is absent", async () => {
-    const state: CoordinationToolState = { alias: "backend", coordinator: null };
+    const state: CoordinationToolState = { alias: "backend", coordinator: null, sessionId: null };
     const result = (await callCoordinationTool(
       "coordination_send",
       { to: "frontend", payload: { kind: "repo-ready" } },

--- a/test/crosslink/ipc-bridge.test.ts
+++ b/test/crosslink/ipc-bridge.test.ts
@@ -297,6 +297,51 @@ describe("AL-16 IPC bridge — file-based cross-process coordination", () => {
     });
   });
 
+  it("rejects spoofed `from` where record.from != outbox alias", async () => {
+    await withFixture(["a", "b", "c"], async ({ rootDir, coordinator }) => {
+      const outbox = getOutboxPath(SESSION_ID, "a", rootDir);
+      await mkdir(join(rootDir, "sessions", SESSION_ID, "coordination"), {
+        recursive: true,
+      });
+      // Admin "a" writes a record claiming to be from "b" (spoof).
+      const spoof: IpcRecord = {
+        id: "spoof-1",
+        from: "b", // lie
+        to: "c",
+        payload: {
+          kind: "repo-ready",
+          alias: "b",
+          ticketId: "T-spoof",
+          prUrl: "https://x.test/pull/1",
+          announcedAt: "2026-04-22T00:00:00Z",
+        },
+        writtenAt: "2026-04-22T00:00:00Z",
+      };
+      await writeFile(outbox, JSON.stringify(spoof) + "\n", "utf8");
+
+      const bridge = new IpcBridge({ sessionId: SESSION_ID, coordinator, rootDir });
+      bridge.registerAlias("a");
+      bridge.registerAlias("b");
+      bridge.registerAlias("c");
+
+      const events: string[] = [];
+      bridge.on("ipc-event", (e: { kind: string; detail?: string }) => {
+        if (e.kind === "route-failure") events.push(e.detail ?? "");
+      });
+      await bridge.drainOnce();
+
+      // Spoof rejected before coordinator.send — c's inbox must NOT carry the message.
+      let inboxRaw = "";
+      try {
+        inboxRaw = await readFile(getInboxPath(SESSION_ID, "c", rootDir), "utf8");
+      } catch {
+        // inbox file may not exist at all, which is the stronger proof.
+      }
+      expect(inboxRaw).not.toContain("T-spoof");
+      expect(events.some((d) => d.includes("spoof-rejected"))).toBe(true);
+    });
+  });
+
   it("bridge stop is idempotent + clears the poll timer", async () => {
     await withFixture(["a"], async ({ rootDir, coordinator }) => {
       const bridge = new IpcBridge({

--- a/test/crosslink/ipc-bridge.test.ts
+++ b/test/crosslink/ipc-bridge.test.ts
@@ -58,8 +58,10 @@ async function withFixture(
     name: "#ipc-bridge",
     description: "ipc bridge tests",
   });
+  // Cast the fake pool to the Coordinator's pool parameter: it consumes
+  // `getSession` + `listSessions` opaquely, so a minimal fake is safe.
   const coordinator = new Coordinator({
-    pool: makeFakePool(aliases),
+    pool: makeFakePool(aliases) as unknown as ConstructorParameters<typeof Coordinator>[0]["pool"],
     channelStore,
     channelId: channel.channelId,
   });

--- a/test/crosslink/ipc-bridge.test.ts
+++ b/test/crosslink/ipc-bridge.test.ts
@@ -1,0 +1,319 @@
+/**
+ * AL-16 IPC bridge integration tests.
+ *
+ * Cover the three seams individually then the end-to-end loop:
+ *
+ *  - `writeOutboxRecord` — child-side append via the file-based fallback.
+ *  - `IpcBridge` parent-side tail + route → inbox fan-out.
+ *  - `coordination_receive` — child-side drain with cursor persistence.
+ *  - End-to-end: admin A's `coordination_send` (via file) → bridge
+ *    routes through coordinator → admin B's `coordination_receive`
+ *    (via file) returns the same message body.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Coordinator } from "../../src/crosslink/coordinator.js";
+import {
+  IpcBridge,
+  writeOutboxRecord,
+  readInboxCursor,
+  type IpcRecord,
+} from "../../src/crosslink/ipc-bridge.js";
+import { getInboxPath, getOutboxPath, getInboxCursorPath } from "../../src/crosslink/ipc-paths.js";
+import {
+  callCoordinationTool,
+  COORDINATION_RECEIVE_TOOL,
+  COORDINATION_SEND_TOOL,
+  type CoordinationToolState,
+} from "../../src/mcp/coordination-tools.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+
+const SESSION_ID = "ipc-bridge-test";
+
+interface FakePool {
+  getSession(alias: string): { alias: string } | null;
+  listSessions(): Array<{ alias: string }>;
+}
+
+function makeFakePool(aliases: string[]): FakePool {
+  const set = new Map(aliases.map((a) => [a, { alias: a }]));
+  return {
+    getSession: (a) => set.get(a) ?? null,
+    listSessions: () => [...set.values()],
+  };
+}
+
+async function withFixture(
+  aliases: string[],
+  body: (ctx: { rootDir: string; coordinator: Coordinator; channelId: string }) => Promise<void>
+): Promise<void> {
+  const rootDir = await mkdtemp(join(tmpdir(), "al-16-ipc-"));
+  process.env.RELAY_HOME = rootDir;
+  const channelStore = new ChannelStore(join(rootDir, "channels"));
+  const channel = await channelStore.createChannel({
+    name: "#ipc-bridge",
+    description: "ipc bridge tests",
+  });
+  const coordinator = new Coordinator({
+    pool: makeFakePool(aliases),
+    channelStore,
+    channelId: channel.channelId,
+  });
+  try {
+    await body({ rootDir, coordinator, channelId: channel.channelId });
+  } finally {
+    await coordinator.close();
+    await rm(rootDir, { recursive: true, force: true });
+    delete process.env.RELAY_HOME;
+  }
+}
+
+describe("AL-16 IPC bridge — file-based cross-process coordination", () => {
+  let originalHome: string | undefined;
+  beforeEach(() => {
+    originalHome = process.env.RELAY_HOME;
+  });
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.RELAY_HOME;
+    else process.env.RELAY_HOME = originalHome;
+  });
+
+  it("writeOutboxRecord + bridge routes the message into target's inbox", async () => {
+    await withFixture(["backend", "frontend"], async ({ rootDir, coordinator }) => {
+      const bridge = new IpcBridge({ sessionId: SESSION_ID, coordinator, rootDir });
+      bridge.registerAlias("backend");
+      bridge.registerAlias("frontend");
+      await bridge.start();
+      try {
+        const record: IpcRecord = {
+          id: "m-1",
+          from: "backend",
+          to: "frontend",
+          payload: {
+            kind: "repo-ready",
+            alias: "backend",
+            ticketId: "T-1",
+            prUrl: "https://example.com/x/pull/1",
+            announcedAt: "2026-04-22T00:00:00Z",
+          },
+          writtenAt: "2026-04-22T00:00:00Z",
+        };
+        await writeOutboxRecord(SESSION_ID, "backend", record, rootDir);
+        await bridge.drainOnce();
+
+        const inboxRaw = await readFile(getInboxPath(SESSION_ID, "frontend", rootDir), "utf8");
+        expect(inboxRaw).toContain("m-1");
+        const line = JSON.parse(inboxRaw.trim()) as IpcRecord;
+        expect(line.from).toBe("backend");
+        expect(line.to).toBe("frontend");
+        expect((line.payload as { kind: string }).kind).toBe("repo-ready");
+      } finally {
+        await bridge.stop();
+      }
+    });
+  });
+
+  it("bridge tolerates a torn trailing line — reprocesses once the writer completes it", async () => {
+    await withFixture(["a", "b"], async ({ rootDir, coordinator }) => {
+      const outbox = getOutboxPath(SESSION_ID, "a", rootDir);
+      await mkdir(join(rootDir, "sessions", SESSION_ID, "coordination"), {
+        recursive: true,
+      });
+      // Pre-seed a valid line + a torn tail (no newline).
+      await writeFile(
+        outbox,
+        `${JSON.stringify({
+          id: "valid-1",
+          from: "a",
+          to: "b",
+          payload: {
+            kind: "repo-ready",
+            alias: "a",
+            ticketId: "T-9",
+            prUrl: "https://x.test/pull/9",
+            announcedAt: "2026-04-22T00:00:00Z",
+          },
+          writtenAt: "2026-04-22T00:00:00Z",
+        })}\n{"id":"torn","from":"a`,
+        "utf8"
+      );
+
+      const bridge = new IpcBridge({ sessionId: SESSION_ID, coordinator, rootDir });
+      bridge.registerAlias("a");
+      bridge.registerAlias("b");
+      // Don't seed the cursor to EOF — tests want to observe pre-seeded records.
+      await bridge.drainOnce();
+
+      // Only the complete record lands in the inbox.
+      const inbox = await readFile(getInboxPath(SESSION_ID, "b", rootDir), "utf8");
+      expect(inbox).toContain("valid-1");
+      expect(inbox).not.toContain("torn");
+    });
+  });
+
+  it("coordination_receive returns only messages since last cursor", async () => {
+    await withFixture(["admin-a"], async ({ rootDir }) => {
+      // Pre-seed two records directly into admin-a's inbox so the
+      // `receive` tool has something to read without a running bridge.
+      const inbox = getInboxPath(SESSION_ID, "admin-a", rootDir);
+      await mkdir(join(rootDir, "sessions", SESSION_ID, "coordination"), {
+        recursive: true,
+      });
+      const lines = [
+        {
+          id: "m-1",
+          from: "backend",
+          to: "admin-a",
+          payload: {
+            kind: "repo-ready",
+            alias: "backend",
+            ticketId: "T-1",
+            prUrl: "https://x.test/pull/1",
+            announcedAt: "2026-04-22T00:00:00Z",
+          },
+          writtenAt: "2026-04-22T00:00:00Z",
+        },
+        {
+          id: "m-2",
+          from: "frontend",
+          to: "admin-a",
+          payload: {
+            kind: "repo-ready",
+            alias: "frontend",
+            ticketId: "T-2",
+            prUrl: "https://x.test/pull/2",
+            announcedAt: "2026-04-22T00:00:01Z",
+          },
+          writtenAt: "2026-04-22T00:00:01Z",
+        },
+      ];
+      await writeFile(inbox, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+
+      const state: CoordinationToolState = {
+        alias: "admin-a",
+        coordinator: null,
+        sessionId: SESSION_ID,
+        rootDir,
+      };
+      const first = (await callCoordinationTool(COORDINATION_RECEIVE_TOOL, {}, state)) as {
+        ok: boolean;
+        messages: IpcRecord[];
+      };
+      expect(first.ok).toBe(true);
+      expect(first.messages.map((m) => m.id)).toEqual(["m-1", "m-2"]);
+
+      const second = (await callCoordinationTool(COORDINATION_RECEIVE_TOOL, {}, state)) as {
+        messages: IpcRecord[];
+      };
+      expect(second.messages).toHaveLength(0);
+    });
+  });
+
+  it("coordination_send falls back to outbox file when coordinator is null but sessionId is set", async () => {
+    await withFixture(["backend", "frontend"], async ({ rootDir }) => {
+      const state: CoordinationToolState = {
+        alias: "backend",
+        coordinator: null,
+        sessionId: SESSION_ID,
+        rootDir,
+      };
+      const result = (await callCoordinationTool(
+        COORDINATION_SEND_TOOL,
+        {
+          to: "frontend",
+          payload: {
+            kind: "repo-ready",
+            alias: "backend",
+            ticketId: "T-7",
+            prUrl: "https://x.test/pull/7",
+            announcedAt: "2026-04-22T00:00:00Z",
+          },
+        },
+        state
+      )) as { ok: boolean; routedVia?: string; messageId?: string };
+      expect(result.ok).toBe(true);
+      expect(result.routedVia).toBe("ipc-file");
+      expect(typeof result.messageId).toBe("string");
+
+      const outbox = await readFile(getOutboxPath(SESSION_ID, "backend", rootDir), "utf8");
+      expect(outbox).toContain("T-7");
+    });
+  });
+
+  it("end-to-end: send via file → bridge routes → receive via file returns same body", async () => {
+    await withFixture(["backend", "frontend"], async ({ rootDir, coordinator }) => {
+      const bridge = new IpcBridge({ sessionId: SESSION_ID, coordinator, rootDir });
+      bridge.registerAlias("backend");
+      bridge.registerAlias("frontend");
+      await bridge.start();
+      try {
+        const sendState: CoordinationToolState = {
+          alias: "backend",
+          coordinator: null,
+          sessionId: SESSION_ID,
+          rootDir,
+        };
+        await callCoordinationTool(
+          COORDINATION_SEND_TOOL,
+          {
+            to: "frontend",
+            payload: {
+              kind: "repo-ready",
+              alias: "backend",
+              ticketId: "T-E2E",
+              prUrl: "https://x.test/pull/99",
+              announcedAt: "2026-04-22T00:00:00Z",
+            },
+          },
+          sendState
+        );
+        await bridge.drainOnce();
+
+        const recvState: CoordinationToolState = {
+          alias: "frontend",
+          coordinator: null,
+          sessionId: SESSION_ID,
+          rootDir,
+        };
+        const recv = (await callCoordinationTool(COORDINATION_RECEIVE_TOOL, {}, recvState)) as {
+          messages: IpcRecord[];
+        };
+        expect(recv.messages).toHaveLength(1);
+        expect(recv.messages[0].payload.kind).toBe("repo-ready");
+        expect((recv.messages[0].payload as { ticketId: string }).ticketId).toBe("T-E2E");
+      } finally {
+        await bridge.stop();
+      }
+
+      // Cursor file should be written post-receive.
+      const cursor = await readInboxCursor(SESSION_ID, "frontend", rootDir);
+      expect(cursor.offset).toBeGreaterThan(0);
+      const cursorFile = getInboxCursorPath(SESSION_ID, "frontend", rootDir);
+      expect((await readFile(cursorFile, "utf8")).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("bridge stop is idempotent + clears the poll timer", async () => {
+    await withFixture(["a"], async ({ rootDir, coordinator }) => {
+      const bridge = new IpcBridge({
+        sessionId: SESSION_ID,
+        coordinator,
+        rootDir,
+        pollIntervalMs: 20,
+      });
+      bridge.registerAlias("a");
+      await bridge.start();
+      await bridge.stop();
+      await bridge.stop(); // idempotent
+      // After stop, start() is a no-op (bridge permanently stopped).
+      await bridge.start();
+      // If the timer leaked, vitest would hang; we're verifying no leak by
+      // simply reaching here with an unref'd poller cleared.
+      expect(true).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes the cross-process gap flagged when AL-16 merged: the MCP server for a repo-admin session runs as a Claude-CLI child process, so the parent's in-process \`Coordinator\` reference never crosses the boundary. Every production \`coordination_send\` was returning \`coordinator-not-configured\`.

## What it adds
- **\`src/crosslink/ipc-paths.ts\`** — canonical outbox/inbox/cursor paths under \`~/.relay/sessions/<sessionId>/coordination/\`.
- **\`src/crosslink/ipc-bridge.ts\`** — parent-side \`IpcBridge\`: tails each admin's outbox, routes via the live Coordinator, mirrors the successful send into the target's inbox. Plus child-side helpers (\`writeOutboxRecord\`, \`readInboxCursor\`, \`writeInboxCursor\`).
- **\`src/mcp/coordination-tools.ts\`** — \`coordination_send\` now falls back to outbox append when \`coordinator\` is null but \`sessionId\` is set; new \`coordination_receive\` tool drains the inbox with exactly-once cursor semantics.
- **Repo-admin spawner** threads \`RELAY_SESSION_ID\` + \`RELAY_AGENT_ALIAS\` into the child env.
- **MCP server** reads those env vars to populate \`coordinationState\`.
- **\`coordination_receive\`** added to the repo-admin role allowlist.
- Bridge wired into \`startAutonomousSession\`. Teardown order: drain → stop bridge → close coordinator → stop pool.

## Acceptance criteria
- [x] IpcBridge routes outbox → coordinator → inbox end-to-end (integration test).
- [x] \`coordination_send\` with null coordinator falls back to outbox file append; returns \`{ok: true, routedVia: \"ipc-file\"}\`.
- [x] \`coordination_receive\` returns only messages since last cursor; cursor persists across tool invocations.
- [x] RELAY_SESSION_ID + RELAY_AGENT_ALIAS threaded through spawner.
- [x] Bridge polling rate-limited + stops cleanly; no leaked timers.
- [x] Cycle detection still fires via the bridge path (coordinator.send runs the same validation).

## Test plan
- \`pnpm typecheck\` — clean.
- \`pnpm vitest run --exclude '.claude/**' --exclude 'gui/**'\` — 816 pass / 23 skipped. 6 new integration cases in \`test/crosslink/ipc-bridge.test.ts\`.
- \`pnpm dlx prettier --check\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)