### PR TITLE
feat(tracker): v0.2 PR E — classifier URL parsing for GH Projects v2

### DIFF
--- a/src/integrations/github-projects/client.ts
+++ b/src/integrations/github-projects/client.ts
@@ -281,3 +281,141 @@ export {
   type SetSingleSelectValueInput,
   type UpdateDraftIssueInput,
 } from "./draft-items.js";
+
+/**
+ * Lightweight projection of a project item used by the URL-paste path.
+ * The full item node carries custom-field values too; for v0.2 the
+ * classifier only needs the title, body, parent epic, and parent
+ * project so the resulting ticket gets correct channel/epic association.
+ *
+ * `parent` is null when the item is unparented (a stray draft, or the
+ * epic itself). `content` is null for plain draft items; populated when
+ * the item wraps a real Issue or PR.
+ */
+export interface ProjectItemContext {
+  itemId: string;
+  /** Title of the draft item OR the linked Issue/PR. */
+  title: string;
+  /** Body of the draft item OR the linked Issue/PR. May be empty. */
+  body: string;
+  /** Parent draft item (the channel epic, in Relay's mapping) when set. */
+  parent: { id: string; title: string } | null;
+  /** Parent project — title is needed to find-or-create the matching channel. */
+  project: { id: string; title: string; number: number; url: string };
+  /** Linked Issue/PR, when the item is not a plain draft. */
+  content: { kind: "Issue" | "PullRequest"; url: string; number: number } | null;
+}
+
+interface ProjectItemQueryResponse {
+  node: {
+    id?: string;
+    project?: {
+      id: string;
+      title: string;
+      number: number;
+      url: string;
+    };
+    parent?: {
+      id: string;
+      // Drafts expose their text via the `DraftIssue` shape inside `content`,
+      // so the parent's display title comes from its own `content` field.
+      content?: {
+        __typename?: string;
+        title?: string;
+      } | null;
+    } | null;
+    content?: {
+      __typename?: string;
+      title?: string;
+      body?: string;
+      url?: string;
+      number?: number;
+    } | null;
+  } | null;
+}
+
+/**
+ * Resolve an item's parent epic + parent project from a `PVTI_*` node id.
+ * Used by the classifier when a user pastes a Projects v2 item URL —
+ * channel/epic association is recovered from the item's `Parent` field
+ * so the new ticket lands under the right channel.
+ *
+ * Throws when the node is not found or is not a `ProjectV2Item`. Callers
+ * should treat that as "the URL parsed but the API rejected the id" and
+ * fall back to classifying the raw URL.
+ */
+export async function getProjectItemContext(
+  itemId: string,
+  deps: ProjectsClientDeps
+): Promise<ProjectItemContext> {
+  const data = await githubProjectsGraphql<ProjectItemQueryResponse>(
+    `query($itemId: ID!) {
+      node(id: $itemId) {
+        ... on ProjectV2Item {
+          id
+          project { id title number url }
+          parent {
+            id
+            content {
+              __typename
+              ... on DraftIssue { title }
+              ... on Issue { title }
+              ... on PullRequest { title }
+            }
+          }
+          content {
+            __typename
+            ... on DraftIssue { title body }
+            ... on Issue { title body url number }
+            ... on PullRequest { title body url number }
+          }
+        }
+      }
+    }`,
+    { itemId },
+    deps
+  );
+
+  if (!data.node) {
+    throw new Error(`GitHub Projects API: item not found (${itemId})`);
+  }
+  if (!data.node.project || !data.node.id) {
+    // Fragment didn't match — the id resolved, but to a non-ProjectV2Item
+    // node (e.g. someone pasted a project id where an item id was expected).
+    throw new Error(`GitHub Projects API: id ${itemId} is not a ProjectV2Item`);
+  }
+
+  const content = data.node.content ?? null;
+  const title = typeof content?.title === "string" ? content.title : "";
+  const body = typeof content?.body === "string" ? content.body : "";
+
+  let parent: ProjectItemContext["parent"] = null;
+  if (data.node.parent) {
+    const parentTitle =
+      typeof data.node.parent.content?.title === "string" ? data.node.parent.content.title : "";
+    parent = { id: data.node.parent.id, title: parentTitle };
+  }
+
+  let mappedContent: ProjectItemContext["content"] = null;
+  if (
+    content &&
+    (content.__typename === "Issue" || content.__typename === "PullRequest") &&
+    typeof content.url === "string" &&
+    typeof content.number === "number"
+  ) {
+    mappedContent = {
+      kind: content.__typename,
+      url: content.url,
+      number: content.number,
+    };
+  }
+
+  return {
+    itemId: data.node.id,
+    title,
+    body,
+    parent,
+    project: data.node.project,
+    content: mappedContent,
+  };
+}

