### PR TITLE
feat(providers): multi-provider profiles (store + dispatch + GUI) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 ---
 
+> ⚠️ **Beta — pre-v1.** Relay is actively developed and hasn't cut a 1.0 yet. APIs, CLI flags, file layouts under `~/.relay/`, and GUI surfaces can change between releases. Expect bugs. If you hit one, please [open an issue](https://github.com/jcast90/relay/issues/new) with a reproduction — or send a PR. Work-in-progress features + things up for grabs live on the [GitHub Projects board](https://github.com/users/jcast90/projects/3) — pick something up and collaborate.
+
 ## What Relay is
 
 Relay turns a sentence, a GitHub issue URL, or a Linear ticket into a **running plan of AI-coded work** — with tickets, verification loops, live PR tracking, and optional human approval gates. Sessions run inside your normal Claude or Codex CLI; Relay wraps them with an MCP server that records everything into Slack-style **channels** you can query later.
@@ -47,6 +49,7 @@ CLI: **`rly`**.
 - [CLI reference](#cli-reference)
 - [MCP tools](#mcp-tools)
 - [Integrations](#integrations)
+- [Multi-provider](#multi-provider)
 - [Unattended mode](#unattended-mode)
 - [Storage & execution backends](#storage--execution-backends)
 - [Configuration](#configuration)
@@ -377,6 +380,32 @@ With `GITHUB_TOKEN` set, any orchestrator run starts a background poller that us
 
 `src/channels/ao-notifier.ts` exports `HarnessChannelNotifier implements Notifier` — so you can drop Relay in as a notifier plugin for Composio's `ao` orchestrator without a rewrite.
 
+## Multi-provider
+
+Relay's two CLI adapters (`claude`, `codex`) accept any endpoint that speaks their wire protocol, so **any provider exposing an OpenAI-compatible or Anthropic-compatible HTTP API works today with zero code changes** — just set the adapter's base-URL + key env vars. Known-good targets: MiniMax, OpenRouter, DeepSeek, Groq, Together, LiteLLM, vLLM.
+
+```bash
+# Route Codex through MiniMax.
+export HARNESS_PROVIDER=codex
+export OPENAI_BASE_URL=https://api.minimax.io/v1
+export OPENAI_API_KEY=$MINIMAX_API_KEY
+export HARNESS_AGENT_ATLAS_MODEL=MiniMax-M2
+rly run "Add a health endpoint"
+```
+
+For smoke-testing + per-agent overrides + named profiles, see [`docs/providers.md`](./docs/providers.md).
+
+```bash
+rly providers profiles list              # named profiles
+rly providers profiles add <id> ...      # save a profile for reuse
+rly providers default <id|clear>         # pick a default profile
+rly channel set-provider <ch> <pid>      # pin a channel to a profile
+```
+
+Profiles never store secrets — they reference env-var names (e.g. `apiKeyEnvRef: "MINIMAX_API_KEY"`), and `rly providers profiles add` rejects any `--env KEY=VAL` whose value looks like a raw key. The GUI has a Provider dropdown per channel (Settings drawer → About tab) and a Providers tab in the global Settings page for full CRUD.
+
+**Not yet shipped:** native adapters for coding CLIs that aren't Claude- or Codex-compatible (Cursor, Gemini, Aider). See the Roadmap for status.
+
 ## Unattended mode
 
 For multi-hour runs where you don't want to click "allow" on every tool call:
@@ -519,7 +548,7 @@ Per-area quick loops:
 
 ## Contributing
 
-Issues and PRs welcome. If you're considering a larger change, open an issue first so we can align on shape before you burn time.
+Relay is pre-v1 and issues/PRs are genuinely welcome — including from folks who've never contributed before. If you hit a bug, file it with a reproduction. If you want to help: the [GitHub Projects board](https://github.com/users/jcast90/projects/3) is the canonical list of work-in-progress features and things up for grabs. Pick a card, comment "I'll take this," and open a PR. For larger changes, open an issue first so we can align on shape before you burn time.
 
 See [`AGENTS.md`](./AGENTS.md) for the coding-agent conventions.
 

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -176,6 +176,14 @@ pub struct Channel {
     /// bottom of the sidebar. See `Section` for the grouping model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub section_id: Option<String>,
+    /// Provider profile ID overriding `HARNESS_PROVIDER` for agents
+    /// dispatched on behalf of this channel. The profile itself (adapter,
+    /// model, env overlay) lives in the provider-profile store owned by
+    /// the TypeScript side; the Rust dashboards only need to round-trip
+    /// the reference so a future "show provider profile" pill can read it.
+    /// Optional + `#[serde(default)]` for back-compat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_profile_id: Option<String>,
 }
 
 /// A sidebar grouping ("section") for channels — maps to Slack's
@@ -1764,6 +1772,7 @@ mod tests {
             full_access: None,
             kind: None,
             section_id: None,
+            provider_profile_id: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             updated_at: Some("2026-01-01T00:00:00Z".to_string()),
         }
@@ -1941,6 +1950,7 @@ mod tests {
             full_access: None,
             kind: None,
             section_id: None,
+            provider_profile_id: None,
             created_at: None,
             updated_at: None,
         }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,121 @@
+# Providers
+
+> **Status: beta.** Multi-provider support is actively being built — expect rough edges, breaking CLI flag changes, and dispatch paths that aren't yet wired up. If you hit a bug, please [open an issue](https://github.com/jcast90/relay/issues/new) with a reproduction, or send a PR. Tracked work: [GitHub Project — Multi-provider](https://github.com/jcast90/relay/projects) _(TODO: replace with real project URL once created)_.
+
+Relay dispatches work through CLI-based coding agents. Out of the box it ships adapters for two:
+
+- **Claude** (Anthropic's `claude` CLI)
+- **Codex** (OpenAI's `codex` CLI)
+
+Neither adapter is hard-wired to a single vendor's endpoint. Because both CLIs respect standard base-URL environment variables, **any provider exposing an OpenAI-compatible or Anthropic-compatible HTTP API can be reached through the existing adapters with zero code changes**. This document lists the known-good combinations and shows the env vars you need.
+
+> If you want a native adapter for a coding CLI that is neither Claude- nor Codex-compatible (e.g. `cursor-agent`, `gemini`), that's a different feature — see the "native adapters" note at the bottom.
+
+## How it works
+
+Relay's CLI adapters (`src/agents/cli-agents.ts`) shell out to the `claude` / `codex` binary with structured-output flags. The subprocess env is sanitised by default, but each adapter opts a small allowlist back in so the underlying CLI can pick up its own auth config:
+
+- `ClaudeCliAgent` forwards: `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`, `CLAUDE_CONFIG_DIR`, `CLAUDE_HOME`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, plus AWS / Vertex credentials.
+- `CodexCliAgent` forwards: `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`, `AZURE_OPENAI_*`, `CODEX_HOME`.
+
+Set the right ones in your shell and Relay picks them up. No config file needed.
+
+## Selecting a provider
+
+```bash
+# default provider for all dispatched agents
+export HARNESS_PROVIDER=claude   # or codex
+
+# per-agent overrides (agent ids: atlas, pixel, forge, lens, probe)
+export HARNESS_AGENT_ATLAS_PROVIDER=codex
+export HARNESS_AGENT_ATLAS_MODEL=gpt-4.1-mini
+```
+
+`rly run "<feature request>"` then routes each agent through its configured provider.
+
+## Recipes
+
+All recipes assume you've installed the underlying CLI (`claude` or `codex`) and have `rly` on your PATH.
+
+### OpenAI-compatible providers through Codex
+
+Set `HARNESS_PROVIDER=codex`, then point the OpenAI client at the provider's endpoint:
+
+```bash
+export HARNESS_PROVIDER=codex
+export OPENAI_BASE_URL=<provider endpoint>
+export OPENAI_API_KEY=<your key>
+export HARNESS_AGENT_ATLAS_MODEL=<provider model id>
+# (repeat the MODEL override for pixel / forge / lens / probe as needed)
+```
+
+Known-good endpoints:
+
+| Provider   | `OPENAI_BASE_URL`                      | Example model id            |
+| ---------- | -------------------------------------- | --------------------------- |
+| MiniMax    | `https://api.minimax.io/v1`            | `MiniMax-M2`                |
+| OpenRouter | `https://openrouter.ai/api/v1`         | `anthropic/claude-sonnet-4` |
+| DeepSeek   | `https://api.deepseek.com/v1`          | `deepseek-coder`            |
+| Groq       | `https://api.groq.com/openai/v1`       | `llama-3.3-70b-versatile`   |
+| Together   | `https://api.together.xyz/v1`          | `Qwen/Qwen2.5-Coder-32B`    |
+| LiteLLM    | `http://localhost:4000` (your gateway) | whatever you've proxied     |
+| vLLM       | `http://localhost:8000/v1`             | your served model           |
+
+Models with weak instruction-following or no structured-output support will produce results the orchestrator rejects. If a provider refuses Codex's `--output-schema` flag, it's not viable through this path.
+
+> Want to save these env vars under a reusable name? See [Named profiles](#named-profiles-experimental) below — `rly providers profiles add <id>` persists the recipe to `~/.relay/provider-profiles.json` (secrets stay in your shell).
+
+### Anthropic-compatible providers through Claude
+
+Set `HARNESS_PROVIDER=claude` and point the Anthropic client at the alternate endpoint:
+
+```bash
+export HARNESS_PROVIDER=claude
+export ANTHROPIC_BASE_URL=<provider endpoint>
+export ANTHROPIC_AUTH_TOKEN=<your key>
+export ANTHROPIC_MODEL=<provider model id>
+```
+
+This works for any proxy that speaks the Anthropic `/v1/messages` protocol (LiteLLM in Anthropic-compat mode, Bedrock proxies, etc.). For native Bedrock / Vertex, use the Claude CLI's own flags (`CLAUDE_CODE_USE_BEDROCK=1` / `CLAUDE_CODE_USE_VERTEX=1`) plus the appropriate cloud credentials — both are already in the env allowlist.
+
+## Smoke-testing your setup
+
+```bash
+rly providers check            # all configured providers
+rly providers check --provider codex
+rly providers list             # show what Relay sees in your env
+```
+
+`check` runs a short structured-output prompt end-to-end through the adapter you'd actually use at runtime, so it catches base-URL, auth, and schema-compat problems before a real `rly run` fails halfway through a plan.
+
+## Named profiles (experimental)
+
+A "provider profile" is a named bundle of adapter + env overrides + default model that you can save once and refer to by id later. Profiles live at `~/.relay/provider-profiles.json`. This PR adds the store and the CLI; the dispatch pipeline does not consume profiles yet — that is coming in a follow-up.
+
+**Profiles never store secrets.** The profile JSON references env-var _names_ via `apiKeyEnvRef` and stores non-secret `envOverrides` (base URLs, org ids, model names). You still export the actual key in your shell the way you do today. `rly providers profiles add` rejects any `--env KEY=VAL` whose value looks like a raw API key and points you at `--api-key-ref` instead.
+
+```bash
+# Create a profile for MiniMax on the Codex adapter.
+rly providers profiles add minimax \
+  --adapter codex \
+  --display-name "MiniMax (M2)" \
+  --env OPENAI_BASE_URL=https://api.minimax.io/v1 \
+  --api-key-ref MINIMAX_API_KEY \
+  --model MiniMax-M2
+
+# Inspect / list / remove / mark default.
+rly providers profiles list
+rly providers profiles show minimax
+rly providers profiles remove minimax
+rly providers default minimax     # set default
+rly providers default             # print default
+rly providers default clear       # unset default
+```
+
+`id` must match `[a-z0-9-]{1,32}`. `displayName` defaults to the id. `--env` can be repeated.
+
+## Native adapters (not yet)
+
+Everything above goes through the Claude or Codex CLI. Providers that ship their _own_ coding CLI (Cursor's `cursor-agent`, Google's `gemini`, Aider, etc.) need a native adapter — new class in `src/agents/cli-agents.ts`, new case in `src/agents/factory.ts`, widened `AgentProvider` union in `src/domain/agent.ts`, matching widening in `crates/harness-data/src/lib.rs`. That's a bigger change and isn't done yet. If you want it for a specific CLI, open an issue describing the CLI's arg shape and structured-output story.
+
+Providers that are API-only (no coding CLI, no file/tool-use loop) can't be dropped in as a peer of Claude or Codex at all — Relay dispatches _agentic sessions_, not single LLM completions.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # Providers
 
-> **Status: beta.** Multi-provider support is actively being built — expect rough edges, breaking CLI flag changes, and dispatch paths that aren't yet wired up. If you hit a bug, please [open an issue](https://github.com/jcast90/relay/issues/new) with a reproduction, or send a PR. Tracked work: [GitHub Project — Multi-provider](https://github.com/jcast90/relay/projects) _(TODO: replace with real project URL once created)_.
+> Relay is pre-v1 — see the [top-level beta note](../README.md#what-relay-is) in the README. This page is accurate as of the current release; CLI flags and the named-profiles surface may change. Issues and PRs welcome.
 
 Relay dispatches work through CLI-based coding agents. Out of the box it ships adapters for two:
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -63,7 +63,7 @@ Known-good endpoints:
 
 Models with weak instruction-following or no structured-output support will produce results the orchestrator rejects. If a provider refuses Codex's `--output-schema` flag, it's not viable through this path.
 
-> Want to save these env vars under a reusable name? See [Named profiles](#named-profiles-experimental) below — `rly providers profiles add <id>` persists the recipe to `~/.relay/provider-profiles.json` (secrets stay in your shell).
+> Want to save these env vars under a reusable name? See [Named profiles](#named-profiles) below — `rly providers profiles add <id>` persists the recipe to `~/.relay/provider-profiles.json` (secrets stay in your shell).
 
 ### Anthropic-compatible providers through Claude
 
@@ -78,19 +78,9 @@ export ANTHROPIC_MODEL=<provider model id>
 
 This works for any proxy that speaks the Anthropic `/v1/messages` protocol (LiteLLM in Anthropic-compat mode, Bedrock proxies, etc.). For native Bedrock / Vertex, use the Claude CLI's own flags (`CLAUDE_CODE_USE_BEDROCK=1` / `CLAUDE_CODE_USE_VERTEX=1`) plus the appropriate cloud credentials — both are already in the env allowlist.
 
-## Smoke-testing your setup
+## Named profiles
 
-```bash
-rly providers check            # all configured providers
-rly providers check --provider codex
-rly providers list             # show what Relay sees in your env
-```
-
-`check` runs a short structured-output prompt end-to-end through the adapter you'd actually use at runtime, so it catches base-URL, auth, and schema-compat problems before a real `rly run` fails halfway through a plan.
-
-## Named profiles (experimental)
-
-A "provider profile" is a named bundle of adapter + env overrides + default model that you can save once and refer to by id later. Profiles live at `~/.relay/provider-profiles.json`. This PR adds the store and the CLI; the dispatch pipeline does not consume profiles yet — that is coming in a follow-up.
+A "provider profile" is a named bundle of adapter + env overrides + default model that you can save once and refer to by id later. Profiles live at `~/.relay/provider-profiles.json`. The dispatch path consumes them: a channel pinned to a profile via `rly channel set-provider` (or the GUI dropdown) runs through that profile's adapter + envOverrides + default model. Resolution order is channel profile → global default (`rly providers default <id>`) → legacy `HARNESS_PROVIDER` env.
 
 **Profiles never store secrets.** The profile JSON references env-var _names_ via `apiKeyEnvRef` and stores non-secret `envOverrides` (base URLs, org ids, model names). You still export the actual key in your shell the way you do today. `rly providers profiles add` rejects any `--env KEY=VAL` whose value looks like a raw API key and points you at `--api-key-ref` instead.
 
@@ -112,7 +102,16 @@ rly providers default             # print default
 rly providers default clear       # unset default
 ```
 
-`id` must match `[a-z0-9-]{1,32}`. `displayName` defaults to the id. `--env` can be repeated.
+`id` must match `[a-z0-9-]{1,32}`. `displayName` defaults to the id. `--env` can be repeated. Every CLI command above accepts `--json` for machine-readable output (which the GUI Tauri layer uses).
+
+To pin a channel to a profile:
+
+```bash
+rly channel set-provider <channelId> <profileId>   # pin
+rly channel set-provider <channelId> clear         # inherit default / HARNESS_PROVIDER
+```
+
+The GUI exposes the same surface: Settings drawer → About → Provider dropdown on each channel, and a Providers tab in the global Settings page for full CRUD.
 
 ## Native adapters (not yet)
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -784,18 +784,17 @@ fn upsert_provider_profile(profile: ProviderProfileInput) -> Result<serde_json::
         profile.adapter.clone(),
         "--display-name".into(),
         profile.display_name.clone(),
-        "--upsert".into(),
         "--json".into(),
     ];
     if let Some(ref model) = profile.default_model {
         if !model.is_empty() {
-            args.push("--default-model".into());
+            args.push("--model".into());
             args.push(model.clone());
         }
     }
     if let Some(ref key) = profile.api_key_env_ref {
         if !key.is_empty() {
-            args.push("--api-key-env-ref".into());
+            args.push("--api-key-ref".into());
             args.push(key.clone());
         }
     }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -536,6 +536,7 @@ fn create_dm(
         full_access: None,
         kind: Some("dm".to_string()),
         section_id: None,
+        provider_profile_id: None,
         created_at: Some(now.to_rfc3339()),
         updated_at: Some(now.to_rfc3339()),
     };

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -722,6 +722,127 @@ fn set_channel_tier(channel_id: String, tier: Option<String>) -> Result<(), Stri
     data::save_channel(&ch)
 }
 
+// ─── Provider profiles ───────────────────────────────────────────
+// Added by PR 3 of the multi-provider series. All commands shell out
+// to the `rly providers …` / `rly channel set-provider` CLI paths
+// added by PRs 1 and 2 respectively — keeping one mutation path
+// across CLI + GUI. When the underlying subcommand isn't available
+// yet (PR 1/2 not merged), `cli_json` surfaces the non-zero exit
+// with stderr attached so the GUI shows a clear error banner rather
+// than silently succeeding.
+
+#[tauri::command]
+fn list_provider_profiles() -> Result<serde_json::Value, String> {
+    cli_json(&["providers", "profiles", "list", "--json"])
+}
+
+/// Read the globally-selected default profile id. The CLI prints
+/// `{ "defaultProfileId": "<id>" | null }` in JSON mode; absence of
+/// a default is normal and maps to `Ok(null)` on the renderer side.
+#[tauri::command]
+fn get_default_provider_profile_id() -> Result<Option<String>, String> {
+    let value = cli_json(&["providers", "default", "--json"])?;
+    Ok(value
+        .get("defaultProfileId")
+        .and_then(|v| v.as_str())
+        .map(String::from))
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderProfileInput {
+    pub id: String,
+    pub display_name: String,
+    pub adapter: String,
+    #[serde(default)]
+    pub env_overrides: BTreeMap<String, String>,
+    #[serde(default)]
+    pub api_key_env_ref: Option<String>,
+    #[serde(default)]
+    pub default_model: Option<String>,
+}
+
+#[tauri::command]
+fn upsert_provider_profile(profile: ProviderProfileInput) -> Result<serde_json::Value, String> {
+    validate_id_segment(&profile.id, "profile.id")?;
+    if profile.display_name.trim().is_empty() {
+        return Err("profile.displayName must not be empty".into());
+    }
+    if profile.adapter != "claude" && profile.adapter != "codex" {
+        return Err(format!(
+            "profile.adapter must be 'claude' or 'codex' (got '{}')",
+            profile.adapter
+        ));
+    }
+    let mut args: Vec<String> = vec![
+        "providers".into(),
+        "profiles".into(),
+        "add".into(),
+        profile.id.clone(),
+        "--adapter".into(),
+        profile.adapter.clone(),
+        "--display-name".into(),
+        profile.display_name.clone(),
+        "--upsert".into(),
+        "--json".into(),
+    ];
+    if let Some(ref model) = profile.default_model {
+        if !model.is_empty() {
+            args.push("--default-model".into());
+            args.push(model.clone());
+        }
+    }
+    if let Some(ref key) = profile.api_key_env_ref {
+        if !key.is_empty() {
+            args.push("--api-key-env-ref".into());
+            args.push(key.clone());
+        }
+    }
+    for (k, v) in profile.env_overrides.iter() {
+        if k.is_empty() {
+            continue;
+        }
+        args.push("--env".into());
+        args.push(format!("{}={}", k, v));
+    }
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    cli_json(&refs)
+}
+
+#[tauri::command]
+fn remove_provider_profile(id: String) -> Result<serde_json::Value, String> {
+    validate_id_segment(&id, "id")?;
+    cli_json(&["providers", "profiles", "remove", &id, "--json"])
+}
+
+#[tauri::command]
+fn set_default_provider_profile(id: Option<String>) -> Result<serde_json::Value, String> {
+    let target = match id.as_deref() {
+        None | Some("") => "clear".to_string(),
+        Some(s) => {
+            validate_id_segment(s, "id")?;
+            s.to_string()
+        }
+    };
+    cli_json(&["providers", "default", &target, "--json"])
+}
+
+#[tauri::command]
+fn set_channel_provider_profile(
+    channel_id: String,
+    profile_id: Option<String>,
+) -> Result<serde_json::Value, String> {
+    validate_id_segment(&channel_id, "channelId")?;
+    let target = match profile_id.as_deref() {
+        None | Some("") => "clear".to_string(),
+        Some(s) => {
+            validate_id_segment(s, "profileId")?;
+            s.to_string()
+        }
+    };
+    cli_json(&["channel", "set-provider", &channel_id, &target, "--json"])
+}
+
 #[tauri::command]
 fn get_settings() -> data::GuiSettings {
     data::load_gui_settings()
@@ -2745,6 +2866,13 @@ pub fn run() {
             // earlier (AL-9 owner); AL-10's duplicate was dropped.
             list_autonomous_sessions,
             get_session_state,
+            // Provider profiles (PR 3 of multi-provider series).
+            list_provider_profiles,
+            get_default_provider_profile_id,
+            upsert_provider_profile,
+            remove_provider_profile,
+            set_default_provider_profile,
+            set_channel_provider_profile,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -13,6 +13,7 @@ import type {
   GuiSettings,
   PendingPlan,
   PersistedChatMessage,
+  ProviderProfile,
   RewindResult,
   RewindSnapshot,
   RunIndexEntry,
@@ -204,6 +205,23 @@ export const api = {
   // session dir for the autonomous driver to observe. AL-10 reuses it
   // for the session-header stop button.
   stopSession: (sessionId: string) => invoke<void>("stop_session", { sessionId }),
+
+  // Provider profiles — named bundles of adapter + env overrides that
+  // resolve into the environment handed to agent subprocesses. All
+  // writes round-trip through the `rly providers …` CLI so the CLI
+  // and GUI share a single mutation path. Added by PR 3 of the
+  // multi-provider series; PR 1 wires the CLI commands these invoke.
+  listProviderProfiles: () => invoke<ProviderProfile[]>("list_provider_profiles"),
+  getDefaultProviderProfileId: () =>
+    invoke<string | null>("get_default_provider_profile_id"),
+  upsertProviderProfile: (profile: ProviderProfile) =>
+    invoke<ProviderProfile>("upsert_provider_profile", { profile }),
+  removeProviderProfile: (id: string) =>
+    invoke<void>("remove_provider_profile", { id }),
+  setDefaultProviderProfile: (id: string | null) =>
+    invoke<void>("set_default_provider_profile", { id }),
+  setChannelProviderProfile: (channelId: string, profileId: string | null) =>
+    invoke<void>("set_channel_provider_profile", { channelId, profileId }),
 };
 
 export type ChatEvent =

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -212,12 +212,10 @@ export const api = {
   // and GUI share a single mutation path. Added by PR 3 of the
   // multi-provider series; PR 1 wires the CLI commands these invoke.
   listProviderProfiles: () => invoke<ProviderProfile[]>("list_provider_profiles"),
-  getDefaultProviderProfileId: () =>
-    invoke<string | null>("get_default_provider_profile_id"),
+  getDefaultProviderProfileId: () => invoke<string | null>("get_default_provider_profile_id"),
   upsertProviderProfile: (profile: ProviderProfile) =>
     invoke<ProviderProfile>("upsert_provider_profile", { profile }),
-  removeProviderProfile: (id: string) =>
-    invoke<void>("remove_provider_profile", { id }),
+  removeProviderProfile: (id: string) => invoke<void>("remove_provider_profile", { id }),
   setDefaultProviderProfile: (id: string | null) =>
     invoke<void>("set_default_provider_profile", { id }),
   setChannelProviderProfile: (channelId: string, profileId: string | null) =>

--- a/gui/src/components/ChannelSettingsDrawer.tsx
+++ b/gui/src/components/ChannelSettingsDrawer.tsx
@@ -326,9 +326,8 @@ function AboutTab({
             color: "var(--color-text-muted)",
           }}
         >
-          Profile chosen here wins at dispatch. "Inherit default" falls back to
-          the global default profile, or <code>HARNESS_PROVIDER</code> if none
-          is set.
+          Profile chosen here wins at dispatch. "Inherit default" falls back to the global default
+          profile, or <code>HARNESS_PROVIDER</code> if none is set.
         </p>
         <select
           value={profileId}

--- a/gui/src/components/ChannelSettingsDrawer.tsx
+++ b/gui/src/components/ChannelSettingsDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
 import { confirmAction, notifyError } from "../lib/dialogs";
-import type { Channel, Spawn } from "../types";
+import type { Channel, ProviderProfile, Spawn } from "../types";
 
 type Tab = "repos" | "members" | "about";
 
@@ -214,6 +214,35 @@ function AboutTab({
   const [busy, setBusy] = useState(false);
   const [tier, setTier] = useState<string>(channel.tier ?? "");
   const [fullAccess, setFullAccess] = useState<boolean>(channel.fullAccess === true);
+  const [profiles, setProfiles] = useState<ProviderProfile[]>([]);
+  const [profileId, setProfileId] = useState<string>(channel.providerProfileId ?? "");
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listProviderProfiles()
+      .then((list) => {
+        if (!cancelled) setProfiles(list);
+      })
+      .catch(() => {
+        // PR 1 may not be merged yet — treat as "no profiles configured"
+        // rather than popping an error dialog every time the drawer opens.
+        if (!cancelled) setProfiles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const saveProfile = async (next: string) => {
+    setProfileId(next);
+    try {
+      await api.setChannelProviderProfile(channel.channelId, next || null);
+      onRefresh();
+    } catch (err) {
+      await notifyError(`Provider update failed: ${err}`);
+    }
+  };
 
   const toggleFullAccess = async () => {
     const next = !fullAccess;
@@ -286,6 +315,39 @@ function AboutTab({
           <option value="bugfix">Bugfix</option>
           <option value="chore">Chore</option>
           <option value="question">Question</option>
+        </select>
+      </div>
+      <div className="drawer-section">
+        <h4>Provider</h4>
+        <p
+          style={{
+            margin: "0 0 8px",
+            fontSize: "var(--font-size-xs)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          Profile chosen here wins at dispatch. "Inherit default" falls back to
+          the global default profile, or <code>HARNESS_PROVIDER</code> if none
+          is set.
+        </p>
+        <select
+          value={profileId}
+          onChange={(e) => saveProfile(e.target.value)}
+          style={{
+            padding: "6px 10px",
+            border: "1px solid var(--color-paper-line)",
+            borderRadius: 4,
+            background: "var(--color-paper-base)",
+            fontFamily: "var(--font-ui)",
+            fontSize: "var(--font-size-base)",
+          }}
+        >
+          <option value="">Inherit default</option>
+          {profiles.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.displayName} ({p.adapter})
+            </option>
+          ))}
         </select>
       </div>
       <div className="drawer-section">

--- a/gui/src/components/SettingsPage.tsx
+++ b/gui/src/components/SettingsPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { api } from "../api";
-import type { GuiSettings } from "../types";
+import type { GuiSettings, ProviderProfile } from "../types";
 import { useAppearance, type AvatarStyle, type Density } from "../lib/appearance";
 
-type Section = "ticketing" | "appearance" | "general";
+type Section = "ticketing" | "providers" | "appearance" | "general";
 
 type Props = {
   settings: GuiSettings;
@@ -42,6 +42,12 @@ export function SettingsPage({ settings, onSaved, onClose }: Props) {
           Ticketing
         </button>
         <button
+          className={`settings-nav-item ${section === "providers" ? "active" : ""}`}
+          onClick={() => setSection("providers")}
+        >
+          Providers
+        </button>
+        <button
           className={`settings-nav-item ${section === "appearance" ? "active" : ""}`}
           onClick={() => setSection("appearance")}
         >
@@ -61,6 +67,7 @@ export function SettingsPage({ settings, onSaved, onClose }: Props) {
         {section === "ticketing" && (
           <TicketingSection draft={draft} onChange={save} saving={saving} error={error} />
         )}
+        {section === "providers" && <ProvidersSection />}
         {section === "appearance" && <AppearanceSection />}
         {section === "general" && <GeneralSection />}
       </div>
@@ -184,6 +191,304 @@ function GeneralSection() {
           execution contexts; each (channel, repo) pair has its own agent instance.
         </p>
       </div>
+    </>
+  );
+}
+
+type EnvRow = { key: string; value: string };
+
+type DraftProfile = {
+  id: string;
+  displayName: string;
+  adapter: "claude" | "codex";
+  defaultModel: string;
+  apiKeyEnvRef: string;
+  envRows: EnvRow[];
+};
+
+const emptyDraft = (): DraftProfile => ({
+  id: "",
+  displayName: "",
+  adapter: "claude",
+  defaultModel: "",
+  apiKeyEnvRef: "",
+  envRows: [],
+});
+
+function ProvidersSection() {
+  const [profiles, setProfiles] = useState<ProviderProfile[]>([]);
+  const [defaultId, setDefaultId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [draft, setDraft] = useState<DraftProfile>(emptyDraft());
+
+  const refresh = async () => {
+    try {
+      const [list, def] = await Promise.all([
+        api.listProviderProfiles(),
+        api.getDefaultProviderProfileId(),
+      ]);
+      setProfiles(list);
+      setDefaultId(def);
+      setError(null);
+    } catch (err) {
+      setProfiles([]);
+      setDefaultId(null);
+      setError(String(err));
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const addProfile = async () => {
+    if (!draft.id.trim() || !draft.displayName.trim()) {
+      setError("Profile id and display name are required.");
+      return;
+    }
+    const envOverrides: Record<string, string> = {};
+    for (const row of draft.envRows) {
+      if (row.key.trim()) envOverrides[row.key.trim()] = row.value;
+    }
+    const now = new Date().toISOString();
+    const next: ProviderProfile = {
+      id: draft.id.trim(),
+      displayName: draft.displayName.trim(),
+      adapter: draft.adapter,
+      envOverrides,
+      apiKeyEnvRef: draft.apiKeyEnvRef.trim() || undefined,
+      defaultModel: draft.defaultModel.trim() || undefined,
+      createdAt: now,
+      updatedAt: now,
+    };
+    setBusy(true);
+    // Optimistic: drop the draft into the list so the table reflects the
+    // add immediately; the refetch below reconciles against server truth.
+    setProfiles((prev) => [...prev.filter((p) => p.id !== next.id), next]);
+    try {
+      await api.upsertProviderProfile(next);
+      setDraft(emptyDraft());
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const makeDefault = async (id: string | null) => {
+    const prev = defaultId;
+    setDefaultId(id);
+    try {
+      await api.setDefaultProviderProfile(id);
+      await refresh();
+    } catch (err) {
+      setDefaultId(prev);
+      setError(String(err));
+    }
+  };
+
+  const remove = async (id: string) => {
+    const prev = profiles;
+    setProfiles(prev.filter((p) => p.id !== id));
+    try {
+      await api.removeProviderProfile(id);
+      await refresh();
+    } catch (err) {
+      setProfiles(prev);
+      setError(String(err));
+    }
+  };
+
+  const addEnvRow = () =>
+    setDraft((d) => ({ ...d, envRows: [...d.envRows, { key: "", value: "" }] }));
+  const updateEnvRow = (i: number, patch: Partial<EnvRow>) =>
+    setDraft((d) => ({
+      ...d,
+      envRows: d.envRows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)),
+    }));
+  const removeEnvRow = (i: number) =>
+    setDraft((d) => ({ ...d, envRows: d.envRows.filter((_, idx) => idx !== i) }));
+
+  return (
+    <>
+      <h2>Providers</h2>
+      <div className="warning" style={{ marginBottom: 16 }}>
+        Profiles reference env var names — Relay never stores secrets.
+      </div>
+      <div className="settings-section">
+        <h3>Profiles</h3>
+        <p className="help">
+          Each profile bundles an adapter (Claude or Codex CLI) with env overrides
+          that get applied when Relay dispatches an agent. Set one as default,
+          or pin a specific profile per channel in that channel's settings.
+        </p>
+        {profiles.length === 0 ? (
+          <p className="help">
+            <em>No profiles configured yet.</em>
+          </p>
+        ) : (
+          <table
+            style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              fontSize: "var(--font-size-sm)",
+            }}
+          >
+            <thead>
+              <tr style={{ textAlign: "left", color: "var(--color-text-dim)" }}>
+                <th style={{ padding: "6px 8px" }}>ID</th>
+                <th style={{ padding: "6px 8px" }}>Name</th>
+                <th style={{ padding: "6px 8px" }}>Adapter</th>
+                <th style={{ padding: "6px 8px" }}>Model</th>
+                <th style={{ padding: "6px 8px" }}>Key env var</th>
+                <th style={{ padding: "6px 8px" }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {profiles.map((p) => (
+                <tr
+                  key={p.id}
+                  style={{ borderTop: "1px solid var(--color-paper-line)" }}
+                >
+                  <td style={{ padding: "6px 8px", fontFamily: "var(--font-mono)" }}>
+                    {p.id}
+                    {defaultId === p.id && (
+                      <span
+                        style={{
+                          marginLeft: 6,
+                          fontSize: "var(--font-size-xs)",
+                          color: "var(--color-accent-mint)",
+                        }}
+                      >
+                        DEFAULT
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ padding: "6px 8px" }}>{p.displayName}</td>
+                  <td style={{ padding: "6px 8px" }}>{p.adapter}</td>
+                  <td style={{ padding: "6px 8px" }}>{p.defaultModel ?? "—"}</td>
+                  <td
+                    style={{
+                      padding: "6px 8px",
+                      fontFamily: "var(--font-mono)",
+                    }}
+                  >
+                    {p.apiKeyEnvRef ?? "—"}
+                  </td>
+                  <td style={{ padding: "6px 8px", textAlign: "right" }}>
+                    {defaultId !== p.id && (
+                      <button onClick={() => makeDefault(p.id)} style={{ marginRight: 6 }}>
+                        Make default
+                      </button>
+                    )}
+                    <button className="danger" onClick={() => remove(p.id)}>
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="settings-section">
+        <h3>Add profile</h3>
+        <label>
+          ID
+          <input
+            value={draft.id}
+            onChange={(e) => setDraft({ ...draft, id: e.target.value })}
+            placeholder="minimax-pro"
+          />
+        </label>
+        <label>
+          Display name
+          <input
+            value={draft.displayName}
+            onChange={(e) => setDraft({ ...draft, displayName: e.target.value })}
+            placeholder="MiniMax Pro"
+          />
+        </label>
+        <label>
+          Adapter
+          <select
+            value={draft.adapter}
+            onChange={(e) =>
+              setDraft({ ...draft, adapter: e.target.value as "claude" | "codex" })
+            }
+          >
+            <option value="claude">claude</option>
+            <option value="codex">codex</option>
+          </select>
+        </label>
+        <label>
+          Default model (optional)
+          <input
+            value={draft.defaultModel}
+            onChange={(e) => setDraft({ ...draft, defaultModel: e.target.value })}
+            placeholder="claude-sonnet-4"
+          />
+        </label>
+        <label>
+          API key env var (optional)
+          <input
+            value={draft.apiKeyEnvRef}
+            onChange={(e) => setDraft({ ...draft, apiKeyEnvRef: e.target.value })}
+            placeholder="MINIMAX_API_KEY"
+          />
+        </label>
+        <div style={{ marginTop: 10 }}>
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>Env overrides</div>
+          {draft.envRows.map((row, i) => (
+            <div
+              key={i}
+              style={{ display: "flex", gap: 6, marginBottom: 4, alignItems: "center" }}
+            >
+              <input
+                placeholder="KEY"
+                value={row.key}
+                onChange={(e) => updateEnvRow(i, { key: e.target.value })}
+                style={{ flex: 1 }}
+              />
+              <span>=</span>
+              <input
+                placeholder="value"
+                value={row.value}
+                onChange={(e) => updateEnvRow(i, { value: e.target.value })}
+                style={{ flex: 2 }}
+              />
+              <button onClick={() => removeEnvRow(i)} className="danger">
+                ✕
+              </button>
+            </div>
+          ))}
+          <button onClick={addEnvRow} style={{ marginTop: 4 }}>
+            Add row
+          </button>
+        </div>
+        <div style={{ marginTop: 12 }}>
+          <button onClick={addProfile} disabled={busy}>
+            {busy ? "Saving…" : "Add profile"}
+          </button>
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <h3>Default</h3>
+        <p className="help">
+          Channels without a pinned profile fall back to this default at
+          dispatch time. Clear it to fall through to <code>HARNESS_PROVIDER</code>.
+        </p>
+        <button onClick={() => makeDefault(null)} disabled={!defaultId}>
+          Clear default
+        </button>
+      </div>
+
+      {error && <div className="error">{error}</div>}
     </>
   );
 }

--- a/gui/src/components/SettingsPage.tsx
+++ b/gui/src/components/SettingsPage.tsx
@@ -321,9 +321,9 @@ function ProvidersSection() {
       <div className="settings-section">
         <h3>Profiles</h3>
         <p className="help">
-          Each profile bundles an adapter (Claude or Codex CLI) with env overrides
-          that get applied when Relay dispatches an agent. Set one as default,
-          or pin a specific profile per channel in that channel's settings.
+          Each profile bundles an adapter (Claude or Codex CLI) with env overrides that get applied
+          when Relay dispatches an agent. Set one as default, or pin a specific profile per channel
+          in that channel's settings.
         </p>
         {profiles.length === 0 ? (
           <p className="help">
@@ -349,10 +349,7 @@ function ProvidersSection() {
             </thead>
             <tbody>
               {profiles.map((p) => (
-                <tr
-                  key={p.id}
-                  style={{ borderTop: "1px solid var(--color-paper-line)" }}
-                >
+                <tr key={p.id} style={{ borderTop: "1px solid var(--color-paper-line)" }}>
                   <td style={{ padding: "6px 8px", fontFamily: "var(--font-mono)" }}>
                     {p.id}
                     {defaultId === p.id && (
@@ -417,9 +414,7 @@ function ProvidersSection() {
           Adapter
           <select
             value={draft.adapter}
-            onChange={(e) =>
-              setDraft({ ...draft, adapter: e.target.value as "claude" | "codex" })
-            }
+            onChange={(e) => setDraft({ ...draft, adapter: e.target.value as "claude" | "codex" })}
           >
             <option value="claude">claude</option>
             <option value="codex">codex</option>
@@ -444,10 +439,7 @@ function ProvidersSection() {
         <div style={{ marginTop: 10 }}>
           <div style={{ fontWeight: 600, marginBottom: 4 }}>Env overrides</div>
           {draft.envRows.map((row, i) => (
-            <div
-              key={i}
-              style={{ display: "flex", gap: 6, marginBottom: 4, alignItems: "center" }}
-            >
+            <div key={i} style={{ display: "flex", gap: 6, marginBottom: 4, alignItems: "center" }}>
               <input
                 placeholder="KEY"
                 value={row.key}
@@ -480,8 +472,8 @@ function ProvidersSection() {
       <div className="settings-section">
         <h3>Default</h3>
         <p className="help">
-          Channels without a pinned profile fall back to this default at
-          dispatch time. Clear it to fall through to <code>HARNESS_PROVIDER</code>.
+          Channels without a pinned profile fall back to this default at dispatch time. Clear it to
+          fall through to <code>HARNESS_PROVIDER</code>.
         </p>
         <button onClick={() => makeDefault(null)} disabled={!defaultId}>
           Clear default

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -69,9 +69,31 @@ export type Channel = {
   // Sidebar grouping. `undefined` means the channel lives in the
   // "Uncategorized" bucket at the bottom of the sidebar.
   sectionId?: string;
+  // Per-channel provider-profile override. When unset, dispatch falls back
+  // to the global default profile (or `HARNESS_PROVIDER`). Wired up by
+  // PR 2 of the provider-profiles series; this GUI tolerates the field
+  // being absent on older channel files.
+  providerProfileId?: string;
   // ISO 8601; optional for back-compat with older channel files.
   createdAt?: string;
   updatedAt?: string;
+};
+
+// A named bundle of adapter + env overrides that resolves at dispatch
+// time into the environment handed to the agent subprocess. Mirrors the
+// PR 1 `src/domain/provider-profile.ts` shape — kept local to the GUI
+// so PR 3 doesn't depend on PR 1 being merged first. Secrets are never
+// stored; `apiKeyEnvRef` is the *name* of the env var Relay reads at
+// dispatch time.
+export type ProviderProfile = {
+  id: string;
+  displayName: string;
+  adapter: "claude" | "codex";
+  envOverrides: Record<string, string>;
+  apiKeyEnvRef?: string;
+  defaultModel?: string;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type Section = {

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -60,6 +60,25 @@ interface CliAgentOptions {
    * `--dangerously-skip-permissions` is set.
    */
   role?: AgentRoleName;
+  /**
+   * Provider-profile env overlay. Explicit key/value pairs merged into the
+   * sanitized subprocess env — these OVERRIDE any same-named var from the
+   * parent shell, which is the whole point: a channel bound to the
+   * "openrouter" profile can ship `OPENAI_BASE_URL=https://openrouter…`
+   * even when the user's shell exports a different value.
+   *
+   * Secrets do NOT belong here — the profile's `apiKeyEnvRef` is the
+   * channel to forward a raw key, and PR 1's store refuses to persist
+   * secret-shaped values under `envOverrides`.
+   */
+  envOverlay?: Record<string, string>;
+  /**
+   * Extra env-var names appended to the adapter's default pass-env list
+   * ({@link CLAUDE_PASS_ENV} / {@link CODEX_PASS_ENV}). Used to forward a
+   * profile's `apiKeyEnvRef` — Relay never dereferences the secret; the
+   * subprocess reads it from its own env.
+   */
+  extraPassEnv?: string[];
 }
 
 interface ParsedProviderResult {
@@ -169,6 +188,8 @@ abstract class CliAgentBase implements Agent {
    */
   protected readonly fullAccess: boolean;
   protected readonly role?: AgentRoleName;
+  protected readonly envOverlay?: Record<string, string>;
+  protected readonly extraPassEnv: readonly string[];
 
   constructor(options: CliAgentOptions) {
     this.id = options.id;
@@ -181,18 +202,32 @@ abstract class CliAgentBase implements Agent {
     this.onStreamLine = options.onStreamLine;
     this.fullAccess = options.fullAccess === true;
     this.role = options.role;
+    this.envOverlay = options.envOverlay;
+    // De-dupe so the invoker's allowlist set doesn't carry redundant
+    // names. Order doesn't matter; presence does.
+    this.extraPassEnv = Array.from(new Set(options.extraPassEnv ?? []));
   }
 
   /**
-   * AL-11: env overlay applied when spawning the CLI. Sets
-   * `RELAY_AGENT_ROLE=<role>` so the MCP server in the dispatched session
-   * activates per-role enforcement. Returns `undefined` when the agent is
-   * unrestricted so the invoker's default env is untouched (parity with
-   * pre-AL-11 behaviour).
+   * Combined env overlay applied when spawning the CLI:
+   *
+   *   - `RELAY_AGENT_ROLE=<role>` (AL-11) activates the MCP per-role
+   *     allowlist in the dispatched session.
+   *   - Provider-profile `envOverlay` entries override parent-shell values
+   *     so the adapter can switch base URL / model for this run only.
+   *
+   * Returns `undefined` when no overlay is needed, keeping the invoker's
+   * default env path untouched for pre-AL-11 / pre-profile callers.
    */
   protected roleEnvOverlay(): Record<string, string> | undefined {
-    if (!this.role) return undefined;
-    return { RELAY_AGENT_ROLE: this.role };
+    const out: Record<string, string> = {};
+    if (this.role) out.RELAY_AGENT_ROLE = this.role;
+    if (this.envOverlay) {
+      for (const [key, value] of Object.entries(this.envOverlay)) {
+        out[key] = value;
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
   }
 
   async run(request: WorkRequest) {
@@ -283,8 +318,10 @@ export class CodexCliAgent extends CliAgentBase {
         timeoutMs: 300_000,
         // Codex authenticates via its own config or API key env vars. The
         // invoker strips secrets by default (OSS-03); opt these back in so
-        // users who rely on env-based auth aren't silently broken.
-        passEnv: [...CODEX_PASS_ENV],
+        // users who rely on env-based auth aren't silently broken. The
+        // profile's `apiKeyEnvRef` (if any) is appended via
+        // `extraPassEnv` so Relay never has to dereference the secret.
+        passEnv: [...CODEX_PASS_ENV, ...this.extraPassEnv],
         env: this.roleEnvOverlay(),
       });
 
@@ -361,8 +398,10 @@ export class ClaudeCliAgent extends CliAgentBase {
       timeoutMs: 300_000,
       // Claude CLI authenticates via its own config dir or API key env vars.
       // The invoker strips secrets by default (OSS-03); opt these back in so
-      // users who rely on env-based auth aren't silently broken.
-      passEnv: [...CLAUDE_PASS_ENV],
+      // users who rely on env-based auth aren't silently broken. The
+      // profile's `apiKeyEnvRef` (if any) is appended via `extraPassEnv` so
+      // Relay never has to dereference the secret.
+      passEnv: [...CLAUDE_PASS_ENV, ...this.extraPassEnv],
       env: this.roleEnvOverlay(),
     });
 
@@ -408,7 +447,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       args,
       cwd: this.cwd,
       timeoutMs: 300_000,
-      passEnv: [...CLAUDE_PASS_ENV],
+      passEnv: [...CLAUDE_PASS_ENV, ...this.extraPassEnv],
       env: this.roleEnvOverlay(),
     });
 

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -90,6 +90,22 @@ interface AgentFactoryOptions {
    * have full-access on and the restricted role on at the same time.
    */
   role?: AgentRoleName;
+  /**
+   * Provider-profile env overlay merged into every spawned agent's
+   * subprocess env. Overrides same-named values from the parent shell so
+   * a channel bound to a non-default profile can flip `ANTHROPIC_BASE_URL`
+   * / `OPENAI_BASE_URL` / `ANTHROPIC_MODEL` / `HARNESS_AGENT_*_MODEL`
+   * without mutating the operator's global environment.
+   */
+  envOverlay?: Record<string, string>;
+  /**
+   * Extra env-var names appended to each adapter's default pass-env list.
+   * Used to forward the profile's `apiKeyEnvRef` so the CLI subprocess
+   * can read its own auth token. Relay never dereferences the secret —
+   * the name just gets added to the allowlist the invoker copies from
+   * `process.env`.
+   */
+  extraPassEnv?: string[];
 }
 
 export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
@@ -119,6 +135,8 @@ export function createLiveAgents(options: AgentFactoryOptions): Agent[] {
       onStreamLine,
       fullAccess: options.fullAccess,
       role: options.role,
+      envOverlay: options.envOverlay,
+      extraPassEnv: options.extraPassEnv,
     });
   });
 }

--- a/src/agents/provider-profile-lookup.ts
+++ b/src/agents/provider-profile-lookup.ts
@@ -1,35 +1,14 @@
-/**
- * Provider-profile shape the dispatch path consumes. Structural subset of
- * the schema PR 1 defines in `src/domain/provider-profile.ts` — dispatch
- * only needs `adapter`, `defaultModel`, `envOverrides`, and
- * `apiKeyEnvRef`, so PR 1's extra fields (id / displayName /
- * createdAt / updatedAt) are elided for runtime-less import purposes.
- *
- * TODO(PR1): once PR 1 lands, delete this interface and re-export
- * `ProviderProfile` from `../domain/provider-profile.js`. The live types
- * are structurally compatible, so callers need no changes.
- */
-export interface ProviderProfile {
-  id: string;
-  displayName: string;
-  adapter: "claude" | "codex";
-  envOverrides: Record<string, string>;
-  apiKeyEnvRef?: string;
-  defaultModel?: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import type { ProviderProfile } from "../domain/provider-profile.js";
+
+export type { ProviderProfile };
 
 /**
  * Narrow read-only view of the provider-profile store the dispatch path
- * needs. Typed as a shape (not imported from the store directly) so
- * orchestrator tests can run against an in-memory impl without on-disk
- * state, and so this PR stays decoupled from PR 1's
- * `ProviderProfileStore` landing.
- *
- * TODO(PR1): PR 1's `ProviderProfileStore` already satisfies this shape —
- * callers can pass `new ProviderProfileStore()` directly once the import
- * unblocks. Keep the indirection for test ergonomics; don't delete it.
+ * needs. Kept as a shape (not a direct store import) so orchestrator tests
+ * can run against {@link InMemoryProviderProfileLookup} without touching
+ * `~/.relay/provider-profiles.json`. `ProviderProfileStore` from
+ * `src/storage/provider-profile-store.ts` satisfies this interface
+ * structurally.
  */
 export interface ProviderProfileLookup {
   getProfile(id: string): Promise<ProviderProfile | null>;
@@ -37,26 +16,9 @@ export interface ProviderProfileLookup {
 }
 
 /**
- * Null-implementation default: every query returns `null`. Used while
- * PR 1's `ProviderProfileStore` is still in flight so dispatch never has
- * to reference that module; swap it for the real store in a single line
- * once PR 1 merges (see `dispatch.ts` TODO(PR1) comment).
- */
-export class NullProviderProfileLookup implements ProviderProfileLookup {
-  async getProfile(_id: string): Promise<ProviderProfile | null> {
-    return null;
-  }
-
-  async getDefaultProfileId(): Promise<string | null> {
-    return null;
-  }
-}
-
-/**
  * Deterministic in-memory implementation used by orchestrator tests.
- * Accepts a static profile map + optional default id. Returns
- * `Promise<null>` for unknown ids so callers exercise the missing-profile
- * branch exactly the same way the on-disk store does.
+ * Returns `Promise<null>` for unknown ids so callers exercise the
+ * missing-profile branch exactly the same way the on-disk store does.
  */
 export class InMemoryProviderProfileLookup implements ProviderProfileLookup {
   constructor(

--- a/src/agents/provider-profile-lookup.ts
+++ b/src/agents/provider-profile-lookup.ts
@@ -1,0 +1,74 @@
+/**
+ * Provider-profile shape the dispatch path consumes. Structural subset of
+ * the schema PR 1 defines in `src/domain/provider-profile.ts` — dispatch
+ * only needs `adapter`, `defaultModel`, `envOverrides`, and
+ * `apiKeyEnvRef`, so PR 1's extra fields (id / displayName /
+ * createdAt / updatedAt) are elided for runtime-less import purposes.
+ *
+ * TODO(PR1): once PR 1 lands, delete this interface and re-export
+ * `ProviderProfile` from `../domain/provider-profile.js`. The live types
+ * are structurally compatible, so callers need no changes.
+ */
+export interface ProviderProfile {
+  id: string;
+  displayName: string;
+  adapter: "claude" | "codex";
+  envOverrides: Record<string, string>;
+  apiKeyEnvRef?: string;
+  defaultModel?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Narrow read-only view of the provider-profile store the dispatch path
+ * needs. Typed as a shape (not imported from the store directly) so
+ * orchestrator tests can run against an in-memory impl without on-disk
+ * state, and so this PR stays decoupled from PR 1's
+ * `ProviderProfileStore` landing.
+ *
+ * TODO(PR1): PR 1's `ProviderProfileStore` already satisfies this shape —
+ * callers can pass `new ProviderProfileStore()` directly once the import
+ * unblocks. Keep the indirection for test ergonomics; don't delete it.
+ */
+export interface ProviderProfileLookup {
+  getProfile(id: string): Promise<ProviderProfile | null>;
+  getDefaultProfileId(): Promise<string | null>;
+}
+
+/**
+ * Null-implementation default: every query returns `null`. Used while
+ * PR 1's `ProviderProfileStore` is still in flight so dispatch never has
+ * to reference that module; swap it for the real store in a single line
+ * once PR 1 merges (see `dispatch.ts` TODO(PR1) comment).
+ */
+export class NullProviderProfileLookup implements ProviderProfileLookup {
+  async getProfile(_id: string): Promise<ProviderProfile | null> {
+    return null;
+  }
+
+  async getDefaultProfileId(): Promise<string | null> {
+    return null;
+  }
+}
+
+/**
+ * Deterministic in-memory implementation used by orchestrator tests.
+ * Accepts a static profile map + optional default id. Returns
+ * `Promise<null>` for unknown ids so callers exercise the missing-profile
+ * branch exactly the same way the on-disk store does.
+ */
+export class InMemoryProviderProfileLookup implements ProviderProfileLookup {
+  constructor(
+    private readonly profiles: Map<string, ProviderProfile> = new Map(),
+    private readonly defaultProfileId: string | null = null
+  ) {}
+
+  async getProfile(id: string): Promise<ProviderProfile | null> {
+    return this.profiles.get(id) ?? null;
+  }
+
+  async getDefaultProfileId(): Promise<string | null> {
+    return this.defaultProfileId;
+  }
+}

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -192,6 +192,7 @@ export class ChannelStore {
         | "starred"
         | "kind"
         | "sectionId"
+        | "providerProfileId"
       >
     >
   ): Promise<Channel | null> {
@@ -328,6 +329,63 @@ export class ChannelStore {
       rationale: `Agent subprocesses dispatched for this channel will ${
         next ? "run with" : "no longer receive"
       } --dangerously-skip-permissions (Claude) / --sandbox workspace-write --ask-for-approval never (Codex).`,
+      alternatives: [],
+      decidedBy,
+      decidedByName,
+      linkedArtifacts: [],
+    });
+
+    return updated;
+  }
+
+  /**
+   * Bind (or clear) the provider-profile reference on a channel. Mirrors
+   * the `setFullAccess` pattern: atomic write of the channel manifest,
+   * followed by a decision entry so the audit trail captures every
+   * invocation (including no-op re-binds to the same profile).
+   *
+   * Pass `null` to clear the binding and fall back to the dispatcher's
+   * default resolution chain (explicit default profile → `HARNESS_PROVIDER`).
+   * The profile id itself is NOT validated here — the CLI is expected to
+   * confirm it exists before calling; the store accepts whatever id the
+   * caller passes so the interface stays backend-agnostic (PR 1 owns the
+   * referential-integrity check).
+   */
+  async setProviderProfileId(
+    channelId: string,
+    profileId: string | null,
+    actor?: { id?: string; name?: string; source?: string }
+  ): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
+    const existing = await this.getChannel(channelId);
+    if (!existing) return null;
+
+    const previous = existing.providerProfileId ?? null;
+    const next = profileId;
+
+    const updated: Channel = {
+      ...existing,
+      providerProfileId: next ?? undefined,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeChannel(updated);
+
+    const decidedBy = actor?.id ?? "user";
+    const decidedByName = actor?.name ?? "User";
+    const label = next ?? "(none — inherit default)";
+    await this.recordDecision(channelId, {
+      runId: null,
+      ticketId: null,
+      title: `Provider profile set to ${label}`,
+      description:
+        `Channel ${channelId} providerProfileId set to ${next ?? "null"} ` +
+        `(previous: ${previous ?? "null"}).`,
+      rationale:
+        next !== null
+          ? `Agents dispatched for this channel will use profile '${next}' ` +
+            `instead of the process-wide HARNESS_PROVIDER default.`
+          : `Agents dispatched for this channel will fall back to the explicit ` +
+            `default profile (if any) or HARNESS_PROVIDER.`,
       alternatives: [],
       decidedBy,
       decidedByName,

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -123,6 +123,15 @@ export interface Channel {
    * on the next load.
    */
   sectionId?: string;
+  /**
+   * Provider profile ID that overrides the process-wide `HARNESS_PROVIDER`
+   * env for agents dispatched on behalf of this channel. The profile itself
+   * (adapter, default model, env overlay, `apiKeyEnvRef`) lives in the
+   * provider-profile store (PR 1); the channel only stores the reference.
+   * Absent = inherit whatever the dispatcher's default resolution chooses
+   * (explicit default profile → `HARNESS_PROVIDER`). Optional for back-compat.
+   */
+  providerProfileId?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/domain/provider-profile.ts
+++ b/src/domain/provider-profile.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const PROVIDER_PROFILE_ID_PATTERN = /^[a-z0-9-]{1,32}$/;
+
+export const ProviderProfileAdapterSchema = z.enum(["claude", "codex"]);
+
+export type ProviderProfileAdapter = z.infer<typeof ProviderProfileAdapterSchema>;
+
+export const ProviderProfileSchema = z.object({
+  id: z.string().regex(PROVIDER_PROFILE_ID_PATTERN, "id must be 1-32 chars of [a-z0-9-]"),
+  displayName: z.string().min(1).max(128),
+  adapter: ProviderProfileAdapterSchema,
+  envOverrides: z.record(z.string(), z.string()).default({}),
+  apiKeyEnvRef: z
+    .string()
+    .regex(/^[A-Z][A-Z0-9_]*$/, "apiKeyEnvRef must be an env var name (UPPER_SNAKE)")
+    .optional(),
+  defaultModel: z.string().min(1).max(256).optional(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+});
+
+export type ProviderProfile = z.infer<typeof ProviderProfileSchema>;
+
+/**
+ * Heuristic: does this value look like a raw API key that shouldn't be
+ * persisted to disk? We flag prefixes used by known vendors (Anthropic,
+ * OpenAI session tokens, GitHub, Slack, etc.) and long opaque base64-ish
+ * runs. False positives are acceptable — we point the user at
+ * `apiKeyEnvRef` either way.
+ */
+export function isLikelySecretValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+
+  const lower = trimmed.toLowerCase();
+  const prefixes = [
+    "sk-",
+    "sk_",
+    "pk-",
+    "anthropic_",
+    "anthropic-",
+    "sess-",
+    "sess_",
+    "ghp_",
+    "gho_",
+    "ghs_",
+    "github_pat_",
+    "xoxb-",
+    "xoxp-",
+    "aws_",
+    "akia",
+    "bearer ",
+  ];
+  for (const p of prefixes) {
+    if (lower.startsWith(p)) return true;
+  }
+
+  // Long opaque token: 32+ chars of base64url-ish. Env values that legitimately
+  // need to be this long (URLs, JSON blobs) contain characters outside this
+  // class, so the check is narrow enough to skip e.g. `https://...`.
+  if (/^[A-Za-z0-9_\-+/=]{32,}$/.test(trimmed)) return true;
+
+  return false;
+}
+
+export type EnvOverrideValidationResult = { ok: true } | { ok: false; key: string; reason: string };
+
+/**
+ * Refuse any env override whose value looks like a raw secret. Callers (CLI,
+ * store) surface the returned `key` + `reason` so the user can redirect the
+ * value into `apiKeyEnvRef` instead.
+ */
+export function validateEnvOverrides(
+  overrides: Record<string, string> | undefined
+): EnvOverrideValidationResult {
+  if (!overrides) return { ok: true };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (typeof value !== "string") {
+      return { ok: false, key, reason: "value must be a string" };
+    }
+    if (isLikelySecretValue(value)) {
+      return {
+        ok: false,
+        key,
+        reason:
+          "value looks like a raw API key; set the secret in your shell and reference it via --api-key-ref <ENV_NAME> instead of --env",
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -731,6 +731,47 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (sub === "set-provider") {
+    const channelId = args[1];
+    const profileArg = args[2];
+    if (!channelId || !profileArg) {
+      console.error(
+        "Usage: rly channel set-provider <channelId> <profileId|clear> [--source <s>] [--actor <name>] [--json]"
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // `clear` is the explicit "fall back to default resolution" token.
+    // Accepting a literal id is the common case; anything else is user
+    // error we surface rather than silently coercing.
+    const nextProfileId: string | null = profileArg === "clear" ? null : profileArg;
+
+    const sourceArg = parseNamedArg(args, "--source");
+    const actorName = parseNamedArg(args, "--actor");
+    const actor = {
+      source: sourceArg ?? "cli",
+      name: actorName ?? "CLI",
+      id: actorName ?? "cli",
+    };
+
+    const updated = await store.setProviderProfileId(channelId, nextProfileId, actor);
+
+    if (args.includes("--json")) {
+      jsonOut(updated);
+    } else if (updated) {
+      // TODO(PR1): resolve the display name through the profile store
+      // once the import unblocks. Until then, print the id so the
+      // audit-visible output stays informative.
+      const label = updated.providerProfileId ?? "(none — inherit default)";
+      console.log(`Channel provider set to ${label} (${updated.providerProfileId ?? "cleared"})`);
+    } else {
+      console.error(`Channel not found: ${channelId}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   if (sub === "update") {
     const channelId = args[1];
     if (!channelId) {
@@ -880,7 +921,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
 
   if (!sub) {
     console.error(
-      "Usage: rly channel <channelId|create|archive|unarchive|set-full-access|update|feed|post|assign>"
+      "Usage: rly channel <channelId|create|archive|unarchive|set-full-access|set-provider|update|feed|post|assign>"
     );
     process.exitCode = 1;
     return;
@@ -2824,7 +2865,7 @@ async function printTopLevelHelp(): Promise<void> {
     "",
     "Channels & sessions:",
     "  channels                 List channels (most-recently-active first)",
-    "  channel <subcommand>     Manage channels (create/update/archive/set-full-access/feed/post/assign/...)",
+    "  channel <subcommand>     Manage channels (create/update/archive/set-full-access/set-provider/feed/post/assign/...)",
     "  section <subcommand>     Manage sidebar sections (list/create/rename/decommission/restore/delete)",
     "  session <subcommand>     Manage session transcripts",
     "  board <channelId>        Kanban view of tickets",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3348,28 +3348,42 @@ function printProfileHuman(profile: ProviderProfile): void {
 
 async function handleProviderDefaultCommand(args: string[]): Promise<number> {
   const store = new ProviderProfileStore();
-  const arg = args[0];
+  const jsonMode = args.includes("--json");
+  const positionals = args.filter((a) => a !== "--json");
+  const arg = positionals[0];
 
   if (!arg) {
     const current = await store.getDefaultProfileId();
-    console.log(current ?? "(no default profile set)");
+    if (jsonMode) {
+      console.log(JSON.stringify({ defaultProfileId: current }));
+    } else {
+      console.log(current ?? "(no default profile set)");
+    }
     return 0;
   }
 
   if (arg === "--help" || arg === "-h" || arg === "help") {
-    console.log("Usage: rly providers default [<id> | clear]");
+    console.log("Usage: rly providers default [<id> | clear] [--json]");
     return 0;
   }
 
   if (arg === "clear") {
     await store.setDefaultProfileId(null);
-    console.log("Cleared default profile.");
+    if (jsonMode) {
+      console.log(JSON.stringify({ defaultProfileId: null }));
+    } else {
+      console.log("Cleared default profile.");
+    }
     return 0;
   }
 
   try {
     await store.setDefaultProfileId(arg);
-    console.log(`Default profile set to '${arg}'.`);
+    if (jsonMode) {
+      console.log(JSON.stringify({ defaultProfileId: arg }));
+    } else {
+      console.log(`Default profile set to '${arg}'.`);
+    }
     return 0;
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -772,11 +772,14 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     if (args.includes("--json")) {
       jsonOut(updated);
     } else if (updated) {
-      // TODO(PR1): resolve the display name through the profile store
-      // once the import unblocks. Until then, print the id so the
-      // audit-visible output stays informative.
-      const label = updated.providerProfileId ?? "(none — inherit default)";
-      console.log(`Channel provider set to ${label} (${updated.providerProfileId ?? "cleared"})`);
+      let label = "(none — inherit default)";
+      if (updated.providerProfileId) {
+        const profile = await new ProviderProfileStore().getProfile(updated.providerProfileId);
+        label = profile
+          ? `${profile.displayName} (${profile.id})`
+          : `${updated.providerProfileId} (profile not found)`;
+      }
+      console.log(`Channel provider set to ${label}`);
     } else {
       console.error(`Channel not found: ${channelId}`);
       process.exitCode = 1;
@@ -3271,6 +3274,10 @@ async function runProfilesAdd(store: ProviderProfileStore, args: string[]): Prom
       apiKeyEnvRef,
       defaultModel,
     });
+    if (rest.includes("--json")) {
+      console.log(JSON.stringify(profile, null, 2));
+      return 0;
+    }
     console.log(`Saved profile '${profile.id}':`);
     console.log(`  displayName: ${profile.displayName}`);
     console.log(`  adapter:     ${profile.adapter}`);
@@ -3291,11 +3298,15 @@ async function runProfilesAdd(store: ProviderProfileStore, args: string[]): Prom
 async function runProfilesRemove(store: ProviderProfileStore, args: string[]): Promise<number> {
   const id = args[0];
   if (!id || id.startsWith("--")) {
-    console.error("Usage: rly providers profiles remove <id>");
+    console.error("Usage: rly providers profiles remove <id> [--json]");
     return 1;
   }
   const removed = await store.removeProfile(id);
-  console.log(removed ? `Removed profile '${id}'.` : `No profile '${id}' — nothing to do.`);
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ id, removed }));
+  } else {
+    console.log(removed ? `Removed profile '${id}'.` : `No profile '${id}' — nothing to do.`);
+  }
   return 0;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,13 @@ import { submitApproval } from "./orchestrator/approval-gate.js";
 import { getWorkspaceDir } from "./cli/workspace-registry.js";
 import { ApprovalsQueue, type ApprovalRecord } from "./approvals/queue.js";
 import { getRelayDir } from "./cli/paths.js";
+import {
+  type ProviderProfile,
+  type ProviderProfileAdapter,
+  ProviderProfileAdapterSchema,
+  validateEnvOverrides,
+} from "./domain/provider-profile.js";
+import { ProviderProfileStore } from "./storage/provider-profile-store.js";
 
 export async function main(): Promise<void> {
   const cwd = process.cwd();
@@ -124,6 +131,11 @@ export async function main(): Promise<void> {
 
   if (command === "config") {
     await handleConfigCommand(args);
+    return;
+  }
+
+  if (command === "providers") {
+    process.exitCode = await handleProvidersCommand(args);
     return;
   }
 
@@ -2860,6 +2872,7 @@ async function printTopLevelHelp(): Promise<void> {
     "  workspaces               List registered workspaces",
     "  welcome                  Interactive first-run walkthrough",
     "  config <subcommand>      Manage global config (add/remove project dirs)",
+    "  providers <subcommand>   Manage named provider profiles (see docs/providers.md)",
     "  rebuild                  Rebuild native artifacts (tui/gui)",
     "",
     "Misc:",
@@ -3086,6 +3099,259 @@ function parseAgentOverrides(): Record<string, { provider?: "claude" | "codex"; 
   }
 
   return overrides;
+}
+
+async function handleProvidersCommand(args: string[]): Promise<number> {
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    console.log("Usage: rly providers <profiles|default> [options]");
+    console.log("");
+    console.log("  profiles <subcommand>      Manage named provider profiles (experimental)");
+    console.log("  default [<id> | clear]     Get / set the default provider profile");
+    console.log("");
+    console.log("See docs/providers.md for the conceptual overview.");
+    return 0;
+  }
+
+  if (sub === "profiles") {
+    return handleProviderProfilesCommand(args.slice(1));
+  }
+  if (sub === "default") {
+    return handleProviderDefaultCommand(args.slice(1));
+  }
+
+  console.error(`Unknown providers subcommand: ${sub}`);
+  console.error("Usage: rly providers <profiles|default>");
+  return 1;
+}
+
+async function handleProviderProfilesCommand(args: string[]): Promise<number> {
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    printProviderProfilesHelp();
+    return sub ? 0 : 1;
+  }
+
+  const store = new ProviderProfileStore();
+
+  if (sub === "list") return runProfilesList(store, args.slice(1));
+  if (sub === "add") return runProfilesAdd(store, args.slice(1));
+  if (sub === "remove") return runProfilesRemove(store, args.slice(1));
+  if (sub === "show") return runProfilesShow(store, args.slice(1));
+
+  console.error(`Unknown providers profiles subcommand: ${sub}`);
+  printProviderProfilesHelp();
+  return 1;
+}
+
+function printProviderProfilesHelp(): void {
+  console.log("Usage: rly providers profiles <subcommand>");
+  console.log("");
+  console.log("  list [--json]                   List named profiles");
+  console.log("  add <id> --adapter <claude|codex>  Create or update a profile");
+  console.log(
+    "      [--display-name <s>] [--env KEY=VAL ...] [--api-key-ref <ENV_NAME>] [--model <m>]"
+  );
+  console.log("  remove <id>                     Remove a profile (no-op if absent)");
+  console.log("  show <id> [--json]              Show a single profile");
+  console.log("");
+  console.log("Profiles never store secrets — reference env vars via --api-key-ref.");
+}
+
+async function runProfilesList(store: ProviderProfileStore, args: string[]): Promise<number> {
+  const profiles = await store.listProfiles();
+  const defaultId = await store.getDefaultProfileId();
+
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ defaultProfileId: defaultId, profiles }, null, 2));
+    return 0;
+  }
+
+  if (profiles.length === 0) {
+    console.log("(no provider profiles — add one with `rly providers profiles add <id>`)");
+    return 0;
+  }
+
+  for (const p of profiles) {
+    const marker = p.id === defaultId ? " *" : "";
+    const envKeys = Object.keys(p.envOverrides).sort().join(",") || "-";
+    const model = p.defaultModel ?? "-";
+    console.log(
+      `  ${p.id}${marker}  [${p.adapter}]  model=${model}  env=${envKeys}  — ${p.displayName}`
+    );
+  }
+  if (defaultId) {
+    console.log("");
+    console.log(`* default profile: ${defaultId}`);
+  }
+  return 0;
+}
+
+async function runProfilesAdd(store: ProviderProfileStore, args: string[]): Promise<number> {
+  const id = args[0];
+  if (!id || id.startsWith("--")) {
+    console.error("Usage: rly providers profiles add <id> --adapter <claude|codex> [...]");
+    return 1;
+  }
+  const rest = args.slice(1);
+
+  const adapterRaw = parseNamedArg(rest, "--adapter");
+  const adapterParse = ProviderProfileAdapterSchema.safeParse(adapterRaw);
+  if (!adapterParse.success) {
+    console.error(`--adapter must be one of "claude" | "codex" (got: ${adapterRaw ?? "missing"})`);
+    return 1;
+  }
+  const adapter: ProviderProfileAdapter = adapterParse.data;
+
+  const displayName = parseNamedArg(rest, "--display-name") ?? id;
+  const apiKeyEnvRef = parseNamedArg(rest, "--api-key-ref");
+  const defaultModel = parseNamedArg(rest, "--model");
+  const envOverrides = parseRepeatedEnvArgs(rest);
+
+  if ("error" in envOverrides) {
+    console.error(envOverrides.error);
+    return 1;
+  }
+
+  const envCheck = validateEnvOverrides(envOverrides.values);
+  if (!envCheck.ok) {
+    console.error(`Rejected --env ${envCheck.key}: ${envCheck.reason}`);
+    return 1;
+  }
+
+  try {
+    const profile = await store.upsertProfile({
+      id,
+      displayName,
+      adapter,
+      envOverrides: envOverrides.values,
+      apiKeyEnvRef,
+      defaultModel,
+    });
+    console.log(`Saved profile '${profile.id}':`);
+    console.log(`  displayName: ${profile.displayName}`);
+    console.log(`  adapter:     ${profile.adapter}`);
+    if (profile.defaultModel) console.log(`  model:       ${profile.defaultModel}`);
+    if (profile.apiKeyEnvRef) console.log(`  apiKeyEnvRef: ${profile.apiKeyEnvRef}`);
+    const envKeys = Object.keys(profile.envOverrides).sort();
+    if (envKeys.length > 0) {
+      console.log(`  envOverrides:`);
+      for (const k of envKeys) console.log(`    ${k}=${profile.envOverrides[k]}`);
+    }
+    return 0;
+  } catch (err) {
+    console.error(`Failed to save profile: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+async function runProfilesRemove(store: ProviderProfileStore, args: string[]): Promise<number> {
+  const id = args[0];
+  if (!id || id.startsWith("--")) {
+    console.error("Usage: rly providers profiles remove <id>");
+    return 1;
+  }
+  const removed = await store.removeProfile(id);
+  console.log(removed ? `Removed profile '${id}'.` : `No profile '${id}' — nothing to do.`);
+  return 0;
+}
+
+async function runProfilesShow(store: ProviderProfileStore, args: string[]): Promise<number> {
+  const id = args[0];
+  if (!id || id.startsWith("--")) {
+    console.error("Usage: rly providers profiles show <id> [--json]");
+    return 1;
+  }
+  const profile = await store.getProfile(id);
+  if (!profile) {
+    console.error(`No profile '${id}'.`);
+    return 1;
+  }
+  if (args.includes("--json")) {
+    console.log(JSON.stringify(profile, null, 2));
+    return 0;
+  }
+  printProfileHuman(profile);
+  return 0;
+}
+
+function printProfileHuman(profile: ProviderProfile): void {
+  console.log(`id:           ${profile.id}`);
+  console.log(`displayName:  ${profile.displayName}`);
+  console.log(`adapter:      ${profile.adapter}`);
+  if (profile.defaultModel) console.log(`model:        ${profile.defaultModel}`);
+  if (profile.apiKeyEnvRef) console.log(`apiKeyEnvRef: ${profile.apiKeyEnvRef}`);
+  const keys = Object.keys(profile.envOverrides).sort();
+  if (keys.length > 0) {
+    console.log("envOverrides:");
+    for (const k of keys) console.log(`  ${k}=${profile.envOverrides[k]}`);
+  } else {
+    console.log("envOverrides: (none)");
+  }
+  console.log(`createdAt:    ${profile.createdAt}`);
+  console.log(`updatedAt:    ${profile.updatedAt}`);
+}
+
+async function handleProviderDefaultCommand(args: string[]): Promise<number> {
+  const store = new ProviderProfileStore();
+  const arg = args[0];
+
+  if (!arg) {
+    const current = await store.getDefaultProfileId();
+    console.log(current ?? "(no default profile set)");
+    return 0;
+  }
+
+  if (arg === "--help" || arg === "-h" || arg === "help") {
+    console.log("Usage: rly providers default [<id> | clear]");
+    return 0;
+  }
+
+  if (arg === "clear") {
+    await store.setDefaultProfileId(null);
+    console.log("Cleared default profile.");
+    return 0;
+  }
+
+  try {
+    await store.setDefaultProfileId(arg);
+    console.log(`Default profile set to '${arg}'.`);
+    return 0;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}
+
+/**
+ * Parse zero or more `--env KEY=VAL` pairs. Duplicate keys take the last
+ * value, matching typical `env`-style semantics.
+ */
+function parseRepeatedEnvArgs(
+  args: string[]
+): { values: Record<string, string> } | { error: string } {
+  const values: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== "--env") continue;
+    const pair = args[i + 1];
+    if (pair === undefined || pair.startsWith("--")) {
+      return { error: "--env requires a KEY=VAL argument" };
+    }
+    const eq = pair.indexOf("=");
+    if (eq <= 0) {
+      return { error: `--env value must be KEY=VAL (got: ${pair})` };
+    }
+    const key = pair.slice(0, eq);
+    const value = pair.slice(eq + 1);
+    if (!/^[A-Z][A-Z0-9_]*$/.test(key)) {
+      return { error: `--env key must be UPPER_SNAKE (got: ${key})` };
+    }
+    values[key] = value;
+    i += 1;
+  }
+  return { values };
 }
 
 function capitalize(value: string): string {

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -1,9 +1,20 @@
 import { AgentRegistry } from "../agents/registry.js";
 import { createLiveAgents, registerAgentNames } from "../agents/factory.js";
 import { NodeCommandInvoker } from "../agents/command-invoker.js";
+import type { ProviderProfile, ProviderProfileLookup } from "../agents/provider-profile-lookup.js";
+// TODO(PR1): once PR 1 lands, swap the `NullProviderProfileLookup` default
+// below for `new ProviderProfileStore()` — its public shape already
+// satisfies {@link ProviderProfileLookup}. The swap is ~5 lines:
+//   import { ProviderProfileStore } from "../storage/provider-profile-store.js";
+//   const profileLookup = input.providerProfileLookup ?? new ProviderProfileStore();
+// Until then dispatch resolves to `null` (legacy `HARNESS_PROVIDER` path)
+// whenever the caller doesn't inject a lookup.
+import { NullProviderProfileLookup } from "../agents/provider-profile-lookup.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
 import { VerificationRunner } from "../execution/verification-runner.js";
 import { ChannelStore } from "../channels/channel-store.js";
+import type { Channel } from "../domain/channel.js";
+import type { AgentProvider } from "../domain/agent.js";
 import { buildWorkspaceId, getWorkspaceDir } from "../cli/workspace-registry.js";
 import { OrchestratorV2, buildRunId } from "./orchestrator-v2.js";
 import { createPrWatcherFactory } from "../cli/pr-watcher-factory.js";
@@ -13,6 +24,41 @@ export interface DispatchInput {
   featureRequest: string;
   repoPath: string;
   channelId?: string;
+  /**
+   * Provider-profile lookup override. Defaults to a `ProviderProfileStore`
+   * reading `~/.relay/provider-profiles.json`. Tests pass an
+   * `InMemoryProviderProfileLookup` so resolution is deterministic.
+   */
+  providerProfileLookup?: ProviderProfileLookup;
+}
+
+/**
+ * Resolve which provider profile (if any) should shape this run.
+ *
+ *   1. `channel.providerProfileId` → fetch that profile.
+ *   2. Otherwise the lookup's default profile id → fetch it.
+ *   3. Otherwise `null` — `createLiveAgents` falls back to the legacy
+ *      `HARNESS_PROVIDER` env path.
+ *
+ * An explicit id that doesn't resolve returns `null` too: strand the
+ * channel on a deleted profile and you'd otherwise get a cryptic spawn
+ * failure downstream; letting the run inherit `HARNESS_PROVIDER` is
+ * strictly better than silently breaking a chat.
+ */
+export async function resolveChannelProviderProfile(
+  channel: Channel | null,
+  lookup: ProviderProfileLookup
+): Promise<ProviderProfile | null> {
+  if (channel?.providerProfileId) {
+    const direct = await lookup.getProfile(channel.providerProfileId);
+    if (direct) return direct;
+  }
+  const defaultId = await lookup.getDefaultProfileId();
+  if (defaultId) {
+    const fallback = await lookup.getProfile(defaultId);
+    if (fallback) return fallback;
+  }
+  return null;
 }
 
 export interface DispatchResult {
@@ -34,27 +80,38 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const artifactsDir = `${getWorkspaceDir(workspaceId)}/artifacts`;
   const artifactStore = new LocalArtifactStore(artifactsDir, getHarnessStore());
   const channelStore = new ChannelStore(undefined, getHarnessStore());
+  // TODO(PR1): swap the NullProviderProfileLookup default for the real
+  // ProviderProfileStore once PR 1 merges. Dispatch then resolves real
+  // profiles without callers having to pass a lookup by hand.
+  const profileLookup: ProviderProfileLookup =
+    input.providerProfileLookup ?? new NullProviderProfileLookup();
 
-  // Ensure agents are registered
-  const defaultProvider = (process.env.HARNESS_PROVIDER ?? "claude") as "claude" | "codex";
-  await registerAgentNames({ defaultProvider });
-
-  // Resolve or create a channel first — we need its `fullAccess` flag to
-  // decide whether agents should be constructed in unattended mode (AL-0).
+  // Resolve or create a channel first — we need its `fullAccess` flag +
+  // provider-profile binding to decide how to construct agents.
   let channelId = input.channelId;
-  let channelFullAccess = false;
+  let channel: Channel | null;
   if (!channelId) {
-    const channel = await channelStore.createChannel({
+    channel = await channelStore.createChannel({
       name: featureRequest.slice(0, 60),
       description: featureRequest,
       workspaceIds: [workspaceId],
     });
     channelId = channel.channelId;
-    channelFullAccess = channel.fullAccess === true;
   } else {
-    const existing = await channelStore.getChannel(channelId);
-    channelFullAccess = existing?.fullAccess === true;
+    channel = await channelStore.getChannel(channelId);
   }
+  const channelFullAccess = channel?.fullAccess === true;
+
+  // Resolve the effective provider profile (channel → default → none).
+  // When non-null, it overrides the env-driven default provider + supplies
+  // an env overlay the CLI subprocess inherits. Null keeps the legacy
+  // `HARNESS_PROVIDER` path intact for callers that never configured
+  // profiles.
+  const profile = await resolveChannelProviderProfile(channel, profileLookup);
+  const defaultProvider: AgentProvider =
+    profile?.adapter ?? ((process.env.HARNESS_PROVIDER ?? "claude") as AgentProvider);
+
+  await registerAgentNames({ defaultProvider });
 
   // Build agent registry with the per-channel full-access flag threaded
   // through so Claude gets `--dangerously-skip-permissions` / Codex gets
@@ -64,6 +121,9 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const agents = createLiveAgents({
     cwd: repoPath,
     defaultProvider,
+    defaultModel: profile?.defaultModel,
+    envOverlay: profile?.envOverrides,
+    extraPassEnv: profile?.apiKeyEnvRef ? [profile.apiKeyEnvRef] : undefined,
     fullAccess: channelFullAccess,
   });
   for (const agent of agents) {

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -2,14 +2,7 @@ import { AgentRegistry } from "../agents/registry.js";
 import { createLiveAgents, registerAgentNames } from "../agents/factory.js";
 import { NodeCommandInvoker } from "../agents/command-invoker.js";
 import type { ProviderProfile, ProviderProfileLookup } from "../agents/provider-profile-lookup.js";
-// TODO(PR1): once PR 1 lands, swap the `NullProviderProfileLookup` default
-// below for `new ProviderProfileStore()` — its public shape already
-// satisfies {@link ProviderProfileLookup}. The swap is ~5 lines:
-//   import { ProviderProfileStore } from "../storage/provider-profile-store.js";
-//   const profileLookup = input.providerProfileLookup ?? new ProviderProfileStore();
-// Until then dispatch resolves to `null` (legacy `HARNESS_PROVIDER` path)
-// whenever the caller doesn't inject a lookup.
-import { NullProviderProfileLookup } from "../agents/provider-profile-lookup.js";
+import { ProviderProfileStore } from "../storage/provider-profile-store.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
 import { VerificationRunner } from "../execution/verification-runner.js";
 import { ChannelStore } from "../channels/channel-store.js";
@@ -80,11 +73,8 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
   const artifactsDir = `${getWorkspaceDir(workspaceId)}/artifacts`;
   const artifactStore = new LocalArtifactStore(artifactsDir, getHarnessStore());
   const channelStore = new ChannelStore(undefined, getHarnessStore());
-  // TODO(PR1): swap the NullProviderProfileLookup default for the real
-  // ProviderProfileStore once PR 1 merges. Dispatch then resolves real
-  // profiles without callers having to pass a lookup by hand.
   const profileLookup: ProviderProfileLookup =
-    input.providerProfileLookup ?? new NullProviderProfileLookup();
+    input.providerProfileLookup ?? new ProviderProfileStore();
 
   // Resolve or create a channel first — we need its `fullAccess` flag +
   // provider-profile binding to decide how to construct agents.

--- a/src/storage/provider-profile-store.ts
+++ b/src/storage/provider-profile-store.ts
@@ -1,0 +1,159 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getGlobalRoot } from "../cli/workspace-registry.js";
+import {
+  type ProviderProfile,
+  ProviderProfileSchema,
+  validateEnvOverrides,
+} from "../domain/provider-profile.js";
+
+const PROFILES_FILENAME = "provider-profiles.json";
+
+interface ProviderProfilesDoc {
+  defaultProfileId: string | null;
+  profiles: ProviderProfile[];
+}
+
+let tmpCounter = 0;
+
+function emptyDoc(): ProviderProfilesDoc {
+  return { defaultProfileId: null, profiles: [] };
+}
+
+export interface ProviderProfileStoreOptions {
+  /** Root directory. Defaults to `getGlobalRoot()` (i.e. `~/.relay`). Tests override. */
+  rootDir?: string;
+}
+
+export class ProviderProfileStore {
+  private readonly rootDir: string;
+
+  constructor(options: ProviderProfileStoreOptions = {}) {
+    this.rootDir = options.rootDir ?? getGlobalRoot();
+  }
+
+  getPath(): string {
+    return join(this.rootDir, PROFILES_FILENAME);
+  }
+
+  private async readDoc(): Promise<ProviderProfilesDoc> {
+    const path = this.getPath();
+    let content: string;
+    try {
+      content = await readFile(path, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return emptyDoc();
+      }
+      throw new Error(
+        `Failed to read provider-profiles at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err }
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(content);
+    } catch (err) {
+      throw new Error(
+        `Corrupt provider-profiles at ${path}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err }
+      );
+    }
+
+    const doc = (raw ?? {}) as Partial<ProviderProfilesDoc>;
+    const profiles = Array.isArray(doc.profiles)
+      ? doc.profiles
+          .map((p) => ProviderProfileSchema.safeParse(p))
+          .filter((r): r is { success: true; data: ProviderProfile } => r.success)
+          .map((r) => r.data)
+      : [];
+    return {
+      defaultProfileId: typeof doc.defaultProfileId === "string" ? doc.defaultProfileId : null,
+      profiles,
+    };
+  }
+
+  private async writeDoc(doc: ProviderProfilesDoc): Promise<void> {
+    await mkdir(this.rootDir, { recursive: true });
+    const path = this.getPath();
+    const tmpPath = `${path}.tmp.${process.pid}.${tmpCounter++}`;
+    await writeFile(tmpPath, JSON.stringify(doc, null, 2));
+    try {
+      await rename(tmpPath, path);
+    } catch (err) {
+      await rm(tmpPath, { force: true }).catch(() => {});
+      throw new Error(
+        `Failed to commit provider-profiles at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err }
+      );
+    }
+  }
+
+  async listProfiles(): Promise<ProviderProfile[]> {
+    const doc = await this.readDoc();
+    return [...doc.profiles].sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  async getProfile(id: string): Promise<ProviderProfile | null> {
+    const doc = await this.readDoc();
+    return doc.profiles.find((p) => p.id === id) ?? null;
+  }
+
+  async upsertProfile(
+    profile: Omit<ProviderProfile, "createdAt" | "updatedAt"> &
+      Partial<Pick<ProviderProfile, "createdAt" | "updatedAt">>
+  ): Promise<ProviderProfile> {
+    const envCheck = validateEnvOverrides(profile.envOverrides);
+    if (!envCheck.ok) {
+      throw new Error(`Refusing to persist envOverrides[${envCheck.key}]: ${envCheck.reason}`);
+    }
+
+    const doc = await this.readDoc();
+    const now = new Date().toISOString();
+    const existing = doc.profiles.find((p) => p.id === profile.id);
+
+    const merged: ProviderProfile = ProviderProfileSchema.parse({
+      ...profile,
+      envOverrides: profile.envOverrides ?? {},
+      createdAt: existing?.createdAt ?? profile.createdAt ?? now,
+      updatedAt: now,
+    });
+
+    const next = doc.profiles.filter((p) => p.id !== merged.id);
+    next.push(merged);
+    await this.writeDoc({ ...doc, profiles: next });
+    return merged;
+  }
+
+  async removeProfile(id: string): Promise<boolean> {
+    const doc = await this.readDoc();
+    const before = doc.profiles.length;
+    const profiles = doc.profiles.filter((p) => p.id !== id);
+    if (profiles.length === before) return false;
+    const defaultProfileId = doc.defaultProfileId === id ? null : doc.defaultProfileId;
+    await this.writeDoc({ defaultProfileId, profiles });
+    return true;
+  }
+
+  async getDefaultProfileId(): Promise<string | null> {
+    const doc = await this.readDoc();
+    if (!doc.defaultProfileId) return null;
+    // If the referenced profile is gone, report null rather than a dangling id.
+    const exists = doc.profiles.some((p) => p.id === doc.defaultProfileId);
+    return exists ? doc.defaultProfileId : null;
+  }
+
+  async setDefaultProfileId(id: string | null): Promise<void> {
+    const doc = await this.readDoc();
+    if (id !== null && !doc.profiles.some((p) => p.id === id)) {
+      throw new Error(`Cannot set default: profile '${id}' does not exist`);
+    }
+    await this.writeDoc({ ...doc, defaultProfileId: id });
+  }
+}

--- a/test/agents/cli-agents-env-overlay.test.ts
+++ b/test/agents/cli-agents-env-overlay.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import { ClaudeCliAgent, CodexCliAgent } from "../../src/agents/cli-agents.js";
+import type {
+  CommandInvocation,
+  CommandInvoker,
+  CommandResult,
+} from "../../src/agents/command-invoker.js";
+import { ScriptedInvoker } from "../../src/simulation/scripted-invoker.js";
+import type { WorkRequest } from "../../src/domain/agent.js";
+
+/**
+ * PR 2: verify the profile plumbing (`envOverlay` + `extraPassEnv`) reaches
+ * the `CommandInvocation` the adapter hands to the invoker. Wraps the real
+ * `ScriptedInvoker` so the scripted JSON response keeps the adapters happy
+ * while we snapshot every invocation for assertions.
+ */
+class CapturingScriptedInvoker implements CommandInvoker {
+  readonly invocations: CommandInvocation[] = [];
+  private readonly inner: ScriptedInvoker;
+
+  constructor(cwd: string) {
+    this.inner = new ScriptedInvoker(cwd);
+  }
+
+  async exec(invocation: CommandInvocation): Promise<CommandResult> {
+    this.invocations.push(invocation);
+    return this.inner.exec(invocation);
+  }
+}
+
+function makeWorkRequest(): WorkRequest {
+  return {
+    runId: "run-1",
+    phaseId: "phase-1",
+    kind: "implement_phase",
+    specialty: "general",
+    title: "env-overlay test",
+    objective: "verify env overlay + passEnv propagation",
+    acceptanceCriteria: [],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    context: [],
+    artifactContext: [],
+    attempt: 1,
+    maxAttempts: 3,
+    priorEvidence: [],
+  };
+}
+
+describe("cli-agents envOverlay + extraPassEnv (PR2 profile plumbing)", () => {
+  it("Claude: envOverlay entries reach the CommandInvocation.env", async () => {
+    const invoker = new CapturingScriptedInvoker(process.cwd());
+    const agent = new ClaudeCliAgent({
+      id: "atlas",
+      name: "Atlas",
+      provider: "claude",
+      capability: { role: "planner", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      envOverlay: {
+        ANTHROPIC_BASE_URL: "https://proxy.example.com",
+        ANTHROPIC_MODEL: "claude-sonnet-4",
+      },
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const call = invoker.invocations.at(-1);
+    expect(call?.env).toMatchObject({
+      ANTHROPIC_BASE_URL: "https://proxy.example.com",
+      ANTHROPIC_MODEL: "claude-sonnet-4",
+    });
+  });
+
+  it("Claude: envOverlay merges with RELAY_AGENT_ROLE when a role is set", async () => {
+    const invoker = new CapturingScriptedInvoker(process.cwd());
+    const agent = new ClaudeCliAgent({
+      id: "atlas",
+      name: "Atlas",
+      provider: "claude",
+      capability: { role: "planner", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      role: "repo-admin",
+      envOverlay: { ANTHROPIC_BASE_URL: "https://proxy.example.com" },
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const call = invoker.invocations.at(-1);
+    expect(call?.env).toMatchObject({
+      ANTHROPIC_BASE_URL: "https://proxy.example.com",
+      RELAY_AGENT_ROLE: "repo-admin",
+    });
+  });
+
+  it("Claude: extraPassEnv is appended to the default CLAUDE_PASS_ENV list", async () => {
+    const invoker = new CapturingScriptedInvoker(process.cwd());
+    const agent = new ClaudeCliAgent({
+      id: "atlas",
+      name: "Atlas",
+      provider: "claude",
+      capability: { role: "planner", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      extraPassEnv: ["OPENROUTER_API_KEY"],
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const call = invoker.invocations.at(-1);
+    const passEnv = call?.passEnv ?? [];
+    expect(passEnv).toContain("OPENROUTER_API_KEY");
+    expect(passEnv).toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("Codex: envOverlay + extraPassEnv both reach the invocation", async () => {
+    const invoker = new CapturingScriptedInvoker(process.cwd());
+    const agent = new CodexCliAgent({
+      id: "atlas",
+      name: "Atlas",
+      provider: "codex",
+      capability: { role: "planner", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+      envOverlay: { OPENAI_BASE_URL: "https://openrouter.ai/api/v1" },
+      extraPassEnv: ["OPENROUTER_API_KEY"],
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const call = invoker.invocations.at(-1);
+    expect(call?.env).toMatchObject({
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+    });
+    const passEnv = call?.passEnv ?? [];
+    expect(passEnv).toContain("OPENROUTER_API_KEY");
+    expect(passEnv).toContain("OPENAI_API_KEY");
+  });
+
+  it("omitting both options leaves env + passEnv untouched from the pre-PR2 defaults", async () => {
+    const invoker = new CapturingScriptedInvoker(process.cwd());
+    const agent = new ClaudeCliAgent({
+      id: "atlas",
+      name: "Atlas",
+      provider: "claude",
+      capability: { role: "planner", specialties: ["general"] },
+      cwd: process.cwd(),
+      invoker,
+    });
+
+    await agent.run(makeWorkRequest());
+
+    const call = invoker.invocations.at(-1);
+    // No role set, no overlay: env should be undefined (pre-AL-11 parity).
+    expect(call?.env).toBeUndefined();
+    const passEnv = call?.passEnv ?? [];
+    // Default list only — no extras appended.
+    expect(passEnv).toContain("ANTHROPIC_API_KEY");
+    expect(passEnv).not.toContain("OPENROUTER_API_KEY");
+  });
+});

--- a/test/channels/channel-store.test.ts
+++ b/test/channels/channel-store.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+
+describe("ChannelStore.setProviderProfileId", () => {
+  it("writes providerProfileId atomically and records a decision", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "set-provider-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const channel = await store.createChannel({
+        name: "#profile",
+        description: "profile binding",
+      });
+
+      // Bind.
+      const bound = await store.setProviderProfileId(channel.channelId, "openrouter");
+      expect(bound?.providerProfileId).toBe("openrouter");
+
+      // Persisted — re-read bypasses any in-memory state.
+      const reloaded = await store.getChannel(channel.channelId);
+      expect(reloaded?.providerProfileId).toBe("openrouter");
+
+      // Clear.
+      const cleared = await store.setProviderProfileId(channel.channelId, null);
+      expect(cleared?.providerProfileId).toBeUndefined();
+
+      // Each invocation writes a decision — two setter calls, two entries.
+      const decisions = await store.listDecisions(channel.channelId);
+      expect(decisions).toHaveLength(2);
+      // Most-recent-first sort: clear is newer than bind.
+      expect(decisions[0].title).toContain("(none — inherit default)");
+      expect(decisions[1].title).toContain("openrouter");
+
+      // And a feed entry lands for each decision so the audit trail is
+      // visible from `rly channel feed`.
+      const feed = await store.readFeed(channel.channelId);
+      const decisionEntries = feed.filter((e) => e.type === "decision");
+      expect(decisionEntries.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for an unknown channel", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "set-provider-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const result = await store.setProviderProfileId("does-not-exist", "openrouter");
+      expect(result).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-binding to the same profile still records a decision (audit)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "set-provider-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const channel = await store.createChannel({
+        name: "#noop",
+        description: "no-op bind",
+      });
+      await store.setProviderProfileId(channel.channelId, "openrouter");
+      await store.setProviderProfileId(channel.channelId, "openrouter");
+      const decisions = await store.listDecisions(channel.channelId);
+      expect(decisions).toHaveLength(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/domain/channel.test.ts
+++ b/test/domain/channel.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+
+describe("Channel providerProfileId field", () => {
+  it("round-trips providerProfileId through the channel manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "channel-profile-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const created = await store.createChannel({
+        name: "#profile-rt",
+        description: "round-trip test",
+      });
+
+      // Absent on create (back-compat default).
+      expect(created.providerProfileId).toBeUndefined();
+
+      const bound = await store.updateChannel(created.channelId, {
+        providerProfileId: "openrouter",
+      });
+      expect(bound?.providerProfileId).toBe("openrouter");
+
+      const reloaded = await store.getChannel(created.channelId);
+      expect(reloaded?.providerProfileId).toBe("openrouter");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats missing providerProfileId as undefined, not an error", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "channel-profile-"));
+    const store = new ChannelStore(dir);
+
+    try {
+      const created = await store.createChannel({
+        name: "#no-profile",
+        description: "absent field",
+      });
+      // Re-read to simulate a fresh process; ensures the serializer didn't
+      // accidentally stamp `providerProfileId: null` or similar.
+      const reloaded = await store.getChannel(created.channelId);
+      expect(reloaded).not.toBeNull();
+      expect(reloaded!.providerProfileId).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/domain/provider-profile.test.ts
+++ b/test/domain/provider-profile.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isLikelySecretValue,
+  PROVIDER_PROFILE_ID_PATTERN,
+  ProviderProfileSchema,
+  validateEnvOverrides,
+} from "../../src/domain/provider-profile.js";
+
+describe("provider-profile id pattern", () => {
+  it("accepts lowercase ids with digits and dashes", () => {
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("minimax")).toBe(true);
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("openrouter-01")).toBe(true);
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("a")).toBe(true);
+  });
+
+  it("rejects empty, uppercase, or over-long ids", () => {
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("")).toBe(false);
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("MiniMax")).toBe(false);
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("a".repeat(33))).toBe(false);
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("has space")).toBe(false);
+    expect(PROVIDER_PROFILE_ID_PATTERN.test("under_score")).toBe(false);
+  });
+});
+
+describe("isLikelySecretValue", () => {
+  it("flags vendor prefixes", () => {
+    expect(isLikelySecretValue("sk-abcdef")).toBe(true);
+    expect(isLikelySecretValue("sk_ant_123")).toBe(true);
+    expect(isLikelySecretValue("anthropic_live_xyz")).toBe(true);
+    expect(isLikelySecretValue("sess-AB12")).toBe(true);
+    expect(isLikelySecretValue("ghp_1234567890")).toBe(true);
+    expect(isLikelySecretValue("github_pat_xyz")).toBe(true);
+    expect(isLikelySecretValue("xoxb-abc")).toBe(true);
+    expect(isLikelySecretValue("Bearer abc")).toBe(true);
+  });
+
+  it("flags long opaque base64-ish runs", () => {
+    // 40 chars of base64url-ish — classic token shape.
+    expect(isLikelySecretValue("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN")).toBe(true);
+    // Exactly 32 chars — threshold.
+    expect(isLikelySecretValue("a".repeat(32))).toBe(true);
+  });
+
+  it("does not flag ordinary base-URL values", () => {
+    expect(isLikelySecretValue("https://api.minimax.io/v1")).toBe(false);
+    expect(isLikelySecretValue("http://localhost:4000")).toBe(false);
+    expect(isLikelySecretValue("us-east-1")).toBe(false);
+    expect(isLikelySecretValue("MiniMax-M2")).toBe(false);
+    expect(isLikelySecretValue("")).toBe(false);
+  });
+});
+
+describe("validateEnvOverrides", () => {
+  it("accepts empty / undefined overrides", () => {
+    expect(validateEnvOverrides(undefined)).toEqual({ ok: true });
+    expect(validateEnvOverrides({})).toEqual({ ok: true });
+  });
+
+  it("accepts regular base URLs and model names", () => {
+    const result = validateEnvOverrides({
+      OPENAI_BASE_URL: "https://api.minimax.io/v1",
+      OPENAI_MODEL: "MiniMax-M2",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a secret-looking value and names the offending key", () => {
+    const result = validateEnvOverrides({
+      OPENAI_BASE_URL: "https://api.minimax.io/v1",
+      OPENAI_API_KEY: "sk-abcdef1234567890",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.key).toBe("OPENAI_API_KEY");
+      expect(result.reason).toMatch(/api-key-ref/);
+    }
+  });
+});
+
+describe("ProviderProfileSchema", () => {
+  it("round-trips a valid profile", () => {
+    const parsed = ProviderProfileSchema.parse({
+      id: "minimax",
+      displayName: "MiniMax (M2)",
+      adapter: "codex",
+      envOverrides: { OPENAI_BASE_URL: "https://api.minimax.io/v1" },
+      apiKeyEnvRef: "MINIMAX_API_KEY",
+      defaultModel: "MiniMax-M2",
+      createdAt: "2026-04-23T00:00:00.000Z",
+      updatedAt: "2026-04-23T00:00:00.000Z",
+    });
+    expect(parsed.id).toBe("minimax");
+    expect(parsed.adapter).toBe("codex");
+  });
+
+  it("rejects an unknown adapter", () => {
+    expect(() =>
+      ProviderProfileSchema.parse({
+        id: "gemini",
+        displayName: "Gemini",
+        adapter: "gemini",
+        envOverrides: {},
+        createdAt: "2026-04-23T00:00:00.000Z",
+        updatedAt: "2026-04-23T00:00:00.000Z",
+      })
+    ).toThrow();
+  });
+
+  it("rejects a malformed apiKeyEnvRef", () => {
+    expect(() =>
+      ProviderProfileSchema.parse({
+        id: "minimax",
+        displayName: "MiniMax",
+        adapter: "codex",
+        envOverrides: {},
+        apiKeyEnvRef: "not a var name",
+        createdAt: "2026-04-23T00:00:00.000Z",
+        updatedAt: "2026-04-23T00:00:00.000Z",
+      })
+    ).toThrow();
+  });
+});

--- a/test/orchestrator/dispatch-provider-profile.test.ts
+++ b/test/orchestrator/dispatch-provider-profile.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { createLiveAgents } from "../../src/agents/factory.js";
+import {
+  InMemoryProviderProfileLookup,
+  type ProviderProfile,
+} from "../../src/agents/provider-profile-lookup.js";
+import { resolveChannelProviderProfile } from "../../src/orchestrator/dispatch.js";
+import type { Channel } from "../../src/domain/channel.js";
+import type { CommandInvocation, CommandInvoker } from "../../src/agents/command-invoker.js";
+import type { WorkRequest } from "../../src/domain/agent.js";
+
+function makeProfile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
+  return {
+    id: overrides.id ?? "openrouter",
+    displayName: overrides.displayName ?? "OpenRouter",
+    adapter: overrides.adapter ?? "codex",
+    envOverrides: overrides.envOverrides ?? {
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+      HARNESS_AGENT_ATLAS_MODEL: "anthropic/claude-sonnet-4",
+    },
+    apiKeyEnvRef: overrides.apiKeyEnvRef ?? "OPENROUTER_API_KEY",
+    defaultModel: overrides.defaultModel ?? "anthropic/claude-sonnet-4",
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00Z",
+    updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    channelId: overrides.channelId ?? "channel-1",
+    name: overrides.name ?? "#test",
+    description: overrides.description ?? "",
+    status: overrides.status ?? "active",
+    workspaceIds: overrides.workspaceIds ?? [],
+    members: overrides.members ?? [],
+    pinnedRefs: overrides.pinnedRefs ?? [],
+    providerProfileId: overrides.providerProfileId,
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00Z",
+    updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("resolveChannelProviderProfile (dispatch resolution order)", () => {
+  it("prefers channel.providerProfileId over the store default", async () => {
+    const channelProfile = makeProfile({ id: "channel-pick" });
+    const defaultProfile = makeProfile({ id: "default-pick" });
+    const lookup = new InMemoryProviderProfileLookup(
+      new Map([
+        ["channel-pick", channelProfile],
+        ["default-pick", defaultProfile],
+      ]),
+      "default-pick"
+    );
+
+    const resolved = await resolveChannelProviderProfile(
+      makeChannel({ providerProfileId: "channel-pick" }),
+      lookup
+    );
+
+    expect(resolved?.id).toBe("channel-pick");
+  });
+
+  it("falls back to the default profile when the channel has no binding", async () => {
+    const defaultProfile = makeProfile({ id: "default-pick" });
+    const lookup = new InMemoryProviderProfileLookup(
+      new Map([["default-pick", defaultProfile]]),
+      "default-pick"
+    );
+
+    const resolved = await resolveChannelProviderProfile(makeChannel(), lookup);
+
+    expect(resolved?.id).toBe("default-pick");
+  });
+
+  it("returns null when neither the channel nor the store binds a profile", async () => {
+    const lookup = new InMemoryProviderProfileLookup(new Map(), null);
+    const resolved = await resolveChannelProviderProfile(makeChannel(), lookup);
+    expect(resolved).toBeNull();
+  });
+
+  it("returns null when the channel's id points at a deleted profile and no default exists", async () => {
+    const lookup = new InMemoryProviderProfileLookup(new Map(), null);
+    const resolved = await resolveChannelProviderProfile(
+      makeChannel({ providerProfileId: "ghost" }),
+      lookup
+    );
+    // Degrade gracefully — the legacy HARNESS_PROVIDER path runs instead
+    // of crashing a user's chat on a stale id.
+    expect(resolved).toBeNull();
+  });
+
+  it("treats a null channel as unbound (falls back to default)", async () => {
+    const defaultProfile = makeProfile({ id: "default-pick" });
+    const lookup = new InMemoryProviderProfileLookup(
+      new Map([["default-pick", defaultProfile]]),
+      "default-pick"
+    );
+    const resolved = await resolveChannelProviderProfile(null, lookup);
+    expect(resolved?.id).toBe("default-pick");
+  });
+});
+
+// The next two tests confirm `createLiveAgents` forwards envOverlay and
+// extraPassEnv to the invoker. This is the contract dispatch relies on to
+// surface a resolved profile to the CLI subprocess.
+
+class CaptureInvoker implements CommandInvoker {
+  public lastInvocation: CommandInvocation | null = null;
+
+  constructor(private readonly stdout: string) {}
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async exec(invocation: CommandInvocation) {
+    this.lastInvocation = invocation;
+    return { stdout: this.stdout, stderr: "", exitCode: 0 };
+  }
+}
+
+function makeWorkRequest(): WorkRequest {
+  return {
+    runId: "run-1",
+    phaseId: "phase-1",
+    kind: "implement_phase",
+    specialty: "general",
+    title: "test",
+    objective: "test",
+    acceptanceCriteria: [],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    context: [],
+    artifactContext: [],
+    attempt: 1,
+    maxAttempts: 3,
+    priorEvidence: [],
+  };
+}
+
+const AGENT_RESULT = JSON.stringify({
+  summary: "ok",
+  evidence: [],
+  proposedCommands: [],
+  blockers: [],
+});
+
+describe("createLiveAgents envOverlay + extraPassEnv propagation", () => {
+  it("passes the profile's envOverrides into the spawned invocation env", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agents = createLiveAgents({
+      cwd: process.cwd(),
+      defaultProvider: "claude",
+      invoker,
+      envOverlay: { ANTHROPIC_BASE_URL: "https://proxy.example.com" },
+    });
+
+    await agents[0].run(makeWorkRequest());
+
+    expect(invoker.lastInvocation?.env).toMatchObject({
+      ANTHROPIC_BASE_URL: "https://proxy.example.com",
+    });
+  });
+
+  it("appends extraPassEnv to the adapter's default allowlist", async () => {
+    const invoker = new CaptureInvoker(AGENT_RESULT);
+    const agents = createLiveAgents({
+      cwd: process.cwd(),
+      defaultProvider: "claude",
+      invoker,
+      extraPassEnv: ["OPENROUTER_API_KEY"],
+    });
+
+    await agents[0].run(makeWorkRequest());
+
+    const passEnv = invoker.lastInvocation?.passEnv ?? [];
+    expect(passEnv).toContain("OPENROUTER_API_KEY");
+    // Still carries the default Claude vars — extraPassEnv is additive.
+    expect(passEnv).toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/test/storage/provider-profile-store.test.ts
+++ b/test/storage/provider-profile-store.test.ts
@@ -1,0 +1,173 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ProviderProfileStore } from "../../src/storage/provider-profile-store.js";
+
+describe("ProviderProfileStore", () => {
+  let root: string;
+  let store: ProviderProfileStore;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-provider-profiles-"));
+    store = new ProviderProfileStore({ rootDir: root });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns an empty list when the file does not exist yet", async () => {
+    const list = await store.listProfiles();
+    expect(list).toEqual([]);
+    expect(await store.getDefaultProfileId()).toBeNull();
+  });
+
+  it("round-trips a profile via upsert / getProfile / listProfiles", async () => {
+    const profile = await store.upsertProfile({
+      id: "minimax",
+      displayName: "MiniMax (M2)",
+      adapter: "codex",
+      envOverrides: { OPENAI_BASE_URL: "https://api.minimax.io/v1" },
+      apiKeyEnvRef: "MINIMAX_API_KEY",
+      defaultModel: "MiniMax-M2",
+    });
+
+    expect(profile.createdAt).toBeTruthy();
+    expect(profile.updatedAt).toBeTruthy();
+
+    const loaded = await store.getProfile("minimax");
+    expect(loaded?.displayName).toBe("MiniMax (M2)");
+
+    const list = await store.listProfiles();
+    expect(list.map((p) => p.id)).toEqual(["minimax"]);
+  });
+
+  it("upsert replaces by id and preserves createdAt", async () => {
+    const first = await store.upsertProfile({
+      id: "minimax",
+      displayName: "MiniMax",
+      adapter: "codex",
+      envOverrides: {},
+    });
+
+    // Force a different timestamp on the second write.
+    await new Promise((r) => setTimeout(r, 2));
+
+    const second = await store.upsertProfile({
+      id: "minimax",
+      displayName: "MiniMax Pro",
+      adapter: "codex",
+      envOverrides: { OPENAI_BASE_URL: "https://example.test/v1" },
+    });
+
+    expect(second.createdAt).toBe(first.createdAt);
+    expect(second.updatedAt >= first.updatedAt).toBe(true);
+
+    const list = await store.listProfiles();
+    expect(list).toHaveLength(1);
+    expect(list[0].displayName).toBe("MiniMax Pro");
+    expect(list[0].envOverrides).toEqual({ OPENAI_BASE_URL: "https://example.test/v1" });
+  });
+
+  it("removeProfile returns false for an unknown id", async () => {
+    expect(await store.removeProfile("nope")).toBe(false);
+  });
+
+  it("rejects secret-looking values in envOverrides at upsert", async () => {
+    await expect(
+      store.upsertProfile({
+        id: "leaky",
+        displayName: "Leaky",
+        adapter: "codex",
+        envOverrides: {
+          OPENAI_BASE_URL: "https://api.minimax.io/v1",
+          OPENAI_API_KEY: "sk-abcdef1234567890",
+        },
+      })
+    ).rejects.toThrow(/OPENAI_API_KEY/);
+
+    // Nothing should have been persisted.
+    const list = await store.listProfiles();
+    expect(list).toEqual([]);
+  });
+
+  it("round-trips the default profile id", async () => {
+    await store.upsertProfile({
+      id: "minimax",
+      displayName: "MiniMax",
+      adapter: "codex",
+      envOverrides: {},
+    });
+    await store.setDefaultProfileId("minimax");
+    expect(await store.getDefaultProfileId()).toBe("minimax");
+
+    await store.setDefaultProfileId(null);
+    expect(await store.getDefaultProfileId()).toBeNull();
+  });
+
+  it("refuses to set a default pointing at a missing profile", async () => {
+    await expect(store.setDefaultProfileId("ghost")).rejects.toThrow(/does not exist/);
+  });
+
+  it("clears the default when the target profile is removed", async () => {
+    await store.upsertProfile({
+      id: "minimax",
+      displayName: "MiniMax",
+      adapter: "codex",
+      envOverrides: {},
+    });
+    await store.setDefaultProfileId("minimax");
+    expect(await store.getDefaultProfileId()).toBe("minimax");
+
+    expect(await store.removeProfile("minimax")).toBe(true);
+    expect(await store.getDefaultProfileId()).toBeNull();
+  });
+
+  it("tolerates a corrupt entry in an otherwise-valid file", async () => {
+    const path = join(root, "provider-profiles.json");
+    await writeFile(
+      path,
+      JSON.stringify(
+        {
+          defaultProfileId: null,
+          profiles: [
+            { id: "broken" },
+            {
+              id: "ok",
+              displayName: "OK",
+              adapter: "codex",
+              envOverrides: {},
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+
+    const list = await store.listProfiles();
+    expect(list.map((p) => p.id)).toEqual(["ok"]);
+  });
+
+  it("writes via a tmp-file + rename pattern (no leftover tmp files)", async () => {
+    await store.upsertProfile({
+      id: "a",
+      displayName: "A",
+      adapter: "claude",
+      envOverrides: {},
+    });
+
+    const contents = await readFile(join(root, "provider-profiles.json"), "utf8");
+    expect(() => JSON.parse(contents)).not.toThrow();
+
+    // No stray tmp files should remain after a successful write.
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(root);
+    expect(entries.filter((e) => e.includes(".tmp."))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end multi-provider support so users can switch between OpenAI, Anthropic, MiniMax (or any OpenAI-/Anthropic-compatible endpoint) per channel without touching env vars between runs. Three consolidated feature branches + docs land in one PR:

- **Provider-profile store + CLI** — `~/.relay/provider-profiles.json`, `rly providers profiles list|add|remove|show`, `rly providers default <id|clear>`. Profiles reference env-var names; raw secrets in `--env KEY=VAL` are rejected.
- **Channel field + dispatch resolution** — `Channel.providerProfileId` (mirrored into `crates/harness-data`), `ChannelStore.setProviderProfileId` with decision-log entry, `rly channel set-provider`, dispatch resolution order (channel → global default → `HARNESS_PROVIDER`), `envOverlay` + `extraPassEnv` plumbed through `CliAgentOptions` and `createLiveAgents`.
- **GUI** — Provider dropdown on each channel (Settings drawer → About), full-CRUD Providers tab in global Settings, Tauri shell-outs to the `rly` CLI.
- **Docs** — README top-level Beta banner + Multi-provider section + GitHub Projects contributor invite, `docs/providers.md` points back at README beta note.
- **Integration fixes on top of the merges** — swapped PR 2's `NullProviderProfileLookup` stub for the real `ProviderProfileStore`, added `--json` to `rly providers profiles add/remove` for GUI parity, aligned Tauri `upsert_provider_profile` flag names with PR 1 CLI (`--model`, `--api-key-ref`, no `--upsert`).

## Test plan

Automated (all green locally):

- [x] `pnpm typecheck`
- [x] `pnpm test` — 861 passing, 23 skipped (+38 new tests across domain / store / channel / dispatch / env-overlay)
- [x] `pnpm format:check`
- [x] `pnpm build`
- [x] `cargo check --workspace`
- [x] `cd gui && pnpm build`

Manual (recommended before merge):

- [ ] `rly providers profiles add minimax --adapter codex --env OPENAI_BASE_URL=https://api.minimax.io/v1 --api-key-ref MINIMAX_API_KEY --model MiniMax-M2`
- [ ] `rly providers profiles list` shows the profile.
- [ ] `rly channel set-provider <channelId> minimax` prints the displayName.
- [ ] GUI: open a channel → Settings drawer → About → Provider dropdown lists profiles, change persists.
- [ ] GUI: Settings page → Providers tab → Add profile, Remove, Make default.

## LOC note

Larger than the 800-LOC guideline because it consolidates three logically-gated PRs into one atomic unit — splitting the merge would ship dead stub code and a half-functional GUI. Follow-up PRs are planned for native adapters (Cursor, Gemini) and keychain-backed secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)