### PR TITLE
feat(tracker): v0.2 PR C — channel↔epic orchestration + trackerLinks

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -1853,6 +1853,7 @@ mod tests {
             section_id: None,
             provider_profile_id: None,
             pr: None,
+            tracker_links: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             updated_at: Some("2026-01-01T00:00:00Z".to_string()),
         }
@@ -2033,6 +2034,7 @@ mod tests {
             section_id: None,
             provider_profile_id: None,
             pr: None,
+            tracker_links: None,
             created_at: None,
             updated_at: None,
         }

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -192,6 +192,38 @@ pub struct Channel {
     /// with channel files written before the PR-review DM feature.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pr: Option<ChannelPr>,
+    /// External-tracker projection metadata. Populated by the
+    /// channel-hooks in
+    /// `src/integrations/github-projects/channel-hooks.ts` when a project
+    /// is provisioned for the channel. Rust round-trips the field so
+    /// dashboard writes stay lossless; the dashboards do not mint these
+    /// values themselves. Optional + `#[serde(default)]` for back-compat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracker_links: Option<ChannelTrackerLinks>,
+}
+
+/// Per-provider projection metadata for a channel. Mirrors
+/// `src/domain/channel.ts::ChannelTrackerLinks`. New provider blocks
+/// (Linear parity in PR F, #185) land as additional optional fields here.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelTrackerLinks {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_projects: Option<ChannelGitHubProjectsLink>,
+}
+
+/// Stable references for a channel's GitHub Projects v2 projection.
+/// Mirrors `src/domain/channel.ts::ChannelGitHubProjectsLink`. Both ids
+/// are kept because field updates take the project-item id (`PVTI_…`)
+/// while title/body edits take the draft-issue id (`DI_…`).
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelGitHubProjectsLink {
+    pub project_id: String,
+    pub project_number: u64,
+    pub project_url: String,
+    pub epic_item_id: String,
+    pub epic_draft_issue_id: String,
 }
 
 /// PR-review metadata mirrored from `src/domain/channel.ts::ChannelPr`. The

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -978,6 +978,7 @@ fn create_dm(
         section_id: None,
         provider_profile_id: None,
         pr: None,
+        tracker_links: None,
         created_at: Some(now.to_rfc3339()),
         updated_at: Some(now.to_rfc3339()),
     };

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -168,8 +168,41 @@ export interface Channel {
    * transitions to `merged` / `closed`. See {@link ChannelPr}.
    */
   pr?: ChannelPr;
+  /**
+   * External-tracker projection metadata. Populated by the channel-hooks
+   * in `src/integrations/github-projects/channel-hooks.ts` when a project
+   * is provisioned for the channel. Relay is authoritative — these ids
+   * exist purely so the sync worker (PR D, #183) can find the right
+   * project / epic on each tick. Optional + back-compat: a missing field
+   * means no external projection has been set up.
+   */
+  trackerLinks?: ChannelTrackerLinks;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Per-provider projection metadata for a channel. Each tracker the user
+ * opts into gets its own block. Today only `githubProjects` is wired —
+ * Linear parity (PR F, #185) will add a `linear` sibling.
+ */
+export interface ChannelTrackerLinks {
+  githubProjects?: ChannelGitHubProjectsLink;
+}
+
+/**
+ * Stable references for a channel's GitHub Projects v2 projection. Both
+ * `epicItemId` (PVTI_…) and `epicDraftIssueId` (DI_…) are stored because
+ * the two id types serve different mutations: itemId for field updates
+ * and archival, draftIssueId for title/body edits. See
+ * `src/integrations/github-projects/draft-items.ts` for the contract.
+ */
+export interface ChannelGitHubProjectsLink {
+  projectId: string;
+  projectNumber: number;
+  projectUrl: string;
+  epicItemId: string;
+  epicDraftIssueId: string;
 }
 
 /**

--- a/src/integrations/github-projects/channel-hooks.ts
+++ b/src/integrations/github-projects/channel-hooks.ts
@@ -1,0 +1,144 @@
+/**
+ * Channel ↔ Epic lifecycle orchestration. Third slice of the v0.2
+ * tracker work (PR C / #182). Composes the lower-level primitives from
+ * `client.ts`, `fields.ts`, and `draft-items.ts` into three high-level
+ * operations that match the Channel lifecycle: provision, rename,
+ * archive.
+ *
+ * This module is **pure orchestration** — it neither reads from nor
+ * writes to `~/.relay/`. Callers (the eventual MCP tool handlers) are
+ * responsible for persisting the returned `ChannelGitHubProjectsLink`
+ * onto the channel via `ChannelStore.updateChannel`. Keeping the
+ * persistence concern at the call site means tests can exercise the
+ * orchestration without standing up a full channel store, and the
+ * tracker integration can be opted in/out per call site without
+ * threading new flags through `channel-store.ts`.
+ *
+ * The MCP-handler wiring (channel_create / channel_update /
+ * channel_archive) is deliberately deferred to a follow-up PR. PR C
+ * ships the orchestration + types; the wiring lands behind `tracker`
+ * config (PR G, #186) so it can be feature-flagged without churning
+ * this module.
+ */
+import type { ChannelGitHubProjectsLink } from "../../domain/channel.js";
+import {
+  archiveItem,
+  createDraftItem,
+  ensureCustomFields,
+  listProjectFields,
+  resolveProject,
+  setSingleSelectValue,
+  updateDraftIssue,
+  type ProjectOwnerRef,
+  type ProjectsClientDeps,
+} from "./client.js";
+
+export interface ProvisionEpicInput {
+  /** Display name for the channel — becomes the epic draft-issue title. */
+  channelName: string;
+  /** Channel description — becomes the epic draft-issue body. Optional. */
+  channelDescription?: string;
+  /** Owner login + type that hosts the project. */
+  ownerRef: ProjectOwnerRef;
+  /**
+   * Project title to find or create. Per the design doc the convention
+   * is the channel's primary repo alias (so a channel rooted at
+   * `relay-core-ui` lives in a Project titled "relay-core-ui").
+   * Callers compute this — keeping the rule out of this module lets PR
+   * G's config block override it without code changes here.
+   */
+  projectTitle: string;
+}
+
+/**
+ * Provision a GitHub Projects v2 epic for a channel. Idempotent on the
+ * project-resolution and field-bootstrap legs (both `resolveProject`
+ * and `ensureCustomFields` are designed to be safe on re-run); the
+ * draft-item creation is **not** idempotent and will produce a
+ * duplicate epic if called twice. Callers must check
+ * `channel.trackerLinks?.githubProjects` before invoking and skip if
+ * an epic already exists.
+ *
+ * Sequence:
+ *   1. resolveProject(ownerRef, projectTitle) — find or create
+ *   2. ensureCustomFields(projectId, ["Status", "Type", "Priority"]) — bootstrap
+ *   3. createDraftItem({ projectId, title: channelName, body: channelDescription })
+ *   4. setSingleSelectValue(Type=epic) on the new item
+ *
+ * Step 4 is best-effort: if the Type field can't be located or the
+ * `epic` option doesn't exist (because the user manually customized the
+ * field), provisioning still succeeds and the epic is left untyped.
+ * The sync worker (PR D, #183) will surface a warning then. We don't
+ * abort here because the most useful state is "epic exists" — a missing
+ * Type tag is recoverable by hand.
+ */
+export async function provisionEpicForChannel(
+  input: ProvisionEpicInput,
+  deps: ProjectsClientDeps
+): Promise<ChannelGitHubProjectsLink> {
+  const project = await resolveProject(input.ownerRef, input.projectTitle, deps);
+  await ensureCustomFields(project.id, ["Status", "Type", "Priority"], deps);
+
+  const epic = await createDraftItem(
+    {
+      projectId: project.id,
+      title: input.channelName,
+      body: input.channelDescription,
+    },
+    deps
+  );
+
+  // Best-effort Type=epic stamp. See the JSDoc above for the rationale.
+  const fields = await listProjectFields(project.id, deps);
+  const typeField = fields.find((f) => f.name === "Type");
+  const epicOption = typeField?.options?.find((o) => o.name === "epic");
+  if (typeField && epicOption) {
+    await setSingleSelectValue(
+      {
+        projectId: project.id,
+        itemId: epic.itemId,
+        fieldId: typeField.id,
+        optionId: epicOption.id,
+      },
+      deps
+    );
+  }
+
+  return {
+    projectId: project.id,
+    projectNumber: project.number,
+    projectUrl: project.url,
+    epicItemId: epic.itemId,
+    epicDraftIssueId: epic.draftIssueId,
+  };
+}
+
+/**
+ * Rename the epic draft issue for a channel. Called from the
+ * channel_update hook when `name` changes. Pure pass-through to
+ * `updateDraftIssue` — kept as its own function so the call site reads
+ * intent ("rename the epic") rather than mechanism ("edit a draft
+ * issue"), and so the Linear parity work in PR F can pattern-match the
+ * same shape.
+ */
+export async function renameEpicForChannel(
+  link: ChannelGitHubProjectsLink,
+  newName: string,
+  deps: ProjectsClientDeps
+): Promise<void> {
+  await updateDraftIssue({ draftIssueId: link.epicDraftIssueId, title: newName }, deps);
+}
+
+/**
+ * Archive the epic for a channel. Called from the channel_archive
+ * hook. Idempotent: archiving an already-archived item is a no-op on
+ * GitHub's side. The project itself is intentionally left alone — it
+ * may host other channels' epics under a future "shared project" model
+ * even though today every channel maps to its own project.
+ */
+export async function archiveEpicForChannel(
+  link: ChannelGitHubProjectsLink,
+  deps: ProjectsClientDeps
+): Promise<void> {
+  await archiveItem({ projectId: link.projectId, itemId: link.epicItemId }, deps);
+}

--- a/test/integrations/github-projects-channel-hooks.test.ts
+++ b/test/integrations/github-projects-channel-hooks.test.ts
@@ -231,6 +231,11 @@ describe("github-projects/channel-hooks", () => {
       expect(out.epicItemId).toBe("PVTI_e1");
       // No setSingleSelectValue call.
       expect(calls.every((c) => !/updateProjectV2ItemFieldValue/.test(c.body.query))).toBe(true);
+      // Pin call count too — a regression that adds a stray field-write
+      // between createDraftItem and the final list would otherwise slip
+      // through silently. Expected: resolveProject + listFields(ensure)
+      // + createDraft + listFields(re-read) = 4 calls.
+      expect(calls).toHaveLength(4);
     });
   });
 

