### PR TITLE
feat(tracker): v0.2 PR B — draft-item CRUD + Status/Type/Priority field bootstrap

### DIFF
--- a/src/integrations/github-projects/client.ts
+++ b/src/integrations/github-projects/client.ts
@@ -255,25 +255,29 @@ export async function listProjectFields(
     .map((n) => ({ id: n.id, name: n.name, options: n.options }));
 }
 
-export interface EnsureFieldsResult {
-  existing: string[];
-  /** Always empty in PR A — populated once PR B (#181) wires field creation. */
-  created: string[];
-}
+// `ensureCustomFields` and the field-creation primitives moved to
+// `./fields.ts` in PR B (#181). Re-export so existing imports keep
+// working and `client.ts` stays the canonical entry point for the
+// integration.
+export {
+  createSingleSelectField,
+  defaultFieldOptions,
+  ensureCustomFields,
+  ensureCustomFieldsWithOptions,
+  type CreateSingleSelectFieldInput,
+  type EnsureFieldsResult,
+  type SingleSelectColor,
+  type SingleSelectOptionInput,
+} from "./fields.js";
 
-/**
- * Stub for the Status/Type/Priority bootstrap. PR A only reports which
- * of the requested fields already exist; PR B will create the missing
- * ones. We ship the stub now so PR C (channel/epic wiring) can call
- * the eventual API surface without holding for the full bootstrap.
- */
-export async function ensureCustomFields(
-  projectId: string,
-  fieldNames: readonly string[],
-  deps: ProjectsClientDeps
-): Promise<EnsureFieldsResult> {
-  const fields = await listProjectFields(projectId, deps);
-  const present = new Set(fields.map((f) => f.name));
-  const existing = fieldNames.filter((name) => present.has(name));
-  return { existing, created: [] };
-}
+export {
+  archiveItem,
+  createDraftItem,
+  setSingleSelectValue,
+  updateDraftIssue,
+  type ArchiveItemInput,
+  type CreateDraftItemInput,
+  type DraftItemRef,
+  type SetSingleSelectValueInput,
+  type UpdateDraftIssueInput,
+} from "./draft-items.js";

