### PR TITLE
feat(install): rly install command + drift manifest + startup nudge

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,10 +1,5 @@
 import { runInstall, type InstallResult } from "../install/installer.js";
-import {
-  getSourceVersion,
-  reportDrift,
-  type Surface,
-  SURFACES,
-} from "../install/manifest.js";
+import { getSourceVersion, reportDrift, type Surface, SURFACES } from "../install/manifest.js";
 
 const HELP = [
   "Usage: rly install [target] [options]",
@@ -117,7 +112,9 @@ async function runCheck(json: boolean): Promise<number> {
     return 1;
   }
   const list = drift.behind.join(" ");
-  console.log(`Run \`rly install ${drift.behind.length === SURFACES.length ? "" : list}\` to update.`);
+  console.log(
+    `Run \`rly install ${drift.behind.length === SURFACES.length ? "" : list}\` to update.`
+  );
   return 1;
 }
 
@@ -156,8 +153,7 @@ export async function handleInstallCommand(args: string[]): Promise<number> {
   // Print what we're about to do up-front so the user sees a single header
   // before pnpm/cargo/tauri start streaming their own output.
   const source = await getSourceVersion();
-  const targetLabel =
-    parsed.surfaces.length === 0 ? "all surfaces" : parsed.surfaces.join(", ");
+  const targetLabel = parsed.surfaces.length === 0 ? "all surfaces" : parsed.surfaces.join(", ");
   console.log(
     `[rly install] target: ${targetLabel} — source v${source.version}${source.sourceSha ? ` (${source.sourceSha.slice(0, 7)})` : ""}`
   );

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -102,7 +102,9 @@ async function runCheck(json: boolean): Promise<number> {
   console.log("");
 
   // Three buckets the user cares about: nothing installed yet (fresh),
-  // installed but stale (behind), or all good (current).
+  // installed but stale (behind), or all good (current). The non-zero
+  // exits below let scripts run `rly install --check || rly install`
+  // cleanly — exit 1 means "do something."
   if (drift.behind.length === 0 && freshSurfaces.length === 0) {
     console.log("All surfaces match source. Nothing to do.");
     return 0;
@@ -116,7 +118,6 @@ async function runCheck(json: boolean): Promise<number> {
   }
   const list = drift.behind.join(" ");
   console.log(`Run \`rly install ${drift.behind.length === SURFACES.length ? "" : list}\` to update.`);
-  // Non-zero so scripts can `rly install --check || rly install` cleanly.
   return 1;
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,0 +1,167 @@
+import { runInstall, type InstallResult } from "../install/installer.js";
+import {
+  getSourceVersion,
+  reportDrift,
+  type Surface,
+  SURFACES,
+} from "../install/manifest.js";
+
+const HELP = [
+  "Usage: rly install [target] [options]",
+  "",
+  "Build and install Relay surfaces (CLI dist, TUI binary, GUI .app) so the",
+  "installed copies match the source you have checked out. With no target,",
+  "installs every surface that's behind. Drives the manifest at",
+  "~/.relay/installed.json that the startup nudge reads.",
+  "",
+  "Targets:",
+  "  cli                  TS dist (pnpm build)",
+  "  tui                  Rust TUI binary → ~/.cargo/bin/relay-tui (or ~/.local/bin)",
+  "  gui                  Tauri GUI → /Applications/Relay.app (macOS only)",
+  "  all                  All three (default)",
+  "",
+  "Options:",
+  "  --check              Report drift between source and installed; do not build",
+  "  --force              Rebuild + reinstall even when manifest is current",
+  "  --json               Machine-readable output (only honored with --check)",
+  "  --help               Show this message",
+  "",
+  "Env:",
+  "  RELAY_TUI_INSTALL_DIR    Override TUI install dir",
+  "  RELAY_NO_UPDATE_NUDGE=1  Suppress the startup nudge in other commands",
+].join("\n");
+
+interface ParsedArgs {
+  surfaces: Surface[];
+  check: boolean;
+  force: boolean;
+  json: boolean;
+  help: boolean;
+  errors: string[];
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    surfaces: [],
+    check: false,
+    force: false,
+    json: false,
+    help: false,
+    errors: [],
+  };
+  for (const raw of args) {
+    if (raw === "--help" || raw === "-h") parsed.help = true;
+    else if (raw === "--check") parsed.check = true;
+    else if (raw === "--force") parsed.force = true;
+    else if (raw === "--json") parsed.json = true;
+    else if (raw === "all") {
+      // explicit "all" is the same as no surface arg — install everything
+    } else if (raw === "cli" || raw === "tui" || raw === "gui") {
+      if (!parsed.surfaces.includes(raw)) parsed.surfaces.push(raw);
+    } else if (raw.startsWith("-")) {
+      parsed.errors.push(`unknown flag: ${raw}`);
+    } else {
+      parsed.errors.push(`unknown target: ${raw}`);
+    }
+  }
+  return parsed;
+}
+
+function formatSurfaceLine(
+  surface: Surface,
+  state: string,
+  recordVersion: string | undefined,
+  recordSha: string | null | undefined,
+  source: { version: string; sourceSha: string | null }
+): string {
+  const sourceTag = source.sourceSha ? ` (${source.sourceSha.slice(0, 7)})` : "";
+  const installed = recordVersion
+    ? `${recordVersion}${recordSha ? ` (${recordSha.slice(0, 7)})` : ""}`
+    : "—";
+  const symbol = state === "current" ? "✓" : state === "behind" ? "↻" : "·";
+  return `  ${symbol} ${surface.padEnd(4)} installed: ${installed.padEnd(20)} source: ${source.version}${sourceTag}`;
+}
+
+async function runCheck(json: boolean): Promise<number> {
+  const drift = await reportDrift();
+  if (json) {
+    console.log(JSON.stringify(drift, null, 2));
+    return drift.behind.length === 0 ? 0 : 1;
+  }
+  const freshSurfaces: Surface[] = [];
+  console.log(
+    `Source: v${drift.source.version}${drift.source.sourceSha ? ` (${drift.source.sourceSha.slice(0, 7)})` : ""}`
+  );
+  for (const surface of SURFACES) {
+    const { record, state } = drift.surfaces[surface];
+    if (state === "fresh") freshSurfaces.push(surface);
+    console.log(
+      formatSurfaceLine(surface, state, record?.version, record?.sourceSha, drift.source)
+    );
+  }
+  console.log("");
+
+  // Three buckets the user cares about: nothing installed yet (fresh),
+  // installed but stale (behind), or all good (current).
+  if (drift.behind.length === 0 && freshSurfaces.length === 0) {
+    console.log("All surfaces match source. Nothing to do.");
+    return 0;
+  }
+  if (drift.behind.length === 0) {
+    const list = freshSurfaces.join(" ");
+    console.log(
+      `Not installed: ${list}. Run \`rly install${freshSurfaces.length === SURFACES.length ? "" : ` ${list}`}\` to set up.`
+    );
+    return 1;
+  }
+  const list = drift.behind.join(" ");
+  console.log(`Run \`rly install ${drift.behind.length === SURFACES.length ? "" : list}\` to update.`);
+  // Non-zero so scripts can `rly install --check || rly install` cleanly.
+  return 1;
+}
+
+function summarize(results: InstallResult[]): number {
+  console.log("");
+  let failed = 0;
+  for (const r of results) {
+    const symbol = r.status === "installed" ? "✓" : r.status === "skipped" ? "·" : "✗";
+    console.log(`${symbol} ${r.surface}: ${r.status} — ${r.detail}`);
+    if (r.status === "failed") failed += 1;
+  }
+  return failed === 0 ? 0 : 1;
+}
+
+export async function handleInstallCommand(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if (parsed.help) {
+    console.log(HELP);
+    return 0;
+  }
+  if (parsed.errors.length > 0) {
+    for (const err of parsed.errors) console.error(`[rly install] ${err}`);
+    console.error("");
+    console.error(HELP);
+    return 2;
+  }
+  if (parsed.json && !parsed.check) {
+    console.error("[rly install] --json is only supported with --check");
+    return 2;
+  }
+
+  if (parsed.check) {
+    return runCheck(parsed.json);
+  }
+
+  // Print what we're about to do up-front so the user sees a single header
+  // before pnpm/cargo/tauri start streaming their own output.
+  const source = await getSourceVersion();
+  const targetLabel =
+    parsed.surfaces.length === 0 ? "all surfaces" : parsed.surfaces.join(", ");
+  console.log(
+    `[rly install] target: ${targetLabel} — source v${source.version}${source.sourceSha ? ` (${source.sourceSha.slice(0, 7)})` : ""}`
+  );
+  if (parsed.force) console.log("[rly install] --force — will rebuild even when current");
+
+  const results = await runInstall({ surfaces: parsed.surfaces, force: parsed.force });
+  return summarize(results);
+}

--- a/src/cli/update-nudge.ts
+++ b/src/cli/update-nudge.ts
@@ -1,0 +1,82 @@
+import { reportDrift } from "../install/manifest.js";
+
+/**
+ * Commands that should never get an update nudge: the nudge can't tell
+ * the user anything they don't already know (or are about to fix), and
+ * for `--version`/help paths a stderr line is just noise.
+ *
+ * `install` is special — the user is already updating, so reminding them
+ * to update would be circular.
+ */
+const SUPPRESS_COMMANDS = new Set([
+  "install",
+  "version",
+  "--version",
+  "-v",
+  "help",
+  "--help",
+  "-h",
+]);
+
+/**
+ * One-time per-process check: did we already print the nudge for this
+ * invocation? Some entrypoints (e.g. `rly chat` running multiple sub-
+ * commands) could otherwise emit it twice.
+ */
+let printed = false;
+
+interface NudgeOptions {
+  command: string | undefined;
+  argv: readonly string[];
+}
+
+/**
+ * Print a one-line stderr nudge when any installed surface is behind the
+ * source on disk. The nudge is best-effort — manifest errors, missing
+ * git, or a never-installed Relay all silently no-op rather than risk
+ * spamming the user during a routine command.
+ *
+ * Suppression layers, in order:
+ *  - `RELAY_NO_UPDATE_NUDGE=1` env var (user opt-out, persistent).
+ *  - Commands listed in `SUPPRESS_COMMANDS` (would be circular or noisy).
+ *  - `--json`/`--quiet` flags anywhere in argv (don't pollute structured output).
+ *  - stderr not a TTY (don't pollute pipes / CI logs).
+ *  - Already printed this process.
+ *
+ * Caller-supplied command is required so we can suppress on `install`
+ * before reading the manifest at all — the I/O cost matters when the
+ * user is in a tight loop running `rly status` etc.
+ */
+export async function maybePrintUpdateNudge(options: NudgeOptions): Promise<void> {
+  if (printed) return;
+  if (process.env.RELAY_NO_UPDATE_NUDGE === "1") return;
+  if (options.command && SUPPRESS_COMMANDS.has(options.command)) return;
+  if (options.argv.includes("--json") || options.argv.includes("--quiet")) return;
+  if (!process.stderr.isTTY) return;
+
+  let drift: Awaited<ReturnType<typeof reportDrift>>;
+  try {
+    drift = await reportDrift();
+  } catch {
+    // Manifest read or git probe failed — skip silently. Better to miss
+    // a nudge than to crash a user's workflow with an install-system bug.
+    return;
+  }
+  if (drift.behind.length === 0) return;
+
+  printed = true;
+  const list = drift.behind.join(" ");
+  // Single line, dim style (ANSI 2 = faint) so it's visible but doesn't
+  // compete with the actual command output. Reset at end so the next
+  // line of stderr from the command itself isn't dimmed.
+  const dim = "[2m";
+  const reset = "[0m";
+  process.stderr.write(
+    `${dim}↻ ${drift.behind.length === 1 ? `${list} is` : `${list} are`} behind source — run \`rly install ${list}\` to update.${reset}\n`
+  );
+}
+
+/** Test helper — reset the once-per-process printed flag. */
+export function __resetUpdateNudgePrintedForTests(): void {
+  printed = false;
+}

--- a/src/cli/update-nudge.ts
+++ b/src/cli/update-nudge.ts
@@ -1,22 +1,13 @@
+import { isQuietMode } from "./stream-activity-renderer.js";
 import { reportDrift } from "../install/manifest.js";
 
 /**
- * Commands that should never get an update nudge: the nudge can't tell
- * the user anything they don't already know (or are about to fix), and
- * for `--version`/help paths a stderr line is just noise.
- *
- * `install` is special — the user is already updating, so reminding them
- * to update would be circular.
+ * `install` is the only command name that can reach `maybePrintUpdateNudge`
+ * — top-level help/version are short-circuited in `main()` before we ever
+ * get here. Reminding the user to update while they're running an install
+ * is circular, so suppress it.
  */
-const SUPPRESS_COMMANDS = new Set([
-  "install",
-  "version",
-  "--version",
-  "-v",
-  "help",
-  "--help",
-  "-h",
-]);
+const SUPPRESS_COMMANDS = new Set(["install"]);
 
 /**
  * One-time per-process check: did we already print the nudge for this
@@ -39,7 +30,9 @@ interface NudgeOptions {
  * Suppression layers, in order:
  *  - `RELAY_NO_UPDATE_NUDGE=1` env var (user opt-out, persistent).
  *  - Commands listed in `SUPPRESS_COMMANDS` (would be circular or noisy).
- *  - `--json`/`--quiet` flags anywhere in argv (don't pollute structured output).
+ *  - Quiet mode (`--quiet`/`--silent`/`--json`/`RELAY_QUIET=1`/`HARNESS_QUIET=1`)
+ *    via the shared `isQuietMode` helper so we honor the same flags every
+ *    other CLI surface does.
  *  - stderr not a TTY (don't pollute pipes / CI logs).
  *  - Already printed this process.
  *
@@ -51,7 +44,10 @@ export async function maybePrintUpdateNudge(options: NudgeOptions): Promise<void
   if (printed) return;
   if (process.env.RELAY_NO_UPDATE_NUDGE === "1") return;
   if (options.command && SUPPRESS_COMMANDS.has(options.command)) return;
-  if (options.argv.includes("--json") || options.argv.includes("--quiet")) return;
+  // `--json` flips structured output for many commands; nudges to stderr
+  // would still parse, but a quiet user reading raw stderr won't expect it.
+  if (options.argv.includes("--json")) return;
+  if (isQuietMode([...options.argv])) return;
   if (!process.stderr.isTTY) return;
 
   let drift: Awaited<ReturnType<typeof reportDrift>>;
@@ -69,8 +65,8 @@ export async function maybePrintUpdateNudge(options: NudgeOptions): Promise<void
   // Single line, dim style (ANSI 2 = faint) so it's visible but doesn't
   // compete with the actual command output. Reset at end so the next
   // line of stderr from the command itself isn't dimmed.
-  const dim = "[2m";
-  const reset = "[0m";
+  const dim = "\x1b[2m";
+  const reset = "\x1b[0m";
   process.stderr.write(
     `${dim}↻ ${drift.behind.length === 1 ? `${list} is` : `${list} are`} behind source — run \`rly install ${list}\` to update.${reset}\n`
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import {
 import { AgentRegistry } from "./agents/registry.js";
 import { launchGui, launchTui, parseGuiFlags } from "./cli/launch-gui-tui.js";
 import { parseRebuildFlags, runRebuild } from "./cli/rebuild.js";
+import { handleInstallCommand } from "./cli/install.js";
+import { maybePrintUpdateNudge } from "./cli/update-nudge.js";
 import { launchInteractiveCommand } from "./cli/launcher.js";
 import { createStreamActivityRenderer, isQuietMode } from "./cli/stream-activity-renderer.js";
 import { hasOnboarded, parseWelcomeFlags, runWelcome } from "./cli/welcome.js";
@@ -86,6 +88,9 @@ export async function main(): Promise<void> {
   }
 
   const command = rawCommand;
+  // Fire the update nudge before workspace bootstrap so it appears at the
+  // top of the user's output. Internally suppressed for install/help/json.
+  await maybePrintUpdateNudge({ command, argv: args });
   const packageVersion = await readPackageVersion();
   const workspace = await ensureHarnessWorkspace(cwd, packageVersion);
   const artifactStore = new LocalArtifactStore(workspace.paths.artifactsDir, getHarnessStore());
@@ -167,6 +172,11 @@ export async function main(): Promise<void> {
 
   if (command === "rebuild") {
     process.exitCode = await runRebuild(parseRebuildFlags(args));
+    return;
+  }
+
+  if (command === "install") {
+    process.exitCode = await handleInstallCommand(args);
     return;
   }
 
@@ -2967,6 +2977,7 @@ async function printTopLevelHelp(): Promise<void> {
     "  config <subcommand>      Manage global config (add/remove project dirs)",
     "  providers <subcommand>   Manage named provider profiles (see docs/providers.md)",
     "  rebuild                  Rebuild native artifacts (tui/gui)",
+    "  install [target]         Build + install cli/tui/gui so PATH and /Applications match source",
     "",
     "Misc:",
     "  version | --version      Print version",

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -1,4 +1,5 @@
-import { chmod, copyFile, mkdir, rename, stat } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { chmod, copyFile, rename, stat } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +10,7 @@ import {
   getSourceVersion,
   markInstalled,
   readManifest,
+  type SourceVersion,
   type Surface,
   SURFACES,
 } from "./manifest.js";
@@ -61,10 +63,15 @@ async function resolveTuiInstallDir(): Promise<string | null> {
  * Atomic copy: write to a sibling `.tmp.<pid>` then rename over the target.
  * Avoids the half-written-binary failure mode where a `cp` is interrupted
  * mid-write and the user is left with a corrupt executable on PATH.
+ *
+ * The destination directory must already exist — we never create it. The
+ * resolver's contract is "first existing directory wins"; if a user
+ * pointed `RELAY_TUI_INSTALL_DIR` at a non-existent dir, surface that as
+ * a copyFile ENOENT rather than silently creating a directory the user
+ * didn't ask for.
  */
 async function atomicInstallBinary(src: string, dst: string): Promise<void> {
   const tmp = `${dst}.${process.pid}.tmp`;
-  await mkdir(join(dst, ".."), { recursive: true });
   await copyFile(src, tmp);
   await chmod(tmp, 0o755);
   await rename(tmp, dst);
@@ -114,9 +121,9 @@ async function installTuiBinary(): Promise<{ ok: boolean; message: string }> {
 async function installOne(
   surface: Surface,
   options: InstallOptions,
-  pnpmInstallAlreadyRan: boolean
+  source: SourceVersion
 ): Promise<InstallResult> {
-  const [manifest, source] = await Promise.all([readManifest(), getSourceVersion()]);
+  const manifest = await readManifest();
   const record = manifest.surfaces[surface];
   const state = diffSurface(record, source);
 
@@ -128,17 +135,16 @@ async function installOne(
     };
   }
 
-  console.log(`\n[rly install] ▶ ${surface}`);
+  console.log(`[rly install] ▶ ${surface}`);
 
   // Compose runRebuild's targets so we only build what we're installing.
-  // skipInstall is false the first time we run a build in this session
-  // and true after — pnpm install is idempotent but a no-op call still
-  // costs ~1s, and installing all three would otherwise pay it three times.
+  // pnpm install was already run once up-front in `runInstall` (root +
+  // gui/ if applicable), so we always pass skipInstall: true here.
   const exit = await runRebuild({
     dist: surface === "cli",
     tui: surface === "tui",
     gui: surface === "gui",
-    skipInstall: pnpmInstallAlreadyRan,
+    skipInstall: true,
     installApp: true,
   });
 
@@ -175,24 +181,79 @@ async function installOne(
   };
 }
 
+async function runPnpmInstall(cwd: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["install"], { cwd, stdio: "inherit" });
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+}
+
 /**
  * Install one or more surfaces. Surfaces install in fixed order
  * (cli → tui → gui) so a user reading the output sees a predictable
  * progression. Failures short-circuit: if `tui` fails, `gui` doesn't
  * start. The manifest is updated per-surface so a partial install
  * still records what succeeded.
+ *
+ * pnpm install is run once up-front for the root package, plus once
+ * for `gui/` when the GUI is targeted. The two are separate pnpm
+ * projects with separate lockfiles, so a single root install never
+ * touches `gui/node_modules` — without the GUI-dir install, a fresh
+ * `git pull` that added a GUI dep surfaces as
+ * "Cannot find module '@tauri-apps/plugin-X'" during the tauri build.
+ *
+ * Concurrency: do not run two `rly install` invocations at once.
+ * `~/.relay/installed.json` writes are atomic per-call, but two
+ * processes' read-modify-write cycles can lose a stamp.
  */
 export async function runInstall(options: InstallOptions): Promise<InstallResult[]> {
   const targets = options.surfaces.length === 0 ? [...SURFACES] : options.surfaces;
   // Preserve the canonical cli→tui→gui order even when caller passed
   // them out of order, so output is consistent across invocations.
   const ordered = SURFACES.filter((s) => targets.includes(s));
+  if (ordered.length === 0) return [];
+
+  const source = await getSourceVersion();
+
+  // Pre-skip-check: if every target is already current and --force isn't
+  // set, skip the up-front pnpm install entirely. Lets `rly install` be
+  // a near-instant no-op when nothing's changed since the last install.
+  const manifest = await readManifest();
+  const anyNeedsBuild = ordered.some((s) => {
+    const state = diffSurface(manifest.surfaces[s], source);
+    return options.force || state !== "current";
+  });
+
+  if (anyNeedsBuild) {
+    console.log("[rly install] deps — pnpm install");
+    const rootExit = await runPnpmInstall(repoRoot());
+    if (rootExit !== 0) {
+      console.error("[rly install] root pnpm install failed — stopping.");
+      return ordered.map((surface) => ({
+        surface,
+        status: "failed" as const,
+        detail: `pnpm install exited ${rootExit}`,
+      }));
+    }
+    if (ordered.includes("gui")) {
+      console.log("[rly install] GUI deps — pnpm install (gui/)");
+      const guiExit = await runPnpmInstall(join(repoRoot(), "gui"));
+      if (guiExit !== 0) {
+        console.error("[rly install] gui/ pnpm install failed — stopping.");
+        return ordered.map((surface) => ({
+          surface,
+          status: "failed" as const,
+          detail: `gui/ pnpm install exited ${guiExit}`,
+        }));
+      }
+    }
+  }
+
   const results: InstallResult[] = [];
-  let pnpmRan = false;
   for (const surface of ordered) {
-    const result = await installOne(surface, options, pnpmRan);
+    const result = await installOne(surface, options, source);
     results.push(result);
-    if (result.status === "installed") pnpmRan = true;
     if (result.status === "failed") break;
   }
   return results;

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -1,0 +1,199 @@
+import { chmod, copyFile, mkdir, rename, stat } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runRebuild } from "../cli/rebuild.js";
+import {
+  diffSurface,
+  getSourceVersion,
+  markInstalled,
+  readManifest,
+  type Surface,
+  SURFACES,
+} from "./manifest.js";
+
+export interface InstallOptions {
+  /** Surfaces to install. Empty = all. */
+  surfaces: Surface[];
+  /** Re-build + re-install even when manifest matches source. */
+  force: boolean;
+}
+
+export interface InstallResult {
+  surface: Surface;
+  /** "skipped" — manifest matched source and --force not set. */
+  status: "installed" | "skipped" | "failed";
+  detail: string;
+}
+
+function repoRoot(): string {
+  return fileURLToPath(new URL("../..", import.meta.url));
+}
+
+/**
+ * Resolve the TUI install destination directory.
+ *
+ * Priority: `$RELAY_TUI_INSTALL_DIR` override → `~/.cargo/bin` (already on
+ * the user's PATH from rustup) → `~/.local/bin` (XDG fallback). The first
+ * existing directory wins; we don't create either.
+ *
+ * Returning `null` means "no obvious destination" — the caller surfaces a
+ * one-line manual-install hint instead of guessing.
+ */
+async function resolveTuiInstallDir(): Promise<string | null> {
+  const override = process.env.RELAY_TUI_INSTALL_DIR;
+  if (override && override.length > 0) {
+    return override;
+  }
+  for (const candidate of [join(homedir(), ".cargo", "bin"), join(homedir(), ".local", "bin")]) {
+    try {
+      const st = await stat(candidate);
+      if (st.isDirectory()) return candidate;
+    } catch {
+      // Try next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * Atomic copy: write to a sibling `.tmp.<pid>` then rename over the target.
+ * Avoids the half-written-binary failure mode where a `cp` is interrupted
+ * mid-write and the user is left with a corrupt executable on PATH.
+ */
+async function atomicInstallBinary(src: string, dst: string): Promise<void> {
+  const tmp = `${dst}.${process.pid}.tmp`;
+  await mkdir(join(dst, ".."), { recursive: true });
+  await copyFile(src, tmp);
+  await chmod(tmp, 0o755);
+  await rename(tmp, dst);
+}
+
+/**
+ * Post-build install for the TUI: copy the freshly built binary onto the
+ * user's PATH. Mirrors what `cargo install --path tui` would do, but
+ * without re-running cargo (the build already happened during rebuild).
+ */
+async function installTuiBinary(): Promise<{ ok: boolean; message: string }> {
+  const built = join(repoRoot(), "target", "release", "relay-tui");
+  try {
+    const st = await stat(built);
+    if (!st.isFile()) {
+      return { ok: false, message: `expected binary at ${built}` };
+    }
+  } catch {
+    return { ok: false, message: `built binary missing at ${built}` };
+  }
+
+  const dir = await resolveTuiInstallDir();
+  if (!dir) {
+    return {
+      ok: false,
+      message: `no install dir found (tried ~/.cargo/bin, ~/.local/bin). Set RELAY_TUI_INSTALL_DIR or copy ${built} onto your PATH manually.`,
+    };
+  }
+
+  const dst = join(dir, "relay-tui");
+  try {
+    await atomicInstallBinary(built, dst);
+  } catch (err) {
+    return {
+      ok: false,
+      message: `failed to install ${dst}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return { ok: true, message: `installed to ${dst}` };
+}
+
+/**
+ * Install a single surface: build via runRebuild, do any post-build copy,
+ * then stamp the manifest. Skips the build entirely when the manifest is
+ * already at source unless `--force` is set.
+ */
+async function installOne(
+  surface: Surface,
+  options: InstallOptions,
+  pnpmInstallAlreadyRan: boolean
+): Promise<InstallResult> {
+  const [manifest, source] = await Promise.all([readManifest(), getSourceVersion()]);
+  const record = manifest.surfaces[surface];
+  const state = diffSurface(record, source);
+
+  if (!options.force && state === "current") {
+    return {
+      surface,
+      status: "skipped",
+      detail: `already at ${source.version}${source.sourceSha ? ` (${source.sourceSha.slice(0, 7)})` : ""}`,
+    };
+  }
+
+  console.log(`\n[rly install] ▶ ${surface}`);
+
+  // Compose runRebuild's targets so we only build what we're installing.
+  // skipInstall is false the first time we run a build in this session
+  // and true after — pnpm install is idempotent but a no-op call still
+  // costs ~1s, and installing all three would otherwise pay it three times.
+  const exit = await runRebuild({
+    dist: surface === "cli",
+    tui: surface === "tui",
+    gui: surface === "gui",
+    skipInstall: pnpmInstallAlreadyRan,
+    installApp: true,
+  });
+
+  if (exit !== 0) {
+    return {
+      surface,
+      status: "failed",
+      detail: `build exited ${exit}`,
+    };
+  }
+
+  // Post-build install steps. CLI's artifact (dist/) is consumed in-place
+  // by `bin/rly.mjs` so there's nothing to copy. GUI install is already
+  // handled inside runRebuild via installApp on darwin. TUI is the one
+  // surface where rebuild leaves the binary in `target/release/` and
+  // we have to put it on PATH ourselves.
+  if (surface === "tui") {
+    const result = await installTuiBinary();
+    if (!result.ok) {
+      return { surface, status: "failed", detail: result.message };
+    }
+    console.log(`[rly install] ${result.message}`);
+  } else if (surface === "gui" && platform() !== "darwin") {
+    console.log(
+      `[rly install] GUI built. Linux/Windows have no canonical install location — run from ${join(repoRoot(), "target", "release", "bundle")}/ directly.`
+    );
+  }
+
+  await markInstalled(surface, source.version, source.sourceSha);
+  return {
+    surface,
+    status: "installed",
+    detail: `v${source.version}${source.sourceSha ? ` (${source.sourceSha.slice(0, 7)})` : ""}`,
+  };
+}
+
+/**
+ * Install one or more surfaces. Surfaces install in fixed order
+ * (cli → tui → gui) so a user reading the output sees a predictable
+ * progression. Failures short-circuit: if `tui` fails, `gui` doesn't
+ * start. The manifest is updated per-surface so a partial install
+ * still records what succeeded.
+ */
+export async function runInstall(options: InstallOptions): Promise<InstallResult[]> {
+  const targets = options.surfaces.length === 0 ? [...SURFACES] : options.surfaces;
+  // Preserve the canonical cli→tui→gui order even when caller passed
+  // them out of order, so output is consistent across invocations.
+  const ordered = SURFACES.filter((s) => targets.includes(s));
+  const results: InstallResult[] = [];
+  let pnpmRan = false;
+  for (const surface of ordered) {
+    const result = await installOne(surface, options, pnpmRan);
+    results.push(result);
+    if (result.status === "installed") pnpmRan = true;
+    if (result.status === "failed") break;
+  }
+  return results;
+}

--- a/src/install/manifest.ts
+++ b/src/install/manifest.ts
@@ -152,7 +152,10 @@ export type SurfaceState = "fresh" | "current" | "behind";
  *   couldn't read a SHA on either side).
  * - `behind` — installed differs from source. Nudge.
  */
-export function diffSurface(record: SurfaceRecord | undefined, source: SourceVersion): SurfaceState {
+export function diffSurface(
+  record: SurfaceRecord | undefined,
+  source: SourceVersion
+): SurfaceState {
   if (!record) return "fresh";
   // Prefer SHA comparison — it catches "same version, different commit"
   // (the common case during dev — every PR pre-release shares the version

--- a/src/install/manifest.ts
+++ b/src/install/manifest.ts
@@ -1,0 +1,194 @@
+import { spawnSync } from "node:child_process";
+import { readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getRelayDir } from "../cli/paths.js";
+
+export type Surface = "cli" | "tui" | "gui";
+
+export const SURFACES: readonly Surface[] = ["cli", "tui", "gui"] as const;
+
+export interface SurfaceRecord {
+  /** Semver from package.json at install time. */
+  version: string;
+  /** Repo HEAD SHA at install time, or null if not built from a git checkout. */
+  sourceSha: string | null;
+  /** ISO 8601 UTC timestamp. */
+  installedAt: string;
+}
+
+interface InstallManifest {
+  schemaVersion: 1;
+  surfaces: Partial<Record<Surface, SurfaceRecord>>;
+}
+
+const MANIFEST_FILE = "installed.json";
+
+function manifestPath(): string {
+  return join(getRelayDir(), MANIFEST_FILE);
+}
+
+function emptyManifest(): InstallManifest {
+  return { schemaVersion: 1, surfaces: {} };
+}
+
+function isManifest(value: unknown): value is InstallManifest {
+  if (!value || typeof value !== "object") return false;
+  const m = value as InstallManifest;
+  return m.schemaVersion === 1 && typeof m.surfaces === "object" && m.surfaces !== null;
+}
+
+/**
+ * Read the install manifest. Treats a missing or unreadable file as an empty
+ * manifest — on first install we want to write fresh, not error on the
+ * absent file. A corrupt manifest also resolves to empty so a single bad
+ * write can't permanently brick `rly install`.
+ */
+export async function readManifest(): Promise<InstallManifest> {
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath(), "utf8");
+  } catch {
+    return emptyManifest();
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (isManifest(parsed)) return parsed;
+    return emptyManifest();
+  } catch {
+    return emptyManifest();
+  }
+}
+
+async function writeManifest(manifest: InstallManifest): Promise<void> {
+  const target = manifestPath();
+  const tmp = `${target}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  await rename(tmp, target);
+}
+
+/**
+ * Stamp a surface as installed at the given source version. Atomic
+ * read-modify-write; safe to call concurrently from one process but not
+ * across parallel `rly install` runs (we don't expect that).
+ */
+export async function markInstalled(
+  surface: Surface,
+  version: string,
+  sourceSha: string | null
+): Promise<void> {
+  const manifest = await readManifest();
+  manifest.surfaces[surface] = {
+    version,
+    sourceSha,
+    installedAt: new Date().toISOString(),
+  };
+  await writeManifest(manifest);
+}
+
+export interface SourceVersion {
+  version: string;
+  sourceSha: string | null;
+}
+
+let sourceVersionCache: SourceVersion | null = null;
+
+/**
+ * Detect the source version Relay would install if `rly install` were run
+ * right now: package.json `version` plus the repo HEAD SHA. The SHA is
+ * null when we're not in a git checkout (e.g. running from a published
+ * tarball) — in that case we fall back to comparing only the semver.
+ *
+ * Cached for the process lifetime — neither the package.json version nor
+ * the HEAD SHA changes mid-process during normal use, and the startup
+ * nudge calls this on every command.
+ */
+export async function getSourceVersion(): Promise<SourceVersion> {
+  if (sourceVersionCache) return sourceVersionCache;
+
+  const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+  const packageJsonPath = join(repoRoot, "package.json");
+  let version = "0.0.0";
+  try {
+    const raw = await readFile(packageJsonPath, "utf8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    if (typeof parsed.version === "string") version = parsed.version;
+  } catch {
+    // Falls through to "0.0.0" — manifests will still compare equal across
+    // runs from the same broken tree, just won't carry useful version info.
+  }
+
+  // `git rev-parse HEAD` is fast (~10ms) and avoids pulling a full git
+  // library dependency just to read one ref. Stderr is suppressed because
+  // outside a git checkout this prints to fd 2 even with --quiet.
+  let sourceSha: string | null = null;
+  try {
+    const result = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (result.status === 0) {
+      const trimmed = result.stdout.trim();
+      if (trimmed.length > 0) sourceSha = trimmed;
+    }
+  } catch {
+    // Git not installed or not on PATH — treat as "no SHA".
+  }
+
+  sourceVersionCache = { version, sourceSha };
+  return sourceVersionCache;
+}
+
+export type SurfaceState = "fresh" | "current" | "behind";
+
+/**
+ * Compare a surface's installed record against the current source version.
+ *
+ * - `fresh` — no record. We've never installed this surface, so the
+ *   user is likely running source directly. Don't nudge.
+ * - `current` — matches the source SHA (or matches the semver when we
+ *   couldn't read a SHA on either side).
+ * - `behind` — installed differs from source. Nudge.
+ */
+export function diffSurface(record: SurfaceRecord | undefined, source: SourceVersion): SurfaceState {
+  if (!record) return "fresh";
+  // Prefer SHA comparison — it catches "same version, different commit"
+  // (the common case during dev — every PR pre-release shares the version
+  // string but has a different SHA). Fall back to version-only when either
+  // side is missing a SHA.
+  if (record.sourceSha && source.sourceSha) {
+    return record.sourceSha === source.sourceSha ? "current" : "behind";
+  }
+  return record.version === source.version ? "current" : "behind";
+}
+
+export interface DriftReport {
+  source: SourceVersion;
+  surfaces: Record<Surface, { record: SurfaceRecord | undefined; state: SurfaceState }>;
+  /** Surfaces in the `behind` state — what the nudge / `--check` reports. */
+  behind: Surface[];
+}
+
+/**
+ * Snapshot the current install state vs. source. Drives both the
+ * `rly install --check` output and the startup nudge.
+ */
+export async function reportDrift(): Promise<DriftReport> {
+  const [manifest, source] = await Promise.all([readManifest(), getSourceVersion()]);
+  const surfaces = {} as DriftReport["surfaces"];
+  const behind: Surface[] = [];
+  for (const surface of SURFACES) {
+    const record = manifest.surfaces[surface];
+    const state = diffSurface(record, source);
+    surfaces[surface] = { record, state };
+    if (state === "behind") behind.push(surface);
+  }
+  return { source, surfaces, behind };
+}
+
+/** Test helper — clear the source-version cache so tests can vary it. */
+export function __resetSourceVersionCacheForTests(): void {
+  sourceVersionCache = null;
+}


### PR DESCRIPTION
## Summary

- New \`rly install\` command builds + installs the user-visible Relay surfaces (cli, tui, gui) so the installed copies match the source on disk. Defaults to all three; can target one (\`rly install gui\`).
- Persists \`~/.relay/installed.json\` with per-surface version + git SHA + install time so we can detect drift between installed bits and source.
- Adds a per-command startup nudge that prints a dim one-liner to stderr when any surface is behind source. Suppressed for install/help/version, \`--json\`/\`--quiet\`, non-TTY stderr, and \`RELAY_NO_UPDATE_NUDGE=1\`.
- Adds \`rly install --check\` (drift report + suggested next command, no build) and \`--force\` (rebuild even when current).

## Why

The current onboarding requires \`rly rebuild --all\` to update everything; without flags rebuild only does \`dist\`. Users who run \`rly rebuild\` and relaunch from \`/Applications\` get a stale GUI silently — when that GUI then fails to find a working \`node\`, the failure mode is opaque (\"node: not found\" from the pnpm shim, or \`ERR_UNKNOWN_BUILTIN_MODULE\` from a cached old node binary). \`rly install\` is the single verb that does the right thing by default and gives us a manifest other surfaces can use.

\`rly rebuild\` is unchanged and still serves as the "build only, don't install" verb. The new install command composes \`runRebuild\` rather than duplicating it.

## What's NOT in this PR

- In-app update banner in the GUI (will follow in a separate PR — uses the manifest written here).
- TUI footer nudge (separate PR — uses the same manifest).
- Code-signed Tauri auto-updater (deferred — needs Apple Developer ID, hosted release manifest, and signing in CI; only worth doing once we have outside users).

## Test plan

- [x] \`rly install --help\` renders help
- [x] \`rly install --check\` on a fresh machine reports no manifest, suggests \`rly install\`, exits 1
- [x] \`rly install cli\` rebuilds dist and stamps the manifest
- [x] Re-running \`rly install cli\` short-circuits with \`skipped — already at <ver>\`
- [x] \`rly install cli --force\` rebuilds anyway
- [x] \`rly install tui\` runs cargo + copies binary to \`~/.cargo/bin/relay-tui\` + stamps manifest
- [x] Stale manifest entry triggers nudge on a non-suppressed command (verified via \`script -q\` for TTY)
- [x] \`--json\`, \`--quiet\`, install/version/help commands suppress the nudge
- [x] Bogus target (\`rly install bogus\`) exits 2 with help text
- [x] \`pnpm build\` (tsc) clean