### PR TITLE
fix(gui): chat wire-shape + liveness + full markdown rendering

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -17,7 +17,9 @@
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.1.0",

--- a/gui/pnpm-lock.yaml
+++ b/gui/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2.1.0
@@ -56,7 +62,7 @@ importers:
         version: 5.4.21
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@29.0.2)
+        version: 3.2.4(@types/debug@4.1.13)(jsdom@29.0.2)
 
 packages:
 
@@ -623,11 +629,26 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -639,6 +660,15 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -694,6 +724,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -714,13 +747,31 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -751,6 +802,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -758,6 +812,9 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -784,12 +841,22 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -809,13 +876,41 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -845,6 +940,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -866,8 +964,140 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -883,6 +1113,9 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -909,6 +1142,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -921,6 +1157,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -932,6 +1174,18 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -960,11 +1214,17 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -972,6 +1232,12 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1013,6 +1279,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1022,11 +1294,35 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1122,6 +1418,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1575,9 +1874,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/prop-types@15.7.15': {}
 
@@ -1589,6 +1906,12 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
     dependencies:
@@ -1656,6 +1979,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bail@2.0.2: {}
+
   baseline-browser-mapping@2.10.20: {}
 
   bidi-js@1.0.3:
@@ -1674,6 +1999,8 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -1682,7 +2009,17 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   check-error@2.1.3: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1708,9 +2045,17 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-eql@5.0.2: {}
 
   dequal@2.0.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -1750,11 +2095,17 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1765,13 +2116,54 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-url-attributes@3.0.1: {}
+
   indent-string@4.0.0: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -1809,6 +2201,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -1827,7 +2221,353 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   min-indent@1.0.1: {}
 
@@ -1836,6 +2576,16 @@ snapshots:
   nanoid@3.3.11: {}
 
   node-releases@2.0.37: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -1861,6 +2611,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1: {}
 
   react-dom@18.3.1(react@18.3.1):
@@ -1870,6 +2622,24 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.28
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -1881,6 +2651,40 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 
@@ -1929,9 +2733,16 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-indent@3.0.0:
     dependencies:
@@ -1940,6 +2751,14 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   symbol-tree@3.2.4: {}
 
@@ -1972,15 +2791,62 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   typescript@5.9.3: {}
 
   undici@7.25.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@3.2.4:
     dependencies:
@@ -2008,7 +2874,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@29.0.2):
+  vitest@3.2.4(@types/debug@4.1.13)(jsdom@29.0.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -2034,6 +2900,7 @@ snapshots:
       vite-node: 3.2.4
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.13
       jsdom: 29.0.2
     transitivePeerDependencies:
       - less
@@ -2072,3 +2939,5 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  zwitch@2.0.4: {}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1354,10 +1354,33 @@ fn start_chat(
             }
         };
 
+        // Drain stderr on its own thread. If we leave it unread, the OS pipe
+        // buffer (~64 KB on macOS/Linux) fills and the child blocks on its
+        // next stderr write — the user sees an eternal "thinking…" with no
+        // output. We also keep the captured text so an unsuccessful exit can
+        // surface claude's actual diagnostic to the UI instead of dropping it.
+        let stderr_buf = std::sync::Arc::new(Mutex::new(String::new()));
+        let stderr_handle = child.stderr.take().map(|stderr| {
+            let buf = stderr_buf.clone();
+            std::thread::spawn(move || {
+                let reader = BufReader::new(stderr);
+                for line in reader.lines().map_while(Result::ok) {
+                    eprintln!("[claude stderr] {}", line);
+                    if let Ok(mut guard) = buf.lock() {
+                        if !guard.is_empty() {
+                            guard.push('\n');
+                        }
+                        guard.push_str(&line);
+                    }
+                }
+            })
+        });
+
         let reader = BufReader::new(stdout);
         let mut accum = String::new();
         let mut final_session_id: Option<String> = None;
         let mut cancelled = false;
