### PR TITLE
feat(tracker): v0.2 PR A — GitHub Projects v2 GraphQL client + project resolver

### DIFF
--- a/src/integrations/github-projects/client.ts
+++ b/src/integrations/github-projects/client.ts
@@ -1,0 +1,279 @@
+/**
+ * GitHub Projects v2 GraphQL client. The first slice of the v0.2 tracker
+ * work — owns project resolution (find-or-create by title) and a
+ * read-only inventory of a project's custom fields. Draft-item CRUD and
+ * the Status/Type/Priority bootstrap land in PR B (#181); channel/epic
+ * wiring lands in PR C (#182).
+ *
+ * The client is deliberately framework-free: every call accepts a
+ * `ProjectsClientDeps` bag, so tests inject a stub `fetch` and callers
+ * inject the GitHub token from their own scope (we never read
+ * `process.env.GITHUB_TOKEN` here — see the `passEnv` opt-in in
+ * `src/agents/command-invoker.ts` for the secret-handling contract).
+ */
+
+const GITHUB_API_URL = "https://api.github.com/graphql";
+
+export type GitHubOwnerType = "user" | "organization";
+
+export interface ProjectV2Node {
+  id: string;
+  title: string;
+  number: number;
+  url: string;
+}
+
+export interface ProjectV2FieldNode {
+  id: string;
+  name: string;
+  /** Single-select fields surface their option list; other field kinds omit it. */
+  options?: Array<{ id: string; name: string }>;
+}
+
+export interface ProjectsClientDeps {
+  /** GitHub token with `project` scope (and `read:org` for org-owned projects). */
+  token: string;
+  /** Injectable fetch so tests can stub the network. */
+  fetch?: typeof fetch;
+  /** Override for tests; defaults to the public GraphQL endpoint. */
+  apiUrl?: string;
+}
+
+export interface ProjectOwnerRef {
+  owner: string;
+  ownerType: GitHubOwnerType;
+}
+
+interface GraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string; type?: string; path?: Array<string | number> }>;
+}
+
+/**
+ * Raw GraphQL POST. Throws on network error, non-2xx HTTP, or any
+ * `errors` entry. Callers that want to tolerate a partial response should
+ * wrap this and inspect `error.message` — we deliberately don't paper
+ * over GraphQL errors because the sync worker (PR D) needs to surface
+ * them as channel-feed warnings, not silently drop them.
+ */
+export async function githubProjectsGraphql<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  deps: ProjectsClientDeps
+): Promise<T> {
+  const fetchImpl = deps.fetch ?? fetch;
+  const url = deps.apiUrl ?? GITHUB_API_URL;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${deps.token}`,
+      "User-Agent": "relay-github-projects-client",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub Projects API HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const payload = (await res.json()) as GraphqlResponse<T>;
+  if (payload.errors && payload.errors.length > 0) {
+    throw new Error(`GitHub Projects GraphQL error: ${payload.errors[0].message}`);
+  }
+  if (!payload.data) {
+    throw new Error("GitHub Projects API returned no data");
+  }
+  return payload.data;
+}
+
+/**
+ * Resolve the GraphQL node id of the project owner. The createProjectV2
+ * mutation needs this id; the public `login` is not enough. We split
+ * user vs organization because the two GraphQL roots are distinct
+ * (`user(login:)` vs `organization(login:)`) and one query that tries
+ * both fails the schema-validation pass.
+ */
+export async function getOwnerId(ref: ProjectOwnerRef, deps: ProjectsClientDeps): Promise<string> {
+  if (ref.ownerType === "user") {
+    const data = await githubProjectsGraphql<{ user: { id: string } | null }>(
+      `query($login: String!) { user(login: $login) { id } }`,
+      { login: ref.owner },
+      deps
+    );
+    if (!data.user) {
+      throw new Error(`GitHub user not found: ${ref.owner}`);
+    }
+    return data.user.id;
+  }
+  const data = await githubProjectsGraphql<{ organization: { id: string } | null }>(
+    `query($login: String!) { organization(login: $login) { id } }`,
+    { login: ref.owner },
+    deps
+  );
+  if (!data.organization) {
+    throw new Error(`GitHub organization not found: ${ref.owner}`);
+  }
+  return data.organization.id;
+}
+
+interface ProjectsListNode {
+  projectsV2: { nodes: ProjectV2Node[] };
+}
+
+/**
+ * Look up a project by title under the given owner. GitHub's `query`
+ * argument on `projectsV2` is a fuzzy substring match, so we re-filter
+ * client-side on exact title equality to avoid returning a project
+ * named "relay-core-ui-archive" when the caller asked for
+ * "relay-core-ui". Caps at 20 candidates — the per-page max is 100, but
+ * any owner with that many similarly-named projects has a different
+ * problem.
+ */
+export async function findProjectByTitle(
+  ref: ProjectOwnerRef,
+  title: string,
+  deps: ProjectsClientDeps
+): Promise<ProjectV2Node | null> {
+  const queryStr =
+    ref.ownerType === "user"
+      ? `query($login: String!, $q: String!) {
+          user(login: $login) {
+            projectsV2(first: 20, query: $q) {
+              nodes { id title number url }
+            }
+          }
+        }`
+      : `query($login: String!, $q: String!) {
+          organization(login: $login) {
+            projectsV2(first: 20, query: $q) {
+              nodes { id title number url }
+            }
+          }
+        }`;
+
+  const data = await githubProjectsGraphql<{
+    user?: ProjectsListNode | null;
+    organization?: ProjectsListNode | null;
+  }>(queryStr, { login: ref.owner, q: title }, deps);
+
+  const root = ref.ownerType === "user" ? data.user : data.organization;
+  if (!root) {
+    return null;
+  }
+  const exact = root.projectsV2.nodes.find((p) => p.title === title);
+  return exact ?? null;
+}
+
+/**
+ * Create a new project under the given owner. Caller is expected to
+ * have already verified that no project with this title exists — see
+ * `resolveProject` for the idempotent wrapper.
+ */
+export async function createProject(
+  ownerId: string,
+  title: string,
+  deps: ProjectsClientDeps
+): Promise<ProjectV2Node> {
+  const data = await githubProjectsGraphql<{
+    createProjectV2: { projectV2: ProjectV2Node };
+  }>(
+    `mutation($ownerId: ID!, $title: String!) {
+      createProjectV2(input: { ownerId: $ownerId, title: $title }) {
+        projectV2 { id title number url }
+      }
+    }`,
+    { ownerId, title },
+    deps
+  );
+  return data.createProjectV2.projectV2;
+}
+
+/**
+ * Idempotent project resolver: returns an existing project with the
+ * given title if one is found, otherwise creates it. This is the
+ * primary entry point that PR C will call from the channel-create hook.
+ */
+export async function resolveProject(
+  ref: ProjectOwnerRef,
+  title: string,
+  deps: ProjectsClientDeps
+): Promise<ProjectV2Node> {
+  const existing = await findProjectByTitle(ref, title, deps);
+  if (existing) {
+    return existing;
+  }
+  const ownerId = await getOwnerId(ref, deps);
+  return createProject(ownerId, title, deps);
+}
+
+/**
+ * Read-only inventory of a project's custom fields. PR A returns what
+ * exists; PR B (#181) adds the create-missing-fields path that the
+ * Status/Type/Priority bootstrap needs. Splitting it this way keeps
+ * each PR sub-800 LOC and lets PR A merge without depending on the
+ * field-creation mutations being settled.
+ */
+export async function listProjectFields(
+  projectId: string,
+  deps: ProjectsClientDeps
+): Promise<ProjectV2FieldNode[]> {
+  const data = await githubProjectsGraphql<{
+    node: {
+      fields: {
+        nodes: Array<{
+          id?: string;
+          name?: string;
+          options?: Array<{ id: string; name: string }>;
+        }>;
+      };
+    } | null;
+  }>(
+    `query($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2FieldCommon { id name }
+              ... on ProjectV2SingleSelectField { id name options { id name } }
+            }
+          }
+        }
+      }
+    }`,
+    { projectId },
+    deps
+  );
+  if (!data.node) {
+    throw new Error(`GitHub Projects API: project not found (${projectId})`);
+  }
+  return data.node.fields.nodes
+    .filter(
+      (n): n is { id: string; name: string; options?: Array<{ id: string; name: string }> } =>
+        typeof n.id === "string" && typeof n.name === "string"
+    )
+    .map((n) => ({ id: n.id, name: n.name, options: n.options }));
+}
+
+export interface EnsureFieldsResult {
+  existing: string[];
+  /** Always empty in PR A — populated once PR B (#181) wires field creation. */
+  created: string[];
+}
+
+/**
+ * Stub for the Status/Type/Priority bootstrap. PR A only reports which
+ * of the requested fields already exist; PR B will create the missing
+ * ones. We ship the stub now so PR C (channel/epic wiring) can call
+ * the eventual API surface without holding for the full bootstrap.
+ */
+export async function ensureCustomFields(
+  projectId: string,
+  fieldNames: readonly string[],
+  deps: ProjectsClientDeps
+): Promise<EnsureFieldsResult> {
+  const fields = await listProjectFields(projectId, deps);
+  const present = new Set(fields.map((f) => f.name));
+  const existing = fieldNames.filter((name) => present.has(name));
+  return { existing, created: [] };
+}

--- a/test/integrations/github-projects-client.test.ts
+++ b/test/integrations/github-projects-client.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createProject,
+  ensureCustomFields,
+  findProjectByTitle,
+  getOwnerId,
+  githubProjectsGraphql,
+  listProjectFields,
+  resolveProject,
+  type ProjectsClientDeps,
+} from "../../src/integrations/github-projects/client.js";
+
+/**
+ * PR A scope: GraphQL client + project resolver. No real network in the
+ * default tier — every call goes through an injected `fetch` stub so we
+ * can assert on the request shape and feed deterministic responses.
+ *
+ * The `describe.skip` tier at the bottom is the live-network smoke test;
+ * a maintainer flips it on locally with `HARNESS_LIVE=1` and a real
+ * token. Per AGENTS.md it must stay skipped in default CI.
+ */
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+  body: { query: string; variables: Record<string, unknown> };
+}
+
+function stubFetch(
+  responses: Array<unknown>,
+  options: { status?: number; rawBody?: string } = {}
+): { fetchImpl: typeof fetch; calls: CapturedRequest[] } {
+  const calls: CapturedRequest[] = [];
+  let i = 0;
+  const fetchImpl = vi.fn(async (input: unknown, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const body = JSON.parse(String(init.body ?? "{}"));
+    calls.push({ url, init, body });
+    const payload = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return new Response(options.rawBody ?? JSON.stringify(payload), {
+      status: options.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function deps(fetchImpl: typeof fetch): ProjectsClientDeps {
+  return { token: "ghp_fake", fetch: fetchImpl };
+}
+
+describe("github-projects/client", () => {
+  describe("githubProjectsGraphql", () => {
+    it("posts to the configured endpoint with bearer auth and returns data", async () => {
+      const { fetchImpl, calls } = stubFetch([{ data: { ok: true } }]);
+      const out = await githubProjectsGraphql<{ ok: boolean }>(
+        "query { ok }",
+        { x: 1 },
+        deps(fetchImpl)
+      );
+      expect(out.ok).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe("https://api.github.com/graphql");
+      expect(calls[0].init.method).toBe("POST");
+      const headers = calls[0].init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer ghp_fake");
+      expect(headers["Content-Type"]).toBe("application/json");
+      expect(calls[0].body.variables).toEqual({ x: 1 });
+    });
+
+    it("respects the apiUrl override so tests can target a recorded fixture host", async () => {
+      const { fetchImpl, calls } = stubFetch([{ data: { ok: true } }]);
+      await githubProjectsGraphql(
+        "query { ok }",
+        {},
+        { token: "t", fetch: fetchImpl, apiUrl: "https://example.test/graphql" }
+      );
+      expect(calls[0].url).toBe("https://example.test/graphql");
+    });
+
+    it("throws on non-2xx HTTP so callers never silently drop the response", async () => {
+      const { fetchImpl } = stubFetch([null], { status: 401, rawBody: "bad credentials" });
+      await expect(githubProjectsGraphql("query { ok }", {}, deps(fetchImpl))).rejects.toThrow(
+        /HTTP 401/
+      );
+    });
+
+    it("surfaces GraphQL errors instead of returning partial data", async () => {
+      const { fetchImpl } = stubFetch([{ errors: [{ message: "Field 'foo' doesn't exist" }] }]);
+      await expect(githubProjectsGraphql("query { foo }", {}, deps(fetchImpl))).rejects.toThrow(
+        /Field 'foo' doesn't exist/
+      );
+    });
+
+    it("throws when the response has no data and no errors", async () => {
+      const { fetchImpl } = stubFetch([{}]);
+      await expect(githubProjectsGraphql("query { ok }", {}, deps(fetchImpl))).rejects.toThrow(
+        /no data/
+      );
+    });
+  });
+
+  describe("getOwnerId", () => {
+    it("queries the user root for ownerType=user", async () => {
+      const { fetchImpl, calls } = stubFetch([{ data: { user: { id: "U_kg1" } } }]);
+      const id = await getOwnerId({ owner: "jcast90", ownerType: "user" }, deps(fetchImpl));
+      expect(id).toBe("U_kg1");
+      expect(calls[0].body.query).toMatch(/user\(login:/);
+      expect(calls[0].body.variables).toEqual({ login: "jcast90" });
+    });
+
+    it("queries the organization root for ownerType=organization", async () => {
+      const { fetchImpl, calls } = stubFetch([{ data: { organization: { id: "O_kg1" } } }]);
+      const id = await getOwnerId({ owner: "acme", ownerType: "organization" }, deps(fetchImpl));
+      expect(id).toBe("O_kg1");
+      expect(calls[0].body.query).toMatch(/organization\(login:/);
+    });
+
+    it("throws a targeted error when the owner does not exist", async () => {
+      const { fetchImpl } = stubFetch([{ data: { user: null } }]);
+      await expect(
+        getOwnerId({ owner: "ghost", ownerType: "user" }, deps(fetchImpl))
+      ).rejects.toThrow(/user not found: ghost/);
+    });
+  });
+
+  describe("findProjectByTitle", () => {
+    it("returns the project when GitHub's fuzzy search includes an exact match", async () => {
+      const { fetchImpl } = stubFetch([
+        {
+          data: {
+            user: {
+              projectsV2: {
+                nodes: [
+                  { id: "P1", title: "relay-core-ui-archive", number: 1, url: "u1" },
+                  { id: "P2", title: "relay-core-ui", number: 2, url: "u2" },
+                ],
+              },
+            },
+          },
+        },
+      ]);
+      const out = await findProjectByTitle(
+        { owner: "jcast90", ownerType: "user" },
+        "relay-core-ui",
+        deps(fetchImpl)
+      );
+      expect(out).not.toBeNull();
+      expect(out!.id).toBe("P2");
+    });
+
+    it("returns null when GitHub's fuzzy results contain only near-matches", async () => {
+      const { fetchImpl } = stubFetch([
+        {
+          data: {
+            user: {
+              projectsV2: {
+                nodes: [{ id: "P1", title: "relay-core-ui-archive", number: 1, url: "u" }],
+              },
+            },
+          },
+        },
+      ]);
+      const out = await findProjectByTitle(
+        { owner: "jcast90", ownerType: "user" },
+        "relay-core-ui",
+        deps(fetchImpl)
+      );
+      expect(out).toBeNull();
+    });
+
+    it("returns null when the owner itself resolves to null", async () => {
+      const { fetchImpl } = stubFetch([{ data: { organization: null } }]);
+      const out = await findProjectByTitle(
+        { owner: "ghost-org", ownerType: "organization" },
+        "anything",
+        deps(fetchImpl)
+      );
+      expect(out).toBeNull();
+    });
+  });
+
+  describe("createProject", () => {
+    it("calls createProjectV2 with the owner id and title", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        {
+          data: {
+            createProjectV2: {
+              projectV2: { id: "P_new", title: "relay", number: 7, url: "u" },
+            },
+          },
+        },
+      ]);
+      const out = await createProject("U_owner", "relay", deps(fetchImpl));
+      expect(out.id).toBe("P_new");
+      expect(out.number).toBe(7);
+      expect(calls[0].body.query).toMatch(/createProjectV2/);
+      expect(calls[0].body.variables).toEqual({ ownerId: "U_owner", title: "relay" });
+    });
+  });
+
+  describe("resolveProject", () => {
+    it("returns the existing project without calling createProjectV2", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        {
+          data: {
+            user: {
+              projectsV2: {
+                nodes: [{ id: "P_exists", title: "relay", number: 3, url: "u" }],
+              },
+            },
+          },
+        },
+      ]);
+      const out = await resolveProject(
+        { owner: "jcast90", ownerType: "user" },
+        "relay",
+        deps(fetchImpl)
+      );
+      expect(out.id).toBe("P_exists");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].body.query).not.toMatch(/createProjectV2/);
+    });
+
+    it("creates the project when no exact match is found (3-call sequence)", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        // 1) findProjectByTitle — empty result
+        { data: { user: { projectsV2: { nodes: [] } } } },
+        // 2) getOwnerId — returns the user node id
+        { data: { user: { id: "U_new" } } },
+        // 3) createProject — returns the new project
+        {
+          data: {
+            createProjectV2: {
+              projectV2: { id: "P_fresh", title: "relay", number: 9, url: "u" },
+            },
+          },
+        },
+      ]);
+      const out = await resolveProject(
+        { owner: "jcast90", ownerType: "user" },
+        "relay",
+        deps(fetchImpl)
+      );
+      expect(out.id).toBe("P_fresh");
+      expect(calls).toHaveLength(3);
+      expect(calls[0].body.query).toMatch(/projectsV2\(first: 20/);
+      expect(calls[1].body.query).toMatch(/user\(login:/);
+      expect(calls[2].body.query).toMatch(/createProjectV2/);
+    });
+  });
+
+  describe("listProjectFields", () => {
+    it("returns id+name pairs and preserves single-select option lists", async () => {
+      const { fetchImpl } = stubFetch([
+        {
+          data: {
+            node: {
+              fields: {
+                nodes: [
+                  { id: "F_title", name: "Title" },
+                  {
+                    id: "F_status",
+                    name: "Status",
+                    options: [
+                      { id: "o1", name: "Backlog" },
+                      { id: "o2", name: "In progress" },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ]);
+      const fields = await listProjectFields("P_id", deps(fetchImpl));
+      expect(fields).toHaveLength(2);
+      const status = fields.find((f) => f.name === "Status");
+      expect(status?.options?.length).toBe(2);
+      const title = fields.find((f) => f.name === "Title");
+      expect(title?.options).toBeUndefined();
+    });
+
+    it("filters fragment nodes that didn't match a known field type", async () => {
+      const { fetchImpl } = stubFetch([
+        {
+          data: {
+            node: {
+              fields: {
+                nodes: [
+                  { id: "F_title", name: "Title" },
+                  // An iteration field shape — not matched by either fragment, no id/name
+                  {},
+                ],
+              },
+            },
+          },
+        },
+      ]);
+      const fields = await listProjectFields("P_id", deps(fetchImpl));
+      expect(fields).toHaveLength(1);
+      expect(fields[0].name).toBe("Title");
+    });
+
+    it("throws when the project node is null (deleted or wrong id)", async () => {
+      const { fetchImpl } = stubFetch([{ data: { node: null } }]);
+      await expect(listProjectFields("P_missing", deps(fetchImpl))).rejects.toThrow(
+        /project not found \(P_missing\)/
+      );
+    });
+  });
+
+  describe("ensureCustomFields (PR A stub)", () => {
+    it("reports which requested fields already exist and creates none", async () => {
+      const { fetchImpl } = stubFetch([
+        {
+          data: {
+            node: {
+              fields: {
+                nodes: [
+                  { id: "F_status", name: "Status" },
+                  { id: "F_other", name: "OtherThing" },
+                ],
+              },
+            },
+          },
+        },
+      ]);
+      const out = await ensureCustomFields("P_id", ["Status", "Type", "Priority"], deps(fetchImpl));
+      expect(out.existing).toEqual(["Status"]);
+      // PR A is read-only — creation lands in PR B (#181).
+      expect(out.created).toEqual([]);
+    });
+  });
+});
+
+/**
+ * Live-network smoke test. Off by default — flip on locally with:
+ *   HARNESS_LIVE=1 GITHUB_TOKEN=<your-token> \
+ *   GITHUB_PROJECTS_TEST_OWNER=<login> \
+ *   pnpm vitest run test/integrations/github-projects-client.test.ts
+ *
+ * Per AGENTS.md this stays inside `describe.skip` so default CI never
+ * hits the real API.
+ */
+describe.skip("github-projects/client (live network)", () => {
+  it("resolves a sandbox project against the real GraphQL endpoint", async () => {
+    const token = process.env.GITHUB_TOKEN;
+    const owner = process.env.GITHUB_PROJECTS_TEST_OWNER;
+    if (!token || !owner) {
+      throw new Error("GITHUB_TOKEN and GITHUB_PROJECTS_TEST_OWNER required");
+    }
+    const project = await resolveProject({ owner, ownerType: "user" }, "relay-test-sandbox", {
+      token,
+    });
+    expect(project.id).toMatch(/^PVT_/);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the v0.2 tracker work (closes #180). Establishes the GraphQL client and the project find-or-create lifecycle that PRs B–H build on. Sequenced per `docs/design/tracker-projects-mapping.md`.

## What's in scope

New module `src/integrations/github-projects/client.ts` with:

- **`githubProjectsGraphql<T>`** — generic POST helper. Bearer auth, throws on non-2xx HTTP, surfaces GraphQL `errors` array (no silent partial-data drop).
- **`getOwnerId`** — resolves `user(login:)` vs `organization(login:)` to the GraphQL node id. The two roots can't be merged into one query; doing so fails schema validation.
- **`findProjectByTitle`** — fuzzy lookup via the `query` argument, then a client-side exact-title filter so a search for `relay-core-ui` doesn't return `relay-core-ui-archive`. Caps at 20 candidates.
- **`createProject`** — `createProjectV2` mutation against an owner id.
- **`resolveProject`** — idempotent find-then-create. The primary entry point PR C will call from the channel-create hook.
- **`listProjectFields`** — read-only inventory; preserves single-select option lists, filters out fragment nodes that didn't match a known field type.
- **`ensureCustomFields`** — **stub** for the Status/Type/Priority bootstrap. Reports which requested fields already exist; creates none. Field-creation lands in **PR B (#181)**.

## What's deliberately not here

- Draft-item CRUD → PR B (#181)
- Channel/Epic wiring → PR C (#182)
- Sync worker → PR D (#183)

Splitting it this way keeps PR A sub-800 LOC and lets PR C call the eventual `ensureCustomFields` surface without holding for the bootstrap to settle.

## Secret handling

Token never read from `process.env` — caller passes it via the `deps` bag. Matches the `passEnv` opt-in contract in `src/agents/command-invoker.ts`. AGENTS.md § "Things to watch out for" calls this out.

## Tests

18 vitest cases against a stubbed `fetch` covering:

- POST shape (URL, method, bearer header, content-type, variables payload)
- `apiUrl` override for fixture-host targeting
- Non-2xx HTTP → throws with status code
- GraphQL `errors` array → throws with the first error message
- Response without `data` and without `errors` → throws
- User vs organization owner-id resolution
- Missing owner → targeted error message
- Fuzzy match returning multiple → exact-title filter picks the right one
- Fuzzy match with only near-misses → null
- Owner itself null → null
- `createProject` mutation shape
- `resolveProject` happy path (1-call) and create path (3-call sequence)
- `listProjectFields` preserves single-select options, filters fragment nodes that didn't match a known field type
- `listProjectFields` throws when project node is null
- `ensureCustomFields` stub reports existing-only

Live-network smoke sits inside `describe.skip` per AGENTS.md — flips on with `HARNESS_LIVE=1` + `GITHUB_TOKEN` + `GITHUB_PROJECTS_TEST_OWNER`.

## Verification

```
pnpm typecheck   # clean
pnpm format:check # clean
pnpm test        # 905 passed | 24 skipped (full suite)
pnpm vitest run test/integrations/github-projects-client.test.ts
                 # 18 passed | 1 skipped
```

## Test plan

- [ ] CI fast-tier (ts-verify, rust-check, format-check) passes
- [ ] Reviewer confirms the GraphQL fragment shapes against current GH Projects v2 schema
- [ ] Reviewer confirms the user/organization root split is correct (the alternative — a single combined query — was tried and rejected because of schema-validation failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)