### PR TITLE
feat(tracker): v0.2 PR G — tracker config block + per-channel override + doctor checks

### DIFF
--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -218,6 +218,15 @@ pub struct Channel {
     /// values themselves. Optional + `#[serde(default)]` for back-compat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tracker_links: Option<ChannelTrackerLinks>,
+    /// Per-channel tracker override mirroring
+    /// `src/domain/channel.ts::Channel.trackerOverride`. When set, this
+    /// channel routes through the named provider regardless of the
+    /// global `tracker.default`. Stored as a free-form string here
+    /// (rather than a Rust enum) so a future provider name can land
+    /// without bumping the dashboards. Optional + `#[serde(default)]`
+    /// for back-compat with channel files that predate v0.2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracker_override: Option<String>,
 }
 
 /// Per-provider projection metadata for a channel. Mirrors
@@ -1872,6 +1881,7 @@ mod tests {
             provider_profile_id: None,
             pr: None,
             tracker_links: None,
+            tracker_override: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             updated_at: Some("2026-01-01T00:00:00Z".to_string()),
         }
@@ -2053,6 +2063,7 @@ mod tests {
             provider_profile_id: None,
             pr: None,
             tracker_links: None,
+            tracker_override: None,
             created_at: None,
             updated_at: None,
         }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -979,6 +979,7 @@ fn create_dm(
         provider_profile_id: None,
         pr: None,
         tracker_links: None,
+        tracker_override: None,
         created_at: Some(now.to_rfc3339()),
         updated_at: Some(now.to_rfc3339()),
     };

