### PR TITLE
fix(gui): second pass on hover contrast — deeper surfaces + outline

### DIFF
--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -26,8 +26,14 @@ button {
   cursor: pointer;
   transition: var(--anim-hover-fast);
 }
-button:hover:not(:disabled) { background: var(--color-paper-hover); }
-button:active:not(:disabled) { background: var(--color-paper-pressed); }
+button:hover:not(:disabled) {
+  background: var(--color-paper-hover);
+  border-color: var(--color-text-muted);
+}
+button:active:not(:disabled) {
+  background: var(--color-paper-pressed);
+  border-color: var(--color-text-primary);
+}
 button.primary {
   background: var(--color-accent-coral);
   border-color: var(--color-accent-coral);
@@ -776,11 +782,13 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
    and the primary (coral) chip looked like "dark red on dark red"
    on hover. Explicit bg swaps here so text stays readable. */
 .repo-chip.primary:hover {
-  background: #f6c9c0;
+  /* Deep salmon that's clearly distinct from the resting coral-soft
+     and still gives >4.5:1 contrast against the coral text. */
+  background: #f0a79b;
   border-color: var(--color-accent-coral);
 }
 .repo-chip.attached:hover {
-  background: #c2d3ea;
+  background: #a6bfdf;
   border-color: var(--color-mention-attached-fg);
 }
 .repo-chip.add:hover {

--- a/gui/src/styles/tokens.css
+++ b/gui/src/styles/tokens.css
@@ -13,19 +13,22 @@
   --color-paper-base:  #fbf9f4;
   --color-paper-alt:   #f3f0e7;
   --color-paper-line:  #e5e1d5;
-  /* Hover / pressed surfaces — meaningful luminance drops so state
-     changes are perceptible (WCAG 2.1 SC 1.4.11 asks ≥3:1 for
-     non-text UI indicators; `paper-alt` resting-state surfaces only
-     gave ~1.04:1 when also used as hover). Paper-hover is the
-     go-to for button/item hover on paper-base; paper-pressed is
-     reserved for active/focused controls. */
-  --color-paper-hover:   #e8e1cc;
-  --color-paper-pressed: #d9d0b4;
+  /* Hover / pressed surfaces — first pass shipped at ~1.22:1 which
+     was technically a drop but still read as "hover does nothing."
+     Second pass deepens to ~1.6:1 for hover and ~2.0:1 for pressed.
+     Still under WCAG 1.4.11's 3:1 target (that ratio on a paper-tone
+     surface looks like mud), but combined with the cursor pointer +
+     the border/outline bumps below it's a clearly perceptible state
+     change. If you need a stronger floor, use `prefers-contrast:
+     more` in a follow-up. */
+  --color-paper-hover:   #d8cfb0;
+  --color-paper-pressed: #bdb088;
   /* Dark-surface parallel: ink-deep is the sidebar ground; ink-hover
      is the explicit hover step. ink-panel remains a raised-surface
      resting token (e.g. sidebar group headers), which is why hover
-     needed its own value — one ≈4% step wasn't enough. */
-  --color-ink-hover:     #293553;
+     needed its own value — one ≈4% step wasn't enough. Tuned up
+     alongside the paper-side bump for parity. */
+  --color-ink-hover:     #364370;
 
   /* Text */
   --color-text-primary:      #1b1f2a;


### PR DESCRIPTION
PR #158 was directionally right but too subtle (~1.22:1 luminance ratio on paper-base). @jcast90 reported hovers still "look pretty bad." This pass deepens the tokens and adds a border-color shift for a second visual signal.

- \`paper-hover\`: #e8e1cc → **#d8cfb0** (~1.6:1 vs paper-base)
- \`paper-pressed\`: #d9d0b4 → **#bdb088** (~2.0:1)
- \`ink-hover\`: #293553 → **#364370** (matching bump dark-side)
- button :hover/:active also shift border-color (muted / primary) so there's a second signal
- \`.repo-chip.primary:hover\`: #f6c9c0 → **#f0a79b** (deep salmon, clearly distinct from the resting coral-soft)
- \`.repo-chip.attached:hover\`: #c2d3ea → **#a6bfdf**

Still below WCAG 1.4.11's strict 3:1 on paper surfaces — that ratio requires a mid-tan hover that looks muddy on a warm paper palette. With cursor + border + deeper luminance combined, hovers are now perceptibly different. \`prefers-contrast: more\` remains a future opt-in (see #159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)