+        let mut saw_any_stdout_line = false;
 
         for line in reader.lines() {
             // Rewind (and anything else that wants to abort a live stream)
@@ -1374,9 +1397,16 @@ fn start_chat(
                 Ok(l) => l,
                 Err(_) => break,
             };
+            saw_any_stdout_line = true;
             let json: serde_json::Value = match serde_json::from_str(&line) {
                 Ok(v) => v,
-                Err(_) => continue,
+                Err(e) => {
+                    // Log unparseable lines so a developer running the GUI
+                    // from a terminal can see a format mismatch immediately
+                    // instead of silently swallowing every claude line.
+                    eprintln!("[claude stdout] unparseable json ({}): {}", e, line);
+                    continue;
+                }
             };
             match json.get("type").and_then(|t| t.as_str()) {
                 Some("assistant") => {
@@ -1473,7 +1503,11 @@ fn start_chat(
                 _ => {}
             }
         }
-        let _ = child.wait();
+        let exit_status = child.wait();
+        if let Some(h) = stderr_handle {
+            let _ = h.join();
+        }
+        let stderr_text = stderr_buf.lock().map(|g| g.clone()).unwrap_or_default();
 
         // If rewind (or anything else) cancelled this stream, DO NOT
         // persist a partial assistant message or update the claude session
@@ -1487,6 +1521,41 @@ fn start_chat(
                 ChatEvent::Done {
                     stream_id,
                     final_text: String::new(),
+                },
+            );
+            return;
+        }
+
+        // Surface a useful error when the child exited with nothing on
+        // stdout, or exited non-zero. Prior to this, the GUI would silently
+        // emit `Done { final_text: "" }` and the user would see "thinking…"
+        // disappear with no message — now they see claude's own diagnostic.
+        let exit_failed = match &exit_status {
+            Ok(status) => !status.success(),
+            Err(_) => true,
+        };
+        if accum.is_empty() && (exit_failed || !saw_any_stdout_line) {
+            let exit_desc = match &exit_status {
+                Ok(status) => status
+                    .code()
+                    .map(|c| format!("exit {}", c))
+                    .unwrap_or_else(|| "signal".into()),
+                Err(e) => format!("wait failed: {}", e),
+            };
+            let stderr_snippet = stderr_text.trim();
+            let message = if stderr_snippet.is_empty() {
+                format!(
+                    "claude produced no output ({}). Run the GUI from a terminal to see stderr, or set CLAUDE_BIN.",
+                    exit_desc
+                )
+            } else {
+                format!("claude failed ({}):\n{}", exit_desc, stderr_snippet)
+            };
+            let _ = app_handle.emit(
+                "chat-event",
+                ChatEvent::Error {
+                    stream_id,
+                    message,
                 },
             );
             return;

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1195,16 +1195,111 @@ fn build_rewind_metadata_json(rewind_key: &str) -> String {
 #[derive(Serialize, Clone)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 enum ChatEvent {
-    Started { stream_id: u64 },
-    Chunk { stream_id: u64, text: String },
-    Activity { stream_id: u64, text: String },
-    SessionId { stream_id: u64, claude_session_id: String },
-    Done { stream_id: u64, final_text: String },
-    Error { stream_id: u64, message: String },
+    // Explicit camelCase renames on every field. The enum-level
+    // `rename_all = "camelCase"` only applies to variant NAMES (Started ->
+    // "started") — it does NOT recurse into variant struct fields, so
+    // `stream_id` was serializing as the snake_case `stream_id` on the
+    // wire. The renderer reads `event.streamId`, so every event evaluated
+    // to `undefined` and got filtered out as a streamId mismatch; the
+    // stream card was effectively deaf to the backend.
+    Started {
+        #[serde(rename = "streamId")]
+        stream_id: u64,
+    },
+    Chunk {
+        #[serde(rename = "streamId")]
+        stream_id: u64,
+        text: String,
+    },
+    Activity {
+        #[serde(rename = "streamId")]
+        stream_id: u64,
+        text: String,
+    },
+    SessionId {
+        #[serde(rename = "streamId")]
+        stream_id: u64,
+        #[serde(rename = "claudeSessionId")]
+        claude_session_id: String,
+    },
+    Done {
+        #[serde(rename = "streamId")]
+        stream_id: u64,
+        #[serde(rename = "finalText")]
+        final_text: String,
+    },
+    Error {
+        #[serde(rename = "streamId")]
+        stream_id: u64,
+        message: String,
+    },
 }
 
 // `describe_tool_use` lives in the shared `harness_data::tool_activity`
 // module so the GUI, TUI, and CLI render identical one-liners. See OSS-06.
+
+/// Render a `system`-type stream-json line from claude CLI as a short
+/// activity string, or return None for events we don't want to surface.
+///
+/// claude CLI v2.1.119 emits a flurry of `system` events during startup
+/// (init + one pair of hook_started/hook_response per SessionStart hook)
+/// before any assistant content arrives. Without surfacing them the
+/// activity stack stays empty and the user watches "thinking…" with no
+/// signal that anything is alive — the symptom that originally looked like
+/// the chat was broken. We turn each into one short line; the stack has
+/// its own cap so volume is fine.
+fn describe_system_event(json: &serde_json::Value) -> Option<String> {
+    let subtype = json.get("subtype").and_then(|v| v.as_str())?;
+    match subtype {
+        "init" => {
+            let model = json
+                .get("model")
+                .and_then(|v| v.as_str())
+                .unwrap_or("claude");
+            Some(format!("session init · {}", model))
+        }
+        "hook_started" => {
+            let name = json
+                .get("hook_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("hook");
+            Some(format!("hook {} running", name))
+        }
+        "hook_response" => {
+            let name = json
+                .get("hook_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("hook");
+            let outcome = json
+                .get("outcome")
+                .and_then(|v| v.as_str())
+                .unwrap_or("done");
+            if outcome == "success" {
+                // Success already implied by subsequent events; skip to
+                // keep the stack uncluttered. Errors still surface below.
+                None
+            } else {
+                Some(format!("hook {} {}", name, outcome))
+            }
+        }
+        other => Some(format!("system: {}", other)),
+    }
+}
+
+/// Render a `rate_limit_event` stream-json line as activity, skipping the
+/// allowed-status noise that would otherwise fire on every turn.
+fn describe_rate_limit_event(json: &serde_json::Value) -> Option<String> {
+    let info = json.get("rate_limit_info")?;
+    let status = info.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if status == "allowed" {
+        return None;
+    }
+    let kind = info
+        .get("rateLimitType")
+        .and_then(|v| v.as_str())
+        .unwrap_or("rate_limit");
+    Some(format!("rate limit · {} · {}", kind, status))
+}
 
 #[tauri::command]
 fn start_chat(
@@ -1498,6 +1593,31 @@ fn start_chat(
                                 );
                             }
                         }
+                    }
+                }
+                Some("system") => {
+                    // claude CLI v2.1.119 emits many `system` lines before any
+                    // `assistant` content — init, hook_started, hook_response,
+                    // etc. Without surfacing these, the activity stack sits
+                    // empty and the user sees nothing but "thinking…" while
+                    // hooks run and the session warms up. Emit them as
+                    // Activity lines so the stream card actually shows progress.
+                    if let Some(text) = describe_system_event(&json) {
+                        let _ = app_handle.emit(
+                            "chat-event",
+                            ChatEvent::Activity { stream_id, text },
+                        );
+                    }
+                }
+                Some("rate_limit_event") => {
+                    // Only surface rate-limit events when they would gate the
+                    // run; "allowed" is noise. This keeps the activity stack
+                    // useful on long responses that hit soft limits.
+                    if let Some(text) = describe_rate_limit_event(&json) {
+                        let _ = app_handle.emit(
+                            "chat-event",
+                            ChatEvent::Activity { stream_id, text },
+                        );
                     }
                 }
                 _ => {}
@@ -3156,6 +3276,146 @@ mod tests {
     // AL-8's queue surfaces carry their own test coverage via
     // `test/approvals/queue.test.ts` and the harness-data crate's
     // `ApprovalQueueRecord` parser tests.
+
+    // --- describe_system_event / describe_rate_limit_event ---
+    // Regression guards for the activity-liveness fix: claude CLI v2.1.119
+    // emits `system` and `rate_limit_event` lines before any assistant
+    // content, so if we stop surfacing them the user is back to staring at
+    // "thinking…" with no progress signal.
+
+    #[test]
+    fn describe_system_event_renders_init_with_model() {
+        let json = serde_json::json!({
+            "type": "system",
+            "subtype": "init",
+            "model": "claude-opus-4-7",
+        });
+        assert_eq!(
+            describe_system_event(&json).as_deref(),
+            Some("session init · claude-opus-4-7"),
+        );
+    }
+
+    #[test]
+    fn describe_system_event_renders_hook_started_with_name() {
+        let json = serde_json::json!({
+            "type": "system",
+            "subtype": "hook_started",
+            "hook_name": "SessionStart:startup",
+        });
+        assert_eq!(
+            describe_system_event(&json).as_deref(),
+            Some("hook SessionStart:startup running"),
+        );
+    }
+
+    #[test]
+    fn describe_system_event_suppresses_hook_response_success() {
+        let json = serde_json::json!({
+            "type": "system",
+            "subtype": "hook_response",
+            "hook_name": "SessionStart:startup",
+            "outcome": "success",
+        });
+        // Success adds no information beyond the matching hook_started —
+        // suppress to keep the activity stack tight.
+        assert!(describe_system_event(&json).is_none());
+    }
+
+    #[test]
+    fn describe_system_event_surfaces_hook_response_error() {
+        let json = serde_json::json!({
+            "type": "system",
+            "subtype": "hook_response",
+            "hook_name": "SessionStart:startup",
+            "outcome": "error",
+        });
+        assert_eq!(
+            describe_system_event(&json).as_deref(),
+            Some("hook SessionStart:startup error"),
+        );
+    }
+
+    #[test]
+    fn describe_system_event_falls_back_on_unknown_subtype() {
+        let json = serde_json::json!({
+            "type": "system",
+            "subtype": "some_future_event",
+        });
+        // Forward-compat: a new subtype should still produce a line so the
+        // user never lands back in silent-thinking territory.
+        assert_eq!(
+            describe_system_event(&json).as_deref(),
+            Some("system: some_future_event"),
+        );
+    }
+
+    #[test]
+    fn describe_rate_limit_event_skips_allowed_status() {
+        let json = serde_json::json!({
+            "type": "rate_limit_event",
+            "rate_limit_info": { "status": "allowed", "rateLimitType": "five_hour" },
+        });
+        assert!(describe_rate_limit_event(&json).is_none());
+    }
+
+    // Lock the wire shape: the renderer reads `event.streamId`, not
+    // `event.stream_id`. Serde's enum-level `rename_all = "camelCase"` only
+    // renames variant names — it does not recurse into variant struct
+    // fields, so without explicit `#[serde(rename = "streamId")]` every
+    // event would serialize as `stream_id` and every streamId comparison
+    // in CenterPane.tsx would evaluate to undefined !== n, silently
+    // dropping every chunk, activity, done, and error event. That exact
+    // bug left the stream card frozen on "thinking…". Guard it here.
+    #[test]
+    fn chat_event_wire_shape_uses_camel_case_fields() {
+        let started = serde_json::to_value(ChatEvent::Started { stream_id: 7 }).unwrap();
+        assert_eq!(started["kind"], "started");
+        assert_eq!(started["streamId"], 7);
+        assert!(
+            started.get("stream_id").is_none(),
+            "snake_case field leaked to the wire: {}",
+            started
+        );
+
+        let activity = serde_json::to_value(ChatEvent::Activity {
+            stream_id: 3,
+            text: "hi".into(),
+        })
+        .unwrap();
+        assert_eq!(activity["kind"], "activity");
+        assert_eq!(activity["streamId"], 3);
+        assert_eq!(activity["text"], "hi");
+
+        let done = serde_json::to_value(ChatEvent::Done {
+            stream_id: 5,
+            final_text: "ok".into(),
+        })
+        .unwrap();
+        assert_eq!(done["streamId"], 5);
+        assert_eq!(done["finalText"], "ok");
+        assert!(done.get("final_text").is_none());
+
+        let sid = serde_json::to_value(ChatEvent::SessionId {
+            stream_id: 1,
+            claude_session_id: "c".into(),
+        })
+        .unwrap();
+        assert_eq!(sid["claudeSessionId"], "c");
+        assert!(sid.get("claude_session_id").is_none());
+    }
+
+    #[test]
+    fn describe_rate_limit_event_surfaces_non_allowed_status() {
+        let json = serde_json::json!({
+            "type": "rate_limit_event",
+            "rate_limit_info": { "status": "throttled", "rateLimitType": "five_hour" },
+        });
+        assert_eq!(
+            describe_rate_limit_event(&json).as_deref(),
+            Some("rate limit · five_hour · throttled"),
+        );
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -366,9 +366,7 @@ function StreamCard({
           </button>
         )}
       </div>
-      {stream.accum && (
-        <div className="stream-body">{renderMarkdown(stream.accum, channel)}</div>
-      )}
+      {stream.accum && <div className="stream-body">{renderMarkdown(stream.accum, channel)}</div>}
     </div>
   );
 }

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import type { Channel, ChannelEntry, PersistedChatMessage } from "../types";
-import { renderWithMentions } from "../lib/mentions";
+import { renderMarkdown } from "../lib/mentions";
 import { mentionContext, toUiChannel, type MentionContext } from "../lib/channel";
 import { agentAvatar } from "../lib/agents";
 import { useAppearance } from "../lib/appearance";
@@ -97,7 +97,7 @@ function FeedView({ entries, channel }: { entries: ChannelEntry[]; channel: Ment
                   <span className="msg-time">{formatTime(e.createdAt)}</span>
                 </div>
               )}
-              <div className="msg-body">{renderWithMentions(e.content, channel)}</div>
+              <div className="msg-body">{renderMarkdown(e.content, channel)}</div>
             </div>
           </div>
         );