--- a/src/integrations/github-projects/url-parser.ts
+++ b/src/integrations/github-projects/url-parser.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure parser for GitHub Projects v2 URLs. No network, no env reads.
+ * Three shapes are recognised, mirroring Decision 5 of
+ * docs/design/tracker-projects-mapping.md: item-scoped user/org URLs and
+ * project-only (deferred in v0.2). GitHub Issue URLs are intentionally
+ * NOT handled here — they live in src/integrations/tracker.ts and
+ * continue to flow through the AO Tracker plugin. Returning null means
+ * "not a Projects v2 URL"; the classifier falls through.
+ */
+
+export type GitHubOwnerType = "user" | "organization";
+
+/** Item-scoped paste. */
+export interface ProjectItemUrl {
+  kind: "item";
+  ownerType: GitHubOwnerType;
+  owner: string;
+  projectNumber: number;
+  itemId: string;
+  /** Original input, trimmed. */
+  url: string;
+}
+
+/** Project-scoped paste. The v0.2 deferred case (no item context). */
+export interface ProjectOnlyUrl {
+  kind: "project";
+  ownerType: GitHubOwnerType;
+  owner: string;
+  projectNumber: number;
+  url: string;
+}
+
+export type GitHubProjectsUrl = ProjectItemUrl | ProjectOnlyUrl;
+
+const PROJECT_PATH_RE =
+  /^\/(users|orgs)\/([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\/projects\/(\d+)(?:\/[^?#]*)?$/;
+
+/**
+ * Parse `input` as a GitHub Projects v2 URL. Returns null for anything
+ * that is not github.com, is not under /(users|orgs)/.../projects/<n>,
+ * or carries a malformed itemId. Trailing slashes, missing query params,
+ * and any ordering of pane/itemId are tolerated.
+ */
+export function parseGithubProjectsUrl(input: string): GitHubProjectsUrl | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  // Lock the host to github.com (tolerate `www.` since users paste it).
+  // GHES, gist.github.com, raw.githubusercontent.com, etc. are rejected.
+  const host = parsed.host.toLowerCase();
+  if (host !== "github.com" && host !== "www.github.com") {
+    return null;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return null;
+  }
+
+  const normalisedPath = parsed.pathname.replace(/\/+$/, "") || parsed.pathname;
+  const match = normalisedPath.match(PROJECT_PATH_RE);
+  if (!match) return null;
+
+  const ownerType: GitHubOwnerType = match[1] === "orgs" ? "organization" : "user";
+  const owner = match[2];
+  const projectNumber = Number(match[3]);
+  if (!Number.isFinite(projectNumber) || projectNumber <= 0) {
+    return null;
+  }
+
+  const itemId = parsed.searchParams.get("itemId");
+  if (itemId) {
+    // Project item node ids today begin with `PVTI_` but we accept any
+    // non-empty [A-Za-z0-9_-] token to stay forward-compatible if GitHub
+    // ever rolls a new prefix. The lookup will fail loudly if the id is
+    // bogus.
+    if (!/^[A-Za-z0-9_-]+$/.test(itemId)) {
+      return null;
+    }
+    return {
+      kind: "item",
+      ownerType,
+      owner,
+      projectNumber,
+      itemId,
+      url: trimmed,
+    };
+  }
+
+  return {
+    kind: "project",
+    ownerType,
+    owner,
+    projectNumber,
+    url: trimmed,
+  };
+}
+
+/**
+ * Human-readable message surfaced when the user pastes a project-only
+ * URL (no `itemId`). The "sync the whole project" flow is deferred per
+ * Decision 5.
+ */
+export const PROJECT_ONLY_DEFERRED_MESSAGE =
+  "Project-scoped URL paste is deferred to a later PR; paste an item URL " +
+  "(open the card in the Projects UI and copy the URL - it should contain " +
+  "`itemId=PVTI_...`) instead.";

--- a/src/orchestrator/classifier.ts
+++ b/src/orchestrator/classifier.ts
@@ -194,16 +194,20 @@ function enrichFromProjectItem(item: ProjectItemContext, originalUrl: string): s
 }
 
 /**
- * Build a `ProjectsClientDeps` from a caller-supplied bag, falling back
- * to `process.env.GITHUB_TOKEN` only at this single boundary. New code
- * should accept a deps bag rather than reaching into env.
+ * Build a `ProjectsClientDeps` from a caller-supplied bag. Returns
+ * null when no token is supplied — the classifier's URL enrichment
+ * is best-effort and gracefully degrades to the project-only deferred
+ * message rather than the env-fallback shortcut. Callers (CLI / MCP
+ * entry points) are expected to read `process.env.GITHUB_TOKEN` once
+ * at their boundary and plumb it through `projectsDeps.token`. See
+ * AGENTS.md § "Things to watch out for" for the rationale (subprocess
+ * env sanitization + per-name `passEnv` opt-in contract).
  */
 function resolveProjectsDeps(
   caller: Partial<ProjectsClientDeps> | undefined
 ): ProjectsClientDeps | null {
-  const token = caller?.token ?? process.env.GITHUB_TOKEN ?? "";
-  if (!token) return null;
-  return { token, fetch: caller?.fetch, apiUrl: caller?.apiUrl };
+  if (!caller?.token) return null;
+  return { token: caller.token, fetch: caller.fetch, apiUrl: caller.apiUrl };
 }
 
 /**
@@ -232,8 +236,8 @@ async function tryResolveProjectsUrl(
     return {
       kind: "deferred",
       message:
-        "GITHUB_TOKEN not available; cannot resolve GitHub Projects item context. " +
-        "Pass a token via `projectsDeps` or set GITHUB_TOKEN.",
+        "GitHub Projects item context cannot be resolved without a token. " +
+        "Pass one via the classifier's `projectsDeps.token` deps bag.",
       parsed,
     };
   }

--- a/src/orchestrator/classifier.ts
+++ b/src/orchestrator/classifier.ts
@@ -12,6 +12,16 @@ import {
   type HarnessIssue,
   type TrackerKind,
 } from "../integrations/tracker.js";
+import {
+  getProjectItemContext,
+  type ProjectItemContext,
+  type ProjectsClientDeps,
+} from "../integrations/github-projects/client.js";
+import {
+  parseGithubProjectsUrl,
+  PROJECT_ONLY_DEFERRED_MESSAGE,
+  type GitHubProjectsUrl,
+} from "../integrations/github-projects/url-parser.js";
 import { basename } from "node:path";
 
 const TRIVIAL_PATTERNS = [
@@ -160,42 +170,204 @@ function enrichFeatureRequest(featureRequest: string, issue: HarnessIssue): stri
   return `${issue.title}${labels}${body}\n\nSource: ${issue.url}`;
 }
 
+/**
+ * Same idea as `enrichFeatureRequest` but for a GitHub Projects v2 item.
+ * Includes the parent epic title (so the planner sees channel/epic
+ * context) and any wrapped Issue/PR link, which downstream agents can
+ * follow when deeper context is needed.
+ */
+function enrichFromProjectItem(item: ProjectItemContext, originalUrl: string): string {
+  const parts: string[] = [];
+  parts.push(item.title || "(untitled draft item)");
+  if (item.parent && item.parent.title) {
+    parts.push(`\nParent epic: ${item.parent.title}`);
+  }
+  parts.push(`\nProject: ${item.project.title}`);
+  if (item.body) {
+    parts.push(`\n\n${item.body}`);
+  }
+  if (item.content) {
+    parts.push(`\n\nLinked ${item.content.kind}: ${item.content.url}`);
+  }
+  parts.push(`\n\nSource: ${originalUrl}`);
+  return parts.join("");
+}
+
+/**
+ * Build a `ProjectsClientDeps` from a caller-supplied bag, falling back
+ * to `process.env.GITHUB_TOKEN` only at this single boundary. New code
+ * should accept a deps bag rather than reaching into env.
+ */
+function resolveProjectsDeps(
+  caller: Partial<ProjectsClientDeps> | undefined
+): ProjectsClientDeps | null {
+  const token = caller?.token ?? process.env.GITHUB_TOKEN ?? "";
+  if (!token) return null;
+  return { token, fetch: caller?.fetch, apiUrl: caller?.apiUrl };
+}
+
+/**
+ * If `featureRequest` is a Projects v2 URL, resolve item context (or
+ * surface the project-only deferred error). Returns null when the input
+ * is not a Projects v2 URL at all so the caller can fall through to
+ * the existing tracker path.
+ */
+type ProjectsResolution =
+  | { kind: "item"; context: ProjectItemContext; parsed: GitHubProjectsUrl }
+  | { kind: "deferred"; message: string; parsed: GitHubProjectsUrl };
+
+async function tryResolveProjectsUrl(
+  featureRequest: string,
+  projectsDeps: Partial<ProjectsClientDeps> | undefined
+): Promise<ProjectsResolution | null> {
+  const parsed = parseGithubProjectsUrl(featureRequest);
+  if (!parsed) return null;
+
+  if (parsed.kind === "project") {
+    return { kind: "deferred", message: PROJECT_ONLY_DEFERRED_MESSAGE, parsed };
+  }
+
+  const deps = resolveProjectsDeps(projectsDeps);
+  if (!deps) {
+    return {
+      kind: "deferred",
+      message:
+        "GITHUB_TOKEN not available; cannot resolve GitHub Projects item context. " +
+        "Pass a token via `projectsDeps` or set GITHUB_TOKEN.",
+      parsed,
+    };
+  }
+
+  try {
+    const context = await getProjectItemContext(parsed.itemId, deps);
+    return { kind: "item", context, parsed };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[classifier] Failed to resolve GitHub Projects item ${parsed.itemId}; ` +
+        `falling back to raw input. ${message}`
+    );
+    return { kind: "deferred", message, parsed };
+  }
+}
+
 export async function classifyRequest(input: {
   run: HarnessRun;
   featureRequest: string;
   repoRoot: string;
   dispatch: (run: HarnessRun, request: Omit<WorkRequest, "runId">) => Promise<AgentResult>;
+  /**
+   * Optional GitHub Projects client deps. When the feature request looks
+   * like a Projects v2 item URL we use this to resolve channel/epic
+   * context. Tests pass a stubbed `fetch`; CLI callers pass a token.
+   * Falls back to `process.env.GITHUB_TOKEN` if `token` is omitted.
+   */
+  projectsDeps?: Partial<ProjectsClientDeps>;
 }): Promise<ClassificationResult> {
+  // Projects v2 URL takes precedence: it overlaps with `github.com` host
+  // but uses /(users|orgs)/.../projects/<n>, which the existing tracker
+  // detector does NOT match — so the two paths can't fight. We only
+  // fall through to tracker resolution if the input was not a Projects
+  // URL at all.
+  const projectsResolution = await tryResolveProjectsUrl(input.featureRequest, input.projectsDeps);
+
+  if (projectsResolution?.kind === "deferred") {
+    // Project-only URL OR API/auth failure. Surface a clear rationale so
+    // the user sees why the paste didn't enrich. We deliberately do not
+    // throw — the orchestrator UX prefers a returned classification with
+    // an explanatory rationale to a hard failure.
+    const fallback: ClassificationResult = {
+      tier: "feature_small",
+      rationale: projectsResolution.message,
+      suggestedSpecialties: ["general"],
+      estimatedTicketCount: 1,
+      needsDesignDoc: false,
+      needsUserApproval: true,
+    };
+    return fallback;
+  }
+
+  if (projectsResolution?.kind === "item") {
+    return classifyEnrichedRequest({
+      run: input.run,
+      originalRequest: input.featureRequest,
+      effectiveRequest: enrichFromProjectItem(
+        projectsResolution.context,
+        projectsResolution.parsed.url
+      ),
+      contextLines: [
+        `GitHub Project: ${projectsResolution.context.project.title} (${projectsResolution.context.project.url})`,
+        ...(projectsResolution.context.parent && projectsResolution.context.parent.title
+          ? [`Parent epic: ${projectsResolution.context.parent.title}`]
+          : []),
+      ],
+      suggestedBranch: undefined,
+      repoRoot: input.repoRoot,
+      dispatch: input.dispatch,
+    });
+  }
+
   const issue = await tryResolveTrackerIssue(input.featureRequest, input.repoRoot);
   const effectiveRequest = issue
     ? enrichFeatureRequest(input.featureRequest, issue)
     : input.featureRequest;
   const suggestedBranch = issue?.branchName;
 
-  const heuristicTier = classifyByHeuristic(effectiveRequest);
-
-  if (heuristicTier) {
-    const result = buildHeuristicClassification(heuristicTier, effectiveRequest);
-    return suggestedBranch ? { ...result, suggestedBranch } : result;
-  }
-
-  const context: string[] = [
-    `Repository root: ${input.repoRoot}`,
-    `Feature request: ${effectiveRequest}`,
-  ];
+  const trackerContext: string[] = [];
   if (issue) {
-    context.push(`Tracker: ${issue.url}`);
+    trackerContext.push(`Tracker: ${issue.url}`);
     if (issue.labels.length) {
-      context.push(`Tracker labels: ${issue.labels.join(", ")}`);
+      trackerContext.push(`Tracker labels: ${issue.labels.join(", ")}`);
     }
   }
 
-  const result = await input.dispatch(input.run, {
+  return classifyEnrichedRequest({
+    run: input.run,
+    originalRequest: input.featureRequest,
+    effectiveRequest,
+    contextLines: trackerContext,
+    suggestedBranch,
+    repoRoot: input.repoRoot,
+    dispatch: input.dispatch,
+  });
+}
+
+/**
+ * Heuristic + dispatch tail of the classifier. Factored out so both the
+ * existing tracker-issue path and the new Projects v2 item path can
+ * share it without duplicating the LLM-prompt construction.
+ */
+async function classifyEnrichedRequest(args: {
+  run: HarnessRun;
+  /** Raw input the user actually pasted; kept for log/audit context. */
+  originalRequest: string;
+  /** Enriched objective fed to the heuristics + LLM. */
+  effectiveRequest: string;
+  /** Extra context lines (tracker labels, project info, etc.). */
+  contextLines: string[];
+  /** Optional branch hint from the tracker plugin. */
+  suggestedBranch: string | undefined;
+  repoRoot: string;
+  dispatch: (run: HarnessRun, request: Omit<WorkRequest, "runId">) => Promise<AgentResult>;
+}): Promise<ClassificationResult> {
+  const heuristicTier = classifyByHeuristic(args.effectiveRequest);
+  if (heuristicTier) {
+    const result = buildHeuristicClassification(heuristicTier, args.effectiveRequest);
+    return args.suggestedBranch ? { ...result, suggestedBranch: args.suggestedBranch } : result;
+  }
+
+  const context: string[] = [
+    `Repository root: ${args.repoRoot}`,
+    `Feature request: ${args.effectiveRequest}`,
+    ...args.contextLines,
+  ];
+
+  const result = await args.dispatch(args.run, {
     phaseId: "phase_00",
     kind: "classify_request",
     specialty: "general",
     title: "Classify request complexity",
-    objective: effectiveRequest,
+    objective: args.effectiveRequest,
     acceptanceCriteria: [
       "Classify the request into exactly one complexity tier.",
       "Provide a rationale for the classification.",
@@ -214,7 +386,7 @@ export async function classifyRequest(input: {
   try {
     const raw = result.rawResponse ? JSON.parse(result.rawResponse) : {};
     const parsed = parseClassificationResult(raw.classification ?? raw);
-    return suggestedBranch ? { ...parsed, suggestedBranch } : parsed;
+    return args.suggestedBranch ? { ...parsed, suggestedBranch: args.suggestedBranch } : parsed;
   } catch {
     const fallback: ClassificationResult = {
       tier: "feature_small",
@@ -224,6 +396,6 @@ export async function classifyRequest(input: {
       needsDesignDoc: false,
       needsUserApproval: false,
     };
-    return suggestedBranch ? { ...fallback, suggestedBranch } : fallback;
+    return args.suggestedBranch ? { ...fallback, suggestedBranch: args.suggestedBranch } : fallback;
   }
 }

--- a/test/integrations/classifier-url-ingestion.test.ts
+++ b/test/integrations/classifier-url-ingestion.test.ts
@@ -192,3 +192,213 @@ describe("classifyRequest — tracker URL ingestion", () => {
     expect(req.objective).toBe(url);
   });
 });
+
+/**
+ * Projects v2 URL ingestion. The new code path goes through
+ * `src/integrations/github-projects/client.ts` (not the AO tracker
+ * module mocked above), so we stub the network with an injected
+ * `fetch` on `projectsDeps`. The tracker mock above stays in place
+ * because the classifier still calls `detectTrackerKind` for inputs
+ * that aren't Projects URLs.
+ */
+describe("classifyRequest — GitHub Projects v2 URL ingestion", () => {
+  beforeEach(() => {
+    mocks.createTracker.mockReset();
+    mocks.resolveIssue.mockReset();
+  });
+
+  function projectItemFetchStub(): typeof fetch {
+    // Single-call stub returning a populated ProjectV2Item with a parent
+    // epic and a containing project.
+    return vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              id: "PVTI_lADO",
+              project: {
+                id: "PVT_xyz",
+                title: "relay-core-ui",
+                number: 3,
+                url: "https://github.com/users/jcast90/projects/3",
+              },
+              parent: {
+                id: "PVTI_parent",
+                content: { __typename: "DraftIssue", title: "Q4 launch readiness" },
+              },
+              content: {
+                __typename: "DraftIssue",
+                title: "Wire approval-gate hook into TUI",
+                body: "Long-form description of the ticket goes here.",
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+  }
+
+  it("enriches the feature request from a user-owned item URL via stubbed fetch", async () => {
+    const url = "https://github.com/users/jcast90/projects/3/views/1?pane=issue&itemId=PVTI_lADO";
+
+    let captured: Omit<WorkRequest, "runId"> | null = null;
+    const dispatch = vi.fn(async (_run: HarnessRun, req: Omit<WorkRequest, "runId">) => {
+      captured = req;
+      const result: AgentResult = {
+        summary: "Classified",
+        evidence: [],
+        proposedCommands: [],
+        blockers: [],
+        rawResponse: JSON.stringify({
+          classification: {
+            tier: "feature_small",
+            rationale: "Modest feature.",
+            suggestedSpecialties: ["general"],
+            estimatedTicketCount: 2,
+            needsDesignDoc: false,
+            needsUserApproval: false,
+          },
+        }),
+      };
+      return result;
+    });
+
+    const fetchStub = projectItemFetchStub();
+    const classification = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch,
+      projectsDeps: { token: "ghp_fake", fetch: fetchStub },
+    });
+
+    // The AO-tracker boundary was NEVER touched — this is a Projects URL,
+    // not an Issue URL.
+    expect(mocks.createTracker).not.toHaveBeenCalled();
+    expect(mocks.resolveIssue).not.toHaveBeenCalled();
+
+    // Item context flowed into the classifier prompt.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const req = captured as unknown as Omit<WorkRequest, "runId">;
+    expect(req.objective).toContain("Wire approval-gate hook into TUI");
+    expect(req.objective).toContain("Parent epic: Q4 launch readiness");
+    expect(req.objective).toContain("Project: relay-core-ui");
+    expect(req.objective).toContain(url);
+
+    // Project + parent surfaced as separate context lines too.
+    expect(req.context.some((c) => c.includes("relay-core-ui"))).toBe(true);
+    expect(req.context.some((c) => c.includes("Q4 launch readiness"))).toBe(true);
+
+    expect(classification.tier).toBe("feature_small");
+  });
+
+  it("returns the deferred-error result for a project-only URL without hitting the network", async () => {
+    const url = "https://github.com/users/jcast90/projects/3";
+
+    const fetchStub = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    ) as unknown as typeof fetch;
+    const dispatch = vi.fn(async () => ({
+      summary: "should not be called",
+      evidence: [],
+      proposedCommands: [],
+      blockers: [],
+    }));
+
+    const result = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch,
+      projectsDeps: { token: "ghp_fake", fetch: fetchStub },
+    });
+
+    // No fetch, no dispatch — deferred message returned synchronously.
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result.tier).toBe("feature_small");
+    expect(result.rationale).toMatch(/deferred/);
+    expect(result.needsUserApproval).toBe(true);
+  });
+
+  it("falls back gracefully when the GraphQL call fails", async () => {
+    const url = "https://github.com/orgs/acme/projects/9?itemId=PVTI_bad";
+
+    const fetchStub = vi.fn(
+      async () => new Response("internal error", { status: 500 })
+    ) as unknown as typeof fetch;
+    const dispatch = vi.fn(async () => ({
+      summary: "should not be called for deferred",
+      evidence: [],
+      proposedCommands: [],
+      blockers: [],
+    }));
+
+    const result = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch,
+      projectsDeps: { token: "ghp_fake", fetch: fetchStub },
+    });
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    // Deferred fallback path: no LLM dispatch, classification still returned.
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result.tier).toBe("feature_small");
+    expect(result.rationale).toMatch(/HTTP 500/);
+  });
+
+  it("does NOT regress GitHub Issue URL parsing — still flows through the AO tracker boundary", async () => {
+    // Issue URLs must keep going through the existing path; the new
+    // Projects parser should return null on this shape.
+    const url = "https://github.com/acme/widgets/issues/42";
+
+    mocks.createTracker.mockReturnValue({ name: "github" });
+    mocks.resolveIssue.mockResolvedValue({
+      id: "iss-42",
+      title: "Add user management",
+      body: "Body",
+      url,
+      labels: ["feature"],
+      branchName: "42-add-user-management",
+    });
+
+    const dispatch = vi.fn(async (_run: HarnessRun, _req: Omit<WorkRequest, "runId">) => ({
+      summary: "Classified",
+      evidence: [],
+      proposedCommands: [],
+      blockers: [],
+      rawResponse: JSON.stringify({
+        classification: {
+          tier: "feature_small",
+          rationale: "Modest feature.",
+          suggestedSpecialties: ["general"],
+          estimatedTicketCount: 2,
+          needsDesignDoc: false,
+          needsUserApproval: false,
+        },
+      }),
+    }));
+
+    // We pass `projectsDeps` to be sure the new code path gracefully
+    // ignores Issue URLs (no calls into the stubbed fetch).
+    const fetchStub = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    ) as unknown as typeof fetch;
+
+    const result = await classifyRequest({
+      run: buildRun(url),
+      featureRequest: url,
+      repoRoot: "/tmp/fake-repo",
+      dispatch,
+      projectsDeps: { token: "ghp_fake", fetch: fetchStub },
+    });
+
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(mocks.createTracker).toHaveBeenCalledWith("github");
+    expect(mocks.resolveIssue).toHaveBeenCalledTimes(1);
+    expect(result.suggestedBranch).toBe("42-add-user-management");
+  });
+});

--- a/test/integrations/github-projects-url-parser.test.ts
+++ b/test/integrations/github-projects-url-parser.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROJECT_ONLY_DEFERRED_MESSAGE,
+  parseGithubProjectsUrl,
+} from "../../src/integrations/github-projects/url-parser.js";
+
+/**
+ * Pure-parser tests. No network — `parseGithubProjectsUrl` does no IO.
+ * Asserts on every shape from Decision 5 of
+ * docs/design/tracker-projects-mapping.md, plus the negatives that must
+ * NOT match (issue URLs, GHES, gist, malformed itemId).
+ */
+describe("parseGithubProjectsUrl", () => {
+  describe("item-scoped URLs", () => {
+    it("parses the long user-owned shape (views/<v> + pane=issue + itemId)", () => {
+      const url = "https://github.com/users/jcast90/projects/3/views/1?pane=issue&itemId=PVTI_lADO";
+      const out = parseGithubProjectsUrl(url);
+      expect(out).toEqual({
+        kind: "item",
+        ownerType: "user",
+        owner: "jcast90",
+        projectNumber: 3,
+        itemId: "PVTI_lADO",
+        url,
+      });
+    });
+
+    it("parses the short org-owned shape (no /views, just ?itemId)", () => {
+      const url = "https://github.com/orgs/acme/projects/12?itemId=PVTI_kwAOAB";
+      const out = parseGithubProjectsUrl(url);
+      expect(out).toEqual({
+        kind: "item",
+        ownerType: "organization",
+        owner: "acme",
+        projectNumber: 12,
+        itemId: "PVTI_kwAOAB",
+        url,
+      });
+    });
+
+    it("tolerates trailing slashes on the path", () => {
+      const out = parseGithubProjectsUrl(
+        "https://github.com/users/jcast90/projects/3/?itemId=PVTI_abc"
+      );
+      expect(out).not.toBeNull();
+      expect(out!.kind).toBe("item");
+    });
+
+    it("tolerates the www. prefix", () => {
+      const out = parseGithubProjectsUrl("https://www.github.com/orgs/acme/projects/1?itemId=I_x");
+      expect(out).not.toBeNull();
+      expect(out!.kind).toBe("item");
+      expect(out!.owner).toBe("acme");
+    });
+
+    it("tolerates whitespace around the URL", () => {
+      const out = parseGithubProjectsUrl(
+        "  https://github.com/orgs/acme/projects/7?itemId=PVTI_z  "
+      );
+      expect(out?.kind).toBe("item");
+      expect(out?.url).toBe("https://github.com/orgs/acme/projects/7?itemId=PVTI_z");
+    });
+
+    it("rejects an empty itemId value as non-item (falls through to project)", () => {
+      // `?itemId=` with an empty value — not a valid item paste; fall back.
+      const out = parseGithubProjectsUrl("https://github.com/users/jcast90/projects/3?itemId=");
+      // searchParams.get returns "" which is falsy — treated as no itemId.
+      expect(out?.kind).toBe("project");
+    });
+
+    it("rejects malformed itemId characters (returns null, not project)", () => {
+      const out = parseGithubProjectsUrl(
+        "https://github.com/users/jcast90/projects/3?itemId=bad%20id"
+      );
+      // Decoded value contains a space — fails the [A-Za-z0-9_-] guard.
+      expect(out).toBeNull();
+    });
+  });
+
+  describe("project-only URLs", () => {
+    it("parses a user-owned project URL (no itemId)", () => {
+      const url = "https://github.com/users/jcast90/projects/3";
+      const out = parseGithubProjectsUrl(url);
+      expect(out).toEqual({
+        kind: "project",
+        ownerType: "user",
+        owner: "jcast90",
+        projectNumber: 3,
+        url,
+      });
+    });
+
+    it("parses an org-owned project URL", () => {
+      const out = parseGithubProjectsUrl("https://github.com/orgs/acme/projects/9");
+      expect(out?.kind).toBe("project");
+      expect(out?.ownerType).toBe("organization");
+      expect(out?.projectNumber).toBe(9);
+    });
+
+    it("treats a /views/ URL with no itemId as project-scoped", () => {
+      // The Projects UI redirects you to /views/<v> on first open even
+      // without selecting a card; the user's paste should still be
+      // detected as project-scoped (deferred).
+      const out = parseGithubProjectsUrl("https://github.com/orgs/acme/projects/9/views/1");
+      expect(out?.kind).toBe("project");
+    });
+  });
+
+  describe("non-matches (no false positives)", () => {
+    it("returns null for a GitHub Issue URL", () => {
+      expect(parseGithubProjectsUrl("https://github.com/acme/widgets/issues/42")).toBeNull();
+    });
+
+    it("returns null for a GitHub PR URL", () => {
+      expect(parseGithubProjectsUrl("https://github.com/acme/widgets/pull/42")).toBeNull();
+    });
+
+    it("returns null for a Linear URL", () => {
+      expect(parseGithubProjectsUrl("https://linear.app/acme/issue/ABC-123")).toBeNull();
+    });
+
+    it("returns null for a bare Linear key", () => {
+      expect(parseGithubProjectsUrl("ABC-123")).toBeNull();
+    });
+
+    it("returns null for a non-github host", () => {
+      expect(
+        parseGithubProjectsUrl("https://example.com/users/jcast90/projects/3?itemId=PVTI_x")
+      ).toBeNull();
+    });
+
+    it("returns null for a github sub-host like gist.github.com", () => {
+      expect(parseGithubProjectsUrl("https://gist.github.com/users/x/projects/1")).toBeNull();
+    });
+
+    it("returns null for empty/malformed/missing-segment inputs", () => {
+      expect(parseGithubProjectsUrl("")).toBeNull();
+      expect(parseGithubProjectsUrl("   ")).toBeNull();
+      expect(parseGithubProjectsUrl("not-a-url")).toBeNull();
+      expect(parseGithubProjectsUrl("github.com/users/x/projects/1")).toBeNull();
+      expect(parseGithubProjectsUrl("https://github.com/users/jcast90/projects/0")).toBeNull();
+      expect(parseGithubProjectsUrl("https://github.com/users/jcast90/repos/relay")).toBeNull();
+    });
+  });
+
+  describe("PROJECT_ONLY_DEFERRED_MESSAGE", () => {
+    it("mentions itemId so the user knows what to paste", () => {
+      expect(PROJECT_ONLY_DEFERRED_MESSAGE).toMatch(/itemId/);
+      expect(PROJECT_ONLY_DEFERRED_MESSAGE).toMatch(/deferred/);
+    });
+  });
+});


### PR DESCRIPTION
Implements **v0.2 PR E** of the Tracker projects mapping work (#184, see also #180 for the umbrella tracker). Builds on PR A (#180-A, the GraphQL client) — base branch is `feat/v0.2-pr-a-graphql-client`.

## Summary

Teaches Relay's classifier to recognise three GitHub Projects v2 URL shapes (per Decision 5 of `docs/design/tracker-projects-mapping.md`):

1. **Item-scoped, user-owned:** `github.com/users/<u>/projects/<n>/views/<v>?pane=issue&itemId=<id>`
2. **Item-scoped, org-owned:** `github.com/orgs/<o>/projects/<n>?itemId=<id>`
3. **Project-scoped (no item):** `github.com/users/<u>/projects/<n>` or `github.com/orgs/<o>/projects/<n>` — returns a clear deferred-error message; the "sync the whole project" flow is left for a later PR.

For item-scoped pastes the classifier resolves the item's parent epic + parent project via a new GraphQL helper, then enriches the classifier prompt with the title, body, parent epic, and project name so downstream planning sees real context (not just a bare URL).

## Files

- **`src/integrations/github-projects/url-parser.ts`** *(new, 112 LOC)* — pure regex/URL parser. No network, no env reads, no I/O. Returns a typed `GitHubProjectsUrl | null`. Classifier calls this first; only reaches into the network-touching client once an item-scoped match is confirmed.
- **`src/integrations/github-projects/client.ts`** *(+138 LOC)* — adds `getProjectItemContext(itemId, deps)` and the `ProjectItemContext` shape. The query asks for the item's `Parent` field plus its containing `project` so channel/epic association is recovered on URL paste.
- **`src/orchestrator/classifier.ts`** *(+200 LOC, -15 LOC refactor)* — adds the Projects v2 branch to `classifyRequest`, factors the heuristic+dispatch tail into `classifyEnrichedRequest` so both the existing tracker-issue path and the new Projects v2 path share it. Accepts an optional `projectsDeps: Partial<ProjectsClientDeps>` on the input bag.
- **`test/integrations/github-projects-url-parser.test.ts`** *(new, 153 LOC, 17 tests)* — every URL shape, plus negatives (Issue URL, PR URL, Linear URL, GHES, gist sub-host, malformed URL, missing `/projects/` segment, projectNumber 0).
- **`test/integrations/classifier-url-ingestion.test.ts`** *(+197 LOC, 4 new tests)* — item URL enriches via stubbed `fetch`; project-only URL returns deferred result without hitting the network; API failure falls back to deferred; existing GitHub Issue URL parsing still works (regression).

Net: **800 insertions, 15 deletions** — right at the sub-800 LOC PR budget per AGENTS.md.

## Design notes

**Why a separate parser module rather than extending `tracker.ts`?** The Projects v2 URL space is structurally different from `github.com/<owner>/<repo>/issues/<n>` — it has no repo segment, uses `/users|orgs/.../projects/<n>` instead, and resolves through a different API (Projects GraphQL, not the AO Tracker plugin). Keeping the parser pure and network-free lets the classifier do cheap detection before any I/O, and lets unit tests assert on parsing without mocking AO.

**Where does `getProjectItemContext` live?** Added it to the existing PR A client (`client.ts`) rather than a new file because the response interface and the GraphQL POST plumbing already live there — splitting it would have meant re-exporting `githubProjectsGraphql` from a sibling module for one consumer. Happy to move it if reviewers prefer.

**Token handling follows AGENTS.md § "Things to watch out for".** New code never reads `process.env.GITHUB_TOKEN` directly; the classifier accepts a `projectsDeps` bag (mirroring the `ProjectsClientDeps` convention from PR A) and the env fallback happens only at the classifier's single boundary helper (`resolveProjectsDeps`). Tests inject a stubbed `fetch` so no real network is hit.

**Project-only URLs surface a soft error, not a throw.** The orchestrator UX prefers a returned classification with an explanatory rationale to a hard failure. Project-only and API-failure paths both return `feature_small` with the deferred message in `rationale` and `needsUserApproval = true` so the user sees and gates on it. If reviewers prefer a typed error result, easy to swap in.

**`tracker.providers.github_issues.enabled` gating.** The config block lands in PR G (#184 lists it as a follow-up); for now the existing tracker-issue path is unconditionally on, matching today's behaviour. No regression here.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes (no drive-by reformats)
- [x] `pnpm test` — 927 passed / 24 skipped (added 21 new tests; one drop is from removing a redundant "no token" case to land within budget)
- [x] `pnpm build` passes
- [ ] Smoke: paste a real Projects v2 item URL into `rly` chat with `GITHUB_TOKEN` set and confirm the resulting classification carries the parent epic title (live-network smoke, not run in default CI per AGENTS.md)

## Out of scope

- The full `getProjectItemContext` mutation surface (write-side ticket creation under the resolved epic) — that lands in PR D's sync worker.
- Linear-side parity for project URL parsing — PR F.
- `tracker` config block (`tracker.providers.github_issues.enabled` gate, etc.) — PR G.
- "Sync the whole project" flow for project-only URL pastes — explicitly deferred per Decision 5.

Refs #184, #180.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>