### PR TITLE
feat(gui): agent binary resolution v2 — generalized resolver + settings pin

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -527,6 +527,15 @@ impl Default for TicketProvider {
 pub const POLL_SECONDS_MIN: u32 = 10;
 pub const POLL_SECONDS_MAX: u32 = 3600;
 
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentBinaryPaths {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rly: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GuiSettings {
@@ -540,6 +549,12 @@ pub struct GuiSettings {
     pub linear_poll_seconds: u32,
     #[serde(default = "default_right_rail_open")]
     pub right_rail_open: bool,
+    /// User-pinned absolute paths for agent CLIs. When set, these win
+    /// over env var overrides and auto-detection — the escape hatch for
+    /// users whose binaries live in non-standard locations. Missing
+    /// entries fall through to env vars / PATH / candidate probes.
+    #[serde(default)]
+    pub agent_binaries: AgentBinaryPaths,
 }
 
 impl Default for GuiSettings {
@@ -550,6 +565,7 @@ impl Default for GuiSettings {
             linear_workspace: String::new(),
             linear_poll_seconds: default_poll_interval(),
             right_rail_open: default_right_rail_open(),
+            agent_binaries: AgentBinaryPaths::default(),
         }
     }
 }
@@ -1858,6 +1874,7 @@ mod tests {
             linear_workspace: "acme".to_string(),
             linear_poll_seconds: 45,
             right_rail_open: false,
+            agent_binaries: AgentBinaryPaths::default(),
         };
         save_gui_settings(&s).expect("save ok");
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -358,6 +358,13 @@ struct AgentBinarySpec {
 ///      layouts (pnpm global, homebrew, cmux's bundled wrapper, npm
 ///      global, cargo bin, user-local bin).
 ///
+/// Each candidate must pass an `is_file` check — an invalid pinned path
+/// or a stale env var silently falls through to the next resolver
+/// rather than hard-failing. The Settings → Agent CLIs **Test** button
+/// is the discoverability mechanism for "my pin is wrong"; hard-
+/// failing here would mask the user's env var / candidate fallbacks
+/// when a saved pin later breaks (e.g. brew reinstall).
+///
 /// Returns `None` when nothing resolves; callers decide whether to
 /// fall back to the bare name or surface an error.
 fn resolve_agent_bin(spec: &AgentBinarySpec, pinned: Option<&str>) -> Option<String> {

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -333,54 +333,103 @@ struct CliResult {
     code: Option<i32>,
 }
 
-/// Resolve the `rly` binary to an absolute path.
-///
-/// When the GUI is launched from Finder/Launchpad on macOS, it inherits
-/// launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — shell init
-/// files never run, so per-user install dirs (pnpm global, homebrew,
-/// npm-global, cargo, ~/.local/bin) aren't visible. A bare
-/// `Command::new("rly")` then fails ENOENT even though `rly` is installed.
-///
-/// Resolution order:
-///   1. `$RELAY_BIN` — explicit override, always wins.
-///   2. `$PATH` — works for terminal-launched sessions.
-///   3. Candidate user-local install dirs — covers Finder launches.
-///
-/// Resolved once per process (the CLI location doesn't change under us).
-fn resolve_rly_bin() -> String {
-    static RESOLVED: OnceLock<String> = OnceLock::new();
-    RESOLVED
-        .get_or_init(|| {
-            if let Ok(v) = std::env::var("RELAY_BIN") {
-                if !v.is_empty() {
-                    return v;
-                }
-            }
-            if let Some(p) = find_on_path("rly") {
-                return p;
-            }
-            let home = std::env::var("HOME").unwrap_or_default();
-            let candidates = [
-                format!("{home}/Library/pnpm/rly"),      // pnpm global, macOS
-                format!("{home}/.local/share/pnpm/rly"), // pnpm global, linux
-                "/opt/homebrew/bin/rly".to_string(),     // homebrew, apple silicon
-                "/usr/local/bin/rly".to_string(),        // homebrew intel + /usr/local
-                format!("{home}/.npm-global/bin/rly"),
-                format!("{home}/.local/bin/rly"),
-                format!("{home}/.cargo/bin/rly"),
-            ];
-            for c in &candidates {
-                if std::path::Path::new(c).is_file() {
-                    return c.clone();
-                }
-            }
-            // Nothing found — return the bare name so Command::new produces
-            // the ENOENT and cli_json wraps it with the full args for context.
-            "rly".to_string()
-        })
-        .clone()
+/// Describes how to find one agent CLI binary. One spec per provider
+/// (rly, claude, …) — adding a new provider is a single `const`.
+struct AgentBinarySpec {
+    /// Bare filename on PATH (`rly`, `claude`).
+    name: &'static str,
+    /// Env var that, when set and pointing at an existing file, wins
+    /// over auto-detection. Mirrors `$CLAUDE_BIN` / `$RELAY_BIN` UX.
+    env_override: &'static str,
+    /// Fallback paths probed after PATH lookup. Absolute literals stay
+    /// as-is; relative entries are joined to `$HOME`.
+    candidates: &'static [&'static str],
 }
 
+/// Resolve an agent binary to an absolute path.
+///
+/// Order (highest priority first):
+///   1. `pinned` — path pinned by the user in GUI settings.
+///   2. `spec.env_override` — legacy env var override (`$CLAUDE_BIN` etc.).
+///   3. Augmented PATH lookup — works for terminal launches and, with
+///      the shell-sourced PATH from [`resolve_shell_path`], for GUI
+///      launches too.
+///   4. `spec.candidates` — final fallback covering common install
+///      layouts (pnpm global, homebrew, cmux's bundled wrapper, npm
+///      global, cargo bin, user-local bin).
+///
+/// Returns `None` when nothing resolves; callers decide whether to
+/// fall back to the bare name or surface an error.
+fn resolve_agent_bin(spec: &AgentBinarySpec, pinned: Option<&str>) -> Option<String> {
+    if let Some(p) = pinned {
+        let p = p.trim();
+        if !p.is_empty() && PathBuf::from(p).is_file() {
+            return Some(p.to_string());
+        }
+    }
+    if let Ok(v) = std::env::var(spec.env_override) {
+        let v = v.trim().to_string();
+        if !v.is_empty() && PathBuf::from(&v).is_file() {
+            return Some(v);
+        }
+    }
+    let augmented = augmented_child_path();
+    for dir in std::env::split_paths(&augmented) {
+        let candidate = dir.join(spec.name);
+        if candidate.is_file() {
+            return Some(candidate.to_string_lossy().into_owned());
+        }
+    }
+    let home = std::env::var("HOME").unwrap_or_default();
+    for rel in spec.candidates {
+        let path = if rel.starts_with('/') {
+            PathBuf::from(*rel)
+        } else {
+            PathBuf::from(&home).join(rel)
+        };
+        if path.is_file() {
+            return Some(path.to_string_lossy().into_owned());
+        }
+    }
+    None
+}
+
+const RLY_SPEC: AgentBinarySpec = AgentBinarySpec {
+    name: "rly",
+    env_override: "RELAY_BIN",
+    candidates: &[
+        "Library/pnpm/rly",
+        ".local/share/pnpm/rly",
+        "/opt/homebrew/bin/rly",
+        "/usr/local/bin/rly",
+        ".npm-global/bin/rly",
+        ".local/bin/rly",
+        ".cargo/bin/rly",
+    ],
+};
+
+const CLAUDE_SPEC: AgentBinarySpec = AgentBinarySpec {
+    name: "claude",
+    env_override: "CLAUDE_BIN",
+    candidates: &[
+        ".claude/local/claude",
+        "/Applications/cmux.app/Contents/Resources/bin/claude",
+        "/opt/homebrew/bin/claude",
+        "/usr/local/bin/claude",
+        ".npm-global/bin/claude",
+        ".local/bin/claude",
+    ],
+};
+
+fn agent_spec_for(kind: &str) -> Option<&'static AgentBinarySpec> {
+    match kind {
+        "rly" => Some(&RLY_SPEC),
+        "claude" => Some(&CLAUDE_SPEC),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)] // exercised by tests; kept as a utility
 fn find_on_path(name: &str) -> Option<String> {
     let path = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&path) {
@@ -510,23 +559,25 @@ enum RlyInvocation {
     Shim(String),
 }
 
-fn resolve_rly_invocation() -> RlyInvocation {
-    static RESOLVED: OnceLock<RlyInvocation> = OnceLock::new();
-    RESOLVED
-        .get_or_init(|| {
-            let shim = resolve_rly_bin();
-            if let Some(mjs) = extract_rly_mjs_from_shim(&shim) {
-                if let Some(node) = resolve_node_bin() {
-                    return RlyInvocation::Direct { node, mjs };
-                }
-            }
-            RlyInvocation::Shim(shim)
-        })
-        .clone()
+/// Resolve the current invocation strategy given the settings snapshot.
+///
+/// Intentionally not cached — `cli_run` is called outside any hot loop
+/// and the user's pinned path in settings needs to take effect the next
+/// time they dispatch, without a restart. The cost is a handful of
+/// `is_file` probes.
+fn resolve_rly_invocation(settings: &data::GuiSettings) -> RlyInvocation {
+    let shim = resolve_agent_bin(&RLY_SPEC, settings.agent_binaries.rly.as_deref())
+        .unwrap_or_else(|| "rly".to_string());
+    if let Some(mjs) = extract_rly_mjs_from_shim(&shim) {
+        if let Some(node) = resolve_node_bin() {
+            return RlyInvocation::Direct { node, mjs };
+        }
+    }
+    RlyInvocation::Shim(shim)
 }
 
-fn rly_command() -> Command {
-    match resolve_rly_invocation() {
+fn rly_command(settings: &data::GuiSettings) -> Command {
+    match resolve_rly_invocation(settings) {
         RlyInvocation::Direct { node, mjs } => {
             let mut cmd = Command::new(node);
             cmd.arg(mjs);
@@ -538,8 +589,8 @@ fn rly_command() -> Command {
 
 /// Human-readable description of the current invocation. Used only in
 /// error messages so the user can tell which resolution branch we took.
-fn rly_invocation_debug() -> String {
-    match resolve_rly_invocation() {
+fn rly_invocation_debug(settings: &data::GuiSettings) -> String {
+    match resolve_rly_invocation(settings) {
         RlyInvocation::Direct { node, mjs } => format!("direct: {node} {mjs}"),
         RlyInvocation::Shim(p) => format!("shim: {p}"),
     }
@@ -698,8 +749,11 @@ fn cli_run(args: &[&str]) -> CliResult {
     // on macOS Finder launches, nvm upgrades, and pnpm reinstalls. The
     // augmented PATH is still set for the direct path as defense in
     // depth: any child the mjs spawns (git, for instance) should see
-    // the same sensible PATH a terminal would give it.
-    match rly_command()
+    // the same sensible PATH a terminal would give it. Settings are
+    // read per-call so a user pinning a path in GUI settings takes
+    // effect on the next command without a restart.
+    let settings = data::load_gui_settings();
+    match rly_command(&settings)
         .args(args)
         .env("PATH", augmented_child_path())
         .stdout(Stdio::piped())
@@ -728,12 +782,14 @@ fn cli_json(args: &[&str]) -> Result<serde_json::Value, String> {
         // child never ran. Augment with the resolved path and the
         // RELAY_BIN override so the user has an actionable message.
         if result.code.is_none() {
+            let settings = data::load_gui_settings();
             return Err(format!(
                 "rly {} failed to launch: {} ({}). \
-                 Set RELAY_BIN / RELAY_NODE or install rly on PATH.",
+                 Pin a path in Settings → Agent CLIs, set RELAY_BIN / RELAY_NODE, \
+                 or install rly on PATH.",
                 args.join(" "),
                 result.stderr.trim(),
-                rly_invocation_debug()
+                rly_invocation_debug(&settings)
             ));
         }
         return Err(format!(
@@ -1239,6 +1295,92 @@ fn update_settings(settings: data::GuiSettings) -> Result<(), String> {
     data::save_gui_settings(&settings)
 }
 
+/// Run the full resolver for a given agent kind *without* applying any
+/// user pin, so the GUI can show "here's what we'd pick if you left
+/// this blank" next to the pin input.
+#[tauri::command]
+fn auto_detect_agent_binary(kind: String) -> Option<String> {
+    let spec = agent_spec_for(&kind)?;
+    resolve_agent_bin(spec, None)
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentBinaryTestResult {
+    success: bool,
+    /// Stdout from `{path} --version`, trimmed. Shown to the user as
+    /// confirmation that the binary works.
+    output: String,
+    /// Non-empty when the test failed — surfaces the spawn error or
+    /// stderr tail so the user can see *why*.
+    error: Option<String>,
+}
+
+/// Run `{path} --version` against a candidate agent binary with a
+/// short timeout, so the user can validate their pinned path before
+/// committing to it. Uses the augmented PATH so the binary's own
+/// child lookups (e.g. the `claude` wrapper's real-claude search)
+/// don't fail for environmental reasons.
+#[tauri::command]
+fn test_agent_binary(path: String) -> AgentBinaryTestResult {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return AgentBinaryTestResult {
+            success: false,
+            output: String::new(),
+            error: Some("Path is empty.".to_string()),
+        };
+    }
+    if !PathBuf::from(trimmed).is_file() {
+        return AgentBinaryTestResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("No file at {trimmed}")),
+        };
+    }
+    use std::sync::mpsc;
+    let (tx, rx) = mpsc::channel();
+    let path_owned = trimmed.to_string();
+    std::thread::spawn(move || {
+        let out = Command::new(&path_owned)
+            .arg("--version")
+            .env("PATH", augmented_child_path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        let _ = tx.send(out);
+    });
+    match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(Ok(out)) if out.status.success() => AgentBinaryTestResult {
+            success: true,
+            output: String::from_utf8_lossy(&out.stdout).trim().to_string(),
+            error: None,
+        },
+        Ok(Ok(out)) => AgentBinaryTestResult {
+            success: false,
+            output: String::from_utf8_lossy(&out.stdout).trim().to_string(),
+            error: Some(
+                String::from_utf8_lossy(&out.stderr)
+                    .trim()
+                    .chars()
+                    .take(500)
+                    .collect(),
+            ),
+        },
+        Ok(Err(e)) => AgentBinaryTestResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("Spawn failed: {e}")),
+        },
+        Err(_) => AgentBinaryTestResult {
+            success: false,
+            output: String::new(),
+            error: Some("Timed out after 5s.".to_string()),
+        },
+    }
+}
+
 #[tauri::command]
 fn set_primary_repo(channel_id: String, workspace_id: String) -> Result<(), String> {
     validate_id_segment(&channel_id, "channelId")?;
@@ -1618,7 +1760,17 @@ fn start_chat(
                 .and_then(|v| v.get("prompt").and_then(|p| p.as_str().map(String::from)))
         };
 
-        let claude_bin = std::env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
+        // Resolve claude the same way we resolve rly: settings pin →
+        // $CLAUDE_BIN → augmented PATH → candidate dirs (covers cmux's
+        // bundled wrapper at /Applications/cmux.app/…, .claude/local,
+        // homebrew, npm global). Lets a user point at a specific
+        // install without hunting PATH.
+        let gui_settings = data::load_gui_settings();
+        let claude_bin = resolve_agent_bin(
+            &CLAUDE_SPEC,
+            gui_settings.agent_binaries.claude.as_deref(),
+        )
+        .unwrap_or_else(|| "claude".to_string());
         let mut args: Vec<String> = vec![
             "-p".into(),
             "--output-format".into(),
@@ -1659,7 +1811,9 @@ fn start_chat(
                     ChatEvent::Error {
                         stream_id,
                         message: format!(
-                            "Failed to launch claude: {}. Set CLAUDE_BIN if claude is not on PATH.",
+                            "Failed to launch claude ({claude_bin}): {}. \
+                             Pin a path in Settings → Agent CLIs, set CLAUDE_BIN, \
+                             or install claude on PATH.",
                             e
                         ),
                     },
@@ -3684,6 +3838,8 @@ pub fn run() {
             set_primary_repo,
             get_settings,
             update_settings,
+            auto_detect_agent_binary,
+            test_agent_binary,
             post_to_channel,
             create_session,
             delete_session,

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -83,6 +83,7 @@ export function App() {
           linearWorkspace: "",
           linearPollSeconds: 30,
           rightRailOpen: true,
+          agentBinaries: {},
         });
       });
   }, []);

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
+  AgentBinaryTestResult,
   AgentNameEntry,
   ApprovalQueueRecord,
   AutonomousSessionState,
@@ -115,6 +116,9 @@ export const api = {
     invoke<void>("set_primary_repo", { channelId, workspaceId }),
   getSettings: () => invoke<GuiSettings>("get_settings"),
   updateSettings: (settings: GuiSettings) => invoke<void>("update_settings", { settings }),
+  autoDetectAgentBinary: (kind: "rly" | "claude") =>
+    invoke<string | null>("auto_detect_agent_binary", { kind }),
+  testAgentBinary: (path: string) => invoke<AgentBinaryTestResult>("test_agent_binary", { path }),
   postToChannel: (channelId: string, content: string, from?: string, entryType?: string) =>
     invoke<unknown>("post_to_channel", {
       channelId,

--- a/gui/src/components/SettingsPage.tsx
+++ b/gui/src/components/SettingsPage.tsx
@@ -369,7 +369,7 @@ function AgentCliRow({
           )}
         </span>
       </div>
-      <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+      <div style={{ display: "flex", gap: 8, marginTop: 12, alignItems: "center" }}>
         <button
           type="button"
           onClick={() => onSave(local)}
@@ -379,19 +379,22 @@ function AgentCliRow({
           {saving ? "Saving…" : "Save"}
         </button>
         <button type="button" onClick={runTest} disabled={testing}>
-          {testing ? "Testing…" : "Test"}
+          {testing ? "Testing…" : local.trim() ? "Test" : detected ? "Test auto-detected" : "Test"}
         </button>
-        {value && (
+        {(value || local) && (
           <button
             type="button"
             className="danger"
             onClick={() => {
               setLocal("");
-              onSave("");
+              // Only round-trip through save when there was a saved pin
+              // to clear; clearing a dirty-but-unsaved input is a pure
+              // local reset.
+              if (value) onSave("");
             }}
             disabled={saving}
           >
-            Clear pin
+            {value ? "Clear pin" : "Reset"}
           </button>
         )}
         <span style={{ color: "var(--color-text-dim)", fontSize: "var(--font-size-xs)" }}>

--- a/gui/src/components/SettingsPage.tsx
+++ b/gui/src/components/SettingsPage.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
-import type { GuiSettings, ProviderProfile } from "../types";
+import type { AgentBinaryTestResult, GuiSettings, ProviderProfile } from "../types";
 import { useAppearance, type AvatarStyle, type Density } from "../lib/appearance";
 
-type Section = "ticketing" | "providers" | "appearance" | "general";
+type Section = "ticketing" | "providers" | "agent-clis" | "appearance" | "general";
 
 type Props = {
   settings: GuiSettings;
@@ -48,6 +48,12 @@ export function SettingsPage({ settings, onSaved, onClose }: Props) {
           Providers
         </button>
         <button
+          className={`settings-nav-item ${section === "agent-clis" ? "active" : ""}`}
+          onClick={() => setSection("agent-clis")}
+        >
+          Agent CLIs
+        </button>
+        <button
           className={`settings-nav-item ${section === "appearance" ? "active" : ""}`}
           onClick={() => setSection("appearance")}
         >
@@ -68,6 +74,9 @@ export function SettingsPage({ settings, onSaved, onClose }: Props) {
           <TicketingSection draft={draft} onChange={save} saving={saving} error={error} />
         )}
         {section === "providers" && <ProvidersSection />}
+        {section === "agent-clis" && (
+          <AgentCliSection draft={draft} onChange={save} saving={saving} error={error} />
+        )}
         {section === "appearance" && <AppearanceSection />}
         {section === "general" && <GeneralSection />}
       </div>
@@ -192,6 +201,225 @@ function GeneralSection() {
         </p>
       </div>
     </>
+  );
+}
+
+type AgentKind = "rly" | "claude";
+
+/**
+ * Pinned-path override for each agent CLI. Relay ships with
+ * auto-detection that walks PATH + known install locations, but it
+ * misses unusual setups (custom brew prefix, mise, corporate /opt
+ * installs, portable builds). This section lets the user pin an
+ * absolute path that takes priority over detection — the escape hatch
+ * for "I know where my binary is, stop guessing."
+ *
+ * Precedence mirrored in `resolve_agent_bin` on the Rust side:
+ *   settings pin → env var → PATH → candidate dirs.
+ */
+function AgentCliSection({
+  draft,
+  onChange,
+  saving,
+  error,
+}: {
+  draft: GuiSettings;
+  onChange: (next: GuiSettings) => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const agents: Array<{ key: AgentKind; label: string; envVar: string; description: string }> = [
+    {
+      key: "rly",
+      label: "Relay CLI (rly)",
+      envVar: "RELAY_BIN",
+      description: "The Relay command-line tool. Required for every dispatch.",
+    },
+    {
+      key: "claude",
+      label: "Claude CLI",
+      envVar: "CLAUDE_BIN",
+      description: "Anthropic's Claude Code CLI. Used by the Claude adapter.",
+    },
+  ];
+
+  return (
+    <>
+      <h2>Agent CLIs</h2>
+      <p className="help">
+        Relay auto-detects each CLI on launch (PATH, then common install dirs). Pin an absolute path
+        here when auto-detection misses your install — pins take priority over <code>$PATH</code>
+        and environment overrides, and changes take effect on the next command without a restart.
+      </p>
+      {agents.map((agent) => (
+        <AgentCliRow
+          key={agent.key}
+          agent={agent}
+          value={draft.agentBinaries[agent.key] ?? ""}
+          onSave={(next) =>
+            onChange({
+              ...draft,
+              agentBinaries: {
+                ...draft.agentBinaries,
+                [agent.key]: next.trim() || undefined,
+              },
+            })
+          }
+          saving={saving}
+        />
+      ))}
+      {error && <div className="error">{error}</div>}
+    </>
+  );
+}
+
+function AgentCliRow({
+  agent,
+  value,
+  onSave,
+  saving,
+}: {
+  agent: { key: AgentKind; label: string; envVar: string; description: string };
+  value: string;
+  onSave: (next: string) => void;
+  saving: boolean;
+}) {
+  const [local, setLocal] = useState(value);
+  const [detected, setDetected] = useState<string | null | undefined>(undefined);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<AgentBinaryTestResult | null>(null);
+
+  useEffect(() => {
+    // Re-sync local input when the parent's saved value changes (e.g.
+    // after a save round-trip). Avoid clobbering the user's in-flight
+    // edits by only syncing on true parent-value changes.
+    setLocal(value);
+  }, [value]);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .autoDetectAgentBinary(agent.key)
+      .then((p) => {
+        if (!cancelled) setDetected(p);
+      })
+      .catch(() => {
+        if (!cancelled) setDetected(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent.key]);
+
+  const dirty = local.trim() !== (value ?? "").trim();
+
+  const runTest = async () => {
+    const target = local.trim() || detected || "";
+    if (!target) {
+      setTestResult({
+        success: false,
+        output: "",
+        error: "No path to test — enter one or wait for auto-detect.",
+      });
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await api.testAgentBinary(target);
+      setTestResult(result);
+    } catch (err) {
+      setTestResult({ success: false, output: "", error: String(err) });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="settings-section">
+      <h3>{agent.label}</h3>
+      <p className="help">{agent.description}</p>
+      <label>
+        Pinned path (optional)
+        <input
+          value={local}
+          onChange={(e) => setLocal(e.target.value)}
+          placeholder={detected ?? `/path/to/${agent.key}`}
+          style={{ fontFamily: "var(--font-mono)" }}
+        />
+      </label>
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          marginTop: 8,
+          fontSize: "var(--font-size-sm)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        <span>
+          Auto-detected:{" "}
+          {detected === undefined ? (
+            <em>checking…</em>
+          ) : detected === null ? (
+            <em>not found</em>
+          ) : (
+            <code>{detected}</code>
+          )}
+        </span>
+      </div>
+      <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+        <button
+          type="button"
+          onClick={() => onSave(local)}
+          disabled={saving || !dirty}
+          className="primary"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button type="button" onClick={runTest} disabled={testing}>
+          {testing ? "Testing…" : "Test"}
+        </button>
+        {value && (
+          <button
+            type="button"
+            className="danger"
+            onClick={() => {
+              setLocal("");
+              onSave("");
+            }}
+            disabled={saving}
+          >
+            Clear pin
+          </button>
+        )}
+        <span style={{ color: "var(--color-text-dim)", fontSize: "var(--font-size-xs)" }}>
+          Env var: <code>{agent.envVar}</code>
+        </span>
+      </div>
+      {testResult && (
+        <div
+          className={testResult.success ? "" : "error"}
+          style={{
+            marginTop: 12,
+            padding: 8,
+            background: testResult.success
+              ? "var(--color-accent-mint-soft, var(--color-paper-alt))"
+              : undefined,
+            borderRadius: 4,
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--font-size-xs)",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {testResult.success
+            ? `✓ ${testResult.output || "ok"}`
+            : `✗ ${testResult.error ?? "failed"}`}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -33,12 +33,24 @@ export type ChannelTier = "feature_large" | "feature" | "bugfix" | "chore" | "qu
 // equivalent to `none` at the UI layer.
 export type TicketProvider = "relay" | "linear" | "none" | "unknown";
 
+export type AgentBinaryPaths = {
+  rly?: string;
+  claude?: string;
+};
+
 export type GuiSettings = {
   ticketProvider: TicketProvider;
   linearApiToken: string;
   linearWorkspace: string;
   linearPollSeconds: number;
   rightRailOpen: boolean;
+  agentBinaries: AgentBinaryPaths;
+};
+
+export type AgentBinaryTestResult = {
+  success: boolean;
+  output: string;
+  error: string | null;
 };
 
 export type Channel = {


### PR DESCRIPTION
Closes #170.

## Summary

- Every provider we add (rly today, claude today, codex tomorrow) had its own install-location zoo. This PR collapses resolution to one spec-driven resolver and adds a user-facing pin in Settings so non-standard installs are a one-click fix.
- Concretely, fixes the recurring \`claude: not found\` / \`rly: not found\` class of errors without needing another point fix each time.

## What's in this PR

**Layer 2 — generalized resolver** (\`gui/src-tauri/src/lib.rs\`)
- \`AgentBinarySpec { name, env_override, candidates }\` — one \`const\` per provider (\`RLY_SPEC\`, \`CLAUDE_SPEC\`). Adding a provider is a single spec entry.
- \`resolve_agent_bin(spec, pinned)\` handles the uniform order: **settings pin → env override → augmented PATH → candidate dirs → None**.
- Claude now resolves through the same path — candidates include cmux's bundled wrapper (\`/Applications/cmux.app/…\`), \`.claude/local\`, homebrew, npm global, \`.local/bin\`.
- \`resolve_rly_invocation\` no longer caches — pinned-path changes take effect on the next dispatch without a restart. Cost is a few \`is_file\` probes per \`cli_run\`, dwarfed by the subprocess spawn.

**Layer 3 — user-facing override**
- \`GuiSettings.agent_binaries: AgentBinaryPaths { rly, claude }\` — both optional, serde-default so existing \`gui-settings.json\` loads unchanged.
- New IPC commands: \`auto_detect_agent_binary(kind)\` (runs resolver without a pin so UI can show \"here's what we'd pick\") and \`test_agent_binary(path)\` (\`--version\` with 5s timeout, returns stdout / stderr / spawn error).
- New \"Agent CLIs\" section in Settings with one row per provider: pinned-path input, auto-detected path display, Save / Test / Clear buttons, inline test result.

## Compatibility

- All existing env var overrides (\`CLAUDE_BIN\`, \`RELAY_BIN\`, \`RELAY_NODE\`) still honored; deprioritized below the settings pin.
- Existing settings files load without migration.
- Error messages for both rly and claude now say *\"Pin a path in Settings → Agent CLIs, set \$ENV_BIN, or install on PATH\"* so the fix is discoverable from the failure itself.

## Test plan

- [x] cargo lib 51/51
- [x] harness-data tests pass (gui_settings round-trip includes new field)
- [x] gui vitest 37/37
- [x] tsc clean
- [x] prettier clean
- [ ] Rebuild app, launch from Finder, open Settings → Agent CLIs; verify auto-detect populates, Test runs \`--version\`, pin persists
- [ ] Verify existing \`gui-settings.json\` (no \`agentBinaries\` field) still loads on upgrade
- [ ] Verify legacy \`CLAUDE_BIN\` / \`RELAY_BIN\` env vars still work when no pin is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)