### PR TITLE
chore(release): 0.7.0 — GitHub Projects v2 tracker integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.7.0
+
+### Minor Changes
+
+- GitHub Projects v2 tracker integration (v0.2). Channels project onto a GH Projects v2 board: channel → epic draft item, tickets → child draft items, with `Type` / `Status` / `Priority` custom fields kept in sync by a one-way Relay-authoritative sync worker. Drift on the GitHub side is logged to the channel feed as a `status_update` warning and overwritten on the next tick.
+
+  Shipped slices (PRs A, B, C, D, E, G, H from the v0.2 milestone):
+  - **GraphQL client + project resolver** (#188) — find-or-create-by-title, owner-id resolution for user vs org projects
+  - **Draft-item CRUD + custom-field bootstrap** (#189) — create / update / archive draft items, idempotent Status/Type/Priority field creation with seeded options
+  - **Channel ↔ epic orchestration** (#191) — `provisionEpicForChannel` / `renameEpicForChannel` / `archiveEpicForChannel` plus the `Channel.trackerLinks` shape (TS + Rust mirror with serde defaults for back-compat)
+  - **One-shot sync worker** (#192) — `syncChannelTickets` reconciliation tick with title-drift detection, rate-limit throttling (default min budget 200), stale-id recovery (item-deleted-out-from-under-us repair), and `TicketLedgerEntry.externalIds` for foreign-key tracking
+  - **Classifier URL parsing** (#190) — pasting a Projects v2 item URL into chat resolves the project + epic + creates the ticket; project-only URL pastes return a clear deferred-error message
+  - **Tracker config block** (#198) — `tracker` block in `~/.relay/config.json` with `default` provider, per-provider settings (`github_projects` / `linear` / `github_issues` / `relay_native`), per-channel override via `rly channel update --tracker <name>` (or `none` to unpin), and `rly doctor` diagnostics (default-points-at-missing-provider errors, custom-field 50-option-cap warnings, footgun warnings)
+  - **Documentation** (#197) — new `docs/trackers.md` reference with mapping tables, drift behavior, rate limits, troubleshooting; `docs/getting-started.md` adds a "Linking a channel to GitHub Projects v2" section; `README.md` notes the integration and adds `trackerLinks` to the file-layout tree
+
+  Deferred to follow-up issues (gated behind the new `tracker` config block before any of them auto-fire):
+  - **#193** MCP-handler wiring for `channel_create` / `channel_update` / `channel_archive` (high priority)
+  - **#194** Scheduler / interval timer for `syncChannelTickets` (high priority)
+  - **#195** Status-field drift detection
+  - **#196** Bulk-import an existing GH Projects v2 board into a fresh channel
+  - **#185** Linear parity (PR F — analogous mapping onto Linear projects + sub-issues)
+
+  Migration: configs that predate v0.2 have no `tracker` block; `readConfig` synthesizes the default (`relay_native`, offline-first) so no user action is required. Existing `linear-mirror.ts` users keep working unchanged until #185 lands.
+
+  Test count: 905 → 978 across the v0.2 work. Full Rust workspace passes `cargo check` + `cargo test` for `harness-data`.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "harness-data"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -3124,7 +3124,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-gui"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "harness-data",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tui"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/harness-data/Cargo.toml
+++ b/crates/harness-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-data"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-gui"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jcast90/relay",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Local-first orchestration for coding agents — classify, decompose, dispatch Claude/Codex, and supervise from a dashboard.",
   "keywords": [
     "agent-orchestration",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-tui"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Release bump to **v0.7.0** covering the v0.2 GitHub Projects v2 tracker integration. Generated via `pnpm changeset version` from `.changeset/v0-2-tracker.md`.

## Version bumps

- `package.json` 0.6.1 → 0.7.0
- `crates/harness-data/Cargo.toml` 0.6.1 → 0.7.0
- `gui/src-tauri/Cargo.toml` 0.6.1 → 0.7.0
- `tui/Cargo.toml` 0.6.1 → 0.7.0
- `Cargo.lock` regenerated

## What ships in 0.7.0

Seven merged v0.2 PRs (full notes in CHANGELOG.md):

- **#188** PR A — GraphQL client + project resolver
- **#189** PR B — draft-item CRUD + Status/Type/Priority field bootstrap
- **#191** PR C — channel↔epic orchestration + `trackerLinks` shape
- **#192** PR D — one-shot sync worker with drift + throttle + stale-id recovery
- **#190** PR E — classifier URL parsing for GH Projects v2 URLs
- **#198** PR G — `tracker` config block + `--tracker` channel override + `rly doctor` checks
- **#197** PR H — `docs/trackers.md` reference + getting-started + README annotations

## Follow-ups still open in v0.2 milestone (not blocking 0.7.0)

- **#193** MCP-handler wiring (high priority)
- **#194** Scheduler / interval timer (high priority)
- **#195** Status-field drift detection
- **#196** Bulk-import existing GH Projects v2 boards
- **#185** Linear parity (PR F)

## Migration

Configs predating v0.2 have no `tracker` block; `readConfig` synthesizes the default (`relay_native`, offline-first) so no user action is required. Linear mirror behavior unchanged.

## Release flow on merge + tag push

1. Merge this PR
2. `git tag v0.7.0 && git push origin v0.7.0` triggers `.github/workflows/release.yml`
3. `release-gui` builds Tauri installers for macOS / Linux / Windows
4. `release-github` cuts the GitHub Release with the 0.7.0 CHANGELOG section
5. `release-npm` stays a no-op until `NPM_PUBLISH_ENABLED` repo variable is flipped (Trusted Publisher binding pending per OSS-21 / issue #135)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 978 passed | 24 skipped
- [x] `cargo check --workspace` clean
- [ ] Tag pushed → release-github + release-gui complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)