### PR TITLE
fix(gui): unwrap profiles array (was crashing About + Providers tabs)

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -805,7 +805,15 @@ fn set_channel_tier(channel_id: String, tier: Option<String>) -> Result<(), Stri
 
 #[tauri::command]
 fn list_provider_profiles() -> Result<serde_json::Value, String> {
-    cli_json(&["providers", "profiles", "list", "--json"])
+    // CLI emits `{ "defaultProfileId": ..., "profiles": [...] }`. The
+    // renderer is typed as `Promise<ProviderProfile[]>`, so unwrap the
+    // `profiles` array here — otherwise React's `.map()` on the object
+    // crashes the drawer + the Providers settings tab.
+    let value = cli_json(&["providers", "profiles", "list", "--json"])?;
+    match value.get("profiles") {
+        Some(profiles) => Ok(profiles.clone()),
+        None => Ok(serde_json::json!([])),
+    }
 }
 
 /// Read the globally-selected default profile id. The CLI prints


### PR DESCRIPTION
## Summary

Bug introduced in #131. The CLI's \`rly providers profiles list --json\` emits \`{ "defaultProfileId": ..., "profiles": [...] }\` (object) but the Tauri \`list_provider_profiles\` command passed that through unchanged to the renderer, where both \`ChannelSettingsDrawer\` (About tab) and \`SettingsPage\` (Providers tab) type it as \`ProviderProfile[]\` and call \`.map()\`/\`.filter()\` on it. Result: the React tree crashed any time either surface mounted.

Fix on the Tauri side: unwrap \`.profiles\` before returning so the renderer sees the array it was typed for. Missing key defaults to \`[]\` so a fresh install (no \`~/.relay/provider-profiles.json\`) doesn't surface a fake error.

Reported by @jcast90 on main after pulling #131.

## Test plan

- [x] \`cargo check --workspace\` green
- [ ] Rebuild GUI (\`rly gui --rebuild\` or \`cd gui && pnpm build\`) and verify:
  - [ ] About tab on any channel opens without crashing.
  - [ ] Settings → Providers tab opens without crashing.
  - [ ] Fresh install (no profiles) shows empty state, not an error banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)