### PR TITLE
fix(gui): section creation works, unified sidebar + menu

### DIFF
--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -2,6 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
 import { basename, deriveAlias } from "../lib/alias";
 import type { Section, WorkspaceEntry } from "../types";
+import { PromptModal } from "./PromptModal";
+
+/** Sentinel value used for the "Create new section…" option in the
+ * Section <select>. Picked so it can't collide with a real sectionId
+ * (which are UUIDs). */
+const CREATE_SECTION_SENTINEL = "__create__";
 
 type Props = {
   open: boolean;
@@ -50,6 +56,7 @@ export function NewChannelModal({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [spawnWarning, setSpawnWarning] = useState<string | null>(null);
+  const [sectionPromptOpen, setSectionPromptOpen] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -314,7 +321,14 @@ export function NewChannelModal({
                 Section
                 <select
                   value={sectionId ?? ""}
-                  onChange={(e) => setSectionId(e.target.value || null)}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === CREATE_SECTION_SENTINEL) {
+                      setSectionPromptOpen(true);
+                      return;
+                    }
+                    setSectionId(v || null);
+                  }}
                 >
                   <option value="">None — Uncategorized</option>
                   {sections.map((s) => (
@@ -322,11 +336,10 @@ export function NewChannelModal({
                       {s.name}
                     </option>
                   ))}
+                  <option value={CREATE_SECTION_SENTINEL}>+ Create new section…</option>
                 </select>
                 <small style={{ color: "var(--color-text-dim)" }}>
-                  {sections.length === 0
-                    ? "Create a section from the sidebar to group channels."
-                    : "Change any time from the sidebar kebab menu."}
+                  Change any time from the sidebar kebab menu.
                 </small>
               </label>
             </div>
@@ -501,6 +514,23 @@ export function NewChannelModal({
           </div>
         </div>
       </div>
+
+      <PromptModal
+        open={sectionPromptOpen}
+        title="New section"
+        label="Section name"
+        placeholder="e.g. Billing, Infrastructure"
+        submitLabel="Create"
+        onSubmit={async (value) => {
+          const created = await api.createSection(value);
+          // Refresh the section list and auto-select the new one so the
+          // user doesn't have to re-find it.
+          const next = await api.listSections();
+          setSections(next);
+          setSectionId(created.sectionId);
+        }}
+        onClose={() => setSectionPromptOpen(false)}
+      />
     </div>
   );
 }

--- a/gui/src/components/PromptModal.tsx
+++ b/gui/src/components/PromptModal.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  open: boolean;
+  title: string;
+  label?: string;
+  placeholder?: string;
+  initialValue?: string;
+  submitLabel?: string;
+  onSubmit: (value: string) => Promise<void> | void;
+  onClose: () => void;
+};
+
+/**
+ * In-app text-input modal. Exists because Tauri v2 WKWebView no-ops
+ * `window.prompt` — `prompt` is a Web-platform API that Chromium ships
+ * but WKWebView does not, so the browser-native dialog never appears
+ * and the call silently returns null. Every place that previously
+ * called `window.prompt` should route through this instead.
+ */
+export function PromptModal({
+  open,
+  title,
+  label,
+  placeholder,
+  initialValue,
+  submitLabel,
+  onSubmit,
+  onClose,
+}: Props) {
+  const [value, setValue] = useState(initialValue ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setValue(initialValue ?? "");
+    setError(null);
+    setBusy(false);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [open, initialValue]);
+
+  if (!open) return null;
+
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length > 0 && !busy;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onSubmit(trimmed);
+      onClose();
+    } catch (err) {
+      setError(String(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        className="modal modal-sm"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label={title}
+      >
+        <div className="modal-header">
+          {title}
+          <button className="close-btn" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
+          <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {label && <span>{label}</span>}
+            <input
+              ref={inputRef}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={placeholder}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void submit();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  onClose();
+                }
+              }}
+              disabled={busy}
+            />
+          </label>
+          {error && (
+            <div style={{ color: "var(--color-danger, #f38ba8)", fontSize: 12, marginTop: 8 }}>
+              {error}
+            </div>
+          )}
+        </div>
+        <div className="modal-footer" style={{ justifyContent: "flex-end", gap: 8 }}>
+          <button type="button" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" onClick={submit} disabled={!canSubmit}>
+            {submitLabel ?? "OK"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { confirmAction, notifyError } from "../lib/dialogs";
 import type { Channel, Section } from "../types";
+import { PromptModal } from "./PromptModal";
 
 type Props = {
   channels: Channel[];
@@ -50,6 +51,30 @@ export function Sidebar({
   const [sections, setSections] = useState<Section[]>([]);
   const [workspaceCount, setWorkspaceCount] = useState<number>(0);
 
+  // Unified "+" — one button, dropdown offers "New channel" / "New
+  // section". Replaces two confusing affordances (header-+ on
+  // Channels + a bottom "+ New section" row) that left users unable
+  // to find section creation.
+  const [plusMenuOpen, setPlusMenuOpen] = useState(false);
+  const plusMenuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!plusMenuOpen) return;
+    const close = (e: MouseEvent) => {
+      if (plusMenuRef.current && !plusMenuRef.current.contains(e.target as Node)) {
+        setPlusMenuOpen(false);
+      }
+    };
+    document.addEventListener("click", close);
+    return () => document.removeEventListener("click", close);
+  }, [plusMenuOpen]);
+
+  // Section prompt state — replaces window.prompt (no-op'd by Tauri v2
+  // WKWebView on macOS, see gui/src/lib/dialogs.ts header).
+  type SectionPrompt =
+    | { kind: "create" }
+    | { kind: "rename"; section: Section };
+  const [sectionPrompt, setSectionPrompt] = useState<SectionPrompt | null>(null);
+
   useEffect(() => {
     api
       .listWorkspaces()
@@ -71,26 +96,25 @@ export function Sidebar({
   const toggleSectionOpen = (id: string) =>
     setSectionOpen((prev) => ({ ...prev, [id]: !isSectionOpen(id) }));
 
-  const newSection = async () => {
-    const name = window.prompt("Section name");
-    if (!name?.trim()) return;
-    try {
-      await api.createSection(name.trim());
-      await refreshSections();
-    } catch (err) {
-      await notifyError(`Failed to create section: ${err}`);
-    }
+  const openCreateSection = () => {
+    setPlusMenuOpen(false);
+    setSectionPrompt({ kind: "create" });
   };
 
-  const renameSection = async (section: Section) => {
-    const name = window.prompt("Rename section", section.name);
-    if (!name?.trim() || name.trim() === section.name) return;
-    try {
-      await api.renameSection(section.sectionId, name.trim());
+  const renameSection = (section: Section) => {
+    setSectionPrompt({ kind: "rename", section });
+  };
+
+  const submitSectionPrompt = async (value: string) => {
+    if (!sectionPrompt) return;
+    if (sectionPrompt.kind === "create") {
+      await api.createSection(value);
       await refreshSections();
-    } catch (err) {
-      await notifyError(`Rename failed: ${err}`);
+      return;
     }
+    if (value === sectionPrompt.section.name) return;
+    await api.renameSection(sectionPrompt.section.sectionId, value);
+    await refreshSections();
   };
 
   const decommissionSection = async (section: Section) => {
@@ -217,6 +241,40 @@ export function Sidebar({
 
       <div className="sidebar-divider" />
 
+      <div className="sidebar-new-menu-wrap" ref={plusMenuRef}>
+        <button
+          type="button"
+          className="sidebar-new-menu-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            setPlusMenuOpen((v) => !v);
+          }}
+          aria-haspopup="menu"
+          aria-expanded={plusMenuOpen}
+          aria-label="Create new"
+          title="Create new"
+        >
+          + New
+        </button>
+        {plusMenuOpen && (
+          <div className="sidebar-new-menu" role="menu">
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setPlusMenuOpen(false);
+                onNewChannel(null);
+              }}
+            >
+              New channel
+            </button>
+            <button type="button" role="menuitem" onClick={openCreateSection}>
+              New section
+            </button>
+          </div>
+        )}
+      </div>
+
       <div className="sidebar-scroll">
         {starred.length > 0 && (
           <SidebarSection
@@ -278,8 +336,6 @@ export function Sidebar({
           onToggle={() => setUncategorizedOpen((v) => !v)}
           onAdd={() => onNewChannel(null)}
           addTitle="New channel"
-          onHeaderPlus={sections.length === 0 ? newSection : undefined}
-          headerPlusTitle="New section"
         >
           {uncategorized.length === 0 && sections.length === 0 && (
             <div className="sidebar-empty">No active channels</div>
@@ -294,12 +350,6 @@ export function Sidebar({
             />
           ))}
         </SidebarSection>
-
-        {sections.length > 0 && (
-          <button type="button" className="sidebar-new-section" onClick={newSection}>
-            + New section
-          </button>
-        )}
 
         <SidebarSection
           title="Direct messages"
@@ -362,6 +412,25 @@ export function Sidebar({
           ⚙
         </button>
       </div>
+
+      <PromptModal
+        open={sectionPrompt !== null}
+        title={sectionPrompt?.kind === "rename" ? "Rename section" : "New section"}
+        label="Section name"
+        placeholder="e.g. Billing, Infrastructure"
+        initialValue={sectionPrompt?.kind === "rename" ? sectionPrompt.section.name : ""}
+        submitLabel={sectionPrompt?.kind === "rename" ? "Rename" : "Create"}
+        onSubmit={async (value) => {
+          try {
+            await submitSectionPrompt(value);
+          } catch (err) {
+            const verb = sectionPrompt?.kind === "rename" ? "Rename" : "Create";
+            await notifyError(`${verb} failed: ${err}`);
+            throw err;
+          }
+        }}
+        onClose={() => setSectionPrompt(null)}
+      />
     </div>
   );
 }
@@ -373,8 +442,6 @@ function SidebarSection({
   onToggle,
   onAdd,
   addTitle,
-  onHeaderPlus,
-  headerPlusTitle,
   menu,
   children,
 }: {
@@ -384,10 +451,6 @@ function SidebarSection({
   onToggle: () => void;
   onAdd?: () => void;
   addTitle?: string;
-  /** Extra `+` rendered alongside the section name — used for "New section"
-   * on the first uncategorized bucket when no real sections exist yet. */
-  onHeaderPlus?: () => void;
-  headerPlusTitle?: string;
   menu?: {
     onRename?: () => void;
     onDecommission?: () => void;
@@ -418,19 +481,6 @@ function SidebarSection({
           {title}
           <span className="section-count"> · {count}</span>
         </span>
-        {onHeaderPlus && (
-          <button
-            className="section-add"
-            onClick={(e) => {
-              e.stopPropagation();
-              onHeaderPlus();
-            }}
-            title={headerPlusTitle}
-            aria-label={headerPlusTitle}
-          >
-            +
-          </button>
-        )}
         {menu && (
           <div className="section-menu-wrap" onClick={(e) => e.stopPropagation()}>
             <button

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -70,9 +70,7 @@ export function Sidebar({
 
   // Section prompt state — replaces window.prompt (no-op'd by Tauri v2
   // WKWebView on macOS, see gui/src/lib/dialogs.ts header).
-  type SectionPrompt =
-    | { kind: "create" }
-    | { kind: "rename"; section: Section };
+  type SectionPrompt = { kind: "create" } | { kind: "rename"; section: Section };
   const [sectionPrompt, setSectionPrompt] = useState<SectionPrompt | null>(null);
 
   useEffect(() => {

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -281,6 +281,60 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   background: var(--color-ink-panel);
 }
 
+.sidebar-new-menu-wrap {
+  position: relative;
+  padding: var(--space-3) var(--space-4);
+}
+.sidebar-new-menu-btn {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: transparent;
+  border: 1px dashed var(--color-ink-line);
+  color: var(--color-text-on-dark-muted);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-uppercase);
+  cursor: pointer;
+  text-align: left;
+}
+.sidebar-new-menu-btn:hover,
+.sidebar-new-menu-btn[aria-expanded="true"] {
+  color: var(--color-text-on-dark);
+  border-color: var(--color-text-on-dark-muted);
+  background: var(--color-ink-panel);
+}
+.sidebar-new-menu {
+  position: absolute;
+  top: calc(100% - 2px);
+  left: var(--space-4);
+  right: var(--space-4);
+  z-index: 40;
+  background: var(--color-ink-panel);
+  border: 1px solid var(--color-ink-line);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+  padding: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.sidebar-new-menu button {
+  background: transparent;
+  border: none;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  color: var(--color-text-on-dark);
+  font: inherit;
+  font-size: var(--font-size-base);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+}
+.sidebar-new-menu button:hover {
+  background: var(--color-ink-raised);
+}
+
 .sidebar-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Critical fix — already in production

Users cannot create sections. Reported against the currently-released GUI: sidebar `+` silently does nothing, and NewChannelModal's Section dropdown tells users to "create a section from the sidebar" — a dead end.

## Root cause
`window.prompt` is no-op'd in Tauri v2 WKWebView on macOS. The project already documented this failure mode for `window.confirm` / `window.alert` (see `gui/src/lib/dialogs.ts` header) and routed those through the Tauri dialog plugin — but `window.prompt` has no `ask`/`message`-style plugin equivalent, so `Sidebar.tsx` still called native `window.prompt`, got back `null`, and silently fell through the `!name?.trim()` early-return.

## Changes
1. **New `PromptModal`** — in-app text-input component. Enter / Escape handling, whitespace trim, inline error text, autofocus, disables submit while busy.
2. **`Sidebar.tsx`** — section create/rename now route through `PromptModal`. The two separate `+` affordances (header-+ on Channels + bottom `+ New section` row) collapse into a single `+ New` button at the top of the scroll region that opens a menu: *New channel* / *New section*. Per-section `+` buttons (contextual "New channel in <section>") unchanged. Dead `onHeaderPlus`/`headerPlusTitle` props removed from `SidebarSection`.
3. **`NewChannelModal.tsx`** — Section `<select>` gains a trailing `+ Create new section…` option. Selecting it opens `PromptModal`, creates the section, refreshes the list, auto-selects the new one. Dead-end help text removed.
4. **`styles.css`** — `.sidebar-new-menu-wrap` / `.sidebar-new-menu-btn` / `.sidebar-new-menu` styles for the unified menu (reuses visual language of the old `.sidebar-new-section` button + `.section-menu` popover).

## Test plan
- [ ] Launch Relay.app from Finder — click `+ New` → menu appears with both options
- [ ] *New section* → PromptModal opens → type name → Enter → section appears in sidebar
- [ ] *New channel* → step 1 Section dropdown includes `+ Create new section…` → selecting it opens PromptModal → creating auto-selects the new section in the parent dropdown
- [ ] Rename a section via ⋯ menu → PromptModal pre-fills with current name → Enter renames
- [ ] Cancel (Esc or ×) closes cleanly, doesn't touch data
- [ ] Per-section `+` still creates a channel scoped to that section

## Follow-up PR (committed to ship next)
The reason this regression shipped is we have zero GUI test coverage. The next PR will add:
- `jsdom` + `@testing-library/react` + vitest config for the GUI
- Regression tests: PromptModal submit/cancel, Sidebar `+` menu + section flow, NewChannelModal "Create new section" flow
- A simple grep-guard that fails CI if `window.prompt` / `window.confirm` / `window.alert` appear anywhere under `gui/src/**`
- Wire the suite into CI so these can't ship again

🤖 Generated with [Claude Code](https://claude.com/claude-code)