### PR TITLE
feat(plan): emit Specs section in design docs for feature tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,12 @@ crates/harness-data/      # shared Rust types consumed by tui/ + gui/
 
 Files an agent will commonly touch: `src/orchestrator/*.ts` for pipeline logic, `src/channels/channel-store.ts` for feed/ticket state, `src/mcp/*.ts` for tool definitions, `src/domain/*.ts` for shared shapes.
 
+## Design-doc convention
+
+Design docs live in `docs/design/<feature>.md` and are emitted by `/plan` for tiers that pass `tierNeedsDesignDoc()` (currently: `architectural`, `feature_large`, `feature_small`). Required sections in order: a short status header (Status / Owner / Target version / Related code paths), `## Problem`, `## Goals`, `## Non-goals`, `## Mental model`, `## Architectural decisions` (optional for feature tiers), `## Implementation plan`, `## Specs`, `## Open questions`, `## Sign-off`.
+
+The `## Specs` section captures behavioural requirements as `Given … / When … / Then …` scenarios — one bullet per requirement, scenarios nested under it. See `docs/design/openspec-spike.md` for a worked example and `docs/design/tracker-projects-mapping.md` for the established tone.
+
 ## Cross-dashboard contract
 
 This is where agents quietly break things:

--- a/docs/design/openspec-spike.md
+++ b/docs/design/openspec-spike.md
@@ -47,6 +47,23 @@ One narrow ticket: **add an optional `specs/` block to the design-doc convention
 
 This captures the only OpenSpec idea that doesn't already exist in Relay, costs a small docs + prompt change, and creates zero new sources of truth.
 
+## Specs
+
+The `## Specs` section is the convention this spike establishes. It belongs on every design doc emitted by `/plan` for `feature_small`, `feature_large`, and `architectural` tiers. Format: one bullet per requirement, with one or more `Given … / When … / Then …` scenarios nested under it. The example below documents this very convention so design-doc readers see the shape immediately.
+
+- **`/plan` emits a `## Specs` section in the design doc when the classifier tier is `feature_small`, `feature_large`, or `architectural`.**
+  - Given a request classified as `feature_large`
+    When `/plan` runs and reaches the design-doc step
+    Then the emitted design doc contains a `## Specs` section with at least one requirement bullet and at least one nested `Given/When/Then` scenario.
+  - Given a request classified as `bugfix` or `trivial`
+    When `/plan` runs
+    Then no design doc is emitted, and per-ticket `acceptanceCriteria` covers verification.
+
+- **The `## Specs` section is human-skimmable and lives next to the rest of the design doc — no parallel folder tree.**
+  - Given a contributor opens `docs/design/<feature>.md`
+    When they scroll the file
+    Then `## Specs` appears between `## Implementation plan` and `## Open questions`, with the same heading depth as siblings.
+
 ## Sign-off
 
-Recommendation: **pass on OpenSpec adoption; open a sized-S follow-up for the `specs/` block on design docs.** Close #204 with a link to this doc.
+Recommendation: **pass on OpenSpec adoption; open a sized-S follow-up for the `specs/` block on design docs.** Close #204 with a link to this doc. (Follow-up shipped as #206 / this PR — see the `## Specs` section above for the worked example.)

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -570,7 +570,9 @@ function buildPrompt(agentName: string, request: WorkRequest): string {
     "If this is planning work (kind=draft_plan), include a phasePlan object matching the harness phase-plan schema.",
     "If this is classification work (kind=classify_request), return a classification object with: tier (trivial|bugfix|feature_small|feature_large|architectural|multi_repo), rationale, suggestedSpecialties, estimatedTicketCount, needsDesignDoc, needsUserApproval.",
     "If this is ticket decomposition work (kind=decompose_tickets), return a ticketPlan object with parallelizable tickets and dependsOn edges.",
-    "If this is design doc work (kind=generate_design_doc), provide the design document in your summary.",
+    "If this is design doc work (kind=generate_design_doc), provide the design document in your summary as Markdown with these sections, in order: a short status header (Status / Owner / Target version / Related code paths), `## Problem`, `## Goals`, `## Non-goals`, `## Mental model`, `## Architectural decisions` (optional for feature tiers), `## Implementation plan`, `## Specs`, `## Open questions`, `## Sign-off`.",
+    "The `## Specs` section captures behavioural requirements as `Given … / When … / Then …` scenarios. List each requirement as a bullet, then nest one or more scenarios under it. Skip the section only when no behaviour-visible requirement applies (rare).",
+    "See `docs/design/openspec-spike.md` and `docs/design/tracker-projects-mapping.md` for the established shape — match their tone and section ordering.",
     "Otherwise, omit phasePlan, classification, and ticketPlan.",
   ];
 

