### PR TITLE
docs(readme): lead with cross-repo pain-point hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 <h1 align="center">Relay</h1>
 
 <p align="center">
-  <b>Slack for your coding agents.</b><br/>
-  Coordinate coding agents across repos — with an audit trail.
+  <b>Agent harnesses assume your work lives in one repo. It doesn't.</b><br/>
+  Relay lets one agent talk to agents in your other repos — delegate, coordinate, spin up sub-teams — across every codebase you own.
 </p>
 
 <p align="center">
-  Runs inside your existing Claude or Codex CLI via MCP. Local-first, self-hosted, all state in <code>~/.relay/</code> on your machine. No hosted service, no telemetry.
+  <b>Works natively with <a href="https://github.com/cmux-dev/cmux">cmux</a>.</b> Runs inside your existing Claude or Codex CLI via MCP. Local-first, self-hosted, all state in <code>~/.relay/</code> on your machine. No hosted service, no telemetry.
 </p>
 
 <p align="center">
@@ -32,13 +32,13 @@
 
 ## What makes Relay different
 
-The agent-harness space is crowded, but most tools solve only **one** of: running agents in parallel, orchestrating a single repo, or wrapping everything in a chat UI. Relay is built for the work that needs all three — with first-class cross-repo coordination on top.
+Most agent harnesses assume the work lives in one repo. Real product surfaces don't — UI, backend, ML, infra, SDKs each sit in their own codebase. Relay is built around that shape: one orchestrator agent you talk to, reaching into every repo you own, delegating down a tree.
 
-- 🗣 **Agents talk to each other — not just run side-by-side.** Sessions in different repos discover each other through MCP crosslink tools. A live agent in the `backend` repo can ask the live agent in the `web` repo a question instead of grepping its files. Parallel agent runners don't do this; Relay does.
-- 📋 **One ticket board spans many repos.** Tickets carry a dependency DAG and `assignedAlias` routing — a feature touching 3 repos is one plan with 3 ticket streams, not 3 uncorrelated sessions. Single-repo orchestrators can't express this.
-- 💬 **Every decision is logged with rationale + alternatives.** Like Slack threads, but for architectural choices. Step away for 4 hours, come back to an audit trail — who chose what, why, and what else was considered. Most harnesses don't persist anything beyond the raw transcript.
-- 🎛 **Three dashboards, one source of truth — no cloud.** CLI (`rly`), ratatui TUI, and Tauri desktop GUI all read the same `~/.relay/` files. No sync layer, no split brain, no hosted service, no telemetry. Rare in AI tooling, required in regulated environments.
+- 🌳 **Cross-repo agent-to-agent delegation.** You talk to one orchestrator. It reaches into your other repos and delegates to live agents there, who can spin up their own sub-teams. A request like "ship OAuth across UI, backend, and the SDK" fans out as a delegation tree — orchestrator → repo agents → sub-agents — not three uncorrelated chat sessions you babysit. Sessions in different repos discover each other through MCP crosslink tools and exchange messages directly. Parallel agent runners and single-repo orchestrators don't do this; Relay does.
+- 📋 **One ticket board spans many repos.** Tickets carry a dependency DAG and `assignedAlias` routing — a feature touching 3 repos is one plan with 3 ticket streams, scheduled in order, not 3 disconnected runs. Single-repo orchestrators can't express this.
+- 💬 **An audit trail falls out of the coordination.** Because every cross-repo decision is routed through Relay, you get rationale + alternatives recorded automatically — who chose what, why, what else was considered. Step away for 4 hours, come back to a log that reads like Slack threads for architectural choices. Most harnesses don't persist anything beyond the raw transcript.
 - 🗂 **GitHub Projects v2 integration (v0.2).** Channels project to a GH Projects v2 board automatically — channels become epics, tickets become draft items, with `Type` / `Status` / `Priority` custom fields kept in sync. Relay stays authoritative; drift detected on the GitHub side is logged to the channel feed and overwritten. Paste a Projects item URL into chat and the classifier resolves the project + epic + creates the ticket. See [`docs/trackers.md`](./docs/trackers.md).
+- 🎛 **Three dashboards, one source of truth — no cloud.** CLI (`rly`), ratatui TUI, and Tauri desktop GUI all read the same `~/.relay/` files. No sync layer, no split brain, no hosted service, no telemetry. The chat feed is Slack-shaped, but the GUI is a window onto the delegation tree, not the headline.
 
 ## What Relay is
 


### PR DESCRIPTION
## Summary

- Replace the top "Slack for your coding agents" tagline with a pain-point hook: *"Agent harnesses assume your work lives in one repo. It doesn't."* The lead now names Relay's actual differentiator — cross-repo agent-to-agent delegation — instead of a chat metaphor.
- Reorder the **What makes Relay different** bullets so cross-repo agent-to-agent delegation is bullet #1, with copy that emphasizes the orchestrator -> repo agents -> sub-teams delegation tree. Demote "three dashboards" to the bottom; reframe the audit-trail bullet as a *consequence* of cross-repo coordination.
- Add a visible "Works natively with cmux" callout above the fold as an ecosystem proof point.
- Preserve the entire **Use cases** section and everything below it as-is.

## Why

The dominant pain in the agent-harness space is that most tools assume work happens in a mono-repo. Relay's whole shape addresses that, but the previous lead ("Slack for your coding agents") undersold it as a chat UI. The user signal driving this change: *"if we can capture attention and interest in that first hook then we are set."*

## Notes for reviewers

- Docs-only change. No code, no behavior, no CLI surface touched.
- The Slack metaphor still appears once, scoped to the chat feed inside the GUI bullet — not as the lead.
- The cmux link points at `https://github.com/cmux-dev/cmux`. Worth a sanity check that this is the canonical repo URL the project wants to point at; if there's a better landing page (e.g. a docs site), happy to swap it.
- `pnpm format:check` passes locally. Skipped `pnpm test` / `pnpm build` since this is markdown-only.

## Test plan

- [ ] Eyeball the rendered README on the PR page — first screen should land the pain-point hook, the cross-repo delegation bullet, and the cmux compat callout before the fold.
- [ ] Confirm the cmux URL resolves to the intended target.
- [ ] CI `format-check` job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)