### PR TITLE
perf(gui): chat smoothness — instant send, persistent stream card, throttled scroll

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1341,49 +1341,57 @@ fn start_chat(
     append_args.push(&message);
     let _ = cli_run(&append_args);
 
-    // Resolve MCP config and system prompt up-front (off the streaming thread is fine).
-    let mcp_path = {
-        let mut args: Vec<&str> = vec!["chat", "mcp-config"];
-        let cwd_ref = cwd.clone();
-        if let Some(ref dir) = cwd_ref {
-            args.push("--repo");
-            args.push(dir);
-        }
-        cli_json(&args)
-            .ok()
-            .and_then(|v| v.get("path").and_then(|p| p.as_str().map(String::from)))
-    };
-
-    let system_prompt = {
-        let mut args: Vec<String> = vec![
-            "chat".into(),
-            "system-prompt".into(),
-            "--channel".into(),
-            channel_id.clone(),
-        ];
-        if let Some(ref dir) = cwd {
-            args.push("--repo".into());
-            args.push(dir.clone());
-        }
-        if let Some(ref a) = alias {
-            args.push("--alias".into());
-            args.push(a.clone());
-        }
-        let refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        cli_json(&refs)
-            .ok()
-            .and_then(|v| v.get("prompt").and_then(|p| p.as_str().map(String::from)))
-    };
-
+    // Previously both `rly chat mcp-config` and `rly chat system-prompt`
+    // ran synchronously here, blocking `startChat`'s IPC return for ~0.5-1s
+    // before the composer unblocked. Move them into the spawned thread —
+    // the user's message is already persisted (above) so the renderer can
+    // render it immediately, and we emit `Started` first so the stream
+    // card surfaces right away.
     let app_handle = app.clone();
     let channel_id_thread = channel_id.clone();
     let session_id_thread = session_id.clone();
     let alias_thread = alias.clone();
     let cwd_thread = cwd.clone();
     let claude_sid_thread = claude_session_id.clone();
+    let alias_spawn = alias.clone();
 
     std::thread::spawn(move || {
         let _ = app_handle.emit("chat-event", ChatEvent::Started { stream_id });
+
+        // Resolve MCP config path and system prompt now that the stream
+        // card is up. Surfaced to the user as "session init" activity once
+        // claude emits its init event.
+        let mcp_path: Option<String> = {
+            let mut args: Vec<&str> = vec!["chat", "mcp-config"];
+            if let Some(ref dir) = cwd_thread {
+                args.push("--repo");
+                args.push(dir);
+            }
+            cli_json(&args)
+                .ok()
+                .and_then(|v| v.get("path").and_then(|p| p.as_str().map(String::from)))
+        };
+
+        let system_prompt: Option<String> = {
+            let mut args: Vec<String> = vec![
+                "chat".into(),
+                "system-prompt".into(),
+                "--channel".into(),
+                channel_id_thread.clone(),
+            ];
+            if let Some(ref dir) = cwd_thread {
+                args.push("--repo".into());
+                args.push(dir.clone());
+            }
+            if let Some(ref a) = alias_spawn {
+                args.push("--alias".into());
+                args.push(a.clone());
+            }
+            let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            cli_json(&refs)
+                .ok()
+                .and_then(|v| v.get("prompt").and_then(|p| p.as_str().map(String::from)))
+        };
 
         let claude_bin = std::env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
         let mut args: Vec<String> = vec![

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -154,14 +154,31 @@ export function CenterPane({
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
+    const closingTimers = new Map<number, number>();
     subscribeChatEvents((event: ChatEvent) => {
       setStream((current) => {
         if (!current || event.streamId !== current.streamId) return current;
         return reduceStream(current, event);
       });
       if (event.kind === "done" || event.kind === "error") {
+        // Previously we set `stream` to null immediately on done; the
+        // stream card's amber-bordered container vanished and the
+        // persisted assistant message appeared in its place as a plain
+        // message row, producing a visible "pop". Keep the card mounted
+        // under a `closing` flag for one frame so StreamCard can fade
+        // out while the refreshed sessionMessages render underneath.
+        const { streamId } = event;
+        setStream((current) =>
+          current && current.streamId === streamId ? { ...current, closing: true } : current
+        );
         onRefresh();
-        setStream((current) => (current && current.streamId === event.streamId ? null : current));
+        const prev = closingTimers.get(streamId);
+        if (prev !== undefined) window.clearTimeout(prev);
+        const tid = window.setTimeout(() => {
+          closingTimers.delete(streamId);
+          setStream((current) => (current && current.streamId === streamId ? null : current));
+        }, 180);
+        closingTimers.set(streamId, tid);
       }
     }).then((u) => {
       if (cancelled) u();
@@ -170,6 +187,8 @@ export function CenterPane({
     return () => {
       cancelled = true;
       if (unlisten) unlisten();
+      for (const tid of closingTimers.values()) window.clearTimeout(tid);
+      closingTimers.clear();
     };
   }, [onRefresh]);
 

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -154,31 +154,28 @@ export function CenterPane({
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
-    const closingTimers = new Map<number, number>();
     subscribeChatEvents((event: ChatEvent) => {
       setStream((current) => {
         if (!current || event.streamId !== current.streamId) return current;
         return reduceStream(current, event);
       });
       if (event.kind === "done" || event.kind === "error") {
-        // Previously we set `stream` to null immediately on done; the
-        // stream card's amber-bordered container vanished and the
-        // persisted assistant message appeared in its place as a plain
-        // message row, producing a visible "pop". Keep the card mounted
-        // under a `closing` flag for one frame so StreamCard can fade
-        // out while the refreshed sessionMessages render underneath.
+        // Previously the card faded out and was torn down on done. The
+        // user asked for the activity history to stick around so they
+        // can see what the agent actually did — keep the card mounted,
+        // auto-expand the activity stack, and mark the turn as closed.
+        // The card unmounts on the NEXT user submit (optimistic handler
+        // above calls setStream(null)) or on channel switch. We still
+        // onRefresh so the persisted assistant message + user message
+        // are loaded — SessionMessages dedupes the duplicate assistant
+        // content when a closed stream is present.
         const { streamId } = event;
         setStream((current) =>
-          current && current.streamId === streamId ? { ...current, closing: true } : current
+          current && current.streamId === streamId
+            ? { ...current, closed: true, expanded: true }
+            : current
         );
         onRefresh();
-        const prev = closingTimers.get(streamId);
-        if (prev !== undefined) window.clearTimeout(prev);
-        const tid = window.setTimeout(() => {
-          closingTimers.delete(streamId);
-          setStream((current) => (current && current.streamId === streamId ? null : current));
-        }, 180);
-        closingTimers.set(streamId, tid);
       }
     }).then((u) => {
       if (cancelled) u();
@@ -187,8 +184,6 @@ export function CenterPane({
     return () => {
       cancelled = true;
       if (unlisten) unlisten();
-      for (const tid of closingTimers.values()) window.clearTimeout(tid);
-      closingTimers.clear();
     };
   }, [onRefresh]);
 
@@ -271,6 +266,25 @@ export function CenterPane({
             onStartStream={setStream}
             onSessionCreated={onSessionCreated}
             onSlashNew={isDm ? () => setPromoteOpen(true) : undefined}
+            onOptimisticUserMessage={(content, alias) => {
+              // The real user message gets persisted server-side and
+              // shows up via onRefresh when `done` fires; the optimistic
+              // insert just bridges the perceptual gap between click and
+              // round-trip. `loadSession` is the authority — its re-
+              // render replaces this stub.
+              setSessionMessages((prev) => [
+                ...prev,
+                {
+                  role: "user",
+                  content,
+                  timestamp: new Date().toISOString(),
+                  agentAlias: alias ?? undefined,
+                },
+              ]);
+              // Also clear any previously settled stream so the new
+              // optimistic turn isn't stacked against a stale card.
+              setStream(null);
+            }}
           />
         </>
       )}

--- a/gui/src/components/Composer.tsx
+++ b/gui/src/components/Composer.tsx
@@ -12,6 +12,11 @@ export type ActiveStream = {
   accum: string;
   activity: ActivityEntry[];
   expanded: boolean;
+  // `closing` is true from the moment `done`/`error` arrives until the
+  // persisted assistant message lands in the feed and we unmount the
+  // card. During this window StreamCard renders with a fade-out class so
+  // the transition to the real message row isn't an abrupt DOM swap.
+  closing?: boolean;
 };
 
 export type StreamDispatch = (s: ActiveStream | null) => void;

--- a/gui/src/components/Composer.tsx
+++ b/gui/src/components/Composer.tsx
@@ -12,11 +12,13 @@ export type ActiveStream = {
   accum: string;
   activity: ActivityEntry[];
   expanded: boolean;
-  // `closing` is true from the moment `done`/`error` arrives until the
-  // persisted assistant message lands in the feed and we unmount the
-  // card. During this window StreamCard renders with a fade-out class so
-  // the transition to the real message row isn't an abrupt DOM swap.
-  closing?: boolean;
+  // `closed` is set when `done`/`error` arrives. The card stays mounted
+  // afterwards — activity log + response text preserved — so the user
+  // can review what was run. It only unmounts when the next user turn
+  // starts (composer's optimistic-message handler sets stream=null) or
+  // when the user switches channels. `closed` drives the pulse-dot
+  // going static and the status label flipping to "done".
+  closed?: boolean;
 };
 
 export type StreamDispatch = (s: ActiveStream | null) => void;
@@ -31,6 +33,11 @@ type Props = {
   // DM-only: invoked when the user types `/new` at the start of the
   // composer and hits Enter. If omitted, `/new` is sent as a normal message.
   onSlashNew?: () => void;
+  // Fires synchronously on click, before any backend round-trips. Lets
+  // the parent append an optimistic user-role message to the session
+  // view so the user sees their own turn immediately instead of waiting
+  // on create-session / rewind-snapshot / start-chat IPC to round-trip.
+  onOptimisticUserMessage?: (content: string, alias: string | null) => void;
 };
 
 export function Composer({
@@ -41,6 +48,7 @@ export function Composer({
   onStartStream,
   onSessionCreated,
   onSlashNew,
+  onOptimisticUserMessage,
 }: Props) {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
@@ -162,11 +170,20 @@ export function Composer({
       onSlashNew();
       return;
     }
+    // Clear the composer + drop optimistic user message IMMEDIATELY so the
+    // send feels instant. Previously we awaited three round-trips
+    // (maybe-createSession, rewindSnapshot, startChat) before clearing —
+    // the user typed, hit send, and watched their own text sit in the
+    // field for ~300ms. Now the visual acknowledgement is synchronous
+    // with the click; the backend catches up asynchronously below.
+    const { alias, body } = parseAliasPrefix(raw, aliases);
+    const target = alias ?? primaryAlias;
+    setText("");
+    onOptimisticUserMessage?.(body, target || null);
+
     setBusy(true);
     setError(null);
     try {
-      const { alias, body } = parseAliasPrefix(raw, aliases);
-      const target = alias ?? primaryAlias;
       const repo = target ? channel.repoAssignments.find((r) => r.alias === target) : null;
       const cwd = repo?.repoPath;
       const aliasKey = target || "general";
@@ -206,7 +223,6 @@ export function Composer({
         activity: [],
         expanded: false,
       });
-      setText("");
     } catch (err) {
       setError(String(err));
     } finally {
@@ -557,8 +573,12 @@ function parseAliasPrefix(
   return { alias: candidate, body: match[2] };
 }
 
+// Ring buffer cap on activity entries. Big enough to cover a long
+// multi-tool turn (init events + many tool uses), small enough to keep
+// the DOM trivial when the card stays mounted post-done for review.
+const ACTIVITY_STACK_MAX = 80;
+
 export function reduceStream(current: ActiveStream, event: ChatEvent): ActiveStream {
-  const ACTIVITY_STACK_MAX = 20;
   switch (event.kind) {
     case "chunk":
       return { ...current, accum: current.accum + event.text };

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import type { Channel, ChannelEntry, PersistedChatMessage } from "../types";
 import { renderMarkdown } from "../lib/mentions";
@@ -8,6 +8,20 @@ import { useAppearance } from "../lib/appearance";
 import type { ActiveStream } from "./Composer";
 
 const ACTIVITY_TOP_N = 3;
+
+/**
+ * Memoized markdown body. `renderMarkdown` runs react-markdown + remark-gfm
+ * over the full text on every call; during streaming, MessageList
+ * re-renders on every chunk and a naive call would re-parse the growing
+ * accum each time (O(n²) over the reply). Memoize on text + channel
+ * identity — channel is held stable by `useMemo` in parents.
+ */
+const MarkdownBody = memo(
+  function MarkdownBody({ text, channel }: { text: string; channel: MentionContext }) {
+    return <>{renderMarkdown(text, channel)}</>;
+  },
+  (prev, next) => prev.text === next.text && prev.channel === next.channel
+);
 
 type Props = {
   channel: Channel;
@@ -31,11 +45,29 @@ export function MessageList({
   onRewound,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const ui = mentionContext(toUiChannel(channel));
+  // Memoize mention context so `MarkdownBody` (which takes it as a prop)
+  // can compare by reference rather than re-rendering the markdown AST
+  // every time MessageList re-renders — the common case during streaming.
+  const ui = useMemo(() => mentionContext(toUiChannel(channel)), [channel]);
 
+  // Throttle scroll-to-bottom through requestAnimationFrame. The previous
+  // implementation forced a layout (scrollTop = scrollHeight) on every
+  // chunk; on a fast-streaming reply that fires ~30x/sec and each write
+  // triggers a synchronous layout, which the user perceives as jitter.
+  // rAF collapses bursts to one scroll per paint.
+  const pendingScroll = useRef(false);
   useEffect(() => {
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (pendingScroll.current) return;
+    pendingScroll.current = true;
+    const raf = requestAnimationFrame(() => {
+      pendingScroll.current = false;
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      pendingScroll.current = false;
+    };
   }, [sessionMessages.length, feed.length, sessionId, stream?.accum.length]);
 
   return (
@@ -97,7 +129,9 @@ function FeedView({ entries, channel }: { entries: ChannelEntry[]; channel: Ment
                   <span className="msg-time">{formatTime(e.createdAt)}</span>
                 </div>
               )}
-              <div className="msg-body">{renderMarkdown(e.content, channel)}</div>
+              <div className="msg-body">
+                <MarkdownBody text={e.content} channel={channel} />
+              </div>
             </div>
           </div>
         );
@@ -142,7 +176,7 @@ function SessionMessages({
   streamId: number | null;
   onRewound: () => void;
 }) {
-  const ui = mentionContext(toUiChannel(channel));
+  const ui = useMemo(() => mentionContext(toUiChannel(channel)), [channel]);
   const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(null);
 
   if (messages.length === 0)
@@ -191,7 +225,9 @@ function SessionMessages({
                   </span>
                 </div>
               )}
-              <div className="msg-body">{renderMarkdown(m.content, ui)}</div>
+              <div className="msg-body">
+                <MarkdownBody text={m.content} channel={ui} />
+              </div>
             </div>
           </div>
         );
@@ -331,42 +367,61 @@ function StreamCard({
   const visible = total === 0 ? [] : stream.activity.slice(total - visibleCount);
   const hiddenCount = total - visibleCount;
 
+  const authorKey = stream.alias ?? "assistant";
+  const authorLabel = stream.alias ? `@${stream.alias}` : "assistant";
+  // Wrap the streaming content in the same .message / role-assistant
+  // layout used for persisted assistant messages so the transition at
+  // `done` is an in-place content swap, not a DOM-subtree replacement.
+  // The `closing` class drives a short fade-out; the amber pulse dot
+  // lives inside a status pill next to the author label, which stays
+  // stable across the thinking→writing transition (no card-color flip).
   return (
-    <div className="stream-card">
-      <div className="stream-card-head">
-        <span className="dot" />
-        <span className="author">{stream.alias ? `@${stream.alias}` : "assistant"}</span>
-        <span>
-          {stream.accum ? "writing response" : "thinking"}
-          {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
-        </span>
-      </div>
-      <div className={`stream-activity ${stream.expanded ? "expanded" : ""}`}>
-        {visible.map((entry, i) => {
-          const isNewest = i === visible.length - 1;
-          return (
-            <div
-              key={`${entry.ts}-${i}`}
-              className={`stream-activity-line ${isNewest ? "newest" : ""}`}
-              title={new Date(entry.ts).toLocaleTimeString()}
-            >
-              <span>⚙</span>
-              <span>{entry.text}</span>
-            </div>
-          );
-        })}
-        {hiddenCount > 0 && (
-          <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
-            +{hiddenCount} more
-          </button>
+    <div className={`message role-assistant stream-card ${stream.closing ? "closing" : ""}`}>
+      <MsgAvatar seed={authorKey} />
+      <div>
+        <div className="msg-head">
+          <span className="msg-author" style={{ color: authorColor(authorKey) }}>
+            {authorLabel}
+          </span>
+          <span className="stream-status">
+            <span className="dot" aria-hidden />
+            <span>
+              {stream.closing ? "done" : stream.accum ? "writing response" : "thinking"}
+              {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
+            </span>
+          </span>
+        </div>
+        <div className={`stream-activity ${stream.expanded ? "expanded" : ""}`}>
+          {visible.map((entry, i) => {
+            const isNewest = i === visible.length - 1;
+            return (
+              <div
+                key={`${entry.ts}-${i}`}
+                className={`stream-activity-line ${isNewest ? "newest" : ""}`}
+                title={new Date(entry.ts).toLocaleTimeString()}
+              >
+                <span>⚙</span>
+                <span>{entry.text}</span>
+              </div>
+            );
+          })}
+          {hiddenCount > 0 && (
+            <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
+              +{hiddenCount} more
+            </button>
+          )}
+          {stream.expanded && total > ACTIVITY_TOP_N && (
+            <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
+              collapse
+            </button>
+          )}
+        </div>
+        {stream.accum && (
+          <div className="msg-body">
+            <MarkdownBody text={stream.accum} channel={channel} />
+          </div>
         )}
-        {stream.expanded && total > ACTIVITY_TOP_N && (
-          <button type="button" className="stream-activity-more" onClick={onToggleExpanded}>
-            collapse
-          </button>
-        )}
       </div>
-      {stream.accum && <div className="stream-body">{renderMarkdown(stream.accum, channel)}</div>}
     </div>
   );
 }

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -7,7 +7,10 @@ import { agentAvatar } from "../lib/agents";
 import { useAppearance } from "../lib/appearance";
 import type { ActiveStream } from "./Composer";
 
-const ACTIVITY_TOP_N = 3;
+// Collapsed stream card shows the last 6 activity lines by default — 3
+// was too narrow and the user lost visibility into what the agent ran.
+// Expand (and keeping the card mounted post-done) reveals the full list.
+const ACTIVITY_TOP_N = 6;
 
 /**
  * Memoized markdown body. `renderMarkdown` runs react-markdown + remark-gfm
@@ -79,6 +82,7 @@ export function MessageList({
           messages={sessionMessages}
           streaming={!!stream}
           streamId={streamId}
+          closedStreamAccum={stream?.closed ? stream.accum : null}
           onRewound={onRewound}
         />
       ) : (
@@ -167,6 +171,7 @@ function SessionMessages({
   messages,
   streaming,
   streamId,
+  closedStreamAccum,
   onRewound,
 }: {
   channel: Channel;
@@ -174,19 +179,34 @@ function SessionMessages({
   messages: PersistedChatMessage[];
   streaming: boolean;
   streamId: number | null;
+  // When a stream has closed but is still mounted (we keep the card to
+  // preserve activity history), the backend has already persisted its
+  // assistant message — which would render here as a duplicate. Dedupe
+  // by dropping the trailing assistant message when its content matches
+  // the closed stream's accum.
+  closedStreamAccum: string | null;
   onRewound: () => void;
 }) {
   const ui = useMemo(() => mentionContext(toUiChannel(channel)), [channel]);
   const [rewindTarget, setRewindTarget] = useState<PersistedChatMessage | null>(null);
 
-  if (messages.length === 0)
+  const visibleMessages = useMemo(() => {
+    if (!closedStreamAccum || messages.length === 0) return messages;
+    const last = messages[messages.length - 1];
+    if (last.role === "assistant" && last.content === closedStreamAccum) {
+      return messages.slice(0, -1);
+    }
+    return messages;
+  }, [messages, closedStreamAccum]);
+
+  if (visibleMessages.length === 0 && !closedStreamAccum)
     return <div className="chat-empty">No messages in this session yet</div>;
   return (
     <>
-      {messages.map((m, i) => {
+      {visibleMessages.map((m, i) => {
         const rewindKey = m.metadata?.rewindKey;
         const canRewind = m.role === "user" && !!rewindKey && !streaming;
-        const prev = messages[i - 1];
+        const prev = visibleMessages[i - 1];
         const sameAuthor =
           prev && prev.role === m.role && (prev.agentAlias ?? "") === (m.agentAlias ?? "");
         const dt = prev ? Date.parse(m.timestamp) - Date.parse(prev.timestamp) : Infinity;
@@ -370,13 +390,13 @@ function StreamCard({
   const authorKey = stream.alias ?? "assistant";
   const authorLabel = stream.alias ? `@${stream.alias}` : "assistant";
   // Wrap the streaming content in the same .message / role-assistant
-  // layout used for persisted assistant messages so the transition at
-  // `done` is an in-place content swap, not a DOM-subtree replacement.
-  // The `closing` class drives a short fade-out; the amber pulse dot
-  // lives inside a status pill next to the author label, which stays
-  // stable across the thinking→writing transition (no card-color flip).
+  // layout used for persisted assistant messages so on `done` the only
+  // visible change is "dot pulsing → static" and the status label text.
+  // The card stays mounted post-done so the activity log remains
+  // reviewable; it unmounts only when the next user turn starts.
+  const statusLabel = stream.closed ? "done" : stream.accum ? "writing response" : "thinking";
   return (
-    <div className={`message role-assistant stream-card ${stream.closing ? "closing" : ""}`}>
+    <div className={`message role-assistant stream-card ${stream.closed ? "closed" : ""}`}>
       <MsgAvatar seed={authorKey} />
       <div>
         <div className="msg-head">
@@ -386,7 +406,7 @@ function StreamCard({
           <span className="stream-status">
             <span className="dot" aria-hidden />
             <span>
-              {stream.closing ? "done" : stream.accum ? "writing response" : "thinking"}
+              {statusLabel}
               {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
             </span>
           </span>

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1308,12 +1308,10 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
    (pulsing amber dot + "thinking/writing" label) next to the author.
    Closing the card fades out over 180ms; a matching setTimeout on the
    JS side unmounts after the transition. */
-.stream-card {
-  transition: opacity 180ms ease;
-}
-.stream-card.closing {
-  opacity: 0;
-}
+/* `.stream-card` stays mounted from first event through the end of the
+   turn. On done (`.closed`) the pulse stops and the status label flips
+   to "done" — everything else (activity log, response text, author
+   header) remains visible so the user can review what was run. */
 .stream-status {
   display: inline-flex;
   align-items: center;
@@ -1328,11 +1326,17 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   border-radius: 50%;
   background: var(--color-accent-amber);
   animation: var(--anim-pulse);
+  transition:
+    background 180ms ease,
+    opacity 180ms ease;
 }
-.stream-card.closing .stream-status .dot {
-  /* Stop pulsing while fading out — the motion competes with the fade. */
+.stream-card.closed .stream-status .dot {
   animation: none;
-  background: var(--color-paper-line);
+  background: var(--color-text-dim);
+  opacity: 0.6;
+}
+.stream-card.closed .stream-status {
+  color: var(--color-text-dim);
 }
 .stream-activity {
   font-size: var(--font-size-sm);

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1302,29 +1302,38 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   text-align: center;
 }
 
+/* StreamCard now renders inside the same .message / role-assistant
+   layout as persisted assistant turns, so the DOM swap at `done` is
+   invisible. The only in-flight affordance is a small status pill
+   (pulsing amber dot + "thinking/writing" label) next to the author.
+   Closing the card fades out over 180ms; a matching setTimeout on the
+   JS side unmounts after the transition. */
 .stream-card {
-  background: var(--color-paper-alt);
-  border: 1px solid var(--color-paper-line);
-  border-left: 3px solid var(--color-accent-amber);
-  border-radius: var(--radius-card);
-  padding: var(--space-4) var(--space-5);
-  margin-bottom: var(--space-6);
+  transition: opacity 180ms ease;
 }
-.stream-card-head {
-  display: flex;
+.stream-card.closing {
+  opacity: 0;
+}
+.stream-status {
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-3);
-  font-size: var(--font-size-base);
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
-  margin-bottom: var(--space-3);
+  margin-left: var(--space-3);
 }
-.stream-card-head .dot {
-  width: 8px; height: 8px;
+.stream-status .dot {
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--color-accent-amber);
   animation: var(--anim-pulse);
 }
-.stream-card-head .author { color: var(--color-accent-coral); font-weight: var(--font-weight-semibold); }
+.stream-card.closing .stream-status .dot {
+  /* Stop pulsing while fading out — the motion competes with the fade. */
+  animation: none;
+  background: var(--color-paper-line);
+}
 .stream-activity {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);


### PR DESCRIPTION
## Summary
Follow-up to #165. Addresses five user-reported lag/jitter symptoms against the chat pipeline, all found and fixed with the GUI running locally.

### 1. Send latency
`start_chat` synchronously ran `rly chat mcp-config` and `rly chat system-prompt` before returning the stream id, blocking the composer IPC ~0.5–1 s. **Moved both into the spawned worker thread** — `startChat` returns instantly after persisting the user message and allocating the stream id. The worker emits `Started` first and only then shells out before spawning claude.

### 2. "Still feels laggy on click"
Composer was awaiting up to three round-trips (maybe-createSession, rewindSnapshot, startChat) before clearing text or showing the user's turn. **Now the composer clears the field synchronously and fires `onOptimisticUserMessage`**; CenterPane appends the user turn to `sessionMessages` immediately. `loadSession` reconciles on refresh.

### 3. Jump on done + 4. Card color flicker + 5. Activity history vanishing
Three symptoms with a shared fix: **the stream card now stays mounted after `done`.** It's wrapped in the same `.message role-assistant` layout as persisted turns, so the visual container is stable from thinking → writing → done. A `closed` flag stops the pulse dot, flips the status label to "done", and auto-expands the activity stack so the user can review what ran. `SessionMessages` dedupes the trailing persisted assistant message when its content matches the closed stream's accum. The card unmounts only on the next user turn.

Also: `ACTIVITY_TOP_N` 3 → 6 (collapsed view shows more), ring-buffer cap 20 → 80 (long multi-tool turns don't drop history).

### 6. Scroll jitter
Every chunk forced `scrollTop = scrollHeight`, a synchronous layout per chunk. **Wrapped the effect in `requestAnimationFrame`** so bursts collapse to one scroll per paint.

### 7. Markdown re-parse every chunk
`renderMarkdown` re-ran react-markdown over the full growing `accum` each chunk — O(n²) over the reply. **Added a `memo`-wrapped `MarkdownBody`** comparing on text + channel identity, and stabilized the `ui` mention context with `useMemo`.

## Test plan
- [x] `cargo test -p relay-gui` — 51/51
- [x] `pnpm test` — 37/37
- [x] `pnpm tsc -b` — clean
- [x] `pnpm dlx prettier --check` — clean
- [x] Manual: send feels instant (text clears on click, user message appears before IPC returns)
- [x] Manual: stream card stays on screen after done with full activity log expanded; dot stops pulsing and label flips to "done"
- [x] Manual: next user turn unmounts the previous card and restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)