### PR TITLE
docs(tracker): v0.2 PR H — tracker integration docs + migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The agent-harness space is crowded, but most tools solve only **one** of: runnin
 - 📋 **One ticket board spans many repos.** Tickets carry a dependency DAG and `assignedAlias` routing — a feature touching 3 repos is one plan with 3 ticket streams, not 3 uncorrelated sessions. Single-repo orchestrators can't express this.
 - 💬 **Every decision is logged with rationale + alternatives.** Like Slack threads, but for architectural choices. Step away for 4 hours, come back to an audit trail — who chose what, why, and what else was considered. Most harnesses don't persist anything beyond the raw transcript.
 - 🎛 **Three dashboards, one source of truth — no cloud.** CLI (`rly`), ratatui TUI, and Tauri desktop GUI all read the same `~/.relay/` files. No sync layer, no split brain, no hosted service, no telemetry. Rare in AI tooling, required in regulated environments.
+- 🗂 **GitHub Projects v2 integration (v0.2).** Channels project to a GH Projects v2 board automatically — channels become epics, tickets become draft items, with `Type` / `Status` / `Priority` custom fields kept in sync. Relay stays authoritative; drift detected on the GitHub side is logged to the channel feed and overwritten. Paste a Projects item URL into chat and the classifier resolves the project + epic + creates the ticket. See [`docs/trackers.md`](./docs/trackers.md).
 
 ## What Relay is
 
@@ -388,8 +389,12 @@ Built on Composio's [`@aoagents/ao-core`](https://www.npmjs.com/package/@aoagent
 
 Tokens:
 
-- `GITHUB_TOKEN` — GitHub issues + PR watcher
+- `GITHUB_TOKEN` — GitHub issues + PR watcher + GitHub Projects v2 sync (needs `project` scope; `read:org` for org-owned projects)
 - `LINEAR_API_KEY` (or `COMPOSIO_API_KEY`) — Linear issues
+
+### GitHub Projects v2 (v0.2, new)
+
+Relay channels project onto a GH Projects v2 board: channel → epic draft item, ticket → child draft item, with `Type` / `Status` / `Priority` custom fields kept in sync by a one-way Relay-authoritative sync worker. URL-paste a Projects v2 item into chat and the classifier resolves the project + epic + creates the ticket. Reuses `GITHUB_TOKEN`. Full reference: [`docs/trackers.md`](./docs/trackers.md).
 
 ### PR watcher (scm-github)
 