--- a/src/domain/classification.ts
+++ b/src/domain/classification.ts
@@ -78,7 +78,7 @@ export function tierNeedsApproval(tier: ComplexityTier): boolean {
 }
 
 export function tierNeedsDesignDoc(tier: ComplexityTier): boolean {
-  return tier === "architectural";
+  return tier === "architectural" || tier === "feature_large" || tier === "feature_small";
 }
 
 export function tierSkipsPlanning(tier: ComplexityTier): boolean {

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -226,14 +226,14 @@ export class OrchestratorV2 {
     run.plan = planResult.phasePlan ?? createSeedPlan(featureRequest, this.repoRoot);
     await this.transition(run, "PlanGenerated", "phase_00");
 
-    // Step 4: Design doc (architectural tier)
+    // Step 4: Design doc (architectural / feature_large / feature_small)
     if (tierNeedsDesignDoc(classification.tier)) {
       const designResult = await this.dispatch(run, {
         phaseId: "phase_00",
         kind: "generate_design_doc",
         specialty: "general",
         title: "Generate design document",
-        objective: `Create an architectural design document for: ${featureRequest}`,
+        objective: `Create a design document for: ${featureRequest}`,
         acceptanceCriteria: [
           "Document should cover architecture, trade-offs, and implementation approach.",
           "Include component boundaries and data flow.",

--- a/test/classification.test.ts
+++ b/test/classification.test.ts
@@ -48,7 +48,11 @@ describe("classification domain", () => {
     expect(tierNeedsApproval("feature_small")).toBe(false);
 
     expect(tierNeedsDesignDoc("architectural")).toBe(true);
-    expect(tierNeedsDesignDoc("feature_large")).toBe(false);
+    expect(tierNeedsDesignDoc("feature_large")).toBe(true);
+    expect(tierNeedsDesignDoc("feature_small")).toBe(true);
+    expect(tierNeedsDesignDoc("bugfix")).toBe(false);
+    expect(tierNeedsDesignDoc("trivial")).toBe(false);
+    expect(tierNeedsDesignDoc("multi_repo")).toBe(false);
 
     expect(tierSkipsPlanning("trivial")).toBe(true);
     expect(tierSkipsPlanning("bugfix")).toBe(false);

--- a/test/orchestrator-v2.test.ts
+++ b/test/orchestrator-v2.test.ts
@@ -10,6 +10,8 @@ import { NodeCommandInvoker } from "../src/agents/command-invoker.js";
 import { ChannelStore } from "../src/channels/channel-store.js";
 import { LocalArtifactStore } from "../src/execution/artifact-store.js";
 import { FileHarnessStore } from "../src/storage/file-store.js";
+import { STORE_NS } from "../src/storage/namespaces.js";
+import type { HarnessStore } from "../src/storage/store.js";
 import { VerificationRunner } from "../src/execution/verification-runner.js";
 import { OrchestratorV2 } from "../src/orchestrator/orchestrator-v2.js";
 import { ScriptedInvoker } from "../src/simulation/scripted-invoker.js";
@@ -74,7 +76,7 @@ function buildOrchestrator(
   );
   const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
 
-  return new OrchestratorV2(
+  const orchestrator = new OrchestratorV2(
     registry,
     cwd,
     verificationRunner,
@@ -83,6 +85,27 @@ function buildOrchestrator(
     opts.channelStore,
     opts.workspaceId
   );
+
+  return { orchestrator, artifactStore };
+}
+
+async function readSavedDesignDoc(
+  artifactStore: LocalArtifactStore,
+  runId: string
+): Promise<string | undefined> {
+  // The artifact store has no public read-back for design docs today;
+  // #206's coverage need does not justify expanding the public interface.
+  const store = (artifactStore as unknown as { store: HarnessStore }).store;
+  try {
+    const bytes = await store.getBlob({
+      ns: STORE_NS.runArtifacts,
+      id: `${runId}__design-doc`,
+      size: 0,
+    });
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
 }
 
 describe("OrchestratorV2 integration", () => {
@@ -91,7 +114,7 @@ describe("OrchestratorV2 integration", () => {
     const artifactsDir = join(tmpDir, "artifacts");
 
     try {
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir);
+      const { orchestrator, artifactStore } = buildOrchestrator(tmpDir, artifactsDir);
       const run = await orchestrator.run(
         "Implement a new authentication system with JWT tokens and session management"
       );
@@ -115,6 +138,13 @@ describe("OrchestratorV2 integration", () => {
       expect(eventTypes).toContain("ClassificationComplete");
       expect(eventTypes).toContain("PlanGenerated");
       expect(eventTypes).toContain("TicketsCreated");
+
+      // #206: feature_small now triggers the design-doc step. Verify the
+      // artifact landed so a future revert of tierNeedsDesignDoc would fail
+      // this test instead of silently passing.
+      const designDoc = await readSavedDesignDoc(artifactStore, run.id);
+      expect(designDoc).toBeDefined();
+      expect(designDoc!.length).toBeGreaterThan(0);
     } finally {
       await rm(tmpDir, RM_OPTS);
     }
@@ -125,7 +155,7 @@ describe("OrchestratorV2 integration", () => {
     const artifactsDir = join(tmpDir, "artifacts");
 
     try {
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir);
+      const { orchestrator, artifactStore } = buildOrchestrator(tmpDir, artifactsDir);
       const run = await orchestrator.run("Fix typo in README");
 
       expect(run.classification).not.toBeNull();
@@ -138,6 +168,10 @@ describe("OrchestratorV2 integration", () => {
       const eventTypes = run.events.map((e) => e.type);
       expect(eventTypes).toContain("ClassificationComplete");
       expect(eventTypes).toContain("TicketsCreated");
+
+      // #206: trivial must NOT trigger the design-doc step.
+      const designDoc = await readSavedDesignDoc(artifactStore, run.id);
+      expect(designDoc).toBeUndefined();
     } finally {
       await rm(tmpDir, RM_OPTS);
     }
@@ -151,7 +185,7 @@ describe("OrchestratorV2 integration", () => {
       // Override classification by using a request that won't match heuristics
       // The ScriptedInvoker always returns feature_small, so let's test with
       // a direct classification override via a bugfix heuristic
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir);
+      const { orchestrator } = buildOrchestrator(tmpDir, artifactsDir);
       const run = await orchestrator.run(
         "Implement a new authentication system with JWT tokens and session management"
       );
@@ -174,7 +208,7 @@ describe("OrchestratorV2 integration", () => {
         artifactsDir,
         new FileHarnessStore(join(artifactsDir, "__hs__"))
       );
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir);
+      const { orchestrator } = buildOrchestrator(tmpDir, artifactsDir);
       const run = await orchestrator.run("Fix typo in README");
 
       // Verify snapshot was written
@@ -202,7 +236,7 @@ describe("OrchestratorV2 integration", () => {
 
     try {
       const channelStore = new ChannelStore(channelsDir);
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
+      const { orchestrator } = buildOrchestrator(tmpDir, artifactsDir, {
         channelStore,
         workspaceId: "ws-test",
       });
@@ -237,7 +271,7 @@ describe("OrchestratorV2 integration", () => {
 
     try {
       const channelStore = new ChannelStore(channelsDir);
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
+      const { orchestrator } = buildOrchestrator(tmpDir, artifactsDir, {
         channelStore,
         workspaceId: "ws-test",
       });
@@ -272,7 +306,7 @@ describe("OrchestratorV2 integration", () => {
         throw new Error("simulated write failure");
       };
 
-      const orchestrator = buildOrchestrator(tmpDir, artifactsDir, {
+      const { orchestrator } = buildOrchestrator(tmpDir, artifactsDir, {
         channelStore,
         workspaceId: "ws-test",
       });


### PR DESCRIPTION
Closes #206. Implements the OpenSpec spike follow-up (#204 → #205 recommendation).

## Summary
- \`tierNeedsDesignDoc()\` now returns true for \`feature_large\` and \`feature_small\` (in addition to \`architectural\`). Bugfix / trivial / multi_repo still skip the design-doc step.
- \`kind=generate_design_doc\` prompt now spells out the design-doc convention: required sections in order, including a new \`## Specs\` section that captures behavioural requirements as \`Given / When / Then\` scenarios.
- \`AGENTS.md\` gains a \"Design-doc convention\" subsection that documents the shape and points at the two real examples.
- \`docs/design/openspec-spike.md\` gains a worked \`## Specs\` block — meta but useful: it documents this very convention so future design-doc authors see the shape immediately.
- No new state machine, no new folder tree, no new slash commands — pure docs + prompt + tier-gate change as scoped in #206.

## Test plan
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 978 passed / 24 skipped (no regressions; orchestrator-v2 feature_small path still passes after gate change since ScriptedInvoker already handles \`generate_design_doc\`)
- [x] \`pnpm dlx prettier --check\` on changed files — clean
- [ ] Smoke: run \`/plan\` against a real feature_small request and confirm the emitted design doc includes a populated \`## Specs\` section