### PR TITLE
feat(pr-review): DM-per-PR review threads (phase 1-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ The autonomous-loop tickets are mirrored to the public [Relay project board](htt
 
 Exposed to Claude and Codex via the Relay MCP server:
 
-**Harness (8)**: `harness_status`, `harness_list_runs`, `harness_get_run_detail`, `harness_get_artifact`, `harness_approve_plan`, `harness_reject_plan`, `harness_dispatch`, `project_create`
+**Harness (9)**: `harness_status`, `harness_list_runs`, `harness_get_run_detail`, `harness_get_artifact`, `harness_approve_plan`, `harness_reject_plan`, `harness_dispatch`, `project_create`, `pr_review_start`
 
 **Channels (6)**: `channel_create`, `channel_get`, `channel_post`, `channel_record_decision`, `channel_task_board`, `harness_running_tasks`
 

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -184,6 +184,37 @@ pub struct Channel {
     /// Optional + `#[serde(default)]` for back-compat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_profile_id: Option<String>,
+    /// PR-review DM metadata. Present on channels minted by the
+    /// `pr_review_start` MCP tool, absent on every other channel. The Rust
+    /// dashboards round-trip the field so on-disk writes remain lossless
+    /// even when the TUI/GUI edit the channel file (phase-5 work adds the
+    /// actual PR pill UI). Optional + `#[serde(default)]` for back-compat
+    /// with channel files written before the PR-review DM feature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<ChannelPr>,
+}
+
+/// PR-review metadata mirrored from `src/domain/channel.ts::ChannelPr`. The
+/// Rust dashboards never mint these themselves — they only deserialize and
+/// round-trip whatever the TypeScript side wrote.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelPr {
+    pub url: String,
+    pub number: u64,
+    pub repo: ChannelPrRepo,
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_channel_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelPrRepo {
+    pub owner: String,
+    pub name: String,
 }
 
 /// A sidebar grouping ("section") for channels — maps to Slack's
@@ -1773,6 +1804,7 @@ mod tests {
             kind: None,
             section_id: None,
             provider_profile_id: None,
+            pr: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             updated_at: Some("2026-01-01T00:00:00Z".to_string()),
         }
@@ -1951,6 +1983,7 @@ mod tests {
             kind: None,
             section_id: None,
             provider_profile_id: None,
+            pr: None,
             created_at: None,
             updated_at: None,
         }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -689,6 +689,7 @@ fn create_dm(
         kind: Some("dm".to_string()),
         section_id: None,
         provider_profile_id: None,
+        pr: None,
         created_at: Some(now.to_rfc3339()),
         updated_at: Some(now.to_rfc3339()),
     };

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -34,6 +34,13 @@ import type { HarnessStore } from "../storage/store.js";
 // `this.store.mutate` below is the hook that enables it.
 const channelTicketLocks: Map<string, Promise<void>> = new Map();
 
+// Per-PR-URL serialization so concurrent `findOrCreatePrDm` callers (e.g. two
+// `pr_review_start` invocations against the same URL firing at the same time)
+// don't both pass the "does this DM exist" check and both mint a duplicate.
+// Same self-cleaning-tail shape as `channelTicketLocks`. Process-local —
+// cross-process safety arrives alongside the Postgres-backed store.
+const prUrlLocks: Map<string, Promise<void>> = new Map();
+
 // Monotonic suffix so two concurrent writers in the same process never
 // collide on the tmp file used by writeChannelTickets.
 let channelTicketsTmpCounter = 0;
@@ -310,8 +317,11 @@ export class ChannelStore {
     const now = new Date().toISOString();
     const assignments = input.repoAssignment ? [input.repoAssignment] : undefined;
     const primaryWorkspaceId = input.repoAssignment?.workspaceId;
+    // Slice by code points rather than UTF-16 code units so a title ending in
+    // an emoji at the 80-char boundary doesn't split a surrogate pair into a
+    // lone surrogate (which some JSON readers reject).
     const name = input.pr.title
-      ? `${input.pr.repo.name}#${input.pr.number}: ${input.pr.title}`.slice(0, 80)
+      ? [...`${input.pr.repo.name}#${input.pr.number}: ${input.pr.title}`].slice(0, 80).join("")
       : `${input.pr.repo.owner}/${input.pr.repo.name}#${input.pr.number}`;
 
     const channel: Channel = {
@@ -334,6 +344,32 @@ export class ChannelStore {
     await mkdir(join(this.channelsDir, channel.channelId), { recursive: true });
 
     return channel;
+  }
+
+  /**
+   * Atomic "find-or-create" for PR-review DMs. Serializes concurrent callers
+   * keyed on `pr.url` so two simultaneous `pr_review_start` invocations for
+   * the same PR can't both pass the find check and both mint a duplicate.
+   * Returns `{ channel, created }` so callers know whether kickoff side
+   * effects (posting the initial entry, cross-linking to the parent) still
+   * need to fire.
+   *
+   * Lock is process-local (same shape as `channelTicketLocks`). Cross-process
+   * correctness arrives alongside the Postgres-backed store — by then the
+   * invariant moves to a DB-level unique index.
+   */
+  async findOrCreatePrDm(input: {
+    pr: ChannelPr;
+    repoAssignment?: RepoAssignment;
+    workspaceId?: string;
+  }): Promise<{ channel: Channel; created: boolean }> {
+    const key = input.pr.url;
+    return withKeyedLock(prUrlLocks, key, async () => {
+      const existing = await this.findChannelByPrUrl(key);
+      if (existing) return { channel: existing, created: false };
+      const created = await this.createPrDm(input);
+      return { channel: created, created: true };
+    });
   }
 
   /**
@@ -901,25 +937,8 @@ export class ChannelStore {
     return merged;
   }
 
-  private async withChannelLock<T>(channelId: string, fn: () => Promise<T>): Promise<T> {
-    const prev = channelTicketLocks.get(channelId) ?? Promise.resolve();
-    let resolveCurrent!: () => void;
-    const current = new Promise<void>((resolve) => {
-      resolveCurrent = resolve;
-    });
-    const next = prev.then(() => current);
-    channelTicketLocks.set(channelId, next);
-
-    try {
-      await prev;
-      return await fn();
-    } finally {
-      resolveCurrent();
-      // If nobody queued behind us, clean up so the map doesn't grow unbounded.
-      if (channelTicketLocks.get(channelId) === next) {
-        channelTicketLocks.delete(channelId);
-      }
-    }
+  private withChannelLock<T>(channelId: string, fn: () => Promise<T>): Promise<T> {
+    return withKeyedLock(channelTicketLocks, channelId, fn);
   }
 
   // --- Decisions ---
@@ -1108,4 +1127,35 @@ function denormalizeMetadata(
     }
   }
   return out;
+}
+
+/**
+ * Process-local per-key serialization. Callers supplied the map so the lock
+ * domain is explicit — `channelTicketLocks` protects per-channel writes,
+ * `prUrlLocks` protects per-PR find-or-create atomicity. The tail self-cleans
+ * when no one is queued behind the current holder so the map doesn't grow
+ * unbounded across long-lived processes.
+ */
+async function withKeyedLock<T>(
+  locks: Map<string, Promise<void>>,
+  key: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const prev = locks.get(key) ?? Promise.resolve();
+  let resolveCurrent!: () => void;
+  const current = new Promise<void>((resolve) => {
+    resolveCurrent = resolve;
+  });
+  const next = prev.then(() => current);
+  locks.set(key, next);
+
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    resolveCurrent();
+    if (locks.get(key) === next) {
+      locks.delete(key);
+    }
+  }
 }

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -10,6 +10,8 @@ import {
   type ChannelEntry,
   type ChannelEntryType,
   type ChannelMember,
+  type ChannelPr,
+  type ChannelPrState,
   type ChannelRef,
   type ChannelRunLink,
   type ChannelStatus,
@@ -193,6 +195,7 @@ export class ChannelStore {
         | "kind"
         | "sectionId"
         | "providerProfileId"
+        | "pr"
       >
     >
   ): Promise<Channel | null> {
@@ -268,6 +271,87 @@ export class ChannelStore {
   async unarchiveChannel(channelId: string): Promise<Channel | null> {
     assertSafeSegment(channelId, "channelId");
     return this.updateChannel(channelId, { status: "active" });
+  }
+
+  // --- PR review DMs ---
+
+  /**
+   * Find the first non-archived channel whose `pr.url` exactly matches the
+   * supplied URL. Used by `pr_review_start` for idempotency: a second
+   * invocation on the same PR returns the existing DM instead of minting
+   * another. Exact-match dedup (rather than owner+number) survives repo
+   * rename / transfer because the URL itself moves with the PR.
+   */
+  async findChannelByPrUrl(prUrl: string): Promise<Channel | null> {
+    const channels = await this.listChannels();
+    for (const c of channels) {
+      if (c.status === "archived") continue;
+      if (c.pr?.url === prUrl) return c;
+    }
+    return null;
+  }
+
+  /**
+   * Mint a DM channel bound to a pull request. The DM is `kind: "dm"` so the
+   * sidebar segregates it from project channels; lifecycle is driven by the
+   * PR's state (see {@link PrPoller.onPrStateChange} — archives on
+   * merged/closed). Not idempotent on its own — callers must first check
+   * {@link findChannelByPrUrl}. Keeping the two steps separate lets callers
+   * decide how to handle "already exists" (reuse vs. post a 'resumed' entry
+   * vs. error) without baking a policy into the store.
+   */
+  async createPrDm(input: {
+    pr: ChannelPr;
+    repoAssignment?: RepoAssignment;
+    workspaceId?: string;
+  }): Promise<Channel> {
+    await mkdir(this.channelsDir, { recursive: true });
+
+    const now = new Date().toISOString();
+    const assignments = input.repoAssignment ? [input.repoAssignment] : undefined;
+    const primaryWorkspaceId = input.repoAssignment?.workspaceId;
+    const name = input.pr.title
+      ? `${input.pr.repo.name}#${input.pr.number}: ${input.pr.title}`.slice(0, 80)
+      : `${input.pr.repo.owner}/${input.pr.repo.name}#${input.pr.number}`;
+
+    const channel: Channel = {
+      channelId: buildChannelId(),
+      name,
+      description: input.pr.url,
+      status: "active",
+      workspaceIds: input.workspaceId ? [input.workspaceId] : [],
+      members: [],
+      pinnedRefs: [],
+      repoAssignments: assignments,
+      primaryWorkspaceId,
+      kind: "dm",
+      pr: input.pr,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.writeChannel(channel);
+    await mkdir(join(this.channelsDir, channel.channelId), { recursive: true });
+
+    return channel;
+  }
+
+  /**
+   * Update the PR state on a PR-bound DM. When the new state is `merged` or
+   * `closed`, the channel is archived in the same write — the DM's purpose
+   * ends with the PR. No-op (returns `null`) if the channel has no `pr`
+   * block; callers can rely on this to reject mistargeted updates.
+   */
+  async updatePrState(channelId: string, state: ChannelPrState): Promise<Channel | null> {
+    assertSafeSegment(channelId, "channelId");
+    const channel = await this.getChannel(channelId);
+    if (!channel?.pr) return null;
+
+    const nextPr: ChannelPr = { ...channel.pr, state };
+    const nextStatus: ChannelStatus =
+      state === "merged" || state === "closed" ? "archived" : channel.status;
+
+    return this.updateChannel(channelId, { pr: nextPr, status: nextStatus });
   }
 
   /**

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -37,8 +37,37 @@ export const ChannelEntryTypeSchema = z.enum([
   "ref_added",
   "run_started",
   "run_completed",
+  // Cross-link from a parent (usually a repo's "general") channel to a PR
+  // review DM, and vice versa. GUI renders these as a link-out; readers that
+  // don't know the type fall back to the usual status-update layout.
+  "pr_link",
 ]);
 export type ChannelEntryType = z.infer<typeof ChannelEntryTypeSchema>;
+
+/**
+ * PR-review DM metadata. Present on channels minted by `pr_review_start`,
+ * absent on every other channel. Keyed on `url` — `findChannelByPrUrl` uses
+ * exact match so draft→ready transitions and force-pushes stay on the same
+ * DM. `state` mirrors the GitHub PR state so poller updates / GUI pills can
+ * read a single source of truth.
+ */
+export const ChannelPrStateSchema = z.enum(["open", "merged", "closed"]);
+export type ChannelPrState = z.infer<typeof ChannelPrStateSchema>;
+
+export interface ChannelPr {
+  url: string;
+  number: number;
+  repo: { owner: string; name: string };
+  state: ChannelPrState;
+  title?: string;
+  /**
+   * Optional backlink to the channel that spawned the review (typically the
+   * repo's "general" channel). Absent for standalone review DMs — a PR
+   * submitted by an external user against a repo with no Relay project
+   * channel lands in a parentless DM.
+   */
+  parentChannelId?: string;
+}
 
 export interface ChannelMember {
   agentId: string;
@@ -132,6 +161,13 @@ export interface Channel {
    * (explicit default profile → `HARNESS_PROVIDER`). Optional for back-compat.
    */
   providerProfileId?: string;
+  /**
+   * PR-review metadata. Present on DMs minted by the `pr_review_start` MCP
+   * tool; absent on every other channel. Presence implies the channel's
+   * lifecycle is bound to the PR — `PrPoller` archives it when the PR
+   * transitions to `merged` / `closed`. See {@link ChannelPr}.
+   */
+  pr?: ChannelPr;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/integrations/pr-poller.ts
+++ b/src/integrations/pr-poller.ts
@@ -389,7 +389,66 @@ export class PrPoller {
         }
       }
     }
-    if (to === "merged" || to === "closed") this.untrack(entry.ticketId);
+    if (to === "merged" || to === "closed") {
+      await this.archiveReviewDmIfPresent(entry, to);
+      this.untrack(entry.ticketId);
+    }
+  }
+
+  /**
+   * When the tracked row's `channelId` points at a PR-review DM (minted by
+   * the `pr_review_start` MCP tool, identified by the `pr` block on the
+   * channel), flip the DM's `pr.state` to `to` — which also archives it —
+   * and cross-link back to the parent channel when one is set. Silently
+   * skips channels without a `pr` block so project/feature channels that
+   * happen to track a PR continue to behave as today.
+   */
+  private async archiveReviewDmIfPresent(entry: TrackedPr, to: "merged" | "closed"): Promise<void> {
+    let channel;
+    try {
+      channel = await this.channelStore.getChannel(entry.channelId);
+    } catch (err) {
+      console.warn("[pr-poller] failed to read channel for DM archive check", err);
+      return;
+    }
+    if (!channel?.pr) return;
+
+    try {
+      await this.channelStore.postEntry(entry.channelId, {
+        type: "status_update",
+        fromAgentId: null,
+        fromDisplayName: "pr-poller",
+        content: `PR ${to} — archiving review thread.`,
+        metadata: { prUrl: entry.pr.url, prState: to },
+      });
+    } catch (err) {
+      console.warn("[pr-poller] failed to post DM-archive notice", err);
+    }
+
+    try {
+      await this.channelStore.updatePrState(entry.channelId, to);
+    } catch (err) {
+      console.warn("[pr-poller] failed to archive PR DM", err);
+    }
+
+    const parentId = channel.pr.parentChannelId;
+    if (!parentId) return;
+    try {
+      await this.channelStore.postEntry(parentId, {
+        type: "pr_link",
+        fromAgentId: null,
+        fromDisplayName: "PR Review",
+        content: `PR ${to}: ${entry.pr.url}`,
+        metadata: {
+          prUrl: entry.pr.url,
+          prNumber: entry.pr.number,
+          prState: to,
+          dmChannelId: entry.channelId,
+        },
+      });
+    } catch (err) {
+      console.warn("[pr-poller] failed to post parent cross-link on PR close", err);
+    }
   }
 
   private async post(

--- a/src/mcp/pr-review-tool.ts
+++ b/src/mcp/pr-review-tool.ts
@@ -89,19 +89,13 @@ export async function startPrReviewDm(input: StartPrReviewDmInput): Promise<Star
 
   const store = input.store ?? new ChannelStore(undefined, getHarnessStore());
 
-  const existing = await store.findChannelByPrUrl(parsed.canonicalUrl);
-  if (existing) {
-    return {
-      channelId: existing.channelId,
-      parentChannelId: existing.pr?.parentChannelId ?? null,
-      prUrl: parsed.canonicalUrl,
-      reused: true,
-    };
-  }
-
+  // Resolve parent up-front (cheap, idempotent) so `findOrCreatePrDm` has
+  // everything it needs when it wins the lock and mints. On the loser side
+  // of the race `findOrCreatePrDm` returns the existing DM and we drop the
+  // prepared input on the floor.
   const parent = await findGeneralChannelForRepo(store, parsed.name);
 
-  const dm = await store.createPrDm({
+  const { channel: dm, created } = await store.findOrCreatePrDm({
     pr: {
       url: parsed.canonicalUrl,
       number: parsed.number,
@@ -113,6 +107,15 @@ export async function startPrReviewDm(input: StartPrReviewDmInput): Promise<Star
     repoAssignment: parent?.repoAssignment,
     workspaceId: parent?.repoAssignment?.workspaceId,
   });
+
+  if (!created) {
+    return {
+      channelId: dm.channelId,
+      parentChannelId: dm.pr?.parentChannelId ?? null,
+      prUrl: parsed.canonicalUrl,
+      reused: true,
+    };
+  }
 
   await store.postEntry(dm.channelId, {
     type: "status_update",

--- a/src/mcp/pr-review-tool.ts
+++ b/src/mcp/pr-review-tool.ts
@@ -1,0 +1,150 @@
+import { ChannelStore } from "../channels/channel-store.js";
+import type { RepoAssignment } from "../domain/channel.js";
+import { getHarnessStore } from "../storage/factory.js";
+
+/**
+ * Result of a `pr_review_start` invocation.
+ *
+ * `reused` distinguishes "returned an existing DM" (idempotent replay) from
+ * "minted a new DM" so callers can decide whether to re-post kickoff context
+ * without running `getChannel` first.
+ */
+export interface StartPrReviewDmResult {
+  channelId: string;
+  parentChannelId: string | null;
+  prUrl: string;
+  reused: boolean;
+}
+
+export interface StartPrReviewDmInput {
+  prUrl: string;
+  title?: string;
+  /**
+   * Injected store — defaults to the process-wide `~/.relay`-backed store.
+   * Tests pass a tmp-dir-backed `ChannelStore` to avoid polluting the real
+   * channels directory.
+   */
+  store?: ChannelStore;
+}
+
+/**
+ * Parse a github.com PR URL into its (owner, name, number) triple.
+ * Rejects non-github and non-`/pull/` URLs so the caller gets a structured
+ * error rather than silently minting a DM tied to a garbage URL.
+ */
+export function parseGithubPrUrl(
+  url: string
+): { owner: string; name: string; number: number; canonicalUrl: string } | null {
+  const m = url
+    .trim()
+    .match(/^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+?)\/pull\/(\d+)(?:[/?#].*)?$/i);
+  if (!m) return null;
+  const [, owner, name, numStr] = m;
+  const number = Number(numStr);
+  return {
+    owner,
+    name,
+    number,
+    canonicalUrl: `https://github.com/${owner}/${name}/pull/${number}`,
+  };
+}
+
+/**
+ * Locate a `general` channel whose `repoAssignments` reference the supplied
+ * repo (by alias matching `repoName`, case-insensitive). Used to decide
+ * whether the PR-review DM has a parent to cross-link against. Returns
+ * `null` when no match exists — the DM is then standalone, which is the
+ * expected shape for PRs against repos the user hasn't registered with Relay.
+ */
+export async function findGeneralChannelForRepo(
+  store: ChannelStore,
+  repoName: string
+): Promise<{ channelId: string; repoAssignment: RepoAssignment } | null> {
+  const active = await store.listChannels("active");
+  const normalizedRepo = repoName.toLowerCase();
+  for (const c of active) {
+    const channelName = c.name.toLowerCase();
+    if (channelName !== "general" && channelName !== "#general") continue;
+    const match = (c.repoAssignments ?? []).find((r) => r.alias.toLowerCase() === normalizedRepo);
+    if (match) return { channelId: c.channelId, repoAssignment: match };
+  }
+  return null;
+}
+
+/**
+ * Resolve or create a DM-style review thread for a GitHub pull request.
+ *
+ * Idempotent by `prUrl`: a second call with the same URL returns the existing
+ * DM without posting a duplicate kickoff entry. When the PR's repo has an
+ * active `general` channel registered with Relay, the new DM backlinks to it
+ * and a cross-link entry is posted there; otherwise the DM is standalone.
+ */
+export async function startPrReviewDm(input: StartPrReviewDmInput): Promise<StartPrReviewDmResult> {
+  const parsed = parseGithubPrUrl(input.prUrl);
+  if (!parsed) {
+    throw new Error(
+      `prUrl must be a github.com pull request URL (got: ${JSON.stringify(input.prUrl)})`
+    );
+  }
+
+  const store = input.store ?? new ChannelStore(undefined, getHarnessStore());
+
+  const existing = await store.findChannelByPrUrl(parsed.canonicalUrl);
+  if (existing) {
+    return {
+      channelId: existing.channelId,
+      parentChannelId: existing.pr?.parentChannelId ?? null,
+      prUrl: parsed.canonicalUrl,
+      reused: true,
+    };
+  }
+
+  const parent = await findGeneralChannelForRepo(store, parsed.name);
+
+  const dm = await store.createPrDm({
+    pr: {
+      url: parsed.canonicalUrl,
+      number: parsed.number,
+      repo: { owner: parsed.owner, name: parsed.name },
+      state: "open",
+      title: input.title,
+      parentChannelId: parent?.channelId,
+    },
+    repoAssignment: parent?.repoAssignment,
+    workspaceId: parent?.repoAssignment?.workspaceId,
+  });
+
+  await store.postEntry(dm.channelId, {
+    type: "status_update",
+    fromAgentId: null,
+    fromDisplayName: "PR Review",
+    content: `Reviewing pull request: ${parsed.canonicalUrl}`,
+    metadata: {
+      prUrl: parsed.canonicalUrl,
+      prNumber: parsed.number,
+      repoOwner: parsed.owner,
+      repoName: parsed.name,
+    },
+  });
+
+  if (parent) {
+    await store.postEntry(parent.channelId, {
+      type: "pr_link",
+      fromAgentId: null,
+      fromDisplayName: "PR Review",
+      content: `PR opened: ${parsed.canonicalUrl} — review thread started.`,
+      metadata: {
+        prUrl: parsed.canonicalUrl,
+        prNumber: parsed.number,
+        dmChannelId: dm.channelId,
+      },
+    });
+  }
+
+  return {
+    channelId: dm.channelId,
+    parentChannelId: parent?.channelId ?? null,
+    prUrl: parsed.canonicalUrl,
+    reused: false,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import { getHarnessWorkspacePaths, readWorkspaceSummary } from "../cli/workspace
 import { buildWorkspaceId } from "../cli/workspace-registry.js";
 import { CrosslinkStore } from "../crosslink/store.js";
 import { ChannelStore } from "../channels/channel-store.js";
+import { startPrReviewDm } from "./pr-review-tool.js";
 import { getHarnessStore } from "../storage/factory.js";
 import {
   callChannelTool,
@@ -385,6 +386,29 @@ async function handleMessage(
           },
         },
         {
+          name: "pr_review_start",
+          description:
+            "Open (or reuse) a DM-style review thread for a GitHub pull request. " +
+            "The DM is bound to the PR's URL — subsequent calls with the same URL return the existing thread. " +
+            "When the repo has a Relay 'general' channel, a cross-link is posted there pointing at the DM. " +
+            "The DM auto-archives when the PR transitions to merged or closed.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["prUrl"],
+            properties: {
+              prUrl: {
+                type: "string",
+                description: "Full GitHub PR URL, e.g. https://github.com/owner/repo/pull/42",
+              },
+              title: {
+                type: "string",
+                description: "Optional PR title — used in the DM's display name when present.",
+              },
+            },
+          },
+        },
+        {
           // AL-11 declares the name; AL-14 fills in the handler. Advertised
           // here so the repo-admin capability report is stable from day one.
           name: "spawn_worker",
@@ -620,6 +644,11 @@ async function callTool(
         channelId,
       });
       return result;
+    }
+    case "pr_review_start": {
+      const prUrl = String(args.prUrl ?? "");
+      const title = args.title ? String(args.title) : undefined;
+      return startPrReviewDm({ prUrl, title });
     }
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -835,5 +835,49 @@ describe("channel store", () => {
         await rm(dir, { recursive: true, force: true });
       }
     });
+
+    it("findChannelByPrUrl skips a DM that updatePrState archived on merge", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const pr = { url: sampleUrl, number: 42, repo: sampleRepo, state: "open" as const };
+        const dm = await store.createPrDm({ pr });
+
+        await store.updatePrState(dm.channelId, "merged");
+
+        const miss = await store.findChannelByPrUrl(sampleUrl);
+        expect(miss).toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("findOrCreatePrDm is atomic under concurrent callers — exactly one DM wins", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const pr = {
+          url: sampleUrl,
+          number: 42,
+          repo: sampleRepo,
+          state: "open" as const,
+        };
+
+        const results = await Promise.all(
+          Array.from({ length: 5 }, () => store.findOrCreatePrDm({ pr }))
+        );
+
+        const created = results.filter((r) => r.created);
+        expect(created).toHaveLength(1);
+
+        const ids = new Set(results.map((r) => r.channel.channelId));
+        expect(ids.size).toBe(1);
+
+        const listed = (await store.listChannels("active")).filter((c) => c.pr?.url === sampleUrl);
+        expect(listed).toHaveLength(1);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -728,4 +728,112 @@ describe("channel store", () => {
       }
     });
   });
+
+  describe("pr review dms", () => {
+    const sampleRepo = { owner: "acme", name: "widgets" };
+    const sampleUrl = "https://github.com/acme/widgets/pull/42";
+
+    it("createPrDm stamps kind=dm, the pr block, and the repo assignment", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const dm = await store.createPrDm({
+          pr: {
+            url: sampleUrl,
+            number: 42,
+            repo: sampleRepo,
+            state: "open",
+            title: "Add dark-mode toggle",
+          },
+          repoAssignment: {
+            alias: "widgets",
+            workspaceId: "widgets-abc",
+            repoPath: "/tmp/widgets",
+          },
+          workspaceId: "widgets-abc",
+        });
+
+        expect(dm.kind).toBe("dm");
+        expect(dm.pr?.url).toBe(sampleUrl);
+        expect(dm.pr?.state).toBe("open");
+        expect(dm.repoAssignments).toHaveLength(1);
+        expect(dm.primaryWorkspaceId).toBe("widgets-abc");
+        expect(dm.name).toContain("#42");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("findChannelByPrUrl returns the active DM and ignores archived matches", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const pr = { url: sampleUrl, number: 42, repo: sampleRepo, state: "open" as const };
+        const dm = await store.createPrDm({ pr });
+
+        const hit = await store.findChannelByPrUrl(sampleUrl);
+        expect(hit?.channelId).toBe(dm.channelId);
+
+        await store.archiveChannel(dm.channelId);
+        const missAfterArchive = await store.findChannelByPrUrl(sampleUrl);
+        expect(missAfterArchive).toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("findChannelByPrUrl returns null when no channel has that pr", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        await store.createChannel({ name: "#general", description: "plain" });
+        const miss = await store.findChannelByPrUrl(sampleUrl);
+        expect(miss).toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("updatePrState flips pr.state and archives on merged / closed", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const pr = { url: sampleUrl, number: 42, repo: sampleRepo, state: "open" as const };
+        const dm = await store.createPrDm({ pr });
+
+        const merged = await store.updatePrState(dm.channelId, "merged");
+        expect(merged?.pr?.state).toBe("merged");
+        expect(merged?.status).toBe("archived");
+
+        const fresh = await store.createPrDm({
+          pr: {
+            url: "https://github.com/acme/widgets/pull/43",
+            number: 43,
+            repo: sampleRepo,
+            state: "open",
+          },
+        });
+        const closed = await store.updatePrState(fresh.channelId, "closed");
+        expect(closed?.pr?.state).toBe("closed");
+        expect(closed?.status).toBe("archived");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("updatePrState is a no-op on a plain channel without a pr block", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "ch-test-"));
+      const store = new ChannelStore(dir);
+      try {
+        const plain = await store.createChannel({ name: "#general", description: "plain" });
+        const result = await store.updatePrState(plain.channelId, "merged");
+        expect(result).toBeNull();
+
+        const refetch = await store.getChannel(plain.channelId);
+        expect(refetch?.status).toBe("active");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/test/integrations/pr-poller.test.ts
+++ b/test/integrations/pr-poller.test.ts
@@ -333,4 +333,115 @@ describe("PrPoller", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  describe("PR review DM archival", () => {
+    it("archives a PR review DM when the PR merges and posts a parent cross-link", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "pr-poller-dm-merge-"));
+      const store = new ChannelStore(dir);
+      try {
+        const parent = await store.createChannel({ name: "general", description: "parent" });
+        const dm = await store.createPrDm({
+          pr: {
+            url: "https://github.com/acme/widgets/pull/42",
+            number: 42,
+            repo: { owner: "acme", name: "widgets" },
+            state: "open",
+            parentChannelId: parent.channelId,
+          },
+        });
+
+        const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+          async () => "followup-id"
+        );
+        const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+        const scm = scriptedScm([
+          new Map([["acme/widgets#42", seed({ prState: "open" })]]),
+          new Map([["acme/widgets#42", seed({ prState: "merged" })]]),
+        ]);
+        const poller = new PrPoller({ scm, channelStore: store, scheduler });
+        poller.track(makeTracked(dm.channelId));
+
+        await poller.tick();
+        await poller.tick();
+
+        const updatedDm = await store.getChannel(dm.channelId);
+        expect(updatedDm?.status).toBe("archived");
+        expect(updatedDm?.pr?.state).toBe("merged");
+
+        const dmFeed = await store.readFeed(dm.channelId);
+        const archiveNotice = dmFeed.find((e) => e.content.includes("archiving review thread"));
+        expect(archiveNotice).toBeDefined();
+
+        const parentFeed = await store.readFeed(parent.channelId);
+        const crossLink = parentFeed.find(
+          (e) => e.type === "pr_link" && e.content.startsWith("PR merged")
+        );
+        expect(crossLink).toBeDefined();
+        expect(crossLink!.metadata.dmChannelId).toBe(dm.channelId);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("skips DM archival for plain (non-PR) channels", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "pr-poller-plain-"));
+      const store = new ChannelStore(dir);
+      try {
+        const channel = await store.createChannel({ name: "#feature", description: "plain" });
+        const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+          async () => "followup-id"
+        );
+        const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+        const scm = scriptedScm([
+          new Map([["acme/widgets#42", seed({ prState: "open" })]]),
+          new Map([["acme/widgets#42", seed({ prState: "merged" })]]),
+        ]);
+        const poller = new PrPoller({ scm, channelStore: store, scheduler });
+        poller.track(makeTracked(channel.channelId));
+
+        await poller.tick();
+        await poller.tick();
+
+        const after = await store.getChannel(channel.channelId);
+        expect(after?.status).toBe("active");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("archives without a parent cross-link when the DM has no parentChannelId", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "pr-poller-standalone-"));
+      const store = new ChannelStore(dir);
+      try {
+        const dm = await store.createPrDm({
+          pr: {
+            url: "https://github.com/acme/widgets/pull/42",
+            number: 42,
+            repo: { owner: "acme", name: "widgets" },
+            state: "open",
+          },
+        });
+
+        const enqueueFollowUp = vi.fn<(req: FollowUpRequest) => Promise<string>>(
+          async () => "followup-id"
+        );
+        const scheduler: FollowUpDispatcher = { enqueueFollowUp };
+        const scm = scriptedScm([
+          new Map([["acme/widgets#42", seed({ prState: "open" })]]),
+          new Map([["acme/widgets#42", seed({ prState: "closed" })]]),
+        ]);
+        const poller = new PrPoller({ scm, channelStore: store, scheduler });
+        poller.track(makeTracked(dm.channelId));
+
+        await poller.tick();
+        await poller.tick();
+
+        const closed = await store.getChannel(dm.channelId);
+        expect(closed?.status).toBe("archived");
+        expect(closed?.pr?.state).toBe("closed");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/test/mcp/pr-review-tool.test.ts
+++ b/test/mcp/pr-review-tool.test.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import {
+  findGeneralChannelForRepo,
+  parseGithubPrUrl,
+  startPrReviewDm,
+} from "../../src/mcp/pr-review-tool.js";
+
+async function tmpStore(): Promise<{ dir: string; store: ChannelStore }> {
+  const dir = await mkdtemp(join(tmpdir(), "pr-review-tool-test-"));
+  return { dir, store: new ChannelStore(dir) };
+}
+
+describe("parseGithubPrUrl", () => {
+  it("accepts canonical URLs and normalizes trailing junk", () => {
+    expect(parseGithubPrUrl("https://github.com/acme/widgets/pull/42")).toEqual({
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+      canonicalUrl: "https://github.com/acme/widgets/pull/42",
+    });
+    expect(parseGithubPrUrl("https://www.github.com/acme/widgets/pull/42/files")).toEqual({
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+      canonicalUrl: "https://github.com/acme/widgets/pull/42",
+    });
+  });
+
+  it("rejects non-github and non-/pull/ URLs", () => {
+    expect(parseGithubPrUrl("https://gitlab.com/acme/widgets/pull/42")).toBeNull();
+    expect(parseGithubPrUrl("https://github.com/acme/widgets/issues/42")).toBeNull();
+    expect(parseGithubPrUrl("not a url at all")).toBeNull();
+  });
+});
+
+describe("findGeneralChannelForRepo", () => {
+  it("returns the general channel when an assignment alias matches (case-insensitive)", async () => {
+    const { dir, store } = await tmpStore();
+    try {
+      const general = await store.createChannel({
+        name: "general",
+        description: "welcome",
+        repoAssignments: [
+          { alias: "Widgets", workspaceId: "widgets-abc", repoPath: "/tmp/widgets" },
+        ],
+      });
+
+      const hit = await findGeneralChannelForRepo(store, "widgets");
+      expect(hit?.channelId).toBe(general.channelId);
+      expect(hit?.repoAssignment.workspaceId).toBe("widgets-abc");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores channels not named general and archived matches", async () => {
+    const { dir, store } = await tmpStore();
+    try {
+      await store.createChannel({
+        name: "feature-auth",
+        description: "wrong channel",
+        repoAssignments: [
+          { alias: "widgets", workspaceId: "widgets-abc", repoPath: "/tmp/widgets" },
+        ],
+      });
+      const archivedGeneral = await store.createChannel({
+        name: "general",
+        description: "archived",
+        repoAssignments: [
+          { alias: "widgets", workspaceId: "widgets-abc", repoPath: "/tmp/widgets" },
+        ],
+      });
+      await store.archiveChannel(archivedGeneral.channelId);
+
+      const miss = await findGeneralChannelForRepo(store, "widgets");
+      expect(miss).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("startPrReviewDm", () => {
+  const prUrl = "https://github.com/acme/widgets/pull/42";
+
+  it("mints a DM and posts a kickoff entry when no parent exists", async () => {
+    const { dir, store } = await tmpStore();
+    try {
+      const result = await startPrReviewDm({ prUrl, title: "Add dark-mode toggle", store });
+
+      expect(result.reused).toBe(false);
+      expect(result.parentChannelId).toBeNull();
+      expect(result.prUrl).toBe(prUrl);
+
+      const dm = await store.getChannel(result.channelId);
+      expect(dm?.kind).toBe("dm");
+      expect(dm?.pr?.url).toBe(prUrl);
+      expect(dm?.pr?.state).toBe("open");
+
+      const feedRaw = await readFile(join(dir, result.channelId, "feed.jsonl"), "utf8");
+      const entries = feedRaw
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(entries).toHaveLength(1);
+      expect(entries[0].type).toBe("status_update");
+      expect(entries[0].content).toContain(prUrl);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("posts a cross-link in the repo's general channel when one exists", async () => {
+    const { dir, store } = await tmpStore();
+    try {
+      const general = await store.createChannel({
+        name: "general",
+        description: "repo home",
+        repoAssignments: [
+          { alias: "widgets", workspaceId: "widgets-abc", repoPath: "/tmp/widgets" },
+        ],
+      });
+
+      const result = await startPrReviewDm({ prUrl, store });
+      expect(result.parentChannelId).toBe(general.channelId);
+
+      const dm = await store.getChannel(result.channelId);
+      expect(dm?.pr?.parentChannelId).toBe(general.channelId);
+      expect(dm?.repoAssignments?.[0]?.workspaceId).toBe("widgets-abc");
+
+      const parentFeedRaw = await readFile(join(dir, general.channelId, "feed.jsonl"), "utf8");
+      const parentEntries = parentFeedRaw
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const link = parentEntries.find((e) => e.type === "pr_link");
+      expect(link).toBeDefined();
+      expect(link.metadata.dmChannelId).toBe(result.channelId);
+      expect(link.metadata.prUrl).toBe(prUrl);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent: second call with the same URL returns the existing DM and adds no entries", async () => {
+    const { dir, store } = await tmpStore();
+    try {
+      const first = await startPrReviewDm({ prUrl, store });
+      const second = await startPrReviewDm({ prUrl, store });
+
+      expect(second.reused).toBe(true);
+      expect(second.channelId).toBe(first.channelId);
+
+      const feedRaw = await readFile(join(dir, first.channelId, "feed.jsonl"), "utf8");
+      const entries = feedRaw.trim().split("\n").filter(Boolean);
+      expect(entries).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-github URLs with a descriptive error", async () => {
+    const { dir, store } = await tmpStore();
+    try {
+      await expect(
+        startPrReviewDm({ prUrl: "https://gitlab.com/x/y/pull/1", store })
+      ).rejects.toThrow(/github.com pull request/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a PR-review path that mints a DM bound to a GitHub PR URL instead of a full project channel.
- DM carries a structured `pr` block; backlinks to the repo's `general` channel when one exists.
- `PrPoller` auto-archives the DM (and cross-links back to the parent) when the PR merges or closes.
- New MCP tool: `pr_review_start({prUrl, title?})` — idempotent by URL.

## What this is not
- Does **not** reroute the existing `pr-reviewer` wrapper yet (that's phase 4).
- GUI still renders `pr_link` entries as plain status updates; the DM pill lands in phase 5.

## Test plan
- [x] `test/channel-store.test.ts` — 5 new cases (createPrDm / findChannelByPrUrl / updatePrState)
- [x] `test/mcp/pr-review-tool.test.ts` — 8 new cases (parse, parent lookup, mint, cross-link, idempotency, rejection)
- [x] `test/integrations/pr-poller.test.ts` — 3 new cases (DM archival on merge, plain-channel skip, parentless close)
- [x] Full suite: 877 passed / 23 skipped
- [x] `prettier --check` clean, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)