### PR TITLE
fix(gui): plumb kickoff session id through channel-create

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "./api";
 import { maybeSeedFirstRun } from "./lib/firstRun";
 import { useAppearance } from "./lib/appearance";
@@ -65,7 +65,7 @@ export function App() {
       setChannels(cs);
       if (!selectedId && cs.length > 0) {
         const firstActive = cs.find((c) => c.status === "active") ?? cs[0];
-        setSelectedId(firstActive.channelId);
+        selectChannel(firstActive.channelId);
       }
     })();
     return () => {
@@ -103,22 +103,21 @@ export function App() {
       .catch(() => setSessionCounts({}));
   }, [refreshTick]);
 
-  // The kickoff session created by NewChannelModal needs to survive the
-  // selectedId-change effect below (which would otherwise clobber it back
-  // to null). The modal's onCreated handler stashes the new session id
-  // here before calling setSelectedId; this effect promotes it to active
-  // sessionId and clears the ref. Any other selectedId change resets to
-  // "no active session" so CenterPane loads the right channel history.
-  const pendingKickoffSessionId = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (pendingKickoffSessionId.current) {
-      setSessionId(pendingKickoffSessionId.current);
-      pendingKickoffSessionId.current = null;
-    } else {
-      setSessionId(null);
-    }
-  }, [selectedId]);
+  // Atomic setter for the active channel + session pair. The kickoff
+  // path sets both at once; manual channel switches default `sessionId`
+  // back to null so CenterPane loads the right channel history. Doing
+  // this in a single helper (rather than `setSelectedId` + a
+  // selectedId-change effect) avoids the same-id no-op leak — if a
+  // future caller passes the currently-selected channelId, React's
+  // bail-out optimisation would skip the effect and a previously
+  // stashed session id would never get cleared.
+  const selectChannel = useCallback(
+    (channelId: string | null, nextSessionId: string | null = null) => {
+      setSelectedId(channelId);
+      setSessionId(nextSessionId);
+    },
+    []
+  );
 
   const selected = channels.find((c) => c.channelId === selectedId) ?? null;
 