@@ -479,6 +484,7 @@ Verification commands run through an `Executor` abstraction (`src/execution/exec
 ```
 ~/.relay/
   config.json                 # global config (project dirs, etc.)
+                              #   `tracker` config block — see docs/trackers.md
   config.env.template         # copy to config.env and fill in
   workspace-registry.json     # all registered repos
   workspaces/<hash>/
@@ -492,8 +498,10 @@ Verification commands run through an `Executor` abstraction (`src/execution/exec
         approval.json
   channels/<channelId>/
     channel.json              # name, members, repoAssignments, primaryWorkspaceId
+                              #   .trackerLinks.githubProjects → projectId, epicItemId, epicDraftIssueId
+                              #   (populated when the channel is provisioned against GH Projects v2)
     feed.jsonl                # append-only feed
-    tickets.json              # unified ticket board
+    tickets.json              # unified ticket board (each ticket may carry .externalIds)
     runs.json                 # linked orchestrator runs
     tracked-prs.json          # PR-watcher mirror (read by TUI/GUI pr-status surfaces)
     decisions/<id>.json       # one file per decision (atomic writes)

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ Verification commands run through an `Executor` abstraction (`src/execution/exec
         approval.json
   channels/<channelId>/
     channel.json              # name, members, repoAssignments, primaryWorkspaceId
-                              #   .trackerLinks.githubProjects → projectId, epicItemId, epicDraftIssueId
+                              #   .trackerLinks.githubProjects → projectId, projectNumber, projectUrl, epicItemId, epicDraftIssueId
                               #   (populated when the channel is provisioned against GH Projects v2)
     feed.jsonl                # append-only feed
     tickets.json              # unified ticket board (each ticket may carry .externalIds)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,6 +70,25 @@ The primary is told **not** to grep or edit `web/` directly. Instead:
 
 If no `web` agent is live, the primary sees `no_session` and can spawn one from the GUI. Relay opens a terminal tab in the `web` repo running `rly claude`, tracked in `spawns.json`: macOS uses Terminal.app via `osascript` (window/tab ids tracked for targeted close); Linux probes `$TERMINAL` then a chain (`x-terminal-emulator`, `gnome-terminal`, `konsole`, `xterm`, `alacritty`, `kitty`, `wezterm`); Windows prefers `wt.exe`, falls back to `powershell.exe` / `cmd.exe`. Kill closes the tab on macOS and SIGTERMs the crosslink session on Linux/Windows. If no supported terminal is found, spawn surfaces an error and posts a channel-feed entry telling you to `rly claude` in the repo manually.
 
+## Linking a channel to GitHub Projects v2
+
+New in v0.2. If you live on a GitHub Projects v2 board, paste the URL of any item from the board into chat as your first message — Relay's classifier resolves the project, the parent epic, and creates a ticket on the channel pointing at it. Subsequent ticket state changes (created, status changes, title edits) project back onto the board through a one-way sync worker.
+
+Concrete example. The Relay project lives at `https://github.com/users/jcast90/projects/3`. Pick any item on it — say `https://github.com/users/jcast90/projects/3/views/1?pane=issue&itemId=PVTI_lAHO…`. Paste that URL into a fresh `rly claude` session.
+
+What happens, in order:
+
+1. **Classifier** parses the URL into `(ownerType=user, owner=jcast90, projectNumber=3, itemId=PVTI_…)` via `src/integrations/github-projects/url-parser.ts`. No network call yet.
+2. **GraphQL resolve** — the classifier hits the GH GraphQL API (using your `GITHUB_TOKEN`) to fetch the item's title + body + parent epic. The parent epic becomes the channel's logical owner; if the channel doesn't already have a `trackerLinks.githubProjects` block, one is provisioned (project + epic draft item bootstrapped, custom fields ensured).
+3. **Ticket create** — a Relay ticket lands on the channel board with `externalIds.githubProjectItemId` pointing at the original draft item. The ticket title / body match what you pasted; subsequent Relay-side edits will overwrite drift on the board.
+4. **Sync worker** ticks every N seconds (configurable; default budget 200 GraphQL points reserved as headroom — see `docs/trackers.md`). It walks the channel's tickets, creates draft items for the ones that lack `externalIds`, and rewrites titles where the GitHub side has drifted.
+
+The mental model: **Relay is authoritative; the GitHub Project is a projection.** If someone retitles the draft item directly in the GitHub UI, the next sync tick logs a drift event to the channel feed and overwrites it. Teams that want a manually editable board should not link it to a Relay channel — or break the projection per [`docs/trackers.md`](./trackers.md#drift-behavior).
+
+> Bulk-import (existing GH Project → fresh Relay channel) is **not yet wired** in v0.2. Tracking issue: [#196](https://github.com/jcast90/relay/issues/196). For now you can paste individual item URLs as you encounter them and the channel grows organically.
+
+For a deeper reference — config shape, custom-field mapping, drift / rate-limit / troubleshooting — see [`docs/trackers.md`](./trackers.md).
+
 ## Mental model (reference)
 
 For when you want to see the pipeline at a glance:

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -113,6 +113,12 @@ rly channel set-provider <channelId> clear         # inherit default / HARNESS_P
 
 The GUI exposes the same surface: Settings drawer → About → Provider dropdown on each channel, and a Providers tab in the global Settings page for full CRUD.
 
+## GitHub Projects v2 auth
+
+The v0.2 GitHub Projects v2 integration ([`docs/trackers.md`](./trackers.md)) reuses the **existing GitHub auth surface** — no new token, no new env var. The classifier and the sync worker both pick `GITHUB_TOKEN` up at the entry boundary (URL paste, scheduled tick) and pass it down to the GraphQL client through the classifier deps bag (`ProjectsClientDeps` in `src/integrations/github-projects/client.ts`). Internal callers never read the env var directly — they receive it as an explicit dependency, which keeps the integration testable without touching `process.env`.
+
+The token does need an extra scope vs. the existing PR-watcher / issue-tracker uses: `project` for personal projects and `read:org` on top of that for org-owned projects. Once added, the same token covers issues, PRs, and Projects in one place.
+
 ## Native adapters (not yet)
 
 Everything above goes through the Claude or Codex CLI. Providers that ship their _own_ coding CLI (Cursor's `cursor-agent`, Google's `gemini`, Aider, etc.) need a native adapter — new class in `src/agents/cli-agents.ts`, new case in `src/agents/factory.ts`, widened `AgentProvider` union in `src/domain/agent.ts`, matching widening in `crates/harness-data/src/lib.rs`. That's a bigger change and isn't done yet. If you want it for a specific CLI, open an issue describing the CLI's arg shape and structured-output story.

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -1,0 +1,210 @@
+# Trackers
+
+Reference for Relay's external tracker integrations: GitHub Projects v2 (v0.2, new) and Linear (v0.1, read-only mirror; richer parity in flight).
+
+> Relay is pre-v1. The tracker integration landed across PRs A–E in the v0.2 milestone. PR G ([#186](https://github.com/jcast90/relay/issues/186)) introduces the `tracker` config block; before it lands the integration uses sensible defaults — see [Setup](#setup).
+
+## Overview
+
+Relay channels and tickets are the source of truth. External trackers — GitHub Projects v2, Linear — are **one-way projections** of that state. The mental model:
+
+| Relay            | Projects v2                                           | Linear (planned, [#185](https://github.com/jcast90/relay/issues/185)) |
+| ---------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| **Channel**      | Parent draft item with `Type = Epic`                  | Parent Issue with sub-issues                                          |
+| **Ticket**       | Draft item with `Parent = <channel epic>`             | Sub-issue under the channel parent                                    |
+| **Primary repo** | Project (createOrUpdate by repo alias)                | Linear Project (within the configured team)                           |
+| **Status**       | `Status` single-select field option                   | Linear status                                                         |
+| **Priority**     | `Priority` single-select field option                 | Linear priority                                                       |
+| **Type**         | `Type` single-select field option (`Epic` / `Ticket`) | Linear label                                                          |
+
+What Relay projects today (Projects v2):
+
+- **Channels** become epic draft items. Provisioned on first sync via `provisionEpic` in `src/integrations/github-projects/channel-hooks.ts`.
+- **Tickets** become draft items, parented to the channel's epic. Created on every sync tick that finds a Relay ticket without an `externalIds.githubProjectItemId`.
+- **Title drift** is detected and overwritten — Relay's title wins. A `status_update` warning lands in the channel feed so you see the reconciliation.
+- **Type / Status / Priority** custom fields are bootstrapped on first sync (`ensureCustomFields`) and kept in sync from Relay's side. Status field reconciliation specifically is **not yet** covered ([#195](https://github.com/jcast90/relay/issues/195)) — see [Known limitations](#known-limitations).
+
+Direction matters: **Relay → tracker only**. Drift detected on the GitHub side is logged then overwritten on the same tick. Teams that need an editable external board should not link a Relay channel to it (or break the projection — see [Drift behavior](#drift-behavior)).
+
+## Setup
+
+### Token
+
+The integration reuses the existing `GITHUB_TOKEN` env var (also used by the PR watcher and the GitHub issue tracker). Required scopes:
+
+- `project` — read + write Projects v2 items and field values.
+- `read:org` — only when the project is owned by an organization. Not needed for personal projects.
+- `repo` — already required by the PR watcher; mentioned here for completeness.
+
+A fine-grained personal access token (PAT) with the above scopes works. Classic PATs work too. Both are picked up the same way — `process.env.GITHUB_TOKEN` at the entry boundary, then threaded through the integration via `ProjectsClientDeps` (no `process.env` reads downstream). See [`docs/providers.md`](./providers.md#github-projects-v2-auth) for the auth surface.
+
+### Config (PR G, in flight)
+
+PR G ([#186](https://github.com/jcast90/relay/issues/186)) lands a `tracker` block in `~/.relay/config.json`:
+
+```jsonc
+{
+  "tracker": {
+    "default": "github_projects",
+    "providers": {
+      "github_projects": {
+        "owner": "jcast90", // user or org login
+        "project_naming": "per_primary_repo", // or { "fixed": "Work" }
+        "epic_model": "parent_draft_item",
+        "use_draft_items": true,
+        "sync_min_rate_limit_budget": 200, // see Rate limits below
+      },
+      "linear": {
+        "team_key": "REL",
+        "project_naming": "per_primary_repo",
+      },
+      "github_issues": { "enabled": false }, // explicit off
+      "relay_native": { "enabled": true }, // always-on offline fallback
+    },
+  },
+}
+```
+
+Until PR G ships, the integration runs on these defaults: owner inferred from the `GITHUB_TOKEN` user, `project_naming = per_primary_repo`, `epic_model = parent_draft_item`, `use_draft_items = true`, sync budget = 200. Per-channel override via `rly channel update <id> --tracker <name>` lands with PR G as well.
+
+## GitHub Projects v2 mapping
+
+### Field mapping
+
+```
+Relay channel                        GitHub Projects v2
+────────────────                     ───────────────────
+channelId                            (not stored externally)
+name                          ──►    epic draft item title
+description                   ──►    epic draft item body
+trackerLinks.githubProjects.*        (foreign keys back into the project)
+  projectId                          PVT_… node id
+  projectNumber                      integer in the URL
+  projectUrl                         full URL
+  epicItemId                         PVTI_… (item id — used for field updates / archival)
+  epicDraftIssueId                   DI_…   (draft-issue id — used for title/body edits)
+
+Relay ticket                         draft item under the epic
+────────────                         ─────────────────────────
+ticketId                             (not stored externally)
+title                         ──►    draft item title
+description                   ──►    draft item body
+status                        ──►    Status single-select option
+priority                      ──►    Priority single-select option
+specialty                            (not yet projected — backlog)
+externalIds.githubProjectItemId      PVTI_…
+externalIds.githubDraftIssueId       DI_…
+```
+
+The two id types matter — see the contract notes in `src/integrations/github-projects/draft-items.ts`. `itemId` is what you pass to field-update mutations and `archiveProjectV2Item`; `draftIssueId` is what you pass to title/body mutations.
+
+### Status field options
+
+The first sync tick provisions a `Status` single-select field if the project doesn't have one already, with these options:
+
+- `Pending`
+- `Blocked`
+- `Ready`
+- `Executing`
+- `Verifying`
+- `Retry`
+- `Completed`
+- `Failed`
+
+These mirror Relay's ticket lifecycle (see the README's "Tickets" section). If a project already has a customized `Status` field with different option names, Relay logs a warning to the channel feed and falls back to leaving the field unset on its draft items — see [Troubleshooting](#troubleshooting). Full Status reconciliation is tracked under [#195](https://github.com/jcast90/relay/issues/195).
+
+### Project resolution
+
+Per the design doc (`docs/design/tracker-projects-mapping.md` § Decision 3), the project name defaults to the channel's primary repo alias. First sync runs:
+
+1. GraphQL search for an existing Projects v2 owned by the configured `owner` with title matching the primary repo alias.
+2. If none, create one (`createProjectV2`).
+3. Bootstrap `Type` / `Status` / `Priority` custom fields if missing (`ensureCustomFields`, idempotent).
+4. Create the channel epic draft item; persist `epicItemId` + `epicDraftIssueId` onto `channel.json`.
+
+All four steps are idempotent on re-run; the only non-idempotent operation is the epic draft-item create, which is gated by the `trackerLinks.githubProjects` check on the channel.
+
+## Linear
+
+Today's Linear surface is the read-only mirror in `src/integrations/linear-mirror.ts` plus the CLI bindings (`rly channel link-linear`, `rly channel linear-sync`). It mirrors existing Linear issues onto a channel's ticket board for context but does not project Relay tickets back to Linear.
+
+Full Linear parity — channel → parent issue → sub-issues, with the same Relay-authoritative drift behavior as GitHub Projects v2 — lands in PR F ([#185](https://github.com/jcast90/relay/issues/185)). Until it ships, existing `rly channel link-linear` users keep working unchanged: the read-only mirror does not interact with the v0.2 GitHub Projects v2 plumbing.
+
+## Drift behavior
+
+Relay's sync worker is a one-shot reconciliation tick (`runSyncTick` in `src/integrations/github-projects/sync-worker.ts`). On every tick it:
+
+1. Reads the channel's tickets from `channels/<id>/tickets.json`.
+2. For each ticket without `externalIds.githubProjectItemId`, creates a new draft item under the channel epic.
+3. For each ticket _with_ `externalIds`, fetches the GitHub draft item and compares titles. Mismatch → overwrite GitHub with Relay's title and emit a `DriftEvent` of kind `title-changed`.
+4. Logs throttle / rate-limit telemetry on every tick (`SyncTickResult.rateLimit`).
+
+What you'll see in the channel feed when a drift overwrite happens:
+
+```
+status_update
+  Tracker drift overwritten — ticket T-3
+  observed: "Add rate limiter (manual edit)"
+  applied:  "Add rate-limiter middleware"
+```
+
+The `observed` value is whatever was in the GitHub UI before the tick; `applied` is what Relay rewrote it to. If the user wanted to keep the GitHub-side edit, they need to either:
+
+- Edit the title in Relay (the source of truth — channel feed, ticket board, or the `rly channel post` ticket commands), so the next sync no-ops; or
+- **Break the projection** entirely. PR G ([#186](https://github.com/jcast90/relay/issues/186)) ships `rly channel unlink-tracker <id>` for this. Until it lands, the workaround is to manually delete the `trackerLinks.githubProjects` block from `channels/<id>/channel.json` and the `externalIds` map from each ticket — the next sync tick will treat the channel as un-projected and skip.
+
+Drift is by design. Relay is built around an audit trail; one-way projection keeps the audit trail authoritative without forcing the GitHub UI into read-only mode.
+
+## Rate limits
+
+GitHub's GraphQL API has a points-based rate limit (5000 points/hour for personal tokens; higher for app installations). The sync worker tracks remaining budget and refuses to start new work on a tick when the remaining budget drops below a threshold:
+
+- **Default threshold: 200 points.** Conservative — leaves headroom for ad-hoc CLI invocations during reconciliation.
+- **Tunable per-call** via `SyncTickInput.minRateLimitBudget`. Pass `0` to disable throttling (sane only in tests).
+- **Tunable globally** via `tracker.providers.github_projects.sync_min_rate_limit_budget` once PR G ([#186](https://github.com/jcast90/relay/issues/186)) lands.
+
+A throttled tick returns `{ throttled: true, ... }` and emits a feed entry. The next tick re-evaluates the budget and resumes once headroom returns.
+
+The scheduler timer (the loop driver that fires `runSyncTick` on an interval) is **not yet wired** in v0.2 — see [Known limitations](#known-limitations). Until it lands, syncs run on demand: when a channel-create / channel-update MCP tool fires, when the user pastes a Projects URL, or when the loop driver lands ([#194](https://github.com/jcast90/relay/issues/194)).
+
+## Troubleshooting
+
+| Symptom                                                         | Likely cause / fix                                                                                                                                                                                                                                                                                                                                                             |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `403 Resource not accessible by personal access token`          | Token missing `project` scope (or `read:org` for org-owned projects). Add the scope and try again. Personal vs. fine-grained PATs both work.                                                                                                                                                                                                                                   |
+| Sync silently no-ops on a brand-new channel                     | Channel has no `trackerLinks.githubProjects` block. Provisioning runs on channel-create or on the first URL paste — verify one of those happened. Until PR G's MCP-handler wiring ([#193](https://github.com/jcast90/relay/issues/193)) lands, manual provision is via the channel-hooks API.                                                                                  |
+| Status field never updates on the GitHub board                  | Project has a customized `Status` field with non-default option names. Relay falls back to leaving the field unset rather than guessing. Tracking issue: [#195](https://github.com/jcast90/relay/issues/195). Workaround: rename your options to match Relay's lifecycle (Pending / Blocked / Ready / Executing / Verifying / Retry / Completed / Failed) or wait for the fix. |
+| `staleIdCleared` events appear in the sync result               | A draft item Relay knew about was deleted out from under us in the GitHub UI. The integration clears the stale `externalIds` on that ticket so the next tick re-projects from scratch. Expected, not an error.                                                                                                                                                                 |
+| `throttled: true` returned on a tick                            | GraphQL rate-limit budget dropped below the configured threshold (default 200). Wait for the hourly window to reset, or tune `minRateLimitBudget` lower. Frequent throttling on a single project usually means too many tickets in too short a window — open a tracking issue.                                                                                                 |
+| Drift overwrite warning floods the channel feed                 | Someone is editing the GitHub board manually while the sync worker runs. Either stop the manual edits, or break the projection. See [Drift behavior](#drift-behavior).                                                                                                                                                                                                         |
+| Pasted Projects URL classifier "doesn't recognize" the URL      | URL isn't under `github.com/(users\|orgs)/.../projects/<n>`. The parser intentionally rejects malformed item ids and any non-Projects-v2 GitHub URL — paste the URL straight from your browser address bar.                                                                                                                                                                    |
+| Pasted Projects **project-only** URL (no item) returns an error | v0.2 deferred the project-only paste case (per design Decision 5). Workaround: paste a specific item URL.                                                                                                                                                                                                                                                                      |
+
+## Known limitations
+
+The v0.2 PR sequence lands the core integration in pieces. These items are explicitly **not** in v0.2 and have tracking issues:
+
+- **Status-field drift not yet reconciled** — title drift is detected and overwritten; `Status` field drift is not. Full coverage requires per-project option-id resolution. Tracking: [#195](https://github.com/jcast90/relay/issues/195).
+- **Bulk import not wired** — linking an existing GH Project with hundreds of items into a fresh Relay channel does not pull those items into the ticket list. Tracking: [#196](https://github.com/jcast90/relay/issues/196).
+- **MCP-handler wiring pending** — `channel_create` / `channel_update` / `channel_archive` MCP tools do not yet invoke the channel-hooks orchestration. The orchestration primitives are in tree (`src/integrations/github-projects/channel-hooks.ts`); only the wiring is deferred to keep PR C bounded. Tracking: [#193](https://github.com/jcast90/relay/issues/193).
+- **Scheduler timer pending** — `runSyncTick` is a one-shot. The interval loop driver lands behind the `tracker` config block so it can be feature-flagged. Tracking: [#194](https://github.com/jcast90/relay/issues/194).
+- **Linear parity** — see the [Linear](#linear) section. Existing read-only mirror keeps working. Tracking: [#185](https://github.com/jcast90/relay/issues/185).
+
+## Migration
+
+**No migration concern in v0.2.** Relay had no production users with linked external trackers before v0.2 — the GitHub Projects v2 integration is greenfield. The pre-existing `linear-mirror.ts` read-only flow (`rly channel link-linear`, `rly channel linear-sync`) keeps working unchanged until PR F ([#185](https://github.com/jcast90/relay/issues/185)) replaces it with full bidirectional projection.
+
+If you're reading this in a future where v0.2 is no longer recent and wondering why there's no migration script: there was nothing to migrate. The `tracker` config block, the `trackerLinks` channel field, and the `externalIds` ticket field were all introduced together in v0.2 and have been optional / back-compat from day one — a channel without `trackerLinks` is just an un-projected channel and the sync worker no-ops on it.
+
+## Related
+
+- Design doc: [`docs/design/tracker-projects-mapping.md`](./design/tracker-projects-mapping.md) — full rationale, alternatives considered, sign-off criteria.
+- Source map (v0.2 PRs A–E):
+  - `src/integrations/github-projects/client.ts` — GraphQL client + project resolver (PR A, [#188](https://github.com/jcast90/relay/issues/188))
+  - `src/integrations/github-projects/draft-items.ts`, `fields.ts` — draft-item CRUD + custom field bootstrap (PR B, [#189](https://github.com/jcast90/relay/issues/189))
+  - `src/integrations/github-projects/channel-hooks.ts` — channel ↔ epic orchestration (PR C, [#191](https://github.com/jcast90/relay/issues/191))
+  - `src/integrations/github-projects/sync-worker.ts` — one-shot reconciliation tick + drift detection (PR D, [#192](https://github.com/jcast90/relay/issues/192))
+  - `src/integrations/github-projects/url-parser.ts` — Projects v2 URL parsing in the classifier (PR E, [#190](https://github.com/jcast90/relay/issues/190))
+- README: [Integrations § GitHub Projects v2](../README.md#github-projects-v2-v02-new)
+- Getting started: [Linking a channel to GitHub Projects v2](./getting-started.md#linking-a-channel-to-github-projects-v2)
+- Auth: [Providers § GitHub Projects v2 auth](./providers.md#github-projects-v2-auth)

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -49,10 +49,12 @@ PR G ([#186](https://github.com/jcast90/relay/issues/186)) lands a `tracker` blo
     "providers": {
       "github_projects": {
         "owner": "jcast90", // user or org login
+        "ownerType": "user", // or "organization"
         "project_naming": "per_primary_repo", // or { "fixed": "Work" }
         "epic_model": "parent_draft_item",
         "use_draft_items": true,
-        "sync_min_rate_limit_budget": 200, // see Rate limits below
+        "sync_interval_seconds": 30, // sync-worker tick interval (PR #194)
+        "min_rate_limit_budget": 200, // see Rate limits below
       },
       "linear": {
         "team_key": "REL",
@@ -161,7 +163,7 @@ GitHub's GraphQL API has a points-based rate limit (5000 points/hour for persona
 
 - **Default threshold: 200 points.** Conservative — leaves headroom for ad-hoc CLI invocations during reconciliation.
 - **Tunable per-call** via `SyncTickInput.minRateLimitBudget`. Pass `0` to disable throttling (sane only in tests).
-- **Tunable globally** via `tracker.providers.github_projects.sync_min_rate_limit_budget` once PR G ([#186](https://github.com/jcast90/relay/issues/186)) lands.
+- **Tunable globally** via `tracker.providers.github_projects.min_rate_limit_budget` once PR G ([#186](https://github.com/jcast90/relay/issues/186)) lands.
 
 A throttled tick returns `{ throttled: true, ... }` and emits a feed entry. The next tick re-evaluates the budget and resumes once headroom returns.
 


### PR DESCRIPTION
## Summary

Documents the GitHub Projects v2 integration shipped across v0.2 PRs A–E (#188, #189, #191, #192, #190). Closes #187.

- **README** — adds a GH Projects v2 feature bullet, annotates the file-layout tree with `trackerLinks` + the eventual `tracker` config block, adds a dedicated Integrations subsection.
- **docs/getting-started.md** — new "Linking a channel to GitHub Projects v2" walkthrough: paste an item URL, classifier resolves project + epic, creates ticket. Notes that bulk-import (#196) is not yet wired.
- **docs/providers.md** — short GH Projects v2 auth note: reuses `GITHUB_TOKEN` at the entry boundary, threaded via `ProjectsClientDeps` downstream. Token-scope guidance (`project`, `read:org` for org-owned).
- **docs/trackers.md** (new) — comprehensive reference: overview, setup, channel↔project / channel↔epic / ticket↔draft-item field mapping, Status field options, drift behavior + how to break the projection, rate limits + tuning, troubleshooting matrix, known limitations (Status drift #195, bulk import #196, MCP wiring #193, scheduler timer #194, Linear parity #185), migration note.

**Migration**: explicit note that no users had production setups before v0.2 — there is no migration concern. Existing `linear-mirror.ts` (read-only) keeps working unchanged until PR F #185.

**Forward-references PR G** (#186 — `tracker` config block) consistently rather than waiting for it. No source code touched.

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm format:check` — all matched files use Prettier code style
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 955 passed, 24 skipped (no source changes; tests unchanged)
- [ ] Reviewer: spot-check tone matches the rest of `docs/` (concise, honest, links the issues that track gaps)
- [ ] Reviewer: confirm forward-references to PRs F/G are accurate against the open milestone PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)