### PR TITLE
fix(release): derive npm version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Sync package.json version to tag
+        # Derives the npm version from the pushed git tag so the tag is the
+        # single source of truth. Prevents the "cannot publish over the
+        # previously published versions" failure class where package.json
+        # was forgotten during a release cut. GH_REF is runner-provided and
+        # git enforces tag-name character rules, so the substring-strip is
+        # safe (same pattern used by the release-github notes extraction).
+        # jq is preinstalled on ubuntu-latest runners.
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
+        env:
+          GH_REF: ${{ github.ref }}
+        run: |
+          TAG="${GH_REF#refs/tags/v}"
+          CURRENT=$(jq -r .version package.json)
+          if [ "$CURRENT" = "$TAG" ]; then
+            echo "package.json already at $TAG"
+          else
+            echo "Syncing package.json version $CURRENT -> $TAG"
+            jq --arg v "$TAG" '.version = $v' package.json > package.json.tmp
+            mv package.json.tmp package.json
+          fi
+
       - name: Publish gate notice
         if: vars.NPM_PUBLISH_ENABLED != 'true'
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jcast90/relay",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- Adds a `Sync package.json version to tag` step in `release.yml` that rewrites `package.json` to match the pushed tag before `npm publish`. The tag becomes the single source of truth.
- Bumps `package.json` to `0.6.1` so the next tag has a landing spot (v0.6.0 failed at npm with \`cannot publish over the previously published versions: 0.5.1\` because package.json still said 0.5.1 — the workflow publishes whatever is in package.json).

## Why
The v0.6.0 release run (24849839100) failed 5 min in with an npm duplicate-version 403. Root cause: `package.json.version` was forgotten during the tag cut. The GitHub Release + GUI bundles shipped fine (those jobs don't read package.json), but npm never got the new version. This sync step makes that class of failure impossible going forward.

## Test plan
- [ ] Merge this PR
- [ ] Tag `v0.6.1` on main and push
- [ ] Confirm release-npm run succeeds and `@jcast90/relay@0.6.1` appears on npm
- [ ] (Optional belt-and-suspenders) verify the sync step logs "package.json already at 0.6.1" since the bump is in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)