@@ -142,7 +141,7 @@ export function App() {
               includeArchived={includeArchived}
               sessionCounts={sessionCounts}
               runningStreams={runningStreams}
-              onSelect={setSelectedId}
+              onSelect={(id) => selectChannel(id)}
               onNewChannel={(sectionId) => {
                 setNewChannelSection(sectionId ?? null);
                 setModalOpen(true);
@@ -163,7 +162,7 @@ export function App() {
               onSessionCreated={setSessionId}
               onStreamingChanged={setRunningStreams}
               onChannelRemoved={(id) => {
-                if (selectedId === id) setSelectedId(null);
+                if (selectedId === id) selectChannel(null);
                 refresh();
               }}
               onSpinoutToChannel={(kickoff, sectionId) => {
@@ -194,15 +193,11 @@ export function App() {
             setNewChannelKickoff("");
           }}
           onCreated={(id, kickoffSessionId) => {
-            if (kickoffSessionId) {
-              // Stash before setSelectedId so the selectedId-change effect
-              // promotes it to active session in the same render. Without
-              // this, the effect resets sessionId to null and CenterPane's
-              // stream subscription drops the kickoff response, while
-              // Composer treats the user's reply as a fresh session.
-              pendingKickoffSessionId.current = kickoffSessionId;
-            }
-            setSelectedId(id);
+            // Set channel + kickoff session atomically so CenterPane's
+            // stream subscription sees the right sessionId on first
+            // render and Composer doesn't fall through to its
+            // `if (!sessionId) createSession` branch on the user's reply.
+            selectChannel(id, kickoffSessionId);
             setNewChannelKickoff("");
             refresh();
           }}
@@ -211,7 +206,7 @@ export function App() {
           open={dmModalOpen}
           onClose={() => setDmModalOpen(false)}
           onCreated={(id) => {
-            setSelectedId(id);
+            selectChannel(id);
             refresh();
           }}
         />

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "./api";
 import { maybeSeedFirstRun } from "./lib/firstRun";
 import { useAppearance } from "./lib/appearance";
@@ -103,8 +103,21 @@ export function App() {
       .catch(() => setSessionCounts({}));
   }, [refreshTick]);
 
+  // The kickoff session created by NewChannelModal needs to survive the
+  // selectedId-change effect below (which would otherwise clobber it back
+  // to null). The modal's onCreated handler stashes the new session id
+  // here before calling setSelectedId; this effect promotes it to active
+  // sessionId and clears the ref. Any other selectedId change resets to
+  // "no active session" so CenterPane loads the right channel history.
+  const pendingKickoffSessionId = useRef<string | null>(null);
+
   useEffect(() => {
-    setSessionId(null);
+    if (pendingKickoffSessionId.current) {
+      setSessionId(pendingKickoffSessionId.current);
+      pendingKickoffSessionId.current = null;
+    } else {
+      setSessionId(null);
+    }
   }, [selectedId]);
 
   const selected = channels.find((c) => c.channelId === selectedId) ?? null;
@@ -180,7 +193,15 @@ export function App() {
             setModalOpen(false);
             setNewChannelKickoff("");
           }}
-          onCreated={(id) => {
+          onCreated={(id, kickoffSessionId) => {
+            if (kickoffSessionId) {
+              // Stash before setSelectedId so the selectedId-change effect
+              // promotes it to active session in the same render. Without
+              // this, the effect resets sessionId to null and CenterPane's
+              // stream subscription drops the kickoff response, while
+              // Composer treats the user's reply as a fresh session.
+              pendingKickoffSessionId.current = kickoffSessionId;
+            }
             setSelectedId(id);
             setNewChannelKickoff("");
             refresh();

--- a/gui/src/components/NewChannelModal.test.tsx
+++ b/gui/src/components/NewChannelModal.test.tsx
@@ -68,3 +68,82 @@ describe("NewChannelModal — Create new section sentinel", () => {
     });
   });
 });
+
+describe("NewChannelModal — kickoff session plumbing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Provide a workspace so the user can advance past step 2.
+    (api.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { workspaceId: "ws-1", repoPath: "/tmp/repo-one" },
+    ]);
+    // listSections needs to resolve at least once for the modal to mount;
+    // share the same fixture across calls so reopening the modal works.
+    (api.listSections as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  });
+
+  /** Drive the modal through steps 1+2 and return when the kickoff field is mounted. */
+  async function advanceToStep3(user: ReturnType<typeof userEvent.setup>) {
+    await user.type(screen.getByPlaceholderText(/oauth-api-users/i), "test-channel");
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    // Step 2: pick the workspace, mark primary.
+    await user.click(await screen.findByRole("checkbox"));
+    await user.click(screen.getByRole("radio"));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+  }
+
+  it("passes the kickoff session id to onCreated when a first message is provided", async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    (api.createChannel as ReturnType<typeof vi.fn>).mockResolvedValue({ channelId: "ch-42" });
+    (api.spawnAgent as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (api.createSession as ReturnType<typeof vi.fn>).mockResolvedValue({ sessionId: "sess-99" });
+    (api.startChat as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    render(<NewChannelModal open onClose={vi.fn()} onCreated={onCreated} />);
+    await waitFor(() => expect(api.listSections).toHaveBeenCalled());
+    await advanceToStep3(user);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /first message/i }),
+      "investigate something"
+    );
+    await user.click(screen.getByRole("button", { name: /create & post/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("ch-42", "sess-99"));
+  });
+
+  it("passes null kickoffSessionId when the first message is empty", async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    (api.createChannel as ReturnType<typeof vi.fn>).mockResolvedValue({ channelId: "ch-43" });
+    (api.spawnAgent as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    render(<NewChannelModal open onClose={vi.fn()} onCreated={onCreated} />);
+    await waitFor(() => expect(api.listSections).toHaveBeenCalled());
+    await advanceToStep3(user);
+
+    // No first-message text — submit straight away.
+    await user.click(screen.getByRole("button", { name: /create & post/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("ch-43", null));
+    expect(api.createSession).not.toHaveBeenCalled();
+    expect(api.startChat).not.toHaveBeenCalled();
+  });
+
+  it("passes null when the kickoff createSession throws so the warning path doesn't promise a session that never started", async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    (api.createChannel as ReturnType<typeof vi.fn>).mockResolvedValue({ channelId: "ch-44" });
+    (api.spawnAgent as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (api.createSession as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+
+    render(<NewChannelModal open onClose={vi.fn()} onCreated={onCreated} />);
+    await waitFor(() => expect(api.listSections).toHaveBeenCalled());
+    await advanceToStep3(user);
+
+    await user.type(screen.getByRole("textbox", { name: /first message/i }), "this will fail");
+    await user.click(screen.getByRole("button", { name: /create & post/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("ch-44", null));
+  });
+});

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -522,8 +522,17 @@ export function NewChannelModal({
               </button>
             )}
             {step === 3 && (
-              <button className="primary" onClick={submit} disabled={busy}>
-                {busy ? "Creating…" : "Create & post"}
+              <button
+                className="primary"
+                onClick={submit}
+                // Disable on busy AND on the warnings-path lock-out:
+                // once we've emitted onCreated for a channel, a second
+                // click would create a *second* channel + kickoff
+                // session and orphan the first one. The user must close
+                // the modal (the × dismiss) to start over.
+                disabled={busy || spawnWarning !== null}
+              >
+                {busy ? "Creating…" : spawnWarning ? "Created — close modal" : "Create & post"}
               </button>
             )}
           </div>

--- a/gui/src/components/NewChannelModal.tsx
+++ b/gui/src/components/NewChannelModal.tsx
@@ -12,7 +12,15 @@ const CREATE_SECTION_SENTINEL = "__create__";
 type Props = {
   open: boolean;
   onClose: () => void;
-  onCreated: (channelId: string) => void;
+  /**
+   * Fired after the channel is created. When the user provided a
+   * kickoff message, `kickoffSessionId` is the id of the session the
+   * modal already created and started a chat against — the parent
+   * must promote it to the active session so the chat stream renders
+   * and the user's next message continues that session instead of
+   * spawning a fresh one. `null` when no kickoff was sent.
+   */
+  onCreated: (channelId: string, kickoffSessionId: string | null) => void;
   /**
    * Section id to preselect on the first step. Usually the section the
    * user had visible in the sidebar when they clicked +; null = None /
@@ -213,6 +221,7 @@ export function NewChannelModal({
       }
 
       const kickoff = firstMessage.trim();
+      let kickoffSessionId: string | null = null;
       if (kickoff) {
         const primary = sel.find((r) => r.workspaceId === primaryWorkspaceId);
         try {
@@ -225,6 +234,12 @@ export function NewChannelModal({
             cwd: primary?.repoPath,
             autoApprove: true,
           });
+          // Hand the session id up so App.tsx promotes it to the active
+          // sessionId. Without this, CenterPane's chat-event subscription
+          // (filtered by sessionId) silently drops the kickoff response,
+          // and Composer creates a fresh session on the user's next reply
+          // because its `if (!sessionId)` branch fires.
+          kickoffSessionId = session.sessionId;
         } catch (err) {
           warnings.push(`Channel created but kickoff failed: ${err}. Send your message manually.`);
         }
@@ -234,11 +249,11 @@ export function NewChannelModal({
         setSpawnWarning(warnings.join(" · "));
         // Keep the modal open so the user can see the warning; they can close
         // manually via the × after reading it.
-        onCreated(result.channelId);
+        onCreated(result.channelId, kickoffSessionId);
         return;
       }
 
-      onCreated(result.channelId);
+      onCreated(result.channelId, kickoffSessionId);
       onClose();
     } catch (err) {
       setError(String(err));


### PR DESCRIPTION
## Summary

User report: created a channel with a kickoff message; the message posted but the agent didn't respond. Reposting kicked things off, then the next reply spun up a new session instead of continuing.

Both symptoms have one root cause: \`NewChannelModal\`'s kickoff path creates a session and calls \`startChat\` against it, but the new session id never reaches \`App.tsx\`. Two consequences:

1. **Kickoff response is invisible.** \`CenterPane\` filters chat-event streaming by \`sessionId\`. With \`App.sessionId\` staying at null (the \`selectedId\`-change effect at App.tsx:106 resets it on every channel switch), the kickoff response goes to a session no UI is subscribed to. The user's *message* renders because it posts to the channel feed (channel-scoped), not the session stream.

2. **Reply spawns a new session.** \`Composer.tsx:202\` does \`if (!sessionId)\` → \`createSession\`, so the second message starts a parallel chat.

## Fix

- \`NewChannelModal\`: \`onCreated\` now yields \`(channelId, kickoffSessionId)\`. \`null\` when no kickoff message was sent.
- \`App.tsx\`: stash the kickoff session id in a ref *before* \`setSelectedId\`. The existing selectedId-change effect now promotes the ref to \`sessionId\` in the same render instead of clobbering to null.

## Test plan

- [x] \`tsc -b\` clean
- [x] \`vitest run\` — 37 tests pass (modal tests use \`vi.fn()\` so the new signature is backward-compat)
- [x] prettier clean
- [ ] Manual: create channel with kickoff, confirm agent response renders without reposting and a follow-up reply continues the same session.

## What's NOT in this PR

The user also reported separate concerns about the ticket board (no scroll, no default sort, no virtualization at 337 tickets). That's a different change — board polish — and was scoped out for a focused fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)