### PR TITLE
feat(pr-review): route findings to PR DM + GUI affordances (phase 4-5)

### DIFF
--- a/gui/src/components/ChannelHeader.tsx
+++ b/gui/src/components/ChannelHeader.tsx
@@ -65,6 +65,19 @@ export function ChannelHeader({
               {TIER_LABELS[channel.tier]}
             </span>
           )}
+          {channel.pr && (
+            <a
+              className={`channel-header-pr pr-state-${channel.pr.state}`}
+              href={channel.pr.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              title={`Open PR on GitHub — ${channel.pr.state}`}
+            >
+              {channel.pr.repo.owner}/{channel.pr.repo.name}#{channel.pr.number}
+              <span className="pr-state-dot" aria-hidden />
+              <span className="pr-state-label">{channel.pr.state}</span>
+            </a>
+          )}
           <button
             className={`channel-header-star ${channel.starred ? "starred" : ""}`}
             onClick={toggleStar}

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -78,6 +78,33 @@ function FeedView({ entries, channel }: { entries: ChannelEntry[]; channel: Ment
             </div>
           );
         }
+        if (e.type === "pr_link") {
+          const prUrl = e.metadata?.prUrl;
+          const prState = e.metadata?.prState;
+          const dmChannelId = e.metadata?.dmChannelId;
+          return (
+            <div
+              key={e.entryId}
+              className={`message-pr-link ${prState ? `pr-state-${prState}` : ""}`}
+            >
+              <span className="msg-pr-icon" aria-hidden>
+                ⎔
+              </span>
+              <span className="msg-pr-text">{e.content}</span>
+              {prUrl && (
+                <a className="msg-pr-open" href={prUrl} target="_blank" rel="noreferrer noopener">
+                  Open PR →
+                </a>
+              )}
+              {dmChannelId && (
+                <span className="msg-pr-dm" title={dmChannelId}>
+                  review thread
+                </span>
+              )}
+              <span className="msg-pr-time">{formatTime(e.createdAt)}</span>
+            </div>
+          );
+        }
         return (
           <div key={e.entryId} className={`message role-${e.type} ${compact ? "compact" : ""}`}>
             {compact ? (

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -637,6 +637,73 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
 .channel-header-tier.tier-chore         { background: var(--color-paper-alt); color: var(--color-text-muted); }
 .channel-header-tier.tier-question      { background: rgba(74, 127, 208, 0.15); color: var(--color-accent-sky); }
 
+/* PR-review DM pill (phase 5). Clickable link-out to GitHub. The small
+ * state dot uses the same mint/coral/neutral palette as other status chips
+ * so the pill reads at a glance without colliding with the tier colors. */
+.channel-header-pr {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 2px var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  font-family: var(--font-mono);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+  white-space: nowrap;
+  text-decoration: none;
+  background: var(--color-paper-alt);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-soft, rgba(0, 0, 0, 0.08));
+}
+.channel-header-pr:hover { text-decoration: underline; }
+.channel-header-pr .pr-state-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.85;
+}
+.channel-header-pr .pr-state-label { text-transform: uppercase; }
+.channel-header-pr.pr-state-open   { color: #2a7a5a; background: var(--color-accent-mint-soft); }
+.channel-header-pr.pr-state-merged { color: #5a4a90; background: rgba(90, 82, 144, 0.15); }
+.channel-header-pr.pr-state-closed { color: var(--color-text-muted); background: var(--color-paper-alt); }
+
+/* Feed entry rendering for pr_link cross-links (phase 5). Compact row,
+ * similar shape to `.message-tool` so PR notifications don't dominate the
+ * feed. `Open PR →` is an external link; `review thread` shows the DM
+ * channelId as a tooltip (navigation is a future follow-up). */
+.message-pr-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 2px calc(var(--layout-message-avatar) + var(--space-4));
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-dim);
+  margin-bottom: var(--space-2);
+}
+.message-pr-link .msg-pr-icon { color: var(--color-accent-sky); }
+.message-pr-link .msg-pr-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-primary);
+}
+.message-pr-link .msg-pr-open {
+  color: var(--color-accent-sky);
+  text-decoration: none;
+}
+.message-pr-link .msg-pr-open:hover { text-decoration: underline; }
+.message-pr-link .msg-pr-dm { color: var(--color-text-dim); }
+.message-pr-link .msg-pr-time { color: var(--color-text-dim); }
+.message-pr-link.pr-state-merged .msg-pr-icon { color: #5a4a90; }
+.message-pr-link.pr-state-closed .msg-pr-icon { color: var(--color-text-muted); }
+
 .agent-stack { display: inline-flex; flex-shrink: 0; }
 .agent-stack .agent-avatar {
   width: 26px; height: 26px;

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -74,9 +74,26 @@ export type Channel = {
   // PR 2 of the provider-profiles series; this GUI tolerates the field
   // being absent on older channel files.
   providerProfileId?: string;
+  // PR-review DM metadata. Present on channels minted by the
+  // `pr_review_start` MCP tool. Absent on every other channel — the
+  // header treats the `undefined` case as "not a PR DM" and skips the
+  // pill. `state` mirrors the GitHub PR state and is flipped by the
+  // PR poller on merge/close.
+  pr?: ChannelPr;
   // ISO 8601; optional for back-compat with older channel files.
   createdAt?: string;
   updatedAt?: string;
+};
+
+export type ChannelPrState = "open" | "merged" | "closed";
+
+export type ChannelPr = {
+  url: string;
+  number: number;
+  repo: { owner: string; name: string };
+  state: ChannelPrState;
+  title?: string;
+  parentChannelId?: string;
 };
 
 // A named bundle of adapter + env overrides that resolves at dispatch

--- a/src/integrations/pr-reviewer.ts
+++ b/src/integrations/pr-reviewer.ts
@@ -30,6 +30,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { ChannelStore } from "../channels/channel-store.js";
+import type { ChannelPrState } from "../domain/channel.js";
 import type { PrReviewFindings } from "../domain/pr-row.js";
 import { NodeCommandInvoker, type CommandInvoker } from "../agents/command-invoker.js";
 import type { SandboxProvider } from "../execution/sandbox.js";
@@ -149,6 +150,15 @@ export interface ReviewPullRequestOptions {
   channelStore?: ChannelStore;
   /** Channel to post the review summary to. Required when `channelStore` is set. */
   channelId?: string;
+  /**
+   * Live GitHub PR state, when the caller knows it. Phase-4 routing uses
+   * this to decide whether to mint a PR-review DM: open → mint, merged /
+   * closed → skip mint and post to an existing DM if one's there, else
+   * fall back to the tracked channel. Defaults to `"open"` — the poller
+   * only fires the reviewer on newly-tracked PRs, so "open" is the
+   * correct assumption in the current call sites.
+   */
+  prState?: ChannelPrState;
 }
 
 /**
@@ -524,35 +534,59 @@ async function postReviewFeedEntry(
         : `PR review for ${label}: ${findings.blocking} blocking, ${findings.nits} nit${findings.nits === 1 ? "" : "s"}. ${findings.summary}`;
 
   // PR-review DM routing (phase 4):
-  //   - The review lands in a PR-bound DM so findings accumulate against the
-  //     PR itself, not the parent channel that happened to spawn the ticket.
-  //   - When the tracked row's `entry.channelId` is already a DM (i.e. the
-  //     caller was `pr_review_start`), we reuse it; no cross-link needed.
-  //   - Otherwise we find-or-mint a DM keyed on the PR URL and post the
-  //     findings there, then drop a `pr_link` cross-link in the tracked row's
-  //     channel so the parent thread still sees "review complete" without
-  //     the full blob. Idempotent via `findOrCreatePrDm`.
+  //   - When the tracked row's `entry.channelId` is already a PR DM (e.g.
+  //     the `pr_review_start` MCP flow), findings post directly there —
+  //     no mint, no cross-link.
+  //   - When the tracked channel is NOT a DM and the PR is live (`open`),
+  //     we find-or-mint a PR DM keyed on the PR URL and post the full
+  //     findings there, plus a compact `pr_link` cross-link in the parent
+  //     so the feature thread still sees "review complete".
+  //   - When the tracked channel is NOT a DM and the PR is merged / closed
+  //     or the review itself errored, we skip minting a new DM (no sense
+  //     standing up a review thread for a PR that's already closed or a
+  //     run we couldn't fetch) and fall back to posting directly in the
+  //     tracked channel — preserving the pre-phase-4 observability shape
+  //     for that edge case.
+  //   - Cross-link metadata carries the DM's `pr.state` so the GUI pill
+  //     renders with the right open/merged/closed variant without a second
+  //     round-trip.
   const trackedChannelId = options.channelId ?? entry.channelId;
   const trackedChannel = trackedChannelId ? await store.getChannel(trackedChannelId) : null;
   const trackedIsDm = trackedChannel?.pr !== undefined;
+  const liveState: ChannelPrState = options.prState ?? "open";
+  const prHealthy = liveState === "open" && findings.status !== "error";
 
-  let dmChannelId: string;
+  let dmChannelId: string | null;
+  let dmState: ChannelPrState = liveState;
   if (trackedIsDm && trackedChannelId) {
     dmChannelId = trackedChannelId;
+    dmState = trackedChannel?.pr?.state ?? liveState;
+  } else if (!prHealthy) {
+    // Don't mint a DM for a merged/closed PR or for a review that errored
+    // before the subagent even ran. Use an existing DM if one is already
+    // there (e.g. from a prior pr_review_start), otherwise fall back to
+    // posting in the tracked channel directly.
+    const existing = await store.findChannelByPrUrl(entry.pr.url);
+    dmChannelId = existing?.channelId ?? null;
+    dmState = existing?.pr?.state ?? liveState;
   } else {
     const { channel: dm } = await store.findOrCreatePrDm({
       pr: {
         url: entry.pr.url,
         number: entry.pr.number,
         repo: entry.repo,
-        state: "open",
+        state: liveState,
         parentChannelId: trackedChannelId ?? undefined,
       },
     });
     dmChannelId = dm.channelId;
+    dmState = dm.pr?.state ?? liveState;
   }
 
-  await store.postEntry(dmChannelId, {
+  const primaryChannelId = dmChannelId ?? trackedChannelId;
+  if (!primaryChannelId) return;
+
+  await store.postEntry(primaryChannelId, {
     type: "status_update",
     fromAgentId: null,
     fromDisplayName: "pr-reviewer",
@@ -567,7 +601,7 @@ async function postReviewFeedEntry(
     },
   });
 
-  if (trackedChannelId && trackedChannelId !== dmChannelId) {
+  if (dmChannelId && trackedChannelId && trackedChannelId !== dmChannelId) {
     await store.postEntry(trackedChannelId, {
       type: "pr_link",
       fromAgentId: null,
@@ -576,6 +610,7 @@ async function postReviewFeedEntry(
       metadata: {
         ticketId: entry.ticketId,
         prUrl: entry.pr.url,
+        prState: dmState,
         dmChannelId,
         reviewStatus: findings.status,
         blocking: findings.blocking,

--- a/src/integrations/pr-reviewer.ts
+++ b/src/integrations/pr-reviewer.ts
@@ -513,8 +513,7 @@ async function postReviewFeedEntry(
   options: ReviewPullRequestOptions
 ): Promise<void> {
   const store = options.channelStore;
-  const channelId = options.channelId ?? entry.channelId;
-  if (!store || !channelId) return;
+  if (!store) return;
 
   const label = `${entry.repo.owner}/${entry.repo.name}#${entry.pr.number}`;
   const content =
@@ -524,7 +523,36 @@ async function postReviewFeedEntry(
         ? `PR review for ${label} inconclusive — ${findings.summary}`
         : `PR review for ${label}: ${findings.blocking} blocking, ${findings.nits} nit${findings.nits === 1 ? "" : "s"}. ${findings.summary}`;
 
-  await store.postEntry(channelId, {
+  // PR-review DM routing (phase 4):
+  //   - The review lands in a PR-bound DM so findings accumulate against the
+  //     PR itself, not the parent channel that happened to spawn the ticket.
+  //   - When the tracked row's `entry.channelId` is already a DM (i.e. the
+  //     caller was `pr_review_start`), we reuse it; no cross-link needed.
+  //   - Otherwise we find-or-mint a DM keyed on the PR URL and post the
+  //     findings there, then drop a `pr_link` cross-link in the tracked row's
+  //     channel so the parent thread still sees "review complete" without
+  //     the full blob. Idempotent via `findOrCreatePrDm`.
+  const trackedChannelId = options.channelId ?? entry.channelId;
+  const trackedChannel = trackedChannelId ? await store.getChannel(trackedChannelId) : null;
+  const trackedIsDm = trackedChannel?.pr !== undefined;
+
+  let dmChannelId: string;
+  if (trackedIsDm && trackedChannelId) {
+    dmChannelId = trackedChannelId;
+  } else {
+    const { channel: dm } = await store.findOrCreatePrDm({
+      pr: {
+        url: entry.pr.url,
+        number: entry.pr.number,
+        repo: entry.repo,
+        state: "open",
+        parentChannelId: trackedChannelId ?? undefined,
+      },
+    });
+    dmChannelId = dm.channelId;
+  }
+
+  await store.postEntry(dmChannelId, {
     type: "status_update",
     fromAgentId: null,
     fromDisplayName: "pr-reviewer",
@@ -538,6 +566,23 @@ async function postReviewFeedEntry(
       trackedPrStatus,
     },
   });
+
+  if (trackedChannelId && trackedChannelId !== dmChannelId) {
+    await store.postEntry(trackedChannelId, {
+      type: "pr_link",
+      fromAgentId: null,
+      fromDisplayName: "pr-reviewer",
+      content: `PR review for ${label}: ${findings.summary}`,
+      metadata: {
+        ticketId: entry.ticketId,
+        prUrl: entry.pr.url,
+        dmChannelId,
+        reviewStatus: findings.status,
+        blocking: findings.blocking,
+        nits: findings.nits,
+      },
+    });
+  }
 }
 
 /**

--- a/test/integrations/pr-reviewer.test.ts
+++ b/test/integrations/pr-reviewer.test.ts
@@ -147,11 +147,20 @@ describe("reviewPullRequest", () => {
       expect(call[0].passEnv).not.toContain("GITHUB_TOKEN");
       expect(call[0].passEnv).not.toContain("GH_TOKEN");
 
-      const feed = await store.readFeed(channel.channelId);
-      const reviewerEntry = feed.find((e) => e.fromDisplayName === "pr-reviewer");
+      // Phase 4 routing: full findings land in the PR DM; the tracked
+      // (parent) channel receives a pr_link cross-link summary.
+      const dm = await store.findChannelByPrUrl(entry.pr.url);
+      expect(dm).not.toBeNull();
+      const dmFeed = await store.readFeed(dm!.channelId);
+      const reviewerEntry = dmFeed.find((e) => e.fromDisplayName === "pr-reviewer");
       expect(reviewerEntry).toBeDefined();
       expect(reviewerEntry!.content).toContain("1 blocking");
       expect(reviewerEntry!.metadata.reviewStatus).toBe("ready_for_human_ack");
+
+      const parentFeed = await store.readFeed(channel.channelId);
+      const crossLink = parentFeed.find((e) => e.type === "pr_link");
+      expect(crossLink).toBeDefined();
+      expect(crossLink!.metadata.dmChannelId).toBe(dm!.channelId);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -181,8 +190,10 @@ describe("reviewPullRequest", () => {
       expect(result.findings.summary).toContain("gh pr checkout failed");
       // Reviewer must NOT have been invoked when checkout failed.
       expect(invoker.exec).not.toHaveBeenCalled();
-      const feed = await store.readFeed(channel.channelId);
-      const errEntry = feed.find((e) => e.fromDisplayName === "pr-reviewer");
+      const dm = await store.findChannelByPrUrl(entry.pr.url);
+      expect(dm).not.toBeNull();
+      const dmFeed = await store.readFeed(dm!.channelId);
+      const errEntry = dmFeed.find((e) => e.fromDisplayName === "pr-reviewer");
       expect(errEntry).toBeDefined();
       expect(errEntry!.content).toContain("errored");
     } finally {
@@ -211,10 +222,59 @@ describe("reviewPullRequest", () => {
       expect(result.findings.status).toBe("inconclusive");
       expect(result.findings.blocking).toBe(0);
       expect(result.findings.nits).toBe(0);
-      const feed = await store.readFeed(channel.channelId);
-      const inconclusive = feed.find((e) => e.fromDisplayName === "pr-reviewer");
+      const dm = await store.findChannelByPrUrl(entry.pr.url);
+      expect(dm).not.toBeNull();
+      const dmFeed = await store.readFeed(dm!.channelId);
+      const inconclusive = dmFeed.find((e) => e.fromDisplayName === "pr-reviewer");
       expect(inconclusive).toBeDefined();
       expect(inconclusive!.content).toContain("inconclusive");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("posts findings directly in the tracked channel when it is already a PR DM", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-reviewer-dm-tracked-"));
+    const store = new ChannelStore(dir);
+    try {
+      // MCP-initiated flow: `pr_review_start` minted a DM, the poller is
+      // tracking against that DM's channelId, and the reviewer fires.
+      // Findings belong in the DM itself — no extra DM is minted and no
+      // cross-link is posted.
+      const dm = await store.createPrDm({
+        pr: {
+          url: "https://github.com/acme/widgets/pull/42",
+          number: 42,
+          repo: { owner: "acme", name: "widgets" },
+          state: "open",
+        },
+      });
+      const entry = makeEntry({
+        channelId: dm.channelId,
+        openedByAutonomous: true,
+      });
+      const invoker = mockInvoker(
+        ["Summary: LGTM overall", "BLOCKING: src/a.ts issue", "OK: tests"].join("\n")
+      );
+      const checkout = vi.fn(async () => {});
+
+      const beforeCount = (await store.listChannels()).length;
+      await reviewPullRequest(entry, {
+        trustMode: "supervised",
+        invoker,
+        checkout,
+        channelStore: store,
+        channelId: dm.channelId,
+      });
+      const afterCount = (await store.listChannels()).length;
+      expect(afterCount).toBe(beforeCount);
+
+      const feed = await store.readFeed(dm.channelId);
+      const reviewerEntry = feed.find((e) => e.fromDisplayName === "pr-reviewer");
+      expect(reviewerEntry).toBeDefined();
+      expect(reviewerEntry!.content).toContain("1 blocking");
+      const crossLink = feed.find((e) => e.type === "pr_link");
+      expect(crossLink).toBeUndefined();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/integrations/pr-reviewer.test.ts
+++ b/test/integrations/pr-reviewer.test.ts
@@ -190,10 +190,13 @@ describe("reviewPullRequest", () => {
       expect(result.findings.summary).toContain("gh pr checkout failed");
       // Reviewer must NOT have been invoked when checkout failed.
       expect(invoker.exec).not.toHaveBeenCalled();
+      // Phase-4: errored reviews skip DM mint — no thread is created for a
+      // PR we couldn't even fetch. The error lands in the tracked channel
+      // so operators still see the failure in the feature thread.
       const dm = await store.findChannelByPrUrl(entry.pr.url);
-      expect(dm).not.toBeNull();
-      const dmFeed = await store.readFeed(dm!.channelId);
-      const errEntry = dmFeed.find((e) => e.fromDisplayName === "pr-reviewer");
+      expect(dm).toBeNull();
+      const feed = await store.readFeed(channel.channelId);
+      const errEntry = feed.find((e) => e.fromDisplayName === "pr-reviewer");
       expect(errEntry).toBeDefined();
       expect(errEntry!.content).toContain("errored");
     } finally {
@@ -228,6 +231,74 @@ describe("reviewPullRequest", () => {
       const inconclusive = dmFeed.find((e) => e.fromDisplayName === "pr-reviewer");
       expect(inconclusive).toBeDefined();
       expect(inconclusive!.content).toContain("inconclusive");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips DM mint when prState is merged and falls back to the tracked channel", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-reviewer-merged-skip-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-rev", description: "" });
+      const entry = makeEntry({
+        channelId: channel.channelId,
+        openedByAutonomous: true,
+      });
+      const invoker = mockInvoker(
+        ["Summary: late review", "OK: tests pass", "NIT: typo"].join("\n")
+      );
+      const checkout = vi.fn(async () => {});
+
+      await reviewPullRequest(entry, {
+        trustMode: "supervised",
+        invoker,
+        checkout,
+        channelStore: store,
+        channelId: channel.channelId,
+        prState: "merged",
+      });
+
+      // No DM minted for already-merged PR.
+      const dm = await store.findChannelByPrUrl(entry.pr.url);
+      expect(dm).toBeNull();
+
+      // Full findings land in the tracked channel (fallback).
+      const feed = await store.readFeed(channel.channelId);
+      const reviewerEntry = feed.find((e) => e.fromDisplayName === "pr-reviewer");
+      expect(reviewerEntry).toBeDefined();
+      expect(reviewerEntry!.content).toContain("1 nit");
+      const crossLink = feed.find((e) => e.type === "pr_link");
+      expect(crossLink).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stamps pr.state onto the cross-link metadata so the GUI pill renders the right variant", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pr-reviewer-crosslink-state-"));
+    const store = new ChannelStore(dir);
+    try {
+      const channel = await store.createChannel({ name: "#pr-rev", description: "" });
+      const entry = makeEntry({
+        channelId: channel.channelId,
+        openedByAutonomous: true,
+      });
+      const invoker = mockInvoker(["Summary: LGTM", "OK: passes"].join("\n"));
+      const checkout = vi.fn(async () => {});
+
+      await reviewPullRequest(entry, {
+        trustMode: "supervised",
+        invoker,
+        checkout,
+        channelStore: store,
+        channelId: channel.channelId,
+      });
+
+      const parentFeed = await store.readFeed(channel.channelId);
+      const crossLink = parentFeed.find((e) => e.type === "pr_link");
+      expect(crossLink).toBeDefined();
+      expect(crossLink!.metadata.prState).toBe("open");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- **Phase 4** — `pr-reviewer` now routes findings into the PR-bound DM. When the tracked row's own channel is already a DM (MCP-initiated `pr_review_start` flow), findings post directly there. Otherwise a DM is minted via `findOrCreatePrDm` and the tracked (parent) channel receives a compact `pr_link` cross-link with the DM channelId.
- **Phase 5** — GUI grows a PR pill in the channel header (`owner/repo#n · state`, links to GitHub) and renders `pr_link` feed entries as compact cards with external "Open PR →" + "review thread" tooltip on the DM channelId.

Follow-up to #166. Completes the DM-per-PR model end to end.

## Test plan
- [x] `test/integrations/pr-reviewer.test.ts` — updated 3 existing tests to assert findings in the DM + cross-link in parent. Added 1 test for the "tracked channel is already a DM" path.
- [x] Full Vitest: 880 passed / 23 skipped. GUI Vitest: 37 passed.
- [x] `tsc --noEmit` clean for root + `gui/`.
- [x] `prettier --check` clean.
- [x] Rust `Channel` struct already carries the `pr` field from #166 — no Rust change needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)