--- a/src/channels/channel-store.ts
+++ b/src/channels/channel-store.ts
@@ -204,6 +204,7 @@ export class ChannelStore {
         | "providerProfileId"
         | "pr"
         | "trackerLinks"
+        | "trackerOverride"
       >
     >
   ): Promise<Channel | null> {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -2,11 +2,23 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
+import {
+  DEFAULT_TRACKER_CONFIG,
+  parseTrackerConfig,
+  type TrackerConfig,
+} from "../domain/tracker-config.js";
 import { getRelayDir } from "./paths.js";
 
 export interface HarnessGlobalConfig {
   /** Directories to scan for git repos (e.g. ["~/projects", "~/work"]) */
   projectDirs: string[];
+  /**
+   * Tracker integration config. Optional in the on-disk shape — a
+   * config file predating v0.2 has no `tracker` block, and `readConfig`
+   * synthesizes the default (`relay_native` only) so callers can rely
+   * on this field always being present.
+   */
+  tracker: TrackerConfig;
 }
 
 const globalRoot = (): string => getRelayDir();
@@ -25,19 +37,29 @@ function expandHome(p: string): string {
 
 export async function readConfig(): Promise<HarnessGlobalConfig> {
   try {
-    const raw = JSON.parse(await readFile(configPath(), "utf8")) as Partial<HarnessGlobalConfig>;
+    const raw = JSON.parse(await readFile(configPath(), "utf8")) as Record<string, unknown>;
     return {
-      projectDirs: Array.isArray(raw.projectDirs) ? raw.projectDirs.map(expandHome) : [],
+      projectDirs: Array.isArray(raw.projectDirs)
+        ? (raw.projectDirs as string[]).map(expandHome)
+        : [],
+      tracker: parseTrackerConfig(raw.tracker),
     };
   } catch {
-    return { projectDirs: [] };
+    return { projectDirs: [], tracker: DEFAULT_TRACKER_CONFIG };
   }
 }
 
 export async function writeConfig(config: HarnessGlobalConfig): Promise<void> {
   await mkdir(globalRoot(), { recursive: true });
   const tmpPath = `${configPath()}.tmp.${process.pid}`;
-  await writeFile(tmpPath, JSON.stringify(config, null, 2));
+  // Preserve any unknown top-level keys we read off disk so a future
+  // config field added by a newer Relay doesn't get silently dropped
+  // when an older version round-trips the file.
+  const merged: Record<string, unknown> = {
+    projectDirs: config.projectDirs,
+    tracker: config.tracker,
+  };
+  await writeFile(tmpPath, JSON.stringify(merged, null, 2));
   await rename(tmpPath, configPath());
 }
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -51,14 +51,26 @@ export async function readConfig(): Promise<HarnessGlobalConfig> {
 
 export async function writeConfig(config: HarnessGlobalConfig): Promise<void> {
   await mkdir(globalRoot(), { recursive: true });
-  const tmpPath = `${configPath()}.tmp.${process.pid}`;
-  // Preserve any unknown top-level keys we read off disk so a future
+  // Preserve unknown top-level keys we read off disk so a future
   // config field added by a newer Relay doesn't get silently dropped
-  // when an older version round-trips the file.
+  // when an older version round-trips the file. Read the existing
+  // file (best-effort — missing/malformed = empty existing) and spread
+  // it before our known fields.
+  let existing: Record<string, unknown> = {};
+  try {
+    existing = JSON.parse(await readFile(configPath(), "utf8")) as Record<string, unknown>;
+    if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
+      existing = {};
+    }
+  } catch {
+    // file absent or malformed — nothing to preserve, proceed with empty
+  }
   const merged: Record<string, unknown> = {
+    ...existing,
     projectDirs: config.projectDirs,
     tracker: config.tracker,
   };
+  const tmpPath = `${configPath()}.tmp.${process.pid}`;
   await writeFile(tmpPath, JSON.stringify(merged, null, 2));
   await rename(tmpPath, configPath());
 }

--- a/src/domain/channel.ts
+++ b/src/domain/channel.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { AgentProvider, AgentRole } from "./agent.js";
+import type { TrackerProviderName } from "./tracker-config.js";
 
 export const ChannelStatusSchema = z.enum(["active", "archived"]);
 export type ChannelStatus = z.infer<typeof ChannelStatusSchema>;
@@ -177,6 +178,16 @@ export interface Channel {
    * means no external projection has been set up.
    */
   trackerLinks?: ChannelTrackerLinks;
+  /**
+   * Per-channel tracker override. When set, the orchestrator and sync
+   * worker route this channel through the named provider regardless of
+   * the global `tracker.default` in `~/.relay/config.json`. Common
+   * uses: opting one channel into `github_projects` while the
+   * workspace default stays `relay_native`, or temporarily flipping a
+   * misbehaving channel to `relay_native` while debugging. Optional —
+   * `undefined` means "use the workspace default".
+   */
+  trackerOverride?: TrackerProviderName;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/domain/tracker-config.ts
+++ b/src/domain/tracker-config.ts
@@ -1,0 +1,222 @@
+/**
+ * Tracker config schema for `~/.relay/config.json`. Seventh slice of the
+ * v0.2 tracker work (PR G / #186). Surfaces the integration choices
+ * users make at install time as a typed, validated block; PR H (#187)
+ * documents it for humans.
+ *
+ * Default behavior preserves Relay's offline-first posture: a config
+ * without a `tracker` block resolves to the `relay_native` provider,
+ * matching every Relay deployment that existed before v0.2 lands. No
+ * migration step is required — old configs continue to work.
+ */
+import { z } from "zod";
+
+export const TrackerProviderNameSchema = z.enum([
+  "github_projects",
+  "linear",
+  "github_issues",
+  "relay_native",
+]);
+
+export type TrackerProviderName = z.infer<typeof TrackerProviderNameSchema>;
+
+/**
+ * How project titles are derived from a channel. Either "use the
+ * channel's primary repo alias verbatim" (matches the convention from
+ * `docs/design/tracker-projects-mapping.md`) or "use a fixed string for
+ * every channel" (single shared project, useful for small teams that
+ * don't want a project per repo).
+ */
+export const ProjectNamingSchema = z.union([
+  z.literal("per_primary_repo"),
+  z.object({ fixed: z.string().min(1) }),
+]);
+export type ProjectNaming = z.infer<typeof ProjectNamingSchema>;
+
+export const GitHubProjectsConfigSchema = z.object({
+  /** GitHub login (user or org) that hosts the project. */
+  owner: z.string().min(1),
+  /**
+   * `user` for personal projects, `organization` for shared. Drives
+   * which GraphQL root the client queries. Default `user` matches the
+   * common solo workflow.
+   */
+  ownerType: z.enum(["user", "organization"]).default("user"),
+  /** See `ProjectNamingSchema`. Defaults to per-primary-repo. */
+  project_naming: ProjectNamingSchema.default("per_primary_repo"),
+  /**
+   * Native parent-child hierarchy (`parent_draft_item`, the design-doc
+   * choice) vs the custom-field fallback. The custom-field path caps
+   * at ~50 channels per project — `rly doctor` warns when this is set.
+   */
+  epic_model: z.enum(["parent_draft_item", "custom_field"]).default("parent_draft_item"),
+  /**
+   * When false, the integration creates real GitHub Issues instead of
+   * draft items. Strongly discouraged: real Issues clutter the bug
+   * tracker with feature-planning rows and break the
+   * Relay-authoritative drift contract. Default `true`.
+   */
+  use_draft_items: z.boolean().default(true),
+  /** Sync-worker tick interval. Wired by issue #194. */
+  sync_interval_seconds: z.number().int().min(5).max(3600).default(30),
+  /**
+   * Threshold below which the sync worker pauses new work for the
+   * current tick. Matches the default in
+   * `src/integrations/github-projects/sync-worker.ts`.
+   */
+  min_rate_limit_budget: z.number().int().min(0).default(200),
+});
+export type GitHubProjectsConfig = z.infer<typeof GitHubProjectsConfigSchema>;
+
+export const LinearConfigSchema = z.object({
+  /** Linear team prefix, e.g. `REL` for `REL-123` issue keys. */
+  team_key: z.string().min(1),
+  project_naming: ProjectNamingSchema.default("per_primary_repo"),
+});
+export type LinearConfig = z.infer<typeof LinearConfigSchema>;
+
+export const GitHubIssuesConfigSchema = z.object({
+  /**
+   * When false (the default and the recommended posture), Relay does
+   * not mirror tickets onto GitHub Issues. Existing GitHub Issue URL
+   * pasting via the classifier still works — this flag is only about
+   * outbound projection.
+   */
+  enabled: z.boolean().default(false),
+});
+export type GitHubIssuesConfig = z.infer<typeof GitHubIssuesConfigSchema>;
+
+export const RelayNativeConfigSchema = z.object({
+  /**
+   * Always-on offline fallback. Disabling this is a footgun — the
+   * channel board still works regardless of external-tracker status.
+   */
+  enabled: z.boolean().default(true),
+});
+export type RelayNativeConfig = z.infer<typeof RelayNativeConfigSchema>;
+
+export const TrackerProvidersSchema = z
+  .object({
+    github_projects: GitHubProjectsConfigSchema.optional(),
+    linear: LinearConfigSchema.optional(),
+    github_issues: GitHubIssuesConfigSchema.default({ enabled: false }),
+    relay_native: RelayNativeConfigSchema.default({ enabled: true }),
+  })
+  .default({});
+export type TrackerProviders = z.infer<typeof TrackerProvidersSchema>;
+
+export const TrackerConfigSchema = z.object({
+  default: TrackerProviderNameSchema.default("relay_native"),
+  providers: TrackerProvidersSchema,
+});
+export type TrackerConfig = z.infer<typeof TrackerConfigSchema>;
+
+/**
+ * Default tracker config for users who haven't opted into any external
+ * tracker. Matches the migration shape: `relay_native` always-on,
+ * other provider blocks absent. Configs predating v0.2 deserialize to
+ * exactly this value via `TrackerConfigSchema.parse({})`.
+ */
+export const DEFAULT_TRACKER_CONFIG: TrackerConfig = TrackerConfigSchema.parse({});
+
+/**
+ * Parse a raw `tracker` JSON value (or `undefined` when the config
+ * file predates v0.2) into a validated `TrackerConfig`. Throws a zod
+ * error on malformed input — callers should surface that to the user
+ * since proceeding with bad config silently would be worse than
+ * crashing the CLI.
+ */
+export function parseTrackerConfig(input: unknown): TrackerConfig {
+  if (input === undefined || input === null) {
+    return DEFAULT_TRACKER_CONFIG;
+  }
+  return TrackerConfigSchema.parse(input);
+}
+
+/**
+ * Resolve the effective tracker provider for a channel, taking a
+ * per-channel `trackerOverride` into account. The override is honored
+ * even when the global default is `relay_native` — that's the path
+ * for "everything stays Relay-native, except this one channel".
+ */
+export function resolveProviderForChannel(
+  config: TrackerConfig,
+  override?: TrackerProviderName
+): TrackerProviderName {
+  return override ?? config.default;
+}
+
+export interface TrackerConfigDiagnostic {
+  level: "ok" | "warn" | "error";
+  message: string;
+}
+
+/**
+ * Run sanity checks against a parsed tracker config. Used by `rly
+ * doctor` to surface common misconfigurations before they bite at
+ * runtime. Pure — no I/O, no env reads — so it can be unit-tested
+ * cheaply.
+ */
+export function diagnoseTrackerConfig(config: TrackerConfig): TrackerConfigDiagnostic[] {
+  const diagnostics: TrackerConfigDiagnostic[] = [];
+  const def = config.default;
+  const providers = config.providers;
+
+  // Default must point at a provider whose block is present and enabled.
+  if (def === "github_projects" && !providers.github_projects) {
+    diagnostics.push({
+      level: "error",
+      message:
+        'tracker.default is "github_projects" but tracker.providers.github_projects is missing. ' +
+        "Add an `owner` (and optionally `ownerType`) under that block.",
+    });
+  }
+  if (def === "linear" && !providers.linear) {
+    diagnostics.push({
+      level: "error",
+      message:
+        'tracker.default is "linear" but tracker.providers.linear is missing. ' +
+        "Add a `team_key` under that block.",
+    });
+  }
+  if (def === "github_issues" && !providers.github_issues.enabled) {
+    diagnostics.push({
+      level: "error",
+      message:
+        'tracker.default is "github_issues" but tracker.providers.github_issues.enabled is false.',
+    });
+  }
+  if (def === "relay_native" && !providers.relay_native.enabled) {
+    diagnostics.push({
+      level: "error",
+      message: "relay_native is the default but disabled — that combination resolves to nothing.",
+    });
+  }
+
+  // Warn on the custom-field epic model (50-option cap per design doc).
+  if (providers.github_projects?.epic_model === "custom_field") {
+    diagnostics.push({
+      level: "warn",
+      message:
+        'tracker.providers.github_projects.epic_model is "custom_field". GitHub caps single-select ' +
+        "options at ~50; channels accumulating over a year will hit the wall. Consider " +
+        '"parent_draft_item" (the default).',
+    });
+  }
+
+  // Warn when use_draft_items is false — outbound-issue projection clutters the bug tracker.
+  if (providers.github_projects?.use_draft_items === false) {
+    diagnostics.push({
+      level: "warn",
+      message:
+        "tracker.providers.github_projects.use_draft_items is false. Real-Issue projection " +
+        "clutters the bug tracker and breaks the Relay-authoritative drift contract. Prefer the default.",
+    });
+  }
+
+  // No diagnostic = ok.
+  if (diagnostics.length === 0) {
+    diagnostics.push({ level: "ok", message: `tracker.default = ${def}` });
+  }
+  return diagnostics;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./cli/workspace.js";
 import { getGlobalRoot, listRegisteredWorkspaces } from "./cli/workspace-registry.js";
 import { addProjectDir, readConfig, removeProjectDir } from "./cli/config.js";
+import { diagnoseTrackerConfig } from "./domain/tracker-config.js";
 import { LocalArtifactStore } from "./execution/artifact-store.js";
 import { getHarnessStore } from "./storage/factory.js";
 import { buildMcpMessageHandler, startMcpServer } from "./mcp/server.js";
@@ -809,15 +810,21 @@ async function handleChannelCommand(args: string[]): Promise<void> {
 
     if (trackerArg) {
       const validTrackers = ["github_projects", "linear", "github_issues", "relay_native"];
-      if (!validTrackers.includes(trackerArg)) {
+      if (trackerArg === "none") {
+        // Explicit unpin — drop the override so the channel falls back
+        // to the workspace `tracker.default`. `updateChannel` treats
+        // explicit-undefined as "clear" via Object.prototype.hasOwnProperty.
+        patch.trackerOverride = undefined;
+      } else if (!validTrackers.includes(trackerArg)) {
         console.error(
-          `--tracker must be one of: ${validTrackers.join(", ")} (got "${trackerArg}").`
+          `--tracker must be one of: ${validTrackers.join(", ")}, none (got "${trackerArg}").`
         );
         process.exitCode = 1;
         return;
+      } else {
+        patch.trackerOverride =
+          trackerArg as import("./domain/tracker-config.js").TrackerProviderName;
       }
-      patch.trackerOverride =
-        trackerArg as import("./domain/tracker-config.js").TrackerProviderName;
     }
 
     if (reposArg) {
@@ -2853,7 +2860,6 @@ async function printTrackerDoctor(): Promise<void> {
   console.log("Tracker:");
   try {
     const config = await readConfig();
-    const { diagnoseTrackerConfig } = await import("./domain/tracker-config.js");
     const diagnostics = diagnoseTrackerConfig(config.tracker);
     for (const d of diagnostics) {
       const prefix = d.level === "error" ? "  ✗" : d.level === "warn" ? "  !" : "  ✓";

--- a/src/index.ts
+++ b/src/index.ts
@@ -791,7 +791,7 @@ async function handleChannelCommand(args: string[]): Promise<void> {
     const channelId = args[1];
     if (!channelId) {
       console.error(
-        "Usage: rly channel update <channelId> [--repos alias:wsId:path,...] [--primary <alias>]"
+        "Usage: rly channel update <channelId> [--repos alias:wsId:path,...] [--primary <alias>] [--tracker github_projects|linear|github_issues|relay_native]"
       );
       process.exitCode = 1;
       return;
@@ -799,9 +799,26 @@ async function handleChannelCommand(args: string[]): Promise<void> {
 
     const reposArg = parseNamedArg(args, "--repos");
     const primaryArg = parseNamedArg(args, "--primary");
+    const trackerArg = parseNamedArg(args, "--tracker");
     const patch: Partial<
-      Pick<import("./domain/channel.js").Channel, "repoAssignments" | "primaryWorkspaceId">
+      Pick<
+        import("./domain/channel.js").Channel,
+        "repoAssignments" | "primaryWorkspaceId" | "trackerOverride"
+      >
     > = {};
+
+    if (trackerArg) {
+      const validTrackers = ["github_projects", "linear", "github_issues", "relay_native"];
+      if (!validTrackers.includes(trackerArg)) {
+        console.error(
+          `--tracker must be one of: ${validTrackers.join(", ")} (got "${trackerArg}").`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      patch.trackerOverride =
+        trackerArg as import("./domain/tracker-config.js").TrackerProviderName;
+    }
 
     if (reposArg) {
       patch.repoAssignments = reposArg.split(",").map((r) => {
@@ -2819,7 +2836,33 @@ async function printDoctor(input: {
   console.log("");
   await printStatus(input.artifactStore, input.cwd);
   console.log("");
+  await printTrackerDoctor();
+  console.log("");
   await inspectMcp(input);
+}
+
+/**
+ * Surface tracker-config diagnostics in `rly doctor`. Common
+ * misconfigurations (default points at an absent provider, custom-field
+ * epic model with its 50-option cap, real-Issue projection turned on)
+ * surface as warnings or errors so users find them before runtime
+ * does. Pure delegation to `diagnoseTrackerConfig` keeps the rule set
+ * unit-testable.
+ */
+async function printTrackerDoctor(): Promise<void> {
+  console.log("Tracker:");
+  try {
+    const config = await readConfig();
+    const { diagnoseTrackerConfig } = await import("./domain/tracker-config.js");
+    const diagnostics = diagnoseTrackerConfig(config.tracker);
+    for (const d of diagnostics) {
+      const prefix = d.level === "error" ? "  ✗" : d.level === "warn" ? "  !" : "  ✓";
+      console.log(`${prefix} ${d.message}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`  ✗ tracker config unreadable: ${message}`);
+  }
 }
 
 async function printUpStatus(input: {

--- a/test/cli/config-tracker.test.ts
+++ b/test/cli/config-tracker.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readConfig, writeConfig } from "../../src/cli/config.js";
+import { __resetRelayDirCacheForTests } from "../../src/cli/paths.js";
+import { DEFAULT_TRACKER_CONFIG } from "../../src/domain/tracker-config.js";
+
+/**
+ * Round-trip tests for the tracker block in `~/.relay/config.json`.
+ * Drives `HOME` at a tmp dir + resets the relay-dir cache so we never
+ * touch the user's real config.
+ */
+
+describe("cli/config tracker round-trip", () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "relay-cfg-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    __resetRelayDirCacheForTests();
+  });
+
+  afterEach(async () => {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    __resetRelayDirCacheForTests();
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it("synthesizes the default tracker block when the file does not exist", async () => {
+    const cfg = await readConfig();
+    expect(cfg.tracker).toEqual(DEFAULT_TRACKER_CONFIG);
+    expect(cfg.projectDirs).toEqual([]);
+  });
+
+  it("returns the default tracker block when the file has no `tracker` key", async () => {
+    await mkdir(join(tmpHome, ".relay"), { recursive: true });
+    await writeFile(
+      join(tmpHome, ".relay", "config.json"),
+      JSON.stringify({ projectDirs: ["~/projects"] })
+    );
+    const cfg = await readConfig();
+    expect(cfg.tracker).toEqual(DEFAULT_TRACKER_CONFIG);
+  });
+
+  it("preserves the tracker block across a write → read cycle", async () => {
+    await writeConfig({
+      projectDirs: [],
+      tracker: {
+        default: "github_projects",
+        providers: {
+          github_projects: {
+            owner: "jcast90",
+            ownerType: "user",
+            project_naming: "per_primary_repo",
+            epic_model: "parent_draft_item",
+            use_draft_items: true,
+            sync_interval_seconds: 60,
+            min_rate_limit_budget: 300,
+          },
+          github_issues: { enabled: false },
+          relay_native: { enabled: true },
+        },
+      },
+    });
+    const cfg = await readConfig();
+    expect(cfg.tracker.default).toBe("github_projects");
+    expect(cfg.tracker.providers.github_projects?.owner).toBe("jcast90");
+    expect(cfg.tracker.providers.github_projects?.sync_interval_seconds).toBe(60);
+  });
+
+  it("falls back to the default when the file has malformed JSON (rather than crashing the CLI)", async () => {
+    await mkdir(join(tmpHome, ".relay"), { recursive: true });
+    await writeFile(join(tmpHome, ".relay", "config.json"), "{not json");
+    const cfg = await readConfig();
+    expect(cfg.tracker).toEqual(DEFAULT_TRACKER_CONFIG);
+  });
+});

--- a/test/domain/tracker-config.test.ts
+++ b/test/domain/tracker-config.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_TRACKER_CONFIG,
+  diagnoseTrackerConfig,
+  parseTrackerConfig,
+  resolveProviderForChannel,
+  TrackerConfigSchema,
+} from "../../src/domain/tracker-config.js";
+
+/**
+ * Unit tests for the tracker-config schema, defaults, resolver, and
+ * diagnostics. The diagnostics list drives the `rly doctor` output;
+ * pinning every rule here keeps that surface stable.
+ */
+
+describe("tracker-config", () => {
+  describe("DEFAULT_TRACKER_CONFIG", () => {
+    it("resolves to relay_native with no external provider blocks", () => {
+      expect(DEFAULT_TRACKER_CONFIG.default).toBe("relay_native");
+      expect(DEFAULT_TRACKER_CONFIG.providers.relay_native.enabled).toBe(true);
+      expect(DEFAULT_TRACKER_CONFIG.providers.github_issues.enabled).toBe(false);
+      expect(DEFAULT_TRACKER_CONFIG.providers.github_projects).toBeUndefined();
+      expect(DEFAULT_TRACKER_CONFIG.providers.linear).toBeUndefined();
+    });
+  });
+
+  describe("parseTrackerConfig", () => {
+    it("returns the default for undefined input (config file predating v0.2)", () => {
+      expect(parseTrackerConfig(undefined)).toEqual(DEFAULT_TRACKER_CONFIG);
+    });
+
+    it("returns the default for null input (explicit absence)", () => {
+      expect(parseTrackerConfig(null)).toEqual(DEFAULT_TRACKER_CONFIG);
+    });
+
+    it("returns the default for an empty object — every field has a sensible default", () => {
+      expect(parseTrackerConfig({})).toEqual(DEFAULT_TRACKER_CONFIG);
+    });
+
+    it("validates and applies github_projects defaults around required owner", () => {
+      const config = parseTrackerConfig({
+        default: "github_projects",
+        providers: { github_projects: { owner: "jcast90" } },
+      });
+      expect(config.default).toBe("github_projects");
+      expect(config.providers.github_projects?.owner).toBe("jcast90");
+      expect(config.providers.github_projects?.ownerType).toBe("user");
+      expect(config.providers.github_projects?.epic_model).toBe("parent_draft_item");
+      expect(config.providers.github_projects?.use_draft_items).toBe(true);
+      expect(config.providers.github_projects?.sync_interval_seconds).toBe(30);
+      expect(config.providers.github_projects?.min_rate_limit_budget).toBe(200);
+    });
+
+    it("rejects github_projects block without an owner", () => {
+      expect(() =>
+        parseTrackerConfig({
+          default: "github_projects",
+          providers: { github_projects: {} },
+        })
+      ).toThrow();
+    });
+
+    it("rejects unknown provider names in `default`", () => {
+      expect(() => parseTrackerConfig({ default: "jira" })).toThrow();
+    });
+
+    it("rejects out-of-range sync_interval_seconds", () => {
+      expect(() =>
+        parseTrackerConfig({
+          providers: { github_projects: { owner: "x", sync_interval_seconds: 1 } },
+        })
+      ).toThrow();
+      expect(() =>
+        parseTrackerConfig({
+          providers: { github_projects: { owner: "x", sync_interval_seconds: 99999 } },
+        })
+      ).toThrow();
+    });
+
+    it("accepts the per-primary-repo and fixed project_naming shapes", () => {
+      const a = parseTrackerConfig({
+        providers: { github_projects: { owner: "x", project_naming: "per_primary_repo" } },
+      });
+      expect(a.providers.github_projects?.project_naming).toBe("per_primary_repo");
+
+      const b = parseTrackerConfig({
+        providers: { github_projects: { owner: "x", project_naming: { fixed: "Work" } } },
+      });
+      expect(b.providers.github_projects?.project_naming).toEqual({ fixed: "Work" });
+    });
+  });
+
+  describe("resolveProviderForChannel", () => {
+    it("returns the channel override when set", () => {
+      expect(resolveProviderForChannel(DEFAULT_TRACKER_CONFIG, "github_projects")).toBe(
+        "github_projects"
+      );
+    });
+
+    it("falls back to the global default when no override is given", () => {
+      expect(resolveProviderForChannel(DEFAULT_TRACKER_CONFIG)).toBe("relay_native");
+    });
+
+    it("honors the override even when the global default is something else", () => {
+      const cfg = TrackerConfigSchema.parse({
+        default: "github_projects",
+        providers: { github_projects: { owner: "x" } },
+      });
+      expect(resolveProviderForChannel(cfg, "relay_native")).toBe("relay_native");
+    });
+  });
+
+  describe("diagnoseTrackerConfig", () => {
+    it("returns ok for the default config", () => {
+      const out = diagnoseTrackerConfig(DEFAULT_TRACKER_CONFIG);
+      expect(out).toHaveLength(1);
+      expect(out[0].level).toBe("ok");
+    });
+
+    it("flags an error when default points at github_projects with no provider block", () => {
+      const cfg = TrackerConfigSchema.parse({ default: "github_projects" });
+      const out = diagnoseTrackerConfig(cfg);
+      expect(
+        out.some((d) => d.level === "error" && /github_projects is missing/.test(d.message))
+      ).toBe(true);
+    });
+
+    it("flags an error when default points at linear with no provider block", () => {
+      const cfg = TrackerConfigSchema.parse({ default: "linear" });
+      const out = diagnoseTrackerConfig(cfg);
+      expect(out.some((d) => d.level === "error" && /linear is missing/.test(d.message))).toBe(
+        true
+      );
+    });
+
+    it("flags an error when default is github_issues but the block is disabled", () => {
+      const cfg = TrackerConfigSchema.parse({
+        default: "github_issues",
+        providers: { github_issues: { enabled: false } },
+      });
+      const out = diagnoseTrackerConfig(cfg);
+      expect(
+        out.some((d) => d.level === "error" && /github_issues.*enabled is false/.test(d.message))
+      ).toBe(true);
+    });
+
+    it("warns about the custom-field epic model 50-option cap", () => {
+      const cfg = TrackerConfigSchema.parse({
+        default: "github_projects",
+        providers: { github_projects: { owner: "x", epic_model: "custom_field" } },
+      });
+      const out = diagnoseTrackerConfig(cfg);
+      expect(
+        out.some((d) => d.level === "warn" && /50-option cap|caps single-select/.test(d.message))
+      ).toBe(true);
+    });
+
+    it("warns when use_draft_items is false (real-Issue projection is a footgun)", () => {
+      const cfg = TrackerConfigSchema.parse({
+        default: "github_projects",
+        providers: { github_projects: { owner: "x", use_draft_items: false } },
+      });
+      const out = diagnoseTrackerConfig(cfg);
+      expect(
+        out.some((d) => d.level === "warn" && /clutters the bug tracker/.test(d.message))
+      ).toBe(true);
+    });
+
+    it("flags an error when relay_native is the default but disabled", () => {
+      const cfg = TrackerConfigSchema.parse({
+        default: "relay_native",
+        providers: { relay_native: { enabled: false } },
+      });
+      const out = diagnoseTrackerConfig(cfg);
+      expect(out.some((d) => d.level === "error" && /resolves to nothing/.test(d.message))).toBe(
+        true
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Seventh slice of v0.2 tracker work (closes #186). Surfaces the integration choices users make at install time as a typed, validated block in `~/.relay/config.json`, plus a per-channel override and `rly doctor` diagnostics. Unblocks the four follow-ups (#193 MCP wiring, #194 scheduler timer, #195 status drift, #196 bulk import) that all need this config block to know whether/where to project.

## What's in scope

### `src/domain/tracker-config.ts` (new)
- **Zod schemas** for `TrackerConfig`, `GitHubProjectsConfig`, `LinearConfig`, `GitHubIssuesConfig`, `RelayNativeConfig`
- **`DEFAULT_TRACKER_CONFIG`** — `relay_native` only, what configs predating v0.2 deserialize to
- **`parseTrackerConfig(unknown)`** — handles undefined / null / empty-object inputs for back-compat; throws on malformed shapes
- **`resolveProviderForChannel(cfg, override?)`** — per-channel override wins over global default, honored even when default is something else
- **`diagnoseTrackerConfig(cfg)`** — returns the rule-set used by `rly doctor`: default→missing-provider errors, `epic_model: custom_field` 50-option-cap warning, `use_draft_items: false` footgun warning, etc.

### Channel domain
- **`Channel.trackerOverride: TrackerProviderName?`** — TS shape + Rust mirror in `crates/harness-data/src/lib.rs` (stored as `Option<String>` so adding a future provider doesn't bump dashboards) + `gui/src-tauri/src/lib.rs` DM constructor
- `updateChannel` patch shape extended to include `trackerOverride`

### CLI
- **`rly channel update <id> --tracker <name>`** — sets the per-channel override; validates against the four known provider names
- **`rly doctor`** — new "Tracker:" section running `diagnoseTrackerConfig`, ✓/!/✗ per rule

### `cli/config.ts`
- Round-trips the `tracker` block through `readConfig` / `writeConfig`
- Synthesizes `DEFAULT_TRACKER_CONFIG` when the file is absent, lacks the key, or is malformed — rather than crashing the CLI on bad config

## Migration
Configs predating v0.2 have no `tracker` block. `readConfig` synthesizes `DEFAULT_TRACKER_CONFIG` (relay_native, offline-first) so no user action is required. Documented in PR H (#197).

## Tests

**23 new vitest cases**:
- 19 schema/diagnostic tests in `test/domain/tracker-config.test.ts`:
  - Default config shape
  - Parse handles undefined / null / empty object / valid input / malformed input
  - github_projects requires `owner`
  - Unknown provider names rejected in `default`
  - Out-of-range `sync_interval_seconds` rejected
  - Both `project_naming` shapes accepted (`per_primary_repo` and `{ fixed: "..." }`)
  - `resolveProviderForChannel` honors override over default
  - All six diagnostic rules pinned (default→missing/disabled provider errors, custom-field cap warning, use_draft_items footgun warning)
- 4 round-trip tests in `test/cli/config-tracker.test.ts`:
  - Synthesizes default when file missing / key missing / file malformed
  - Round-trips a github_projects-default config through write→read

Full suite: **978 passed | 24 skipped** (was 955 in PR E). Rust crate passes `cargo check --workspace`.

## Verification
```
pnpm typecheck     # clean
pnpm format:check  # clean
pnpm test          # 978 / 24 skipped
cargo check --workspace # clean
```

## Test plan
- [ ] CI fast-tier passes (ts-verify, rust-check, format-check)
- [ ] Reviewer confirms the diagnostic rule-set is the right starting point (no `rly doctor` run-time tests, but the diagnoses array is fully unit-tested)
- [ ] Reviewer confirms storing `trackerOverride` as `Option<String>` (rather than a Rust enum) is fine for forward-compat — adding a 5th provider name doesn't require a Rust change

🤖 Generated with [Claude Code](https://claude.com/claude-code)