--- a/test/integrations/github-projects-channel-hooks.test.ts
+++ b/test/integrations/github-projects-channel-hooks.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  archiveEpicForChannel,
+  provisionEpicForChannel,
+  renameEpicForChannel,
+} from "../../src/integrations/github-projects/channel-hooks.js";
+import type { ProjectsClientDeps } from "../../src/integrations/github-projects/client.js";
+
+/**
+ * Tests for the high-level channel↔epic orchestration. The lower-level
+ * client + draft-items + fields modules are already covered by their
+ * own tests; here we pin down the call **sequence** so future edits to
+ * `provisionEpicForChannel` don't silently reorder the steps in a way
+ * that breaks the channel/project contract (e.g. trying to set
+ * Type=epic before fields exist).
+ */
+
+interface CapturedRequest {
+  body: { query: string; variables: Record<string, unknown> };
+}
+
+function stubFetch(responses: Array<unknown>): {
+  fetchImpl: typeof fetch;
+  calls: CapturedRequest[];
+} {
+  const calls: CapturedRequest[] = [];
+  let i = 0;
+  const fetchImpl = vi.fn(async (_url: unknown, init: RequestInit = {}) => {
+    const body = JSON.parse(String(init.body ?? "{}"));
+    calls.push({ body });
+    const payload = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function deps(fetchImpl: typeof fetch): ProjectsClientDeps {
+  return { token: "ghp_fake", fetch: fetchImpl };
+}
+
+// --- Canned response builders for the multi-step provision flow ---
+
+function findProjectExisting(projectId: string, number: number, title: string): unknown {
+  return {
+    data: {
+      user: {
+        projectsV2: { nodes: [{ id: projectId, title, number, url: `u/${number}` }] },
+      },
+    },
+  };
+}
+
+function listFieldsResponse(
+  fields: Array<{ id: string; name: string; options?: Array<{ id: string; name: string }> }>
+): unknown {
+  return { data: { node: { fields: { nodes: fields } } } };
+}
+
+function addDraftIssueResponse(itemId: string, draftId: string): unknown {
+  return {
+    data: {
+      addProjectV2DraftIssue: {
+        projectItem: { id: itemId, content: { id: draftId } },
+      },
+    },
+  };
+}
+
+function setFieldValueResponse(itemId: string): unknown {
+  return {
+    data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: itemId } } },
+  };
+}
+
+describe("github-projects/channel-hooks", () => {
+  describe("provisionEpicForChannel", () => {
+    it("runs the full sequence and returns a complete tracker link", async () => {
+      const typeFieldOptions = [
+        { id: "OPT_epic", name: "epic" },
+        { id: "OPT_ticket", name: "ticket" },
+      ];
+      const allFields = [
+        { id: "F_status", name: "Status" },
+        { id: "F_type", name: "Type", options: typeFieldOptions },
+        { id: "F_priority", name: "Priority" },
+      ];
+
+      const { fetchImpl, calls } = stubFetch([
+        // 1. resolveProject → findProjectByTitle (existing match)
+        findProjectExisting("PVT_p1", 7, "relay-core-ui"),
+        // 2. ensureCustomFields → listProjectFields (all already present, no creates)
+        listFieldsResponse(allFields),
+        // 3. createDraftItem
+        addDraftIssueResponse("PVTI_e1", "DI_e1"),
+        // 4. listProjectFields (re-read so we can find the Type field id + epic option)
+        listFieldsResponse(allFields),
+        // 5. setSingleSelectValue Type=epic
+        setFieldValueResponse("PVTI_e1"),
+      ]);
+
+      const out = await provisionEpicForChannel(
+        {
+          channelName: "ui-refactor",
+          channelDescription: "Refactor the UI auth flow",
+          ownerRef: { owner: "jcast90", ownerType: "user" },
+          projectTitle: "relay-core-ui",
+        },
+        deps(fetchImpl)
+      );
+
+      expect(out).toEqual({
+        projectId: "PVT_p1",
+        projectNumber: 7,
+        projectUrl: "u/7",
+        epicItemId: "PVTI_e1",
+        epicDraftIssueId: "DI_e1",
+      });
+
+      // Pin the call sequence — order matters for correctness.
+      expect(calls).toHaveLength(5);
+      expect(calls[0].body.query).toMatch(/projectsV2\(first: 20/);
+      expect(calls[1].body.query).toMatch(/fields\(first: 50\)/);
+      expect(calls[2].body.query).toMatch(/addProjectV2DraftIssue/);
+      expect(calls[3].body.query).toMatch(/fields\(first: 50\)/);
+      expect(calls[4].body.query).toMatch(/updateProjectV2ItemFieldValue/);
+
+      // The epic stamp uses the Type field id and the `epic` option id we
+      // surfaced from the field listing — not hard-coded ids.
+      expect(calls[4].body.variables).toMatchObject({
+        itemId: "PVTI_e1",
+        fieldId: "F_type",
+        optionId: "OPT_epic",
+      });
+    });
+
+    it("creates missing fields before creating the epic", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        // resolveProject
+        findProjectExisting("PVT_p1", 1, "relay"),
+        // ensureCustomFields → list (Status only present)
+        listFieldsResponse([{ id: "F_status", name: "Status" }]),
+        // ensureCustomFields → create Type
+        {
+          data: {
+            createProjectV2Field: {
+              projectV2Field: {
+                id: "F_type_new",
+                name: "Type",
+                options: [
+                  { id: "OPT_epic", name: "epic" },
+                  { id: "OPT_ticket", name: "ticket" },
+                ],
+              },
+            },
+          },
+        },
+        // ensureCustomFields → create Priority
+        {
+          data: {
+            createProjectV2Field: {
+              projectV2Field: { id: "F_priority_new", name: "Priority", options: [] },
+            },
+          },
+        },
+        // createDraftItem
+        addDraftIssueResponse("PVTI_e1", "DI_e1"),
+        // listProjectFields again (to find Type field id)
+        listFieldsResponse([
+          { id: "F_status", name: "Status" },
+          {
+            id: "F_type_new",
+            name: "Type",
+            options: [
+              { id: "OPT_epic", name: "epic" },
+              { id: "OPT_ticket", name: "ticket" },
+            ],
+          },
+          { id: "F_priority_new", name: "Priority" },
+        ]),
+        // setSingleSelectValue
+        setFieldValueResponse("PVTI_e1"),
+      ]);
+
+      await provisionEpicForChannel(
+        {
+          channelName: "ch",
+          ownerRef: { owner: "jcast90", ownerType: "user" },
+          projectTitle: "relay",
+        },
+        deps(fetchImpl)
+      );
+
+      // Field creates must precede draft creation.
+      expect(calls[2].body.query).toMatch(/createProjectV2Field/);
+      expect(calls[3].body.query).toMatch(/createProjectV2Field/);
+      expect(calls[4].body.query).toMatch(/addProjectV2DraftIssue/);
+    });
+
+    it("succeeds without stamping Type when the user customized fields away", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        findProjectExisting("PVT_p1", 1, "relay"),
+        // First field listing (used by ensureCustomFields) — Status/Type/Priority all present
+        listFieldsResponse([
+          { id: "F_status", name: "Status" },
+          { id: "F_type", name: "Type", options: [{ id: "OPT_other", name: "story" }] },
+          { id: "F_priority", name: "Priority" },
+        ]),
+        addDraftIssueResponse("PVTI_e1", "DI_e1"),
+        // Second listing — same shape: Type exists but `epic` option is missing
+        listFieldsResponse([
+          { id: "F_status", name: "Status" },
+          { id: "F_type", name: "Type", options: [{ id: "OPT_other", name: "story" }] },
+          { id: "F_priority", name: "Priority" },
+        ]),
+      ]);
+
+      const out = await provisionEpicForChannel(
+        {
+          channelName: "ch",
+          ownerRef: { owner: "jcast90", ownerType: "user" },
+          projectTitle: "relay",
+        },
+        deps(fetchImpl)
+      );
+
+      expect(out.epicItemId).toBe("PVTI_e1");
+      // No setSingleSelectValue call.
+      expect(calls.every((c) => !/updateProjectV2ItemFieldValue/.test(c.body.query))).toBe(true);
+    });
+  });
+
+  describe("renameEpicForChannel", () => {
+    it("calls updateProjectV2DraftIssue with the new title", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        { data: { updateProjectV2DraftIssue: { draftIssue: { id: "DI_e1" } } } },
+      ]);
+
+      await renameEpicForChannel(
+        {
+          projectId: "PVT_p1",
+          projectNumber: 1,
+          projectUrl: "u",
+          epicItemId: "PVTI_e1",
+          epicDraftIssueId: "DI_e1",
+        },
+        "renamed",
+        deps(fetchImpl)
+      );
+
+      expect(calls[0].body.query).toMatch(/updateProjectV2DraftIssue/);
+      expect(calls[0].body.variables).toMatchObject({
+        draftIssueId: "DI_e1",
+        title: "renamed",
+      });
+    });
+  });
+
+  describe("archiveEpicForChannel", () => {
+    it("calls archiveProjectV2Item with the project + epic item ids", async () => {
+      const { fetchImpl, calls } = stubFetch([
+        { data: { archiveProjectV2Item: { item: { id: "PVTI_e1" } } } },
+      ]);
+
+      await archiveEpicForChannel(
+        {
+          projectId: "PVT_p1",
+          projectNumber: 1,
+          projectUrl: "u",
+          epicItemId: "PVTI_e1",
+          epicDraftIssueId: "DI_e1",
+        },
+        deps(fetchImpl)
+      );
+
+      expect(calls[0].body.query).toMatch(/archiveProjectV2Item/);
+      expect(calls[0].body.variables).toEqual({
+        projectId: "PVT_p1",
+        itemId: "PVTI_e1",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Third slice of v0.2 tracker work (#182). Composes the lower-level primitives from PR A (#188, merged) and PR B (#189) into three high-level operations matching the channel lifecycle, and extends the Channel domain shape (TS + Rust) with a `trackerLinks` field so a channel's projection metadata round-trips through every dashboard losslessly.

**Stacked on PR B (#189)** — base will be `main` after #189 merges; rebase will be clean.

## What's in scope

### `src/integrations/github-projects/channel-hooks.ts`
Pure orchestration — callers persist the returned link via `ChannelStore.updateChannel` themselves.

- **`provisionEpicForChannel`** runs:
  1. `resolveProject(ownerRef, projectTitle)` — find or create
  2. `ensureCustomFields(projectId, ["Status","Type","Priority"])` — bootstrap
  3. `createDraftItem({ projectId, title: channelName, body })` — the epic itself
  4. `setSingleSelectValue(Type=epic)` — best-effort stamp

  Step 4 is best-effort: if the user customized the Type field away, provisioning still succeeds and the epic stays untyped. The sync worker (PR D) will warn then. Aborting wouldn't help — the most useful state is "epic exists."

- **`renameEpicForChannel(link, newName, deps)`** — `updateProjectV2DraftIssue` with the new title.
- **`archiveEpicForChannel(link, deps)`** — `archiveProjectV2Item`. Project itself intentionally left alone (future "shared project" model).

### Domain shape
- **`src/domain/channel.ts`** — adds `Channel.trackerLinks`, `ChannelTrackerLinks`, `ChannelGitHubProjectsLink`. Both `PVTI_…` (project-item) and `DI_…` (draft-issue) ids are stored because field updates take the item id while title/body edits take the draft-issue id.
- **`crates/harness-data/src/lib.rs`** — mirrors all three TS shapes with `serde(default, skip_serializing_if)` for back-compat. Per AGENTS.md cross-dashboard contract.
- **`gui/src-tauri/src/lib.rs`** — adds `tracker_links: None` to the DM-channel constructor so existing call sites still compile.

## What's deliberately not here (deferred to follow-ups)
- **MCP-handler wiring** (channel_create / channel_update / channel_archive). Lands behind the `tracker` config block from PR G (#186) so the integration can be feature-flagged without churning this module.
- **Primary-repo-change recreate-epic-in-new-project flow** — needs the config block to know which provider to target.

These deferrals are why PR C ships well under the LOC budget — the wiring concentrates almost all of #182's edge-case complexity, and gating it on PR G's config keeps the code path single-direction (not via env-flags or runtime branching).

## Tests
**5 new vitest cases**:
- Full happy-path sequence — pins the call order so future edits can't silently reorder steps in a way that breaks correctness (e.g. trying to set Type=epic before fields exist)
- Missing-field path: field creates must precede draft creation
- Graceful-skip when the user has customized the Type field away — provisioning succeeds without a Type stamp
- `renameEpicForChannel` calls `updateProjectV2DraftIssue` with the right id + title
- `archiveEpicForChannel` calls `archiveProjectV2Item` with project + epic item ids

Full suite: **928 passed | 24 skipped** (was 923 | 24 in PR B). Rust crate passes `cargo check --workspace`.

## Verification

```
pnpm typecheck    # clean
pnpm format:check # clean
pnpm test         # 928 passed | 24 skipped
cargo check --workspace # clean
```

## LOC
- 5 files: +497 / 0 (sub-800)

## Test plan
- [ ] CI fast-tier passes (ts-verify, rust-check, format-check)
- [ ] Reviewer signs off on the deferred-wiring approach (PR C ships orchestration; wiring lands with PR G config)
- [ ] Reviewer confirms the Rust shape rename strategy (`tracker_links: Option<ChannelTrackerLinks>` with `serde(default)`)
- [ ] Reviewer confirms storing both `epicItemId` (PVTI_…) and `epicDraftIssueId` (DI_…) is the right call (both needed for different mutations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)