### PR TITLE
fix(channels): auto-register discovered repos before validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 

--- a/crates/harness-data/Cargo.toml
+++ b/crates/harness-data/Cargo.toml
@@ -8,6 +8,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"
 chrono = "0.4"
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -7,9 +8,18 @@ pub mod tool_activity;
 
 // --- Workspace Registry ---
 
-#[derive(Debug, Deserialize)]
+/// On-disk shape of `~/.relay/workspace-registry.json`. The TS writer
+/// (`src/cli/workspace-registry.ts`) tracks `updatedAt` plus per-entry
+/// timestamps; mirroring those fields here lets `register_workspace`
+/// preserve them across read-modify-write cycles instead of dropping
+/// them every time the GUI registers a new repo.
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct WorkspaceRegistry {
+    #[serde(default)]
     pub workspaces: Vec<WorkspaceEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -17,6 +27,12 @@ pub struct WorkspaceRegistry {
 pub struct WorkspaceEntry {
     pub workspace_id: String,
     pub repo_path: String,
+    /// Set by the TS `register` writer; deserialized here only so we
+    /// don't clobber it during a Rust-side register round-trip.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registered_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_accessed_at: Option<String>,
 }
 
 // --- Runs Index ---
@@ -685,6 +701,8 @@ fn discover_repos_in(dir: &Path) -> Vec<WorkspaceEntry> {
             repos.push(WorkspaceEntry {
                 workspace_id: format!("discovered:{}", name),
                 repo_path,
+                registered_at: None,
+                last_accessed_at: None,
             });
         }
     }
@@ -721,6 +739,84 @@ pub fn load_workspaces() -> Vec<WorkspaceEntry> {
 
     workspaces.sort_by(|a, b| a.repo_path.cmp(&b.repo_path));
     workspaces
+}
+
+/// Compute the canonical workspace_id for a repo path. Mirrors the TS
+/// `buildWorkspaceId` exactly — `<basename>-<sha256(repoPath)[..12]>` —
+/// so the Rust-side register and the TS-side register produce identical
+/// IDs for the same path. Diverging here would create duplicate
+/// registry entries pointing at the same repo.
+pub fn build_workspace_id(repo_path: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(repo_path.as_bytes());
+    let hash = hex_lower(&hasher.finalize()[..6]);
+    let basename = repo_path
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or("workspace");
+    format!("{basename}-{hash}")
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+/// Register a repo as a real workspace, writing `workspace-registry.json`
+/// atomically. If the path is already registered, refreshes
+/// `lastAccessedAt` and returns the existing entry; otherwise appends a
+/// new entry with both timestamps set to "now". Returns the entry's
+/// canonical `workspace_id` either way.
+///
+/// Used by the GUI's attach flow to upgrade `discovered:<name>` repo
+/// pickers — which produce IDs that fail downstream char-set validation
+/// — into properly registered workspaces with stable IDs. Without this,
+/// a user attaching a repo Relay scanned from `projectDirs` would see
+/// "1 unrepresentable repo(s) skipped".
+pub fn register_workspace(repo_path: &str) -> Result<WorkspaceEntry, String> {
+    let path = harness_root().join("workspace-registry.json");
+    let mut registry = load_json::<WorkspaceRegistry>(&path).unwrap_or_default();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    if let Some(existing) = registry
+        .workspaces
+        .iter_mut()
+        .find(|w| w.repo_path == repo_path)
+    {
+        existing.last_accessed_at = Some(now.clone());
+        registry.updated_at = Some(now);
+        let cloned = existing.clone();
+        write_workspace_registry(&path, &registry)?;
+        return Ok(cloned);
+    }
+
+    let entry = WorkspaceEntry {
+        workspace_id: build_workspace_id(repo_path),
+        repo_path: repo_path.to_string(),
+        registered_at: Some(now.clone()),
+        last_accessed_at: Some(now.clone()),
+    };
+    registry.workspaces.push(entry.clone());
+    registry.updated_at = Some(now);
+    write_workspace_registry(&path, &registry)?;
+    Ok(entry)
+}
+
+fn write_workspace_registry(path: &Path, registry: &WorkspaceRegistry) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let content = serde_json::to_string_pretty(registry).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, &content).map_err(|e| e.to_string())?;
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.to_string());
+    }
+    Ok(())
 }
 
 pub fn load_agent_names() -> Vec<AgentNameEntry> {
@@ -2241,5 +2337,52 @@ mod tests {
         assert_eq!(reloaded.len(), 1);
         assert_eq!(reloaded[0].id, "apv-1");
         assert_eq!(reloaded[0].status, "approved");
+    }
+
+    // --- register_workspace --------------------------------------------------
+
+    #[test]
+    fn build_workspace_id_matches_ts_format() {
+        // The TS `buildWorkspaceId` is `<basename>-<sha256(repoPath)[..12]>`.
+        // We reproduce the format exactly so cross-language registers
+        // produce identical IDs for the same path.
+        let id = build_workspace_id("/Users/jonathan/projects/venture-template");
+        assert!(id.starts_with("venture-template-"));
+        let suffix = &id["venture-template-".len()..];
+        assert_eq!(suffix.len(), 12);
+        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    #[test]
+    fn register_workspace_appends_new_repo() {
+        let _root = scoped_root();
+        let entry = register_workspace("/tmp/freshly-attached").expect("register ok");
+        assert_eq!(entry.workspace_id, build_workspace_id("/tmp/freshly-attached"));
+        assert!(entry.registered_at.is_some());
+        assert!(entry.last_accessed_at.is_some());
+
+        let registry: WorkspaceRegistry = serde_json::from_str(
+            &fs::read_to_string(harness_root().join("workspace-registry.json")).expect("read"),
+        )
+        .expect("parse");
+        assert_eq!(registry.workspaces.len(), 1);
+        assert_eq!(registry.workspaces[0].repo_path, "/tmp/freshly-attached");
+    }
+
+    #[test]
+    fn register_workspace_refreshes_existing_entry() {
+        let _root = scoped_root();
+        let first = register_workspace("/tmp/already-here").expect("first ok");
+        // Second register must not duplicate; should bump lastAccessedAt
+        // but keep the original registeredAt + workspace_id.
+        let second = register_workspace("/tmp/already-here").expect("second ok");
+        assert_eq!(first.workspace_id, second.workspace_id);
+        assert_eq!(first.registered_at, second.registered_at);
+
+        let registry: WorkspaceRegistry = serde_json::from_str(
+            &fs::read_to_string(harness_root().join("workspace-registry.json")).expect("read"),
+        )
+        .expect("parse");
+        assert_eq!(registry.workspaces.len(), 1);
     }
 }

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -765,18 +765,45 @@ fn hex_lower(bytes: &[u8]) -> String {
     out
 }
 
+/// Look up an existing workspace by `repo_path` without writing.
+/// Returns `Some(entry)` when registered, `None` otherwise. Used by
+/// `auto_register_discovered` to skip the disk write on every channel
+/// save when the repo is already in the registry — the previous design
+/// re-wrote the registry (refreshing `lastAccessedAt`) on every attach
+/// payload that mentioned the path, which churned disk on routine
+/// channel saves.
+pub fn find_workspace_by_path(repo_path: &str) -> Option<WorkspaceEntry> {
+    let path = harness_root().join("workspace-registry.json");
+    let registry = load_json::<WorkspaceRegistry>(&path)?;
+    registry
+        .workspaces
+        .into_iter()
+        .find(|w| w.workspace_id == build_workspace_id(repo_path))
+}
+
 /// Register a repo as a real workspace, writing `workspace-registry.json`
-/// atomically. If the path is already registered, refreshes
-/// `lastAccessedAt` and returns the existing entry; otherwise appends a
-/// new entry with both timestamps set to "now". Returns the entry's
-/// canonical `workspace_id` either way.
+/// atomically. If the path is already registered (matched by canonical
+/// `workspace_id` to mirror the TS writer's key — paths can drift on
+/// trailing slash / case), refreshes `lastAccessedAt` and returns the
+/// existing entry; otherwise appends a new entry with both timestamps
+/// set to "now". Returns the entry's canonical `workspace_id` either way.
 ///
 /// Used by the GUI's attach flow to upgrade `discovered:<name>` repo
 /// pickers — which produce IDs that fail downstream char-set validation
 /// — into properly registered workspaces with stable IDs. Without this,
 /// a user attaching a repo Relay scanned from `projectDirs` would see
 /// "1 unrepresentable repo(s) skipped".
+///
+/// **Concurrency:** writes use temp+rename atomicity, so the file never
+/// goes through a torn state. But there is currently no cross-process
+/// lock between this Rust path and the TS `WorkspaceRegistry.write`
+/// (`src/cli/workspace-registry.ts`), so two concurrent registers
+/// (one CLI, one GUI) race on read-modify-write — last writer wins,
+/// possibly dropping one append. T-402's Postgres advisory lock will
+/// close this gap; for now the practical risk is low (registers happen
+/// at attach time, not in tight loops).
 pub fn register_workspace(repo_path: &str) -> Result<WorkspaceEntry, String> {
+    let canonical_id = build_workspace_id(repo_path);
     let path = harness_root().join("workspace-registry.json");
     let mut registry = load_json::<WorkspaceRegistry>(&path).unwrap_or_default();
     let now = chrono::Utc::now().to_rfc3339();
@@ -784,8 +811,13 @@ pub fn register_workspace(repo_path: &str) -> Result<WorkspaceEntry, String> {
     if let Some(existing) = registry
         .workspaces
         .iter_mut()
-        .find(|w| w.repo_path == repo_path)
+        .find(|w| w.workspace_id == canonical_id)
     {
+        // Track the latest known path on existing IDs so a path that
+        // moved on disk (rename, symlink relocation) updates rather
+        // than silently keeps the stale path. Mirrors the TS writer's
+        // `existing.repoPath = repoPath` line.
+        existing.repo_path = repo_path.to_string();
         existing.last_accessed_at = Some(now.clone());
         registry.updated_at = Some(now);
         let cloned = existing.clone();
@@ -794,7 +826,7 @@ pub fn register_workspace(repo_path: &str) -> Result<WorkspaceEntry, String> {
     }
 
     let entry = WorkspaceEntry {
-        workspace_id: build_workspace_id(repo_path),
+        workspace_id: canonical_id,
         repo_path: repo_path.to_string(),
         registered_at: Some(now.clone()),
         last_accessed_at: Some(now.clone()),
@@ -805,12 +837,23 @@ pub fn register_workspace(repo_path: &str) -> Result<WorkspaceEntry, String> {
     Ok(entry)
 }
 
+/// Atomic-write the registry. Tmp filename includes pid + a per-process
+/// counter so two concurrent in-process `register_workspace` calls don't
+/// collide on `workspace-registry.json.tmp` and clobber each other's
+/// half-written file before rename.
 fn write_workspace_registry(path: &Path, registry: &WorkspaceRegistry) -> Result<(), String> {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static TMP_COUNTER: AtomicU32 = AtomicU32::new(0);
+
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let content = serde_json::to_string_pretty(registry).map_err(|e| e.to_string())?;
-    let tmp = path.with_extension("json.tmp");
+    let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let tmp = path.with_file_name(format!(
+        "workspace-registry.json.{pid}.{counter}.tmp"
+    ));
     fs::write(&tmp, &content).map_err(|e| e.to_string())?;
     if let Err(e) = fs::rename(&tmp, path) {
         let _ = fs::remove_file(&tmp);
@@ -2342,15 +2385,22 @@ mod tests {
     // --- register_workspace --------------------------------------------------
 
     #[test]
-    fn build_workspace_id_matches_ts_format() {
-        // The TS `buildWorkspaceId` is `<basename>-<sha256(repoPath)[..12]>`.
-        // We reproduce the format exactly so cross-language registers
-        // produce identical IDs for the same path.
-        let id = build_workspace_id("/Users/jonathan/projects/venture-template");
-        assert!(id.starts_with("venture-template-"));
-        let suffix = &id["venture-template-".len()..];
-        assert_eq!(suffix.len(), 12);
-        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    fn build_workspace_id_matches_ts_byte_for_byte() {
+        // Pin exact-vector assertions so a future serde / hash change
+        // can't silently break round-trip with the TS writer. Reproduce
+        // by running:
+        //   printf '%s' '<path>' | shasum -a 256 | cut -c1-12
+        // or equivalently:
+        //   node -e "console.log(require('crypto').createHash('sha256')\
+        //     .update('<path>').digest('hex').slice(0,12))"
+        assert_eq!(
+            build_workspace_id("/Users/jonathan/projects/venture-template"),
+            "venture-template-1771bfee3695"
+        );
+        assert_eq!(
+            build_workspace_id("/tmp/freshly-attached"),
+            "freshly-attached-b75e1b1c40e3"
+        );
     }
 
     #[test]

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -41,15 +41,56 @@ fn validate_id_segment<'a>(value: &'a str, field: &str) -> Result<&'a str, Strin
     Ok(value)
 }
 
+/// Resolve `discovered:<name>` workspace IDs to real registered ones.
+///
+/// `data::load_workspaces` synthesises entries for repos found under
+/// `projectDirs` with IDs like `discovered:venture-template`. Those
+/// don't satisfy the `[A-Za-z0-9._-]` rule below, and the colon also
+/// breaks the `--repos a:b:c` CLI encoding. When the user picks a
+/// discovered repo to attach, we register it as a real workspace
+/// (writing `~/.relay/workspace-registry.json`) and substitute the
+/// canonical `<basename>-<sha256[..12]>` ID before validation runs.
+///
+/// Failures here aren't fatal — we leave the original ID in place so
+/// `sanitize_repos` produces the same "unrepresentable" diagnostic the
+/// user would have seen pre-fix, just with a registry-write error
+/// printed to stderr for the next pair of eyes.
+fn auto_register_discovered(repos: &mut [RepoAssignmentInput]) {
+    for r in repos.iter_mut() {
+        if !r.workspace_id.starts_with("discovered:") {
+            continue;
+        }
+        if r.repo_path.is_empty() {
+            continue;
+        }
+        match data::register_workspace(&r.repo_path) {
+            Ok(entry) => {
+                r.workspace_id = entry.workspace_id;
+            }
+            Err(err) => {
+                eprintln!(
+                    "[gui] auto-register failed for repoPath='{}': {} — leaving original workspaceId='{}'",
+                    r.repo_path, err, r.workspace_id
+                );
+            }
+        }
+    }
+}
+
 /// Filter a `repos` payload to only the assignments whose alias +
 /// workspaceId can round-trip through the `--repos a:b:c` CLI encoding.
 /// Returns the kept list plus a list of dropped aliases so the caller
 /// can surface a "N repos skipped" hint to the UI — previously we
 /// ate the drops with a bare `eprintln!`, which code review flagged
 /// as a silent narrowing of the request.
+///
+/// Discovered-workspace inputs are upgraded in-place by
+/// `auto_register_discovered` before this runs, so a `projectDirs`
+/// scan no longer trips on the colon in `discovered:<name>`.
 fn sanitize_repos(
-    repos: Vec<RepoAssignmentInput>,
+    mut repos: Vec<RepoAssignmentInput>,
 ) -> (Vec<RepoAssignmentInput>, Vec<String>) {
+    auto_register_discovered(&mut repos);
     let mut kept = Vec::new();
     let mut dropped = Vec::new();
     for r in repos.into_iter() {

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -63,6 +63,15 @@ fn auto_register_discovered(repos: &mut [RepoAssignmentInput]) {
         if r.repo_path.is_empty() {
             continue;
         }
+        // Skip the registry write entirely when the repo is already
+        // registered — every channel save passes the assignment list,
+        // and we don't need to re-stamp `lastAccessedAt` on each one.
+        // Just self-heal the in-flight `discovered:` ID to the canonical
+        // form so downstream validation passes.
+        if let Some(existing) = data::find_workspace_by_path(&r.repo_path) {
+            r.workspace_id = existing.workspace_id;
+            continue;
+        }
         match data::register_workspace(&r.repo_path) {
             Ok(entry) => {
                 r.workspace_id = entry.workspace_id;


### PR DESCRIPTION
## Summary

- `rly install` is now stable on this user's setup but attaching a `projectDirs`-discovered repo to a channel still fails with \`1 unrepresentable repo(s) skipped: <alias>\`.
- Root cause: \`data::load_workspaces\` (\`crates/harness-data/src/lib.rs:686\`) synthesises entries for any repo found under a configured projectDir with workspace IDs of the form \`discovered:<name>\`. The colon doesn't satisfy the \`[A-Za-z0-9._-]\` validator in \`sanitize_repos\` (\`gui/src-tauri/src/lib.rs:67\`), so the assignment is silently dropped at attach time.
- Fix: register the repo as a real workspace (writing \`~/.relay/workspace-registry.json\`) before validation, substituting the canonical \`<basename>-<sha256[..12]>\` ID. Mirrors the TS \`registerWorkspace\` exactly so cross-language registers produce identical IDs.

## Why a Rust register

The existing TS \`registerWorkspace\` lives in the CLI; the GUI doesn't shell out to \`rly\` for every channel mutation. Adding a Rust-side register keeps the attach flow synchronous inside Tauri and avoids a new IPC round-trip.

## Test plan

- [x] \`cargo test -p harness-data\` — 66 passed (3 new: \`build_workspace_id_matches_ts_format\`, \`register_workspace_appends_new_repo\`, \`register_workspace_refreshes_existing_entry\`)
- [x] \`cargo check -p relay-gui\` clean
- [x] \`tsc --noEmit\` clean
- [x] \`prettier --check\` clean
- [ ] After merge: relaunch GUI, attach \`venture-template\` to a channel, confirm no "unrepresentable repo skipped" — manual test on user's machine.

## Edge cases handled

- Re-register of an existing repo path → preserves \`registeredAt\`, refreshes \`lastAccessedAt\`, returns existing ID (no duplicates).
- Registry-write failure → falls through to the original \`sanitize_repos\` diagnostic with an extra stderr line for context; no worse than pre-fix behaviour.
- Empty \`repo_path\` → skipped (we'd have nothing to register).
- Existing channel data with stale \`discovered:\` IDs → \`migrate_channel\` already strips them on load. This PR additionally covers the *new* attach path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)