### PR TITLE
feat(gui): in-app update banner reads `rly install --check`

### DIFF
--- a/gui/src-tauri/build.rs
+++ b/gui/src-tauri/build.rs
@@ -1,3 +1,25 @@
+use std::process::Command;
+
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    // Embed the repo HEAD SHA at build time so the running GUI can detect
+    // when its compiled-in version differs from what `rly install gui` last
+    // wrote to the install manifest. Without this, a freshly built GUI has
+    // no way to tell it's out-of-date relative to a newer source on disk
+    // until the user relaunches it.
+    let sha = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=RELAY_GIT_SHA={}", sha);
+
+    // Re-run when HEAD moves so a `git checkout` between builds doesn't
+    // leave a stale SHA compiled in. Rebuilding on every branch switch is
+    // the cost; the alternative is a stamp that lies.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -873,6 +873,105 @@ fn run_cli(args: Vec<String>) -> Result<CliResult, String> {
     Ok(cli_run(&refs))
 }
 
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct UpdateStatus {
+    /// `rly install --check --json` output verbatim — UI uses
+    /// `behind` and the per-surface `state` for the per-surface labels.
+    drift: serde_json::Value,
+    /// `CARGO_PKG_VERSION` of this GUI binary (always set).
+    running_version: &'static str,
+    /// Repo HEAD SHA at the time *this* GUI was compiled. `None` when the
+    /// build wasn't run from a git checkout (release tarballs, custom
+    /// downstream builds). The frontend treats `None` as "can't compare,
+    /// fall back to the manifest drift signal."
+    running_sha: Option<&'static str>,
+    /// True when the running GUI's compiled-in SHA differs from
+    /// `drift.source.sourceSha`. Catches the "you `rly install gui`'d but
+    /// haven't relaunched yet" case the manifest drift can't see — the
+    /// new install matches source, but the live process is still old.
+    running_behind_source: bool,
+}
+
+/// Read what `rly install --check --json` says, fold in the GUI's own
+/// compiled-in version, and return one struct the renderer can switch on.
+///
+/// Returns errors verbatim from `cli_json` so the UI can show a sensible
+/// "couldn't check" state instead of a silent green light.
+#[tauri::command]
+fn check_relay_update() -> Result<UpdateStatus, String> {
+    let drift = cli_json(&["install", "--check", "--json"])?;
+    // The CLI emits the SHA as `drift.source.sourceSha`. We only look at
+    // the SHA here — semver comparison would also work but during dev
+    // every commit shares 0.7.0 and would never trip a drift signal.
+    let source_sha = drift
+        .get("source")
+        .and_then(|s| s.get("sourceSha"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let running_sha = option_env!("RELAY_GIT_SHA").filter(|s| !s.is_empty());
+    let running_behind_source = match (running_sha, source_sha.as_deref()) {
+        (Some(running), Some(source)) => running != source,
+        // Either side missing a SHA → can't tell. Defer to the manifest
+        // drift signal already in `drift.behind`.
+        _ => false,
+    };
+    Ok(UpdateStatus {
+        drift,
+        running_version: env!("CARGO_PKG_VERSION"),
+        running_sha,
+        running_behind_source,
+    })
+}
+
+/// Open Terminal.app (macOS) or `$TERMINAL` (Linux/Windows fallback) and
+/// run `rly install gui`. The build streams to that terminal window so
+/// the user sees pnpm/cargo/tauri output instead of an opaque modal —
+/// and they choose when to relaunch Relay rather than us yanking it.
+///
+/// We don't try to auto-restart the GUI: replacing /Applications/Relay.app
+/// while the binary is mapped works on APFS but the running process keeps
+/// executing the old code. Asking the user to quit + relaunch is the
+/// honest answer.
+#[tauri::command]
+fn trigger_relay_install_gui() -> Result<(), String> {
+    if cfg!(not(target_os = "macos")) {
+        // Non-macOS users currently have no automatic install path
+        // (`rly install gui` on Linux/Windows just builds the bundle and
+        // tells the user where it is). Surface that explicitly rather
+        // than spawning a terminal that fails opaquely.
+        return Err(
+            "In-app GUI install is macOS-only. Run `rly install gui` from a terminal."
+                .to_string(),
+        );
+    }
+    // Use osascript to open Terminal.app and run `rly install gui`.
+    // The trailing `read` keeps the window open after the install
+    // finishes so the user can read any errors before it closes.
+    // Terminal.app inherits the user's login shell, which already has
+    // PATH set up — no need to resolve rly to an absolute path here.
+    let script = "tell application \"Terminal\"\n\
+                  activate\n\
+                  do script \"rly install gui; echo; \
+                  echo '── Install finished. Quit Relay (⌘Q) and relaunch from /Applications. ──'; \
+                  read -n 1 -s -r -p 'Press any key to close…'\"\n\
+                  end tell";
+    let output = Command::new("osascript")
+        .args(["-e", script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("failed to launch osascript: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "osascript failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RepoAssignmentInput {
@@ -3835,6 +3934,8 @@ pub fn run() {
             list_ticket_ledger,
             list_agent_names,
             run_cli,
+            check_relay_update,
+            trigger_relay_install_gui,
             create_channel,
             archive_channel,
             unarchive_channel,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -896,29 +896,69 @@ struct UpdateStatus {
 /// Read what `rly install --check --json` says, fold in the GUI's own
 /// compiled-in version, and return one struct the renderer can switch on.
 ///
-/// Returns errors verbatim from `cli_json` so the UI can show a sensible
-/// "couldn't check" state instead of a silent green light.
+/// `rly install --check --json` exits 1 whenever any surface is fresh or
+/// behind — that's the "scripts can do `--check || install`" contract.
+/// `cli_json` rejects anything but exit 0, so we re-implement just the
+/// stdout-JSON-parse step here and accept exit 1 as a successful drift
+/// report. Anything else (spawn failure, exit > 1, malformed JSON) still
+/// surfaces as an error so the UI can show "couldn't check" instead of a
+/// silent green light.
 #[tauri::command]
 fn check_relay_update() -> Result<UpdateStatus, String> {
-    let drift = cli_json(&["install", "--check", "--json"])?;
-    // The CLI emits the SHA as `drift.source.sourceSha`. We only look at
-    // the SHA here — semver comparison would also work but during dev
-    // every commit shares 0.7.0 and would never trip a drift signal.
+    let result = cli_run(&["install", "--check", "--json"]);
+    match result.code {
+        Some(0) | Some(1) => {}
+        Some(code) => {
+            return Err(format!(
+                "rly install --check --json exited {code}: {}",
+                result.stderr.trim()
+            ));
+        }
+        None => {
+            // Spawn never produced a child — e.g. rly not on PATH.
+            // Surface the same diagnostic shape `cli_json` would have.
+            let settings = data::load_gui_settings();
+            return Err(format!(
+                "rly install --check --json failed to launch: {} ({}). Pin a path in Settings → Agent CLIs, set RELAY_BIN / RELAY_NODE, or install rly on PATH.",
+                result.stderr.trim(),
+                rly_invocation_debug(&settings)
+            ));
+        }
+    }
+    let drift: serde_json::Value = serde_json::from_str(result.stdout.trim()).map_err(|e| {
+        format!(
+            "invalid JSON from rly install --check --json: {e} (output: {})",
+            result.stdout
+        )
+    })?;
     let source_sha = drift
         .get("source")
         .and_then(|s| s.get("sourceSha"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
+    let source_version = drift
+        .get("source")
+        .and_then(|s| s.get("version"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
     let running_sha = option_env!("RELAY_GIT_SHA").filter(|s| !s.is_empty());
+    let running_version: &'static str = env!("CARGO_PKG_VERSION");
+    // Two ways the running binary can be behind the source on disk:
+    //   1. Compiled-in SHA differs from source SHA (the dev-time signal —
+    //      every commit moves it; semver wouldn't budge).
+    //   2. SHA can't be compared (release-tarball builds where build.rs
+    //      had no .git to read), but the running version differs from
+    //      the source version. Catches release-time updates.
     let running_behind_source = match (running_sha, source_sha.as_deref()) {
         (Some(running), Some(source)) => running != source,
-        // Either side missing a SHA → can't tell. Defer to the manifest
-        // drift signal already in `drift.behind`.
-        _ => false,
+        _ => match source_version.as_deref() {
+            Some(source_ver) => source_ver != running_version,
+            None => false,
+        },
     };
     Ok(UpdateStatus {
         drift,
-        running_version: env!("CARGO_PKG_VERSION"),
+        running_version,
         running_sha,
         running_behind_source,
     })
@@ -945,19 +985,56 @@ fn trigger_relay_install_gui() -> Result<(), String> {
                 .to_string(),
         );
     }
-    // Use osascript to open Terminal.app and run `rly install gui`.
-    // The trailing `read` keeps the window open after the install
-    // finishes so the user can read any errors before it closes.
-    // Terminal.app inherits the user's login shell, which already has
-    // PATH set up — no need to resolve rly to an absolute path here.
-    let script = "tell application \"Terminal\"\n\
-                  activate\n\
-                  do script \"rly install gui; echo; \
-                  echo '── Install finished. Quit Relay (⌘Q) and relaunch from /Applications. ──'; \
-                  read -n 1 -s -r -p 'Press any key to close…'\"\n\
-                  end tell";
+    // Resolve the same `rly` invocation the rest of the GUI uses so a
+    // user with `agent_binaries.rly` pinned (or `RELAY_BIN` set) gets a
+    // consistent install path — without this we'd check version A
+    // through the resolver and install version B through the user's
+    // login-shell PATH. Falls back to a plain `rly` if resolution fails
+    // (resolution returns `Shim("rly")` in that case via the existing
+    // helper, which is what we'd have run anyway).
+    let settings = data::load_gui_settings();
+    let invocation = resolve_rly_invocation(&settings);
+    let install_cmd = match invocation {
+        RlyInvocation::Direct { node, mjs } => {
+            // Reject paths that contain double quotes or backslashes.
+            // We embed them verbatim into a `do script "..."`; an
+            // attacker-controlled `agent_binaries.rly` value with a
+            // quote would otherwise close the AppleScript string and
+            // run arbitrary script. Sane filesystem paths never have
+            // these characters.
+            if node.contains('"') || node.contains('\\') || mjs.contains('"') || mjs.contains('\\')
+            {
+                return Err(
+                    "resolved rly path contains unsafe characters; aborting install launch".into(),
+                );
+            }
+            format!("'{node}' '{mjs}' install gui")
+        }
+        RlyInvocation::Shim(path) => {
+            if path.contains('"') || path.contains('\\') {
+                return Err(
+                    "resolved rly path contains unsafe characters; aborting install launch".into(),
+                );
+            }
+            format!("'{path}' install gui")
+        }
+    };
+    // Use osascript to open Terminal.app and run the resolved install
+    // command. The trailing `read` keeps the window open after the
+    // install finishes so the user can read any errors before it closes.
+    // We use single quotes for path quoting in the shell command (no
+    // expansion needed) and AppleScript double-quote-escapes the whole
+    // thing for `do script`.
+    let script = format!(
+        "tell application \"Terminal\"\n\
+         activate\n\
+         do script \"{install_cmd}; echo; \
+         echo '── Install finished. Quit Relay (⌘Q) and relaunch from /Applications. ──'; \
+         read -n 1 -s -r -p 'Press any key to close…'\"\n\
+         end tell"
+    );
     let output = Command::new("osascript")
-        .args(["-e", script])
+        .args(["-e", &script])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -110,89 +110,91 @@ export function App() {
   const selected = channels.find((c) => c.channelId === selectedId) ?? null;
 
   return (
-    <div className={`app density-${appearance.density} ${rightRailOpen ? "" : "rail-collapsed"}`}>
+    <div className="app-shell">
       <UpdateBanner />
-      {settingsOpen && settings ? (
-        <div style={{ gridColumn: "1 / -1", display: "flex", minHeight: 0 }}>
-          <SettingsPage
-            settings={settings}
-            onSaved={setSettings}
-            onClose={() => setSettingsOpen(false)}
-          />
-        </div>
-      ) : (
-        <>
-          <Sidebar
-            channels={channels}
-            selectedId={selectedId}
-            includeArchived={includeArchived}
-            sessionCounts={sessionCounts}
-            runningStreams={runningStreams}
-            onSelect={setSelectedId}
-            onNewChannel={(sectionId) => {
-              setNewChannelSection(sectionId ?? null);
-              setModalOpen(true);
-            }}
-            onNewDm={() => setDmModalOpen(true)}
-            onToggleIncludeArchived={setIncludeArchived}
-            onOpenSettings={() => setSettingsOpen(true)}
-            onRefresh={refresh}
-          />
-          <CenterPane
-            channel={selected}
-            sessionId={sessionId}
-            refreshTick={refreshTick}
-            rightRailOpen={rightRailOpen}
-            settings={settings}
-            onToggleRail={() => setRightRailOpen((v) => !v)}
-            onRefresh={refresh}
-            onSessionCreated={setSessionId}
-            onStreamingChanged={setRunningStreams}
-            onChannelRemoved={(id) => {
-              if (selectedId === id) setSelectedId(null);
-              refresh();
-            }}
-            onSpinoutToChannel={(kickoff, sectionId) => {
-              setNewChannelKickoff(kickoff);
-              setNewChannelSection(sectionId ?? null);
-              setModalOpen(true);
-            }}
-          />
-          {rightRailOpen && selected && (
-            <RightPane
+      <div className={`app density-${appearance.density} ${rightRailOpen ? "" : "rail-collapsed"}`}>
+        {settingsOpen && settings ? (
+          <div style={{ gridColumn: "1 / -1", display: "flex", minHeight: 0 }}>
+            <SettingsPage
+              settings={settings}
+              onSaved={setSettings}
+              onClose={() => setSettingsOpen(false)}
+            />
+          </div>
+        ) : (
+          <>
+            <Sidebar
+              channels={channels}
+              selectedId={selectedId}
+              includeArchived={includeArchived}
+              sessionCounts={sessionCounts}
+              runningStreams={runningStreams}
+              onSelect={setSelectedId}
+              onNewChannel={(sectionId) => {
+                setNewChannelSection(sectionId ?? null);
+                setModalOpen(true);
+              }}
+              onNewDm={() => setDmModalOpen(true)}
+              onToggleIncludeArchived={setIncludeArchived}
+              onOpenSettings={() => setSettingsOpen(true)}
+              onRefresh={refresh}
+            />
+            <CenterPane
               channel={selected}
               sessionId={sessionId}
-              onSelectSession={setSessionId}
               refreshTick={refreshTick}
+              rightRailOpen={rightRailOpen}
+              settings={settings}
+              onToggleRail={() => setRightRailOpen((v) => !v)}
               onRefresh={refresh}
-              onClose={() => setRightRailOpen(false)}
+              onSessionCreated={setSessionId}
+              onStreamingChanged={setRunningStreams}
+              onChannelRemoved={(id) => {
+                if (selectedId === id) setSelectedId(null);
+                refresh();
+              }}
+              onSpinoutToChannel={(kickoff, sectionId) => {
+                setNewChannelKickoff(kickoff);
+                setNewChannelSection(sectionId ?? null);
+                setModalOpen(true);
+              }}
             />
-          )}
-          {!rightRailOpen && <div />}
-        </>
-      )}
-      <NewChannelModal
-        open={modalOpen}
-        defaultSectionId={newChannelSection}
-        defaultFirstMessage={newChannelKickoff}
-        onClose={() => {
-          setModalOpen(false);
-          setNewChannelKickoff("");
-        }}
-        onCreated={(id) => {
-          setSelectedId(id);
-          setNewChannelKickoff("");
-          refresh();
-        }}
-      />
-      <NewDmModal
-        open={dmModalOpen}
-        onClose={() => setDmModalOpen(false)}
-        onCreated={(id) => {
-          setSelectedId(id);
-          refresh();
-        }}
-      />
+            {rightRailOpen && selected && (
+              <RightPane
+                channel={selected}
+                sessionId={sessionId}
+                onSelectSession={setSessionId}
+                refreshTick={refreshTick}
+                onRefresh={refresh}
+                onClose={() => setRightRailOpen(false)}
+              />
+            )}
+            {!rightRailOpen && <div />}
+          </>
+        )}
+        <NewChannelModal
+          open={modalOpen}
+          defaultSectionId={newChannelSection}
+          defaultFirstMessage={newChannelKickoff}
+          onClose={() => {
+            setModalOpen(false);
+            setNewChannelKickoff("");
+          }}
+          onCreated={(id) => {
+            setSelectedId(id);
+            setNewChannelKickoff("");
+            refresh();
+          }}
+        />
+        <NewDmModal
+          open={dmModalOpen}
+          onClose={() => setDmModalOpen(false)}
+          onCreated={(id) => {
+            setSelectedId(id);
+            refresh();
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -9,6 +9,7 @@ import { NewDmModal } from "./components/NewDmModal";
 import { RightPane } from "./components/RightPane";
 import { SettingsPage } from "./components/SettingsPage";
 import { Sidebar } from "./components/Sidebar";
+import { UpdateBanner } from "./components/UpdateBanner";
 
 const RAIL_OPEN_KEY = "relay.rightRailOpen";
 
@@ -110,6 +111,7 @@ export function App() {
 
   return (
     <div className={`app density-${appearance.density} ${rightRailOpen ? "" : "rail-collapsed"}`}>
+      <UpdateBanner />
       {settingsOpen && settings ? (
         <div style={{ gridColumn: "1 / -1", display: "flex", minHeight: 0 }}>
           <SettingsPage

--- a/gui/src/api.ts
+++ b/gui/src/api.ts
@@ -55,6 +55,35 @@ export const api = {
       args,
     }),
 
+  // Install drift surface — used by the in-app update banner. Mirrors
+  // `rly install --check --json` plus the GUI's compiled-in version
+  // so the banner can also catch the "freshly installed but not yet
+  // relaunched" case.
+  checkRelayUpdate: () =>
+    invoke<{
+      drift: {
+        source: { version: string; sourceSha: string | null };
+        surfaces: Record<
+          "cli" | "tui" | "gui",
+          {
+            record:
+              | {
+                  version: string;
+                  sourceSha: string | null;
+                  installedAt: string;
+                }
+              | undefined;
+            state: "fresh" | "current" | "behind";
+          }
+        >;
+        behind: ("cli" | "tui" | "gui")[];
+      };
+      runningVersion: string;
+      runningSha: string | null;
+      runningBehindSource: boolean;
+    }>("check_relay_update"),
+  triggerRelayInstallGui: () => invoke<void>("trigger_relay_install_gui"),
+
   createChannel: (
     name: string,
     description: string,

--- a/gui/src/components/UpdateBanner.tsx
+++ b/gui/src/components/UpdateBanner.tsx
@@ -94,12 +94,14 @@ export function UpdateBanner() {
   const sourceLabel = `v${status.drift.source.version} (${shortSha(status.drift.source.sourceSha)})`;
   const runningLabel = `v${status.runningVersion}${status.runningSha ? ` (${shortSha(status.runningSha)})` : ""}`;
 
+  // Live region is the message-only span; the buttons and error sit
+  // outside so action labels don't get re-announced on every refresh.
   return (
-    <div className="update-banner" role="status" aria-live="polite">
+    <div className="update-banner">
       <span className="update-banner__icon" aria-hidden="true">
         ↻
       </span>
-      <span className="update-banner__text">
+      <span className="update-banner__text" role="status" aria-live="polite">
         Update available — running {runningLabel}, source {sourceLabel}
       </span>
       <button

--- a/gui/src/components/UpdateBanner.tsx
+++ b/gui/src/components/UpdateBanner.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../api";
+
+type Status = Awaited<ReturnType<typeof api.checkRelayUpdate>>;
+
+const REFRESH_MS = 60_000;
+const DISMISS_KEY = "relay.updateBanner.dismissedSha";
+
+/**
+ * Decide whether to show the banner. Two cases trigger it:
+ *   1. The install manifest's `gui` record is behind the source on disk
+ *      — i.e. `rly install gui` would do something. The user needs to
+ *      run an install.
+ *   2. The running GUI's compiled-in SHA differs from the source SHA
+ *      reported by `rly install --check`. This catches the gap between
+ *      "the user installed a newer GUI" and "the user has actually
+ *      relaunched it" — without this, the banner would disappear the
+ *      moment the install stamps the manifest, and the still-running
+ *      old binary would never tell the user to relaunch.
+ *
+ * Either signal alone is enough.
+ */
+function shouldShow(status: Status, dismissedSha: string | null): boolean {
+  const sourceSha = status.drift.source.sourceSha;
+  if (sourceSha && dismissedSha === sourceSha) return false;
+  if (status.runningBehindSource) return true;
+  if (status.drift.behind.includes("gui")) return true;
+  return false;
+}
+
+function shortSha(sha: string | null | undefined): string {
+  if (!sha) return "—";
+  return sha.slice(0, 7);
+}
+
+export function UpdateBanner() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dismissedSha, setDismissedSha] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY);
+    } catch {
+      return null;
+    }
+  });
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await api.checkRelayUpdate();
+      setStatus(next);
+      setError(null);
+    } catch (e) {
+      // Don't surface check errors — they tend to be transient (rly
+      // not on PATH yet, repo moved, manifest mid-write). The banner
+      // just doesn't show; user can still install via terminal.
+      setError(e instanceof Error ? e.message : String(e));
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const t = setInterval(refresh, REFRESH_MS);
+    return () => clearInterval(t);
+  }, [refresh]);
+
+  const handleInstall = useCallback(async () => {
+    setInstalling(true);
+    try {
+      await api.triggerRelayInstallGui();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setInstalling(false);
+    }
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    if (!status?.drift.source.sourceSha) return;
+    const sha = status.drift.source.sourceSha;
+    setDismissedSha(sha);
+    try {
+      localStorage.setItem(DISMISS_KEY, sha);
+    } catch {
+      // Storage blocked — the dismiss is in-memory for this session
+      // only, which is fine; nothing to surface to the user.
+    }
+  }, [status]);
+
+  if (!status) return null;
+  if (!shouldShow(status, dismissedSha)) return null;
+
+  const sourceLabel = `v${status.drift.source.version} (${shortSha(status.drift.source.sourceSha)})`;
+  const runningLabel = `v${status.runningVersion}${status.runningSha ? ` (${shortSha(status.runningSha)})` : ""}`;
+
+  return (
+    <div className="update-banner" role="status" aria-live="polite">
+      <span className="update-banner__icon" aria-hidden="true">
+        ↻
+      </span>
+      <span className="update-banner__text">
+        Update available — running {runningLabel}, source {sourceLabel}
+      </span>
+      <button
+        type="button"
+        className="update-banner__install"
+        onClick={handleInstall}
+        disabled={installing}
+      >
+        {installing ? "Opening Terminal…" : "Install"}
+      </button>
+      <button
+        type="button"
+        className="update-banner__dismiss"
+        onClick={handleDismiss}
+        title="Dismiss until source moves again"
+      >
+        Dismiss
+      </button>
+      {error && <span className="update-banner__error">{error}</span>}
+    </div>
+  );
+}

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -49,10 +49,22 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
 
 /* ── App shell ─────────────────────────────────────────────────── */
 
+/* `.app-shell` wraps the optional `<UpdateBanner />` and the main `.app`
+ * grid in a vertical flex column so the banner takes its natural height
+ * at the top and the app fills the rest. The banner is normal-flow (not
+ * fixed) so it can't overlay the sidebar header or macOS title bar. */
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  min-height: 0;
+}
+
 .app {
   display: grid;
   grid-template-columns: var(--layout-sidebar) 1fr var(--layout-right-rail);
-  height: 100vh;
+  flex: 1;
+  min-height: 0;
   background: var(--color-paper-base);
 }
 .app.rail-collapsed {
@@ -3312,11 +3324,7 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
 /* ── Update banner ─────────────────────────────────────────────── */
 
 .update-banner {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: var(--space-3);

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -3308,3 +3308,52 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
 .provider-form-field-full {
   grid-column: 1 / -1;
 }
+
+/* ── Update banner ─────────────────────────────────────────────── */
+
+.update-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-5);
+  background: var(--color-accent-amber);
+  color: #1a1a1a;
+  font-size: var(--font-size-sm, 13px);
+  font-weight: var(--font-weight-semibold, 600);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+.update-banner__icon {
+  font-size: 14px;
+  line-height: 1;
+}
+.update-banner__text {
+  flex: 1;
+}
+.update-banner__install,
+.update-banner__dismiss {
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  background: rgba(255, 255, 255, 0.6);
+  color: #1a1a1a;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-sm, 13px);
+  font-weight: var(--font-weight-semibold, 600);
+}
+.update-banner__install:hover:not(:disabled) {
+  background: #fff;
+}
+.update-banner__dismiss {
+  background: transparent;
+  border-color: rgba(0, 0, 0, 0.2);
+  font-weight: var(--font-weight-regular, 400);
+}
+.update-banner__error {
+  flex-basis: 100%;
+  color: #6b1f1f;
+  font-weight: var(--font-weight-regular, 400);
+  margin-top: var(--space-1);
+}


### PR DESCRIPTION
## Summary

- Adds an amber banner across the top of the GUI when the source on disk is ahead of the running GUI.
- Two trigger paths cover the full update lifecycle: (a) install manifest's `gui` record is behind source — the user needs to run install; (b) running GUI's compiled-in SHA differs from source — the user already installed, just needs to relaunch.
- "Install" button opens Terminal.app with `rly install gui` plus a hold prompt, so build output is visible and the user controls when to relaunch.
- "Dismiss" hides the banner until source moves to a different SHA (stored in localStorage).

## Why

PR #208 gave us a manifest, but a user looking at the GUI doesn't open `rly install --check` to learn it's stale. The banner is the in-app surface that closes the loop. Without it, the manifest is just a CLI feature.

## Implementation

- `gui/src-tauri/build.rs`: emits `RELAY_GIT_SHA` at build time via `git rev-parse HEAD`. `cargo:rerun-if-changed` on `.git/HEAD` and `.git/refs/heads` so a `git checkout` between builds invalidates the stamp.
- `gui/src-tauri/src/lib.rs`: two new Tauri commands.
  - `check_relay_update` — calls `cli_json(&["install", "--check", "--json"])`, folds in `env!("CARGO_PKG_VERSION")` + `option_env!("RELAY_GIT_SHA")`, returns one struct.
  - `trigger_relay_install_gui` — macOS-only; uses `osascript` to open Terminal.app running `rly install gui` with a `read`-based hold so errors stay readable. Linux/Windows return a clear error pointing at the terminal command.
- `gui/src/components/UpdateBanner.tsx` — polls every 60s, dismiss-by-SHA via localStorage so dismissals don't leak across versions.
- Wired into `App.tsx` at the top-level wrapper.

## Why no auto-restart

Replacing `/Applications/Relay.app` while the binary is mapped works on APFS but the running process keeps executing the old code. Asking the user to ⌘Q + relaunch is the honest answer; the banner sticks around until they do.

## Why no Tauri auto-updater

That's the right choice for shipping to outside users — but it requires Apple Developer ID, notarization, hosted release manifest, and signing in CI. Real cost: ~a day to set up cleanly, ~$99/yr Apple dev account. Worth doing once Relay has external users; not now. The `rly install gui` flow is the bridge.

## Test plan

- [x] `cargo check` clean (TUI + GUI Rust)
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [ ] Banner appears when running an outdated GUI build (will verify after merging this PR + rebuilding the GUI)
- [ ] Install button spawns Terminal with rly install gui (manual, post-merge)
- [ ] Dismiss survives reload until source SHA changes (manual, post-merge)

## What's NOT in this PR

- TUI footer nudge (PR 3 — same idea, different surface)
- Tauri auto-updater (deferred — requires code signing infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)