--- a/src/integrations/github-projects/draft-items.ts
+++ b/src/integrations/github-projects/draft-items.ts
@@ -1,0 +1,168 @@
+/**
+ * Draft-item CRUD against GitHub Projects v2. Second slice of the v0.2
+ * tracker work (PR B / #181). PR A landed the GraphQL transport and the
+ * project resolver; this file owns the lifecycle of the draft items
+ * that PR C (#182) will use to project channels (Type=epic) and tickets
+ * (Type=ticket) into a project.
+ *
+ * Two id types matter here. Every mutation that operates on a row in
+ * the project board takes the **project-item id** (`PVTI_…`). The
+ * underlying draft-issue text — title and body — is owned by a sibling
+ * **draft-issue id** (`DI_…`) and updated through a separate mutation.
+ * `addProjectV2DraftIssue` hands us both at creation time so callers
+ * never need to query for the draft id later.
+ */
+import { githubProjectsGraphql, type ProjectsClientDeps } from "./client.js";
+
+export interface CreateDraftItemInput {
+  projectId: string;
+  title: string;
+  body?: string;
+}
+
+export interface DraftItemRef {
+  /** Project-item id (PVTI_…) — used for field updates and archival. */
+  itemId: string;
+  /** Draft-issue id (DI_…) — used for title/body edits. */
+  draftIssueId: string;
+}
+
+/**
+ * Create a draft item on a project. Returns both the project-item id
+ * and the underlying draft-issue id; callers should persist whichever
+ * matches the operation they expect to perform next (field updates →
+ * itemId; text edits → draftIssueId).
+ */
+export async function createDraftItem(
+  input: CreateDraftItemInput,
+  deps: ProjectsClientDeps
+): Promise<DraftItemRef> {
+  const data = await githubProjectsGraphql<{
+    addProjectV2DraftIssue: {
+      projectItem: {
+        id: string;
+        content: { id: string } | null;
+      };
+    };
+  }>(
+    `mutation($projectId: ID!, $title: String!, $body: String) {
+      addProjectV2DraftIssue(input: { projectId: $projectId, title: $title, body: $body }) {
+        projectItem {
+          id
+          content { ... on DraftIssue { id } }
+        }
+      }
+    }`,
+    { projectId: input.projectId, title: input.title, body: input.body ?? null },
+    deps
+  );
+  const projectItem = data.addProjectV2DraftIssue.projectItem;
+  if (!projectItem.content) {
+    throw new Error("addProjectV2DraftIssue returned a project item with no draft-issue content");
+  }
+  return { itemId: projectItem.id, draftIssueId: projectItem.content.id };
+}
+
+export interface UpdateDraftIssueInput {
+  draftIssueId: string;
+  title?: string;
+  body?: string;
+}
+
+/**
+ * Update a draft issue's title and/or body. Either field is optional;
+ * GraphQL leaves omitted variables as null and the mutation is a no-op
+ * for those. We assert that at least one field is set so callers don't
+ * accidentally make pointless network calls.
+ */
+export async function updateDraftIssue(
+  input: UpdateDraftIssueInput,
+  deps: ProjectsClientDeps
+): Promise<{ draftIssueId: string }> {
+  if (input.title === undefined && input.body === undefined) {
+    throw new Error("updateDraftIssue requires at least one of { title, body }");
+  }
+  const data = await githubProjectsGraphql<{
+    updateProjectV2DraftIssue: { draftIssue: { id: string } };
+  }>(
+    `mutation($draftIssueId: ID!, $title: String, $body: String) {
+      updateProjectV2DraftIssue(input: { draftIssueId: $draftIssueId, title: $title, body: $body }) {
+        draftIssue { id }
+      }
+    }`,
+    {
+      draftIssueId: input.draftIssueId,
+      title: input.title ?? null,
+      body: input.body ?? null,
+    },
+    deps
+  );
+  return { draftIssueId: data.updateProjectV2DraftIssue.draftIssue.id };
+}
+
+export interface SetSingleSelectValueInput {
+  projectId: string;
+  itemId: string;
+  fieldId: string;
+  optionId: string;
+}
+
+/**
+ * Set the value of a single-select custom field on a project item.
+ * This is the workhorse for moving tickets across Status columns and
+ * stamping Type=epic / Type=ticket on draft items. PR C calls this from
+ * the channel-create hook (Type=epic) and the sync worker in PR D will
+ * call it on every status transition.
+ */
+export async function setSingleSelectValue(
+  input: SetSingleSelectValueInput,
+  deps: ProjectsClientDeps
+): Promise<{ itemId: string }> {
+  const data = await githubProjectsGraphql<{
+    updateProjectV2ItemFieldValue: { projectV2Item: { id: string } };
+  }>(
+    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId,
+        itemId: $itemId,
+        fieldId: $fieldId,
+        value: { singleSelectOptionId: $optionId }
+      }) {
+        projectV2Item { id }
+      }
+    }`,
+    { ...input },
+    deps
+  );
+  return { itemId: data.updateProjectV2ItemFieldValue.projectV2Item.id };
+}
+
+export interface ArchiveItemInput {
+  projectId: string;
+  itemId: string;
+}
+
+/**
+ * Archive a project item. GitHub's UI calls this "Archive"; the
+ * underlying mutation `archiveProjectV2Item` keeps the item in the
+ * project but hides it from the default board views — exactly what we
+ * want when a channel is archived. Idempotent: calling on an
+ * already-archived item is a no-op.
+ */
+export async function archiveItem(
+  input: ArchiveItemInput,
+  deps: ProjectsClientDeps
+): Promise<{ itemId: string }> {
+  const data = await githubProjectsGraphql<{
+    archiveProjectV2Item: { item: { id: string } };
+  }>(
+    `mutation($projectId: ID!, $itemId: ID!) {
+      archiveProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+        item { id }
+      }
+    }`,
+    { ...input },
+    deps
+  );
+  return { itemId: data.archiveProjectV2Item.item.id };
+}

--- a/src/integrations/github-projects/fields.ts
+++ b/src/integrations/github-projects/fields.ts
@@ -1,0 +1,185 @@
+/**
+ * Custom-field bootstrap for GitHub Projects v2. Replaces the read-only
+ * stub that PR A shipped (`ensureCustomFields` returned an empty
+ * `created` array). PR B (#181) wires up the actual field-creation
+ * mutation plus seeded option lists for Status / Type / Priority so PR
+ * C can stand up a fresh project end-to-end.
+ *
+ * The `defaultFieldOptions` table is intentionally narrow — Relay only
+ * needs three single-select fields. Callers outside the channel/epic
+ * flow that want different fields can pass their own option lists via
+ * `ensureCustomFieldsWithOptions`.
+ */
+import {
+  githubProjectsGraphql,
+  listProjectFields,
+  type ProjectsClientDeps,
+  type ProjectV2FieldNode,
+} from "./client.js";
+
+/** GitHub's `ProjectV2SingleSelectFieldOptionColor` enum values. */
+export type SingleSelectColor =
+  | "GRAY"
+  | "BLUE"
+  | "GREEN"
+  | "YELLOW"
+  | "ORANGE"
+  | "RED"
+  | "PINK"
+  | "PURPLE";
+
+export interface SingleSelectOptionInput {
+  name: string;
+  color: SingleSelectColor;
+  /** GraphQL requires a non-null description. Empty string is accepted. */
+  description: string;
+}
+
+/**
+ * Default option seeds for the three custom fields PR C wires from the
+ * channel-create hook. Names match the Relay ticket-status enum values
+ * exactly so the sync worker (PR D) can map without translation.
+ */
+export const defaultFieldOptions: Record<string, SingleSelectOptionInput[]> = {
+  Status: [
+    { name: "backlog", color: "GRAY", description: "Not yet started" },
+    { name: "in_progress", color: "BLUE", description: "Active work" },
+    { name: "needs_review", color: "YELLOW", description: "Awaiting review" },
+    { name: "done", color: "GREEN", description: "Completed" },
+  ],
+  Type: [
+    { name: "epic", color: "PURPLE", description: "Channel-level rollup" },
+    { name: "ticket", color: "GRAY", description: "Individual unit of work" },
+  ],
+  Priority: [
+    { name: "low", color: "GRAY", description: "Low priority" },
+    { name: "med", color: "YELLOW", description: "Medium priority" },
+    { name: "high", color: "RED", description: "High priority" },
+  ],
+};
+
+export interface CreateSingleSelectFieldInput {
+  projectId: string;
+  name: string;
+  options: SingleSelectOptionInput[];
+}
+
+/**
+ * Create a single-select custom field on a project. The
+ * `singleSelectOptions` input is required at creation time — adding
+ * options later goes through a separate mutation we don't need yet.
+ */
+export async function createSingleSelectField(
+  input: CreateSingleSelectFieldInput,
+  deps: ProjectsClientDeps
+): Promise<ProjectV2FieldNode> {
+  const data = await githubProjectsGraphql<{
+    createProjectV2Field: {
+      projectV2Field: {
+        id: string;
+        name: string;
+        options?: Array<{ id: string; name: string }>;
+      };
+    };
+  }>(
+    `mutation(
+      $projectId: ID!,
+      $name: String!,
+      $singleSelectOptions: [ProjectV2SingleSelectFieldOptionInput!]
+    ) {
+      createProjectV2Field(input: {
+        projectId: $projectId,
+        dataType: SINGLE_SELECT,
+        name: $name,
+        singleSelectOptions: $singleSelectOptions
+      }) {
+        projectV2Field {
+          ... on ProjectV2SingleSelectField { id name options { id name } }
+        }
+      }
+    }`,
+    {
+      projectId: input.projectId,
+      name: input.name,
+      singleSelectOptions: input.options,
+    },
+    deps
+  );
+  const created = data.createProjectV2Field.projectV2Field;
+  return { id: created.id, name: created.name, options: created.options };
+}
+
+export interface EnsureFieldsResult {
+  /** Field names already present on the project — left untouched. */
+  existing: string[];
+  /** Field names created by this call. */
+  created: string[];
+}
+
+/**
+ * Idempotent custom-field bootstrap. Lists the project's existing
+ * fields, then creates a single-select for every requested name that
+ * isn't present, using the default option seeds. Returns which names
+ * fell into which bucket so callers can log a meaningful summary.
+ *
+ * Names that have no entry in `defaultFieldOptions` are treated as a
+ * caller error — use `ensureCustomFieldsWithOptions` if you need a
+ * custom seed list.
+ */
+export async function ensureCustomFields(
+  projectId: string,
+  fieldNames: readonly string[],
+  deps: ProjectsClientDeps
+): Promise<EnsureFieldsResult> {
+  for (const name of fieldNames) {
+    if (!defaultFieldOptions[name]) {
+      throw new Error(
+        `ensureCustomFields: no default option seed for "${name}". ` +
+          `Use ensureCustomFieldsWithOptions to supply your own.`
+      );
+    }
+  }
+  const fields = await listProjectFields(projectId, deps);
+  const present = new Set(fields.map((f) => f.name));
+
+  const existing: string[] = [];
+  const created: string[] = [];
+  for (const name of fieldNames) {
+    if (present.has(name)) {
+      existing.push(name);
+      continue;
+    }
+    await createSingleSelectField({ projectId, name, options: defaultFieldOptions[name] }, deps);
+    created.push(name);
+  }
+  return { existing, created };
+}
+
+/**
+ * Lower-level variant for callers that want to bootstrap fields with
+ * their own option lists. Same idempotency contract as
+ * `ensureCustomFields` — fields whose names are already present are
+ * left untouched (their options are NOT reconciled, by design — option
+ * reconciliation across renames is a hairy area we'd rather solve
+ * deliberately when a real need surfaces).
+ */
+export async function ensureCustomFieldsWithOptions(
+  projectId: string,
+  spec: ReadonlyArray<{ name: string; options: SingleSelectOptionInput[] }>,
+  deps: ProjectsClientDeps
+): Promise<EnsureFieldsResult> {
+  const fields = await listProjectFields(projectId, deps);
+  const present = new Set(fields.map((f) => f.name));
+
+  const existing: string[] = [];
+  const created: string[] = [];
+  for (const { name, options } of spec) {
+    if (present.has(name)) {
+      existing.push(name);
+      continue;
+    }
+    await createSingleSelectField({ projectId, name, options }, deps);
+    created.push(name);
+  }
+  return { existing, created };
+}

--- a/test/integrations/github-projects-client.test.ts
+++ b/test/integrations/github-projects-client.test.ts
@@ -312,26 +312,14 @@ describe("github-projects/client", () => {
     });
   });
 
-  describe("ensureCustomFields (PR A stub)", () => {
-    it("reports which requested fields already exist and creates none", async () => {
-      const { fetchImpl } = stubFetch([
-        {
-          data: {
-            node: {
-              fields: {
-                nodes: [
-                  { id: "F_status", name: "Status" },
-                  { id: "F_other", name: "OtherThing" },
-                ],
-              },
-            },
-          },
-        },
-      ]);
-      const out = await ensureCustomFields("P_id", ["Status", "Type", "Priority"], deps(fetchImpl));
-      expect(out.existing).toEqual(["Status"]);
-      // PR A is read-only — creation lands in PR B (#181).
-      expect(out.created).toEqual([]);
+  // `ensureCustomFields` behavior tests moved to
+  // `github-projects-fields.test.ts` in PR B (#181) where the full
+  // create-missing-fields path is exercised. The re-export from
+  // `client.ts` is what we verify here so existing imports keep
+  // resolving.
+  describe("ensureCustomFields (re-export from fields.ts)", () => {
+    it("is re-exported from client.ts so existing imports keep working", () => {
+      expect(typeof ensureCustomFields).toBe("function");
     });
   });
 });

--- a/test/integrations/github-projects-draft-items.test.ts
+++ b/test/integrations/github-projects-draft-items.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  archiveItem,
+  createDraftItem,
+  setSingleSelectValue,
+  updateDraftIssue,
+  type ProjectsClientDeps,
+} from "../../src/integrations/github-projects/client.js";
+
+/**
+ * PR B draft-item CRUD tests. Stubs `fetch` per-call and asserts on
+ * mutation shape + variable forwarding. The two-id-types contract
+ * (project-item id vs draft-issue id) is the part most likely to bite
+ * future callers, so these tests pin both down explicitly.
+ */
+
+interface CapturedRequest {
+  body: { query: string; variables: Record<string, unknown> };
+}
+
+function stubFetch(responses: Array<unknown>): {
+  fetchImpl: typeof fetch;
+  calls: CapturedRequest[];
+} {
+  const calls: CapturedRequest[] = [];
+  let i = 0;
+  const fetchImpl = vi.fn(async (_url: unknown, init: RequestInit = {}) => {
+    const body = JSON.parse(String(init.body ?? "{}"));
+    calls.push({ body });
+    const payload = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function deps(fetchImpl: typeof fetch): ProjectsClientDeps {
+  return { token: "ghp_fake", fetch: fetchImpl };
+}
+
+describe("github-projects/draft-items", () => {
+  describe("createDraftItem", () => {
+    it("returns both the project-item id and the draft-issue id", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        {
+          data: {
+            addProjectV2DraftIssue: {
+              projectItem: { id: "PVTI_1", content: { id: "DI_1" } },
+            },
+          },
+        },
+      ]);
+      const out = await createDraftItem(
+        { projectId: "P_id", title: "Refactor auth", body: "Details" },
+        deps(fetchImpl)
+      );
+      expect(out.itemId).toBe("PVTI_1");
+      expect(out.draftIssueId).toBe("DI_1");
+      expect(calls[0].body.query).toMatch(/addProjectV2DraftIssue/);
+      expect(calls[0].body.variables).toEqual({
+        projectId: "P_id",
+        title: "Refactor auth",
+        body: "Details",
+      });
+    });
+
+    it("forwards body=null when omitted (so GraphQL accepts the variable)", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        {
+          data: {
+            addProjectV2DraftIssue: {
+              projectItem: { id: "PVTI_x", content: { id: "DI_x" } },
+            },
+          },
+        },
+      ]);
+      await createDraftItem({ projectId: "P", title: "T" }, deps(fetchImpl));
+      expect(calls[0].body.variables.body).toBeNull();
+    });
+
+    it("throws if the API returns a project item without draft-issue content", async () => {
+      const { fetchImpl } = stubFetch([
+        {
+          data: {
+            addProjectV2DraftIssue: { projectItem: { id: "PVTI_orphan", content: null } },
+          },
+        },
+      ]);
+      await expect(
+        createDraftItem({ projectId: "P", title: "T" }, deps(fetchImpl))
+      ).rejects.toThrow(/no draft-issue content/);
+    });
+  });
+
+  describe("updateDraftIssue", () => {
+    it("calls updateProjectV2DraftIssue with both fields when both supplied", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        { data: { updateProjectV2DraftIssue: { draftIssue: { id: "DI_1" } } } },
+      ]);
+      const out = await updateDraftIssue(
+        { draftIssueId: "DI_1", title: "New title", body: "New body" },
+        deps(fetchImpl)
+      );
+      expect(out.draftIssueId).toBe("DI_1");
+      expect(calls[0].body.variables).toEqual({
+        draftIssueId: "DI_1",
+        title: "New title",
+        body: "New body",
+      });
+    });
+
+    it("forwards null for omitted fields so the mutation is well-typed", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        { data: { updateProjectV2DraftIssue: { draftIssue: { id: "DI_1" } } } },
+      ]);
+      await updateDraftIssue({ draftIssueId: "DI_1", title: "T only" }, deps(fetchImpl));
+      expect(calls[0].body.variables).toEqual({
+        draftIssueId: "DI_1",
+        title: "T only",
+        body: null,
+      });
+    });
+
+    it("rejects calls with no fields to update before hitting the network", async () => {
+      const { fetchImpl, calls } = stubFetch([{}]);
+      await expect(updateDraftIssue({ draftIssueId: "DI_1" }, deps(fetchImpl))).rejects.toThrow(
+        /at least one of/
+      );
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("setSingleSelectValue", () => {
+    it("calls updateProjectV2ItemFieldValue with the singleSelectOptionId payload", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        { data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_1" } } } },
+      ]);
+      const out = await setSingleSelectValue(
+        {
+          projectId: "P_id",
+          itemId: "PVTI_1",
+          fieldId: "F_status",
+          optionId: "OPT_in_progress",
+        },
+        deps(fetchImpl)
+      );
+      expect(out.itemId).toBe("PVTI_1");
+      expect(calls[0].body.query).toMatch(/updateProjectV2ItemFieldValue/);
+      expect(calls[0].body.query).toMatch(/singleSelectOptionId/);
+      expect(calls[0].body.variables).toEqual({
+        projectId: "P_id",
+        itemId: "PVTI_1",
+        fieldId: "F_status",
+        optionId: "OPT_in_progress",
+      });
+    });
+  });
+
+  describe("archiveItem", () => {
+    it("calls archiveProjectV2Item with project + item ids", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        { data: { archiveProjectV2Item: { item: { id: "PVTI_1" } } } },
+      ]);
+      const out = await archiveItem({ projectId: "P_id", itemId: "PVTI_1" }, deps(fetchImpl));
+      expect(out.itemId).toBe("PVTI_1");
+      expect(calls[0].body.query).toMatch(/archiveProjectV2Item/);
+      expect(calls[0].body.variables).toEqual({ projectId: "P_id", itemId: "PVTI_1" });
+    });
+  });
+});

--- a/test/integrations/github-projects-fields.test.ts
+++ b/test/integrations/github-projects-fields.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createSingleSelectField,
+  defaultFieldOptions,
+  ensureCustomFields,
+  ensureCustomFieldsWithOptions,
+  type ProjectsClientDeps,
+} from "../../src/integrations/github-projects/client.js";
+
+/**
+ * PR B field-bootstrap tests. The PR A stub (which returned
+ * `created: []`) is gone — these tests cover the actual create-missing
+ * path plus idempotency and the option-seed contract.
+ */
+
+interface CapturedRequest {
+  body: { query: string; variables: Record<string, unknown> };
+}
+
+function stubFetch(responses: Array<unknown>): {
+  fetchImpl: typeof fetch;
+  calls: CapturedRequest[];
+} {
+  const calls: CapturedRequest[] = [];
+  let i = 0;
+  const fetchImpl = vi.fn(async (_url: unknown, init: RequestInit = {}) => {
+    const body = JSON.parse(String(init.body ?? "{}"));
+    calls.push({ body });
+    const payload = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function deps(fetchImpl: typeof fetch): ProjectsClientDeps {
+  return { token: "ghp_fake", fetch: fetchImpl };
+}
+
+function listFieldsResponse(
+  fields: Array<{ id: string; name: string; options?: Array<{ id: string; name: string }> }>
+): unknown {
+  return { data: { node: { fields: { nodes: fields } } } };
+}
+
+function createFieldResponse(id: string, name: string): unknown {
+  return {
+    data: {
+      createProjectV2Field: { projectV2Field: { id, name, options: [] } },
+    },
+  };
+}
+
+describe("github-projects/fields", () => {
+  describe("defaultFieldOptions", () => {
+    it("seeds Status with the four Relay ticket statuses", () => {
+      const names = defaultFieldOptions.Status.map((o) => o.name);
+      expect(names).toEqual(["backlog", "in_progress", "needs_review", "done"]);
+    });
+
+    it("seeds Type with epic and ticket", () => {
+      const names = defaultFieldOptions.Type.map((o) => o.name);
+      expect(names).toEqual(["epic", "ticket"]);
+    });
+
+    it("seeds Priority with low/med/high", () => {
+      const names = defaultFieldOptions.Priority.map((o) => o.name);
+      expect(names).toEqual(["low", "med", "high"]);
+    });
+
+    it("uses valid GH single-select colors and non-empty descriptions", () => {
+      const validColors = new Set([
+        "GRAY",
+        "BLUE",
+        "GREEN",
+        "YELLOW",
+        "ORANGE",
+        "RED",
+        "PINK",
+        "PURPLE",
+      ]);
+      for (const name of Object.keys(defaultFieldOptions)) {
+        for (const opt of defaultFieldOptions[name]) {
+          expect(validColors.has(opt.color)).toBe(true);
+          expect(opt.description.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("createSingleSelectField", () => {
+    it("calls createProjectV2Field with SINGLE_SELECT and forwards options", async () => {
+      const { fetchImpl, calls } = stubFetch([createFieldResponse("F_status", "Status")]);
+      const out = await createSingleSelectField(
+        {
+          projectId: "P_id",
+          name: "Status",
+          options: defaultFieldOptions.Status,
+        },
+        deps(fetchImpl)
+      );
+      expect(out.id).toBe("F_status");
+      expect(out.name).toBe("Status");
+      expect(calls[0].body.query).toMatch(/createProjectV2Field/);
+      expect(calls[0].body.query).toMatch(/SINGLE_SELECT/);
+      expect(calls[0].body.variables.singleSelectOptions).toEqual(defaultFieldOptions.Status);
+    });
+  });
+
+  describe("ensureCustomFields", () => {
+    it("creates exactly the missing fields in a single sweep", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        // 1) listProjectFields — Status already exists, Type/Priority don't
+        listFieldsResponse([{ id: "F_status", name: "Status" }]),
+        // 2) createSingleSelectField for Type
+        createFieldResponse("F_type", "Type"),
+        // 3) createSingleSelectField for Priority
+        createFieldResponse("F_priority", "Priority"),
+      ]);
+      const out = await ensureCustomFields("P_id", ["Status", "Type", "Priority"], deps(fetchImpl));
+      expect(out.existing).toEqual(["Status"]);
+      expect(out.created).toEqual(["Type", "Priority"]);
+      expect(calls).toHaveLength(3);
+      expect(calls[1].body.variables.name).toBe("Type");
+      expect(calls[1].body.variables.singleSelectOptions).toEqual(defaultFieldOptions.Type);
+      expect(calls[2].body.variables.name).toBe("Priority");
+    });
+
+    it("creates nothing when all requested fields already exist (idempotent)", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        listFieldsResponse([
+          { id: "F_status", name: "Status" },
+          { id: "F_type", name: "Type" },
+          { id: "F_priority", name: "Priority" },
+        ]),
+      ]);
+      const out = await ensureCustomFields("P_id", ["Status", "Type", "Priority"], deps(fetchImpl));
+      expect(out.existing).toEqual(["Status", "Type", "Priority"]);
+      expect(out.created).toEqual([]);
+      expect(calls).toHaveLength(1);
+    });
+
+    it("rejects names that have no default option seed before any network call", async () => {
+      const { fetchImpl, calls } = stubFetch([listFieldsResponse([])]);
+      await expect(ensureCustomFields("P_id", ["NotInDefaults"], deps(fetchImpl))).rejects.toThrow(
+        /no default option seed for "NotInDefaults"/
+      );
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("ensureCustomFieldsWithOptions", () => {
+    it("accepts caller-supplied option lists and creates missing fields", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        listFieldsResponse([]),
+        createFieldResponse("F_specialty", "Specialty"),
+      ]);
+      const customOptions = [
+        { name: "ui", color: "BLUE" as const, description: "UI" },
+        { name: "be", color: "GREEN" as const, description: "Backend" },
+      ];
+      const out = await ensureCustomFieldsWithOptions(
+        "P_id",
+        [{ name: "Specialty", options: customOptions }],
+        deps(fetchImpl)
+      );
+      expect(out.created).toEqual(["Specialty"]);
+      expect(calls[1].body.variables.singleSelectOptions).toEqual(customOptions);
+    });
+
+    it("leaves existing fields untouched without reconciling their options", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        listFieldsResponse([{ id: "F_existing", name: "Specialty" }]),
+      ]);
+      const out = await ensureCustomFieldsWithOptions(
+        "P_id",
+        [
+          {
+            name: "Specialty",
+            options: [{ name: "x", color: "GRAY", description: "" }],
+          },
+        ],
+        deps(fetchImpl)
+      );
+      expect(out.existing).toEqual(["Specialty"]);
+      expect(out.created).toEqual([]);
+      // No second call — no option reconciliation by design.
+      expect(calls).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Second slice of v0.2 tracker work (closes #181). Builds on **#188 (PR A)** — based against `feat/v0.2-pr-a-graphql-client`, retarget to `main` once #188 lands. Replaces the read-only `ensureCustomFields` stub PR A shipped with the full create-missing-fields path, and adds the draft-item lifecycle mutations PR C (#182) will call from the channel-create hook.

## What's in scope

### `src/integrations/github-projects/draft-items.ts`
- **`createDraftItem`** → returns both `itemId` (PVTI_…) and `draftIssueId` (DI_…) so callers don't need to query for the draft id later. The two-id-types contract is the part most likely to bite future callers; tests pin it down.
- **`updateDraftIssue`** — title and/or body, at least one required. Asserted before any network call.
- **`setSingleSelectValue`** — workhorse for moving items across Status columns and stamping `Type=epic` / `Type=ticket`.
- **`archiveItem`** — idempotent. UI's "Archive" maps to this.

### `src/integrations/github-projects/fields.ts`
- **`defaultFieldOptions`** for Status / Type / Priority. Status option names match the Relay ticket-status enum exactly so PR D's sync worker can map without translation.
- **`createSingleSelectField`** with the seeded option payload.
- **`ensureCustomFields`** full impl: lists existing → creates only the missing → idempotent on re-run. Validates every requested name has a default seed *before* any network call.
- **`ensureCustomFieldsWithOptions`** for callers that need custom seeds (e.g. PR D's `Specialty` field). Existing fields are NOT reconciled to new option lists by design — rename reconciliation is hairy enough to defer until a real need surfaces.

### `src/integrations/github-projects/client.ts`
- Removed the PR A stub for `ensureCustomFields`.
- Re-exports the new surfaces from `fields.ts` and `draft-items.ts` so `client.ts` stays the canonical entry point and existing imports keep resolving.

## What's deliberately not here
- Channel/Epic wiring → PR C (#182)
- Sync worker → PR D (#183)
- Parent-child linkage between epic and tickets → PR C decides the exact mechanism (sub-issue field vs custom Parent field)

## Tests
- **3 new test files**, **18 new tests** total (8 draft-items + 10 fields)
- Existing PR A test for `ensureCustomFields` stub was replaced with a re-export check
- Default-options table is asserted: Status names match the Relay enum, all colors are valid GH enum values, all descriptions non-empty
- Idempotency case: all fields already exist → exactly 1 network call (the list)
- No-default-seed case: throws *before* any network call
- 3-call sweep verified for the partial-existing case

## Verification

```
pnpm typecheck     # clean
pnpm format:check  # clean
pnpm test          # 923 passed | 24 skipped (was 905 | 24 in PR A)
pnpm vitest run test/integrations/github-projects-{client,fields,draft-items}.test.ts
                   # 36 passed | 1 skipped
```

## LOC
- 6 files changed: +755 / −41 (sub-800 LOC budget per AGENTS.md)

## Test plan
- [ ] CI fast-tier (ts-verify, rust-check, format-check) passes
- [ ] Reviewer confirms the GraphQL mutation shapes (`addProjectV2DraftIssue`, `updateProjectV2DraftIssue`, `updateProjectV2ItemFieldValue`, `archiveProjectV2Item`, `createProjectV2Field`)
- [ ] Reviewer signs off on the default-options seed (Status names match Relay's ticket-status enum, Type uses epic/ticket, Priority uses low/med/high)
- [ ] Reviewer signs off on the deliberate non-reconciliation behavior of `ensureCustomFieldsWithOptions` for existing fields

## Once PR A merges
Retarget this PR's base from `feat/v0.2-pr-a-graphql-client` to `main` and rebase. No conflicts expected — only file overlap with PR A is the `ensureCustomFields` removal in `client.ts`, which is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)