@@ -191,7 +191,7 @@ function SessionMessages({
                   </span>
                 </div>
               )}
-              <div className="msg-body">{renderWithMentions(m.content, ui)}</div>
+              <div className="msg-body">{renderMarkdown(m.content, ui)}</div>
             </div>
           </div>
         );
@@ -367,7 +367,7 @@ function StreamCard({
         )}
       </div>
       {stream.accum && (
-        <div className="stream-body">{renderWithMentions(stream.accum, channel)}</div>
+        <div className="stream-body">{renderMarkdown(stream.accum, channel)}</div>
       )}
     </div>
   );

--- a/gui/src/lib/mentions.test.tsx
+++ b/gui/src/lib/mentions.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { isValidElement, type ReactElement } from "react";
-import { renderWithMentions, extractMentions } from "./mentions";
+import { render } from "@testing-library/react";
+import { renderWithMentions, renderMarkdown, extractMentions } from "./mentions";
 
 const channel = {
   repos: ["ui", "be"],
@@ -82,6 +83,51 @@ describe("renderWithMentions", () => {
     );
     expect(asElement(nodes[3]).type).toBe("strong");
     expect(asElement(nodes[5]).type).toBe("code");
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("renders null for empty input", () => {
+    expect(renderMarkdown("", channel)).toBeNull();
+  });
+
+  it("renders headings, bullet lists, and paragraphs as real block elements", () => {
+    const { container } = render(
+      <>{renderMarkdown("## Top picks\n\n- one\n- two\n\nEnjoy.", channel)}</>,
+    );
+    expect(container.querySelector("h2")?.textContent).toBe("Top picks");
+    const items = container.querySelectorAll("li");
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe("one");
+    expect(container.querySelector("p")?.textContent).toBe("Enjoy.");
+  });
+
+  it("preserves @mention chips inside paragraphs", () => {
+    const { container } = render(<>{renderMarkdown("ping @ui now", channel)}</>);
+    const chip = container.querySelector(".mention");
+    expect(chip?.textContent).toBe("@ui");
+    expect(chip?.className).toBe("mention mention-repo-primary");
+  });
+
+  it("renders fenced code blocks with <pre><code>", () => {
+    const { container } = render(<>{renderMarkdown("```\nhello()\n```\n", channel)}</>);
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.querySelector("code")?.textContent?.trim()).toBe("hello()");
+  });
+
+  it("opens links in a new tab so the webview doesn't navigate", () => {
+    const { container } = render(<>{renderMarkdown("See [docs](https://example.com).", channel)}</>);
+    const anchor = container.querySelector("a");
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+    expect(anchor?.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("renders GFM tables (remark-gfm wired up)", () => {
+    const md = "| a | b |\n| - | - |\n| 1 | 2 |\n";
+    const { container } = render(<>{renderMarkdown(md, channel)}</>);
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.querySelectorAll("th")).toHaveLength(2);
   });
 });
 

--- a/gui/src/lib/mentions.test.tsx
+++ b/gui/src/lib/mentions.test.tsx
@@ -93,7 +93,7 @@ describe("renderMarkdown", () => {
 
   it("renders headings, bullet lists, and paragraphs as real block elements", () => {
     const { container } = render(
-      <>{renderMarkdown("## Top picks\n\n- one\n- two\n\nEnjoy.", channel)}</>,
+      <>{renderMarkdown("## Top picks\n\n- one\n- two\n\nEnjoy.", channel)}</>
     );
     expect(container.querySelector("h2")?.textContent).toBe("Top picks");
     const items = container.querySelectorAll("li");
@@ -117,7 +117,9 @@ describe("renderMarkdown", () => {
   });
 
   it("opens links in a new tab so the webview doesn't navigate", () => {
-    const { container } = render(<>{renderMarkdown("See [docs](https://example.com).", channel)}</>);
+    const { container } = render(
+      <>{renderMarkdown("See [docs](https://example.com).", channel)}</>
+    );
     const anchor = container.querySelector("a");
     expect(anchor?.getAttribute("target")).toBe("_blank");
     expect(anchor?.getAttribute("rel")).toContain("noopener");

--- a/gui/src/lib/mentions.tsx
+++ b/gui/src/lib/mentions.tsx
@@ -16,11 +16,7 @@ const INLINE_TOKEN_RE = /(@[a-zA-Z0-9][a-zA-Z0-9_-]*)|(\*\*[^*]+\*\*)|(`[^`]+`)/
 // time react-markdown hands us the children, so we only need mentions.
 const MENTION_RE = /(@[a-zA-Z0-9][a-zA-Z0-9_-]*)/g;
 
-function mentionNode(
-  token: string,
-  channel: ChannelLike,
-  key: string | number,
-): ReactNode {
+function mentionNode(token: string, channel: ChannelLike, key: string | number): ReactNode {
   const alias = token.slice(1);
   const handle = alias.toLowerCase();
   const aliasSet = new Set(channel?.repos ?? []);
@@ -93,8 +89,7 @@ function injectMentions(children: ReactNode, channel: ChannelLike): ReactNode {
       out.push(mentionNode(match[0], channel, k++));
       lastIdx = idx + match[0].length;
     }
-    if (lastIdx < child.length)
-      out.push(<Fragment key={k++}>{child.slice(lastIdx)}</Fragment>);
+    if (lastIdx < child.length) out.push(<Fragment key={k++}>{child.slice(lastIdx)}</Fragment>);
   });
   return <>{out}</>;
 }

--- a/gui/src/lib/mentions.tsx
+++ b/gui/src/lib/mentions.tsx
@@ -1,24 +1,56 @@
 import type { ReactNode } from "react";
+import { Children, Fragment } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { MentionContext } from "./channel";
-
-// `@alias` | `**bold**` | `` `code` ``. No other markdown, no autolinks.
-const TOKEN_RE = /(@[a-zA-Z0-9][a-zA-Z0-9_-]*)|(\*\*[^*]+\*\*)|(`[^`]+`)/g;
 
 type ChannelLike = MentionContext | null | undefined;
 
+// Inline-only tokens still understood by `renderWithMentions`. Full
+// markdown rendering lives in `renderMarkdown` below; this helper stays
+// for surfaces where block-level output (headings, lists, code blocks)
+// would look wrong — e.g. single-line decision descriptions.
+const INLINE_TOKEN_RE = /(@[a-zA-Z0-9][a-zA-Z0-9_-]*)|(\*\*[^*]+\*\*)|(`[^`]+`)/g;
+// Mention-only tokenizer used to re-classify `@alias` text inside the
+// markdown AST. Bold/italic/code are already structural nodes by the
+// time react-markdown hands us the children, so we only need mentions.
+const MENTION_RE = /(@[a-zA-Z0-9][a-zA-Z0-9_-]*)/g;
+
+function mentionNode(
+  token: string,
+  channel: ChannelLike,
+  key: string | number,
+): ReactNode {
+  const alias = token.slice(1);
+  const handle = alias.toLowerCase();
+  const aliasSet = new Set(channel?.repos ?? []);
+  const primary = channel?.primaryRepo ?? "";
+  const isRepo = aliasSet.has(handle);
+  const isPrimary = isRepo && primary === handle;
+  const cls = isPrimary
+    ? "mention mention-repo-primary"
+    : isRepo
+      ? "mention mention-repo-attached"
+      : "mention mention-human";
+  return (
+    <span key={key} className={cls}>
+      {token}
+    </span>
+  );
+}
+
 /**
  * Render a message body as React nodes, recognising mention chips and
- * lightweight inline markdown (bold + inline code). Matches the Tidewater
- * spec: a single render path for chat / DM / decisions bodies.
+ * lightweight inline markdown (bold + inline code). Single-line surfaces
+ * (decisions, feed entries, short descriptions) use this so block-level
+ * markdown can't distort layout.
  */
 export function renderWithMentions(text: string, channel: ChannelLike): ReactNode[] {
   if (!text) return [];
-  const aliasSet = new Set(channel?.repos ?? []);
-  const primary = channel?.primaryRepo ?? "";
   const nodes: ReactNode[] = [];
   let lastIdx = 0;
   let key = 0;
-  for (const match of text.matchAll(TOKEN_RE)) {
+  for (const match of text.matchAll(INLINE_TOKEN_RE)) {
     const idx = match.index ?? 0;
     if (idx > lastIdx) {
       nodes.push(<span key={key++}>{text.slice(lastIdx, idx)}</span>);
@@ -33,20 +65,7 @@ export function renderWithMentions(text: string, channel: ChannelLike): ReactNod
         </code>
       );
     } else {
-      const alias = tok.slice(1);
-      const handle = alias.toLowerCase();
-      const isRepo = aliasSet.has(handle);
-      const isPrimary = isRepo && primary === handle;
-      const cls = isPrimary
-        ? "mention mention-repo-primary"
-        : isRepo
-          ? "mention mention-repo-attached"
-          : "mention mention-human";
-      nodes.push(
-        <span key={key++} className={cls}>
-          {tok}
-        </span>
-      );
+      nodes.push(mentionNode(tok, channel, key++));
     }
     lastIdx = idx + tok.length;
   }
@@ -54,6 +73,71 @@ export function renderWithMentions(text: string, channel: ChannelLike): ReactNod
     nodes.push(<span key={key++}>{text.slice(lastIdx)}</span>);
   }
   return nodes;
+}
+
+// Walk every string child of a rendered markdown node, splitting on
+// `@alias` tokens so mention chips survive inside paragraphs, list
+// items, table cells, etc. Non-string children pass through untouched.
+function injectMentions(children: ReactNode, channel: ChannelLike): ReactNode {
+  const out: ReactNode[] = [];
+  let k = 0;
+  Children.forEach(children, (child) => {
+    if (typeof child !== "string") {
+      out.push(<Fragment key={k++}>{child}</Fragment>);
+      return;
+    }
+    let lastIdx = 0;
+    for (const match of child.matchAll(MENTION_RE)) {
+      const idx = match.index ?? 0;
+      if (idx > lastIdx) out.push(<Fragment key={k++}>{child.slice(lastIdx, idx)}</Fragment>);
+      out.push(mentionNode(match[0], channel, k++));
+      lastIdx = idx + match[0].length;
+    }
+    if (lastIdx < child.length)
+      out.push(<Fragment key={k++}>{child.slice(lastIdx)}</Fragment>);
+  });
+  return <>{out}</>;
+}
+
+/**
+ * Full-fidelity markdown rendering with GFM (tables, task lists,
+ * strikethrough, auto-links) and mention-chip highlighting preserved
+ * inside every block. Use for assistant replies, streaming chunks, and
+ * feed bodies — anywhere claude-generated markdown should render
+ * faithfully. Links open via the system browser by default.
+ */
+export function renderMarkdown(text: string, channel: ChannelLike): ReactNode {
+  if (!text) return null;
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        p: ({ children }) => <p>{injectMentions(children, channel)}</p>,
+        li: ({ children }) => <li>{injectMentions(children, channel)}</li>,
+        h1: ({ children }) => <h1>{injectMentions(children, channel)}</h1>,
+        h2: ({ children }) => <h2>{injectMentions(children, channel)}</h2>,
+        h3: ({ children }) => <h3>{injectMentions(children, channel)}</h3>,
+        h4: ({ children }) => <h4>{injectMentions(children, channel)}</h4>,
+        h5: ({ children }) => <h5>{injectMentions(children, channel)}</h5>,
+        h6: ({ children }) => <h6>{injectMentions(children, channel)}</h6>,
+        em: ({ children }) => <em>{injectMentions(children, channel)}</em>,
+        strong: ({ children }) => <strong>{injectMentions(children, channel)}</strong>,
+        td: ({ children }) => <td>{injectMentions(children, channel)}</td>,
+        th: ({ children }) => <th>{injectMentions(children, channel)}</th>,
+        blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+        // Anchor tags: render but mark them to open externally. Tauri
+        // intercepts `target="_blank"` via the shell plugin; bare
+        // http links in-app would otherwise navigate the webview.
+        a: ({ href, children }) => (
+          <a href={href} target="_blank" rel="noreferrer noopener">
+            {injectMentions(children, channel)}
+          </a>
+        ),
+      }}
+    >
+      {text}
+    </ReactMarkdown>
+  );
 }
 
 /**

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1213,6 +1213,44 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   color: var(--color-text-primary);
   word-wrap: break-word;
 }
+/* react-markdown renders block-level elements directly inside .msg-body.
+   These rules make assistant markdown output readable — matching header
+   scale, tight list spacing, code blocks, tables, and blockquotes. */
+.message .msg-body > :first-child { margin-top: 0; }
+.message .msg-body > :last-child { margin-bottom: 0; }
+.message .msg-body p { margin: var(--space-2) 0; }
+.message .msg-body h1,
+.message .msg-body h2,
+.message .msg-body h3,
+.message .msg-body h4,
+.message .msg-body h5,
+.message .msg-body h6 {
+  margin: var(--space-4) 0 var(--space-2);
+  line-height: var(--line-tight, 1.25);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+.message .msg-body h1 { font-size: 1.35em; }
+.message .msg-body h2 { font-size: 1.2em; }
+.message .msg-body h3 { font-size: 1.1em; }
+.message .msg-body h4,
+.message .msg-body h5,
+.message .msg-body h6 { font-size: 1em; }
+.message .msg-body ul,
+.message .msg-body ol {
+  margin: var(--space-2) 0;
+  padding-left: var(--space-6);
+}
+.message .msg-body li { margin: var(--space-1) 0; }
+.message .msg-body li > p { margin: 0; }
+.message .msg-body code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--color-paper-alt);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-1);
+}
 .message .msg-body pre {
   background: var(--color-paper-alt);
   border: 1px solid var(--color-paper-line);
@@ -1222,6 +1260,39 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   font-family: var(--font-mono);
   font-size: var(--font-size-base);
   margin: var(--space-3) 0;
+}
+.message .msg-body pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+.message .msg-body blockquote {
+  margin: var(--space-3) 0;
+  padding-left: var(--space-4);
+  border-left: 3px solid var(--color-paper-line);
+  color: var(--color-text-muted);
+}
+.message .msg-body a {
+  color: var(--color-accent-sky);
+  text-decoration: underline;
+}
+.message .msg-body table {
+  border-collapse: collapse;
+  margin: var(--space-3) 0;
+  font-size: 0.95em;
+}
+.message .msg-body th,
+.message .msg-body td {
+  border: 1px solid var(--color-paper-line);
+  padding: var(--space-1) var(--space-3);
+  text-align: left;
+}
+.message .msg-body th { background: var(--color-paper-alt); font-weight: var(--font-weight-semibold); }
+.message .msg-body hr {
+  border: 0;
+  border-top: 1px solid var(--color-paper-line);
+  margin: var(--space-4) 0;
 }
 
 .chat-empty {
@@ -1283,7 +1354,51 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   font-size: var(--font-size-md);
   color: var(--color-text-primary);
   line-height: var(--line-relaxed);
+  word-wrap: break-word;
 }
+/* Reuse the .msg-body markdown rules for streaming output — same author
+   (claude), same markdown features, same visual treatment. */
+.stream-body > :first-child { margin-top: 0; }
+.stream-body > :last-child { margin-bottom: 0; }
+.stream-body p { margin: var(--space-2) 0; }
+.stream-body h1,
+.stream-body h2,
+.stream-body h3,
+.stream-body h4,
+.stream-body h5,
+.stream-body h6 {
+  margin: var(--space-4) 0 var(--space-2);
+  line-height: var(--line-tight, 1.25);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+.stream-body h1 { font-size: 1.35em; }
+.stream-body h2 { font-size: 1.2em; }
+.stream-body h3 { font-size: 1.1em; }
+.stream-body ul,
+.stream-body ol { margin: var(--space-2) 0; padding-left: var(--space-6); }
+.stream-body li { margin: var(--space-1) 0; }
+.stream-body li > p { margin: 0; }
+.stream-body code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--color-paper-alt);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-1);
+}
+.stream-body pre {
+  background: var(--color-paper-alt);
+  border: 1px solid var(--color-paper-line);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  margin: var(--space-3) 0;
+}
+.stream-body pre code { background: transparent; border: none; padding: 0; font-size: inherit; }
+.stream-body a { color: var(--color-accent-sky); text-decoration: underline; }
 
 /* ── Composer ─────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
Three real, independent bugs in the chat pipeline, found by running the GUI locally with DevTools open and tailing the backend stderr. All three compounded into the symptom "send message, see 'thinking…', nothing ever comes back."

### 1. Wire-shape bug — the killer
`#[serde(tag = "kind", rename_all = "camelCase")]` on `ChatEvent` only renames **variant names** (Started → "started"); it does **not** recurse into each variant's struct fields. Every event was shipping `stream_id` on the wire while the renderer read `event.streamId`. The CenterPane listener's `event.streamId !== current.streamId` check therefore evaluated `undefined !== 1` for every event, and every chunk / activity / done / error was dropped. The stream card sat on "thinking…" forever even after claude finished.

Fix: explicit `#[serde(rename = "streamId" / "finalText" / "claudeSessionId")]` on every field + regression test `chat_event_wire_shape_uses_camel_case_fields` that fails if anyone drops the attributes.

### 2. Liveness during claude startup
claude CLI v2.1.119 emits a flurry of `system` / `hook_started` / `hook_response` / `init` lines before any `assistant` content arrives. The old parser only reacted to `assistant` + `result`, so the activity stack sat empty for the entire warmup and the user saw nothing. The TUI has the same bug; this PR only fixes the GUI, but the same helpers could be reused there.

Fix: surface these via `describe_system_event` / `describe_rate_limit_event`, with regression coverage for init/hook/unknown fallback paths.

### 3. Markdown rendering
Assistant output was one unreadable line because newlines collapsed and markdown was literal text. Switched `.msg-body`, `.stream-body`, and feed bodies to **react-markdown + remark-gfm** (headings, lists, code blocks, tables, links, strikethrough). Mention chips (`@alias`) are preserved inside any block via a recursive text-node pass. Added CSS for markdown children.

## Supporting changes
- Drain claude's `stderr` on its own thread so the OS pipe buffer can never fill and block the child (the original "eternal thinking" hypothesis before the wire-shape bug was found).
- When the child exits with no stdout or a non-zero status, emit a `ChatEvent::Error` carrying the captured stderr + exit code instead of emitting a silent empty `Done`.
- Log unparseable stdout lines once so stream-json format drift is immediately visible from a terminal.

## Test plan
- [x] `cargo test -p relay-gui` — 51/51 pass (includes 7 new tests: wire-shape guard + system / rate-limit event coverage)
- [x] `pnpm test` — 37/37 pass (+6 new renderMarkdown tests: headings, lists, mentions-in-paragraphs, code blocks, links-open-new-tab, GFM tables)
- [x] `pnpm tsc -b` — clean
- [x] Manual: GUI sends a message → stream card shows activity lines immediately (`session init · …`, hook events, `$ bash …`), streams the reply, renders markdown with headers / bullet lists / bold inline
- [x] Manual: with a running dev build, confirmed output has real `h2`/`ul`/`strong` elements in the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)