### PR TITLE
chore: bump workspace versions to 0.6.1 + fix rly rebuild gui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.5.1"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -3124,7 +3124,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.5.1"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.5.1"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/harness-data/Cargo.toml
+++ b/crates/harness-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-data"
-version = "0.5.1"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-gui",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-gui"
-version = "0.5.1"
+version = "0.6.1"
 edition = "2021"
 
 [lib]

--- a/src/cli/rebuild.ts
+++ b/src/cli/rebuild.ts
@@ -95,6 +95,20 @@ export async function runRebuild(options: RebuildOptions): Promise<number> {
   }
 
   if (options.gui) {
+    // gui/ is its own pnpm project with its own lockfile — it's not part
+    // of the root workspace, so a root `pnpm install` never touches it.
+    // Without this step, a freshly-added GUI dep surfaces as
+    // "Cannot find module '@tauri-apps/plugin-X'" during tsc and the
+    // actual fix (install gui deps) is hidden behind what looks like a
+    // code bug. Cheap no-op when already in sync.
+    if (!options.skipInstall) {
+      console.log("[rly rebuild] GUI deps — pnpm install (gui/)");
+      const installExit = await runTool("pnpm", ["install"], `${repoRoot}/gui`);
+      if (installExit !== 0) {
+        console.error("[rly rebuild] GUI pnpm install failed — stopping.");
+        return installExit;
+      }
+    }
     console.log("[rly rebuild] GUI — pnpm gui:build");
     const exit = await runTool("pnpm", ["gui:build"], repoRoot);
     if (exit !== 0) {

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-tui"
-version = "0.5.1"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bumps workspace internals (`crates/harness-data`, `tui`, `gui/src-tauri`, `gui/package.json`) from 0.5.1 → 0.6.1 so they match the npm release. Regenerates \`Cargo.lock\`. Root \`package.json\` is already at 0.6.1 (PR #127).
- Adds a \`pnpm install\` inside \`gui/\` to \`rly rebuild --gui\`. gui/ is its own pnpm project with its own lockfile and is not part of the root workspace, so a root \`pnpm install\` never touches it. Without this, freshly-added GUI deps surface as a tsc \"Cannot find module '@tauri-apps/plugin-X'\" error.

## Why
Discovered both during a local \`rly rebuild --all\`: build output showed \`harness-data v0.5.1\` / \`relay-tui v0.5.1\` / \`relay-gui@0.5.1\` despite npm being at 0.6.1, and the GUI build died on missing \`@tauri-apps/plugin-dialog\` + \`@tauri-apps/plugin-shell\` that were declared in \`gui/package.json\` but never installed. Each symptom is a small mismatch; together they make rebuild feel unreliable.

## Test plan
- [ ] \`rly rebuild --all\` completes green end-to-end on a clean checkout
- [ ] Cargo output shows \`v0.6.1\` for harness-data / relay-tui / relay-gui
- [ ] \`pnpm tauri build\` in gui/ succeeds without a prior manual \`pnpm install\`
- [ ] \`--skip-install\` still skips the gui-side install (no behavior change for that flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)