### PR TITLE
fix(gui): unlock composer after turn, tighten activity card

### DIFF
--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -61,11 +61,25 @@ export function CenterPane({
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [stream, setStream] = useState<ActiveStream | null>(null);
 
+  // Streams are single-slot in CenterPane but tagged with the channel
+  // they started in. When the user switches channels, the state persists
+  // (so returning to the origin channel still shows the card) but we
+  // hide it from the now-foreground channel. Without this scoping, the
+  // card — and its "streaming" predicate — leaked across channels.
+  const currentStream = stream && channel && stream.channelId === channel.channelId ? stream : null;
+  // A closed stream card is kept mounted so the user can review the
+  // completed turn's activity + response. It is NOT "in flight" though,
+  // so it must not gate the composer's submit button (Composer
+  // disables send while `streaming` is true). `isStreaming` is the
+  // load-bearing predicate for the *current* channel's composer.
+  const isStreaming = !!currentStream && !currentStream.closed;
   // Push streaming presence up to App so the Sidebar's Running row can
-  // show a real count. Single-center-pane app → count is 0 or 1.
+  // show a real count. This reports globally (any channel) because the
+  // sidebar is channel-agnostic — a background stream should still count.
+  const hasLiveStream = !!stream && !stream.closed;
   useEffect(() => {
-    onStreamingChanged?.(stream ? 1 : 0);
-  }, [stream, onStreamingChanged]);
+    onStreamingChanged?.(hasLiveStream ? 1 : 0);
+  }, [hasLiveStream, onStreamingChanged]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [promoteOpen, setPromoteOpen] = useState(false);
   // AL-10: resolve "is there an autonomous session for this channel?" by
@@ -248,8 +262,8 @@ export function CenterPane({
             sessionId={sessionId}
             feed={feed}
             sessionMessages={sessionMessages}
-            stream={stream}
-            streamId={stream?.streamId ?? null}
+            stream={currentStream}
+            streamId={currentStream?.streamId ?? null}
             onToggleStreamExpanded={() =>
               setStream((s) => (s ? { ...s, expanded: !s.expanded } : s))
             }
@@ -262,7 +276,7 @@ export function CenterPane({
             channel={channel}
             sessionId={sessionId}
             activeSession={activeSession}
-            streaming={!!stream}
+            streaming={isStreaming}
             onStartStream={setStream}
             onSessionCreated={onSessionCreated}
             onSlashNew={isDm ? () => setPromoteOpen(true) : undefined}

--- a/gui/src/components/CenterPane.tsx
+++ b/gui/src/components/CenterPane.tsx
@@ -184,9 +184,17 @@ export function CenterPane({
         // are loaded — SessionMessages dedupes the duplicate assistant
         // content when a closed stream is present.
         const { streamId } = event;
+        const errorText = event.kind === "error" ? event.message : undefined;
+        // Mark the stream closed but DON'T auto-expand the activity
+        // stack — auto-expanding caused a visible height pop on done
+        // that registered as a flash. The user can still click "+N
+        // more" to reveal the full log whenever they want. If this was
+        // an error (claude failed to launch, non-zero exit, etc.),
+        // attach the message so StreamCard can render it prominently
+        // instead of showing a misleading "done" with no body.
         setStream((current) =>
           current && current.streamId === streamId
-            ? { ...current, closed: true, expanded: true }
+            ? { ...current, closed: true, error: errorText }
             : current
         );
         onRefresh();
@@ -267,6 +275,18 @@ export function CenterPane({
             onToggleStreamExpanded={() =>
               setStream((s) => (s ? { ...s, expanded: !s.expanded } : s))
             }
+            onStopStream={() => {
+              // Fire-and-forget: the backend's cancel flag truncates
+              // the session log and emits a terminal event, which the
+              // subscriber will flip to `closed`. Don't tear down stream
+              // state here — let the event loop close it so the final
+              // activity line still renders.
+              if (currentStream) {
+                api.cancelChatStream(currentStream.streamId).catch((err) => {
+                  console.warn("[center] cancelChatStream failed", err);
+                });
+              }
+            }}
             onRewound={() => {
               setStream(null);
               onRefresh();
@@ -281,11 +301,11 @@ export function CenterPane({
             onSessionCreated={onSessionCreated}
             onSlashNew={isDm ? () => setPromoteOpen(true) : undefined}
             onOptimisticUserMessage={(content, alias) => {
-              // The real user message gets persisted server-side and
-              // shows up via onRefresh when `done` fires; the optimistic
-              // insert just bridges the perceptual gap between click and
-              // round-trip. `loadSession` is the authority — its re-
-              // render replaces this stub.
+              // Append the user turn to sessionMessages synchronously so
+              // it renders on click, before api.startChat's IPC resolves.
+              // loadSession fires a moment later with the server-
+              // authoritative copy; MarkdownBody memoizes on text so the
+              // body DOM doesn't re-render when the two rows swap.
               setSessionMessages((prev) => [
                 ...prev,
                 {
@@ -296,7 +316,7 @@ export function CenterPane({
                 },
               ]);
               // Also clear any previously settled stream so the new
-              // optimistic turn isn't stacked against a stale card.
+              // turn isn't stacked against a stale card.
               setStream(null);
             }}
           />

--- a/gui/src/components/Composer.tsx
+++ b/gui/src/components/Composer.tsx
@@ -8,6 +8,11 @@ type ActivityEntry = { text: string; ts: number };
 
 export type ActiveStream = {
   streamId: number;
+  // The channel the turn was submitted from. CenterPane gates the card's
+  // render + "am I streaming" predicate on this matching the currently
+  // open channel — otherwise a stream started in channel A would leak
+  // into channel B's view when the user switches.
+  channelId: string;
   alias: string | null;
   accum: string;
   activity: ActivityEntry[];
@@ -218,6 +223,7 @@ export function Composer({
       });
       onStartStream({
         streamId,
+        channelId: channel.channelId,
         alias: target || null,
         accum: "",
         activity: [],

--- a/gui/src/components/Composer.tsx
+++ b/gui/src/components/Composer.tsx
@@ -24,6 +24,11 @@ export type ActiveStream = {
   // when the user switches channels. `closed` drives the pulse-dot
   // going static and the status label flipping to "done".
   closed?: boolean;
+  // When the turn terminated via an `error` event rather than `done`,
+  // we render the error text prominently so the user sees the real
+  // failure (e.g. "claude not found in PATH") instead of a misleading
+  // "done" state with no response body.
+  error?: string;
 };
 
 export type StreamDispatch = (s: ActiveStream | null) => void;

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -7,10 +7,10 @@ import { agentAvatar } from "../lib/agents";
 import { useAppearance } from "../lib/appearance";
 import type { ActiveStream } from "./Composer";
 
-// Collapsed stream card shows the last 6 activity lines by default — 3
-// was too narrow and the user lost visibility into what the agent ran.
-// Expand (and keeping the card mounted post-done) reveals the full list.
-const ACTIVITY_TOP_N = 6;
+// Collapsed stream card shows the 3 most recent activity lines. Enough
+// to signal liveness without dominating the chat surface; the user can
+// expand or keep the card mounted post-done to review the full run.
+const ACTIVITY_TOP_N = 3;
 
 /**
  * Memoized markdown body. `renderMarkdown` runs react-markdown + remark-gfm
@@ -80,7 +80,7 @@ export function MessageList({
           channel={channel}
           sessionId={sessionId}
           messages={sessionMessages}
-          streaming={!!stream}
+          streaming={!!stream && !stream.closed}
           streamId={streamId}
           closedStreamAccum={stream?.closed ? stream.accum : null}
           onRewound={onRewound}

--- a/gui/src/components/MessageList.tsx
+++ b/gui/src/components/MessageList.tsx
@@ -34,6 +34,7 @@ type Props = {
   stream: ActiveStream | null;
   streamId: number | null;
   onToggleStreamExpanded: () => void;
+  onStopStream: () => void;
   onRewound: () => void;
 };
 
@@ -45,6 +46,7 @@ export function MessageList({
   stream,
   streamId,
   onToggleStreamExpanded,
+  onStopStream,
   onRewound,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -57,7 +59,10 @@ export function MessageList({
   // implementation forced a layout (scrollTop = scrollHeight) on every
   // chunk; on a fast-streaming reply that fires ~30x/sec and each write
   // triggers a synchronous layout, which the user perceives as jitter.
-  // rAF collapses bursts to one scroll per paint.
+  // rAF collapses bursts to one scroll per paint. Also depends on
+  // stream.activity.length so each new ⚙ line during the tool-use phase
+  // pulls the viewport down — otherwise activity renders below the
+  // fold and the user has to manually chase it.
   const pendingScroll = useRef(false);
   useEffect(() => {
     if (pendingScroll.current) return;
@@ -71,7 +76,15 @@ export function MessageList({
       cancelAnimationFrame(raf);
       pendingScroll.current = false;
     };
-  }, [sessionMessages.length, feed.length, sessionId, stream?.accum.length]);
+  }, [
+    sessionMessages.length,
+    feed.length,
+    sessionId,
+    stream?.accum.length,
+    stream?.activity.length,
+    stream?.streamId,
+    stream?.closed,
+  ]);
 
   return (
     <div className="chat-scroll" ref={scrollRef}>
@@ -89,7 +102,12 @@ export function MessageList({
         <FeedView entries={feed} channel={ui} />
       )}
       {stream && (
-        <StreamCard stream={stream} channel={ui} onToggleExpanded={onToggleStreamExpanded} />
+        <StreamCard
+          stream={stream}
+          channel={ui}
+          onToggleExpanded={onToggleStreamExpanded}
+          onStop={onStopStream}
+        />
       )}
     </div>
   );
@@ -404,10 +422,15 @@ function StreamCard({
   stream,
   channel,
   onToggleExpanded,
+  onStop,
 }: {
   stream: ActiveStream;
   channel: MentionContext;
   onToggleExpanded: () => void;
+  // Fires when the user clicks Stop on a live (non-closed) card. The
+  // card doesn't manage its own dismissal — the parent runs cancel,
+  // backend emits `done`/`error`, and the subscriber flips `closed`.
+  onStop: () => void;
 }) {
   const total = stream.activity.length;
   const visibleCount = stream.expanded ? total : Math.min(ACTIVITY_TOP_N, total);
@@ -421,9 +444,23 @@ function StreamCard({
   // visible change is "dot pulsing → static" and the status label text.
   // The card stays mounted post-done so the activity log remains
   // reviewable; it unmounts only when the next user turn starts.
-  const statusLabel = stream.closed ? "done" : stream.accum ? "writing response" : "thinking";
+  // "done" (normal close), "failed" (error event), "writing response"
+  // (streaming chunks), "thinking" (no accum yet). The failed label
+  // reads with the error body rendered below so the user sees the
+  // real diagnostic instead of a misleading success state.
+  const statusLabel = stream.error
+    ? "failed"
+    : stream.closed
+      ? "done"
+      : stream.accum
+        ? "writing response"
+        : "thinking";
   return (
-    <div className={`message role-assistant stream-card ${stream.closed ? "closed" : ""}`}>
+    <div
+      className={`message role-assistant stream-card ${stream.closed ? "closed" : ""} ${
+        stream.error ? "errored" : ""
+      }`}
+    >
       <MsgAvatar seed={authorKey} />
       <div>
         <div className="msg-head">
@@ -437,6 +474,17 @@ function StreamCard({
               {total > 0 ? ` · ${total} action${total === 1 ? "" : "s"}` : ""}
             </span>
           </span>
+          {!stream.closed && (
+            <button
+              type="button"
+              className="stream-stop-btn"
+              onClick={onStop}
+              title="Stop this turn"
+              aria-label="Stop"
+            >
+              ⏹ Stop
+            </button>
+          )}
         </div>
         <div className={`stream-activity ${stream.expanded ? "expanded" : ""}`}>
           {visible.map((entry, i) => {
@@ -466,6 +514,11 @@ function StreamCard({
         {stream.accum && (
           <div className="msg-body">
             <MarkdownBody text={stream.accum} channel={channel} />
+          </div>
+        )}
+        {stream.error && (
+          <div className="stream-error" role="alert">
+            <strong>Error:</strong> {stream.error}
           </div>
         )}
       </div>

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1393,17 +1393,66 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   border-radius: 50%;
   background: var(--color-accent-amber);
   animation: var(--anim-pulse);
+  /* Slower ease-out so the active → closed shift reads as the dot
+     settling rather than a binary flash. */
   transition:
-    background 180ms ease,
-    opacity 180ms ease;
+    background 420ms ease-out,
+    opacity 420ms ease-out;
 }
 .stream-card.closed .stream-status .dot {
   animation: none;
   background: var(--color-text-dim);
-  opacity: 0.6;
+  opacity: 0.5;
 }
 .stream-card.closed .stream-status {
   color: var(--color-text-dim);
+  transition: color 420ms ease-out;
+}
+.stream-card.errored .stream-status .dot {
+  background: var(--color-accent-coral);
+  opacity: 1;
+  animation: none;
+}
+.stream-card.errored .stream-status {
+  color: var(--color-accent-coral);
+}
+.stream-error {
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in srgb, var(--color-accent-coral) 8%, transparent);
+  border-left: 3px solid var(--color-accent-coral);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.stream-error strong {
+  color: var(--color-accent-coral);
+  margin-right: var(--space-2);
+}
+/* Inline stop control in the stream card's head row. Muted-coral so it
+   reads as a destructive-but-routine affordance (distinct from the
+   coral "Warning" treatment used in modals). Only rendered while the
+   turn is live — on `.closed` the card no longer mounts it. */
+.stream-stop-btn {
+  margin-left: var(--space-3);
+  padding: 2px var(--space-2);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-sans);
+  color: var(--color-accent-coral);
+  background: transparent;
+  border: 1px solid var(--color-accent-coral);
+  border-radius: 3px;
+  cursor: pointer;
+  line-height: 1.4;
+}
+.stream-stop-btn:hover {
+  background: var(--color-accent-coral-soft);
+}
+.stream-stop-btn:active {
+  transform: translateY(1px);
 }
 .stream-activity {
   font-size: var(--font-size-sm);

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1411,14 +1411,30 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   font-family: var(--font-mono);
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--space-2);
 }
-.stream-activity.expanded { max-height: 220px; overflow-y: auto; }
+/* Expanded view raises the scroll cap and keeps the same gap as
+   collapsed so each entry reads as its own line. */
+.stream-activity.expanded {
+  max-height: 360px;
+  overflow-y: auto;
+}
 .stream-activity-line {
-  display: flex; gap: var(--space-3);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  display: flex;
+  gap: var(--space-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* Preserve per-line height so long activity logs are readable —
+     without these, flex children with nowrap text can collapse to the
+     ascender-only height and lines visually merge. */
+  line-height: 1.5;
+  min-height: 1.5em;
+  align-items: baseline;
 }
-.stream-activity-line.newest { color: var(--color-text-primary); }
+.stream-activity-line.newest {
+  color: var(--color-text-primary);
+}
 .stream-activity-more {
   margin-top: var(--space-2);
   background: transparent;


### PR DESCRIPTION
## Summary
Follow-ups from live testing of #168.

1. **Composer stayed disabled after done.** `streaming={!!stream}` was true for as long as the card was mounted — and we now keep the card mounted post-done to preserve the activity log. Introduced `isStreaming = !!stream && !stream.closed` and made it the predicate for both the composer's disabled state and the sidebar's Running count.

2. **Channel-scope streams.** Tag each `ActiveStream` with the `channelId` it was started from; `CenterPane` only renders the card and treats the stream as "streaming" when its `channelId` matches the current channel. Prior to this a background stream leaked its state into other channels' composers.

3. **Collapsed activity view smaller.** `ACTIVITY_TOP_N` 6 → 3 so the card keeps a small footprint during the turn. Expand still reveals the full log.

4. **Activity-line readability.** Each `.stream-activity-line` gets explicit `line-height: 1.5` + `min-height: 1.5em`; raised expanded `max-height` 220 → 360 and bumped the inter-line gap. Long multi-tool turns no longer squash entries together.

## Test plan
- [x] `pnpm tsc -b` clean
- [x] `pnpm dlx prettier --check` clean
- [ ] Manual: send a message, stream completes, composer unlocks and next send works
- [ ] Manual: collapsed activity shows 3 lines max; expand shows the full log with readable spacing
- [ ] Manual: switch channels mid-stream → background card doesn't bleed into the foreground channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)