### PR TITLE
fix(sandbox): unlink .relay-state stamp before git worktree remove

### DIFF
--- a/src/execution/sandboxes/git-worktree.ts
+++ b/src/execution/sandboxes/git-worktree.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 
@@ -294,6 +294,20 @@ export class GitWorktreeSandboxProvider implements SandboxProvider {
       throw new Error(
         `Cannot destroy sandbox ${ref.id}: owner repo unknown and ref.meta.repoRoot is missing`
       );
+    }
+
+    // The harness is alive and explicitly tearing down — the on-disk stamp's
+    // crash-recovery purpose (sweep walks `.relay-state.json` to find orphans
+    // when a prior process exited without calling destroy) does not apply
+    // here. Strip it before invoking `git worktree remove`, otherwise git
+    // sees its own provider's bookkeeping file as an untracked-file dirty
+    // marker and refuses with `use --force to delete it`. Real agent output
+    // still trips the dirty branch below (and the worktree is preserved with
+    // the agent's work intact).
+    try {
+      await unlink(join(path, ".relay-state.json"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     }
 
     const args = ["worktree", "remove"];

--- a/test/execution/git-worktree-sandbox.test.ts
+++ b/test/execution/git-worktree-sandbox.test.ts
@@ -449,9 +449,12 @@ describe("GitWorktreeSandboxProvider.destroy", () => {
       expect(outcome.stderr).toMatch(/contains modified or untracked files/);
     }
 
-    // On-disk state intact for T-203 recovery.
+    // On-disk worktree intact for T-203 recovery — the agent's uncommitted
+    // work is what matters here. The provider unlinks its own
+    // `.relay-state.json` stamp at the start of destroy (it's harness
+    // bookkeeping, only consulted by the cross-process sweep that walks
+    // orphans left by harness crashes — not by graceful destroy paths).
     expect(await exists(path)).toBe(true);
-    expect(await exists(join(path, ".relay-state.json"))).toBe(true);
 
     await rm(baseDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- Fixes the nightly Integration workflow that has been failing every run since at least 2026-05-02 on `git-worktree-integration` → `creates and destroys a real worktree` ([example failing run](https://github.com/jcast90/relay/actions/runs/25594622768/job/75138310021)).
- Root cause: `create()` writes `.relay-state.json` inside each worktree for the cross-process sweep CLI, then `destroy()` runs `git worktree remove` (no `--force`, by design — preserves uncommitted agent output for T-203 recovery). Git sees the harness's own bookkeeping stamp as an untracked file and refuses; the dirty-fragment matcher fires; the call returns `{ kind: "preserved", reason: "dirty" }` instead of `{ kind: "removed" }`. The provider could never cleanly destroy a sandbox it had created itself.
- Fix: unlink `.relay-state.json` at the start of `destroy()` (best-effort; swallow `ENOENT`) before invoking `git worktree remove`. Real agent output (any other untracked or modified files) still trips the dirty branch and preserves the worktree with agent work intact — the property the existing safety comment guarantees.

## Why this is safe
The stamp's purpose is *crash recovery*: when a prior harness process exited without calling `destroy`, the sweep CLI walks `~/.relay/sandboxes/run-*/T-*/.relay-state.json` to find orphans (`src/orchestrator/worktree-sweep.ts:483`). A graceful `destroy()` call is by definition the non-crash path — the stamp serves no purpose there. Sweep recovery is unaffected.

The existing unit test that asserted the stamp survived a `preserved` destroy was pinning an implementation detail; the semantic the recovery story actually depends on is "the worktree directory (and the agent's uncommitted work) survives", which is still asserted.

## Test plan
- [x] `RELAY_TEST_REAL_GIT=1 pnpm test test/execution/git-worktree-sandbox.test.ts` — 39 tests pass (including the previously-failing `creates and destroys a real worktree`).
- [x] `pnpm test test/execution/git-worktree-sandbox.test.ts test/orchestrator/worktree-sweep.test.ts` — 43 pass, 1 skipped (the gated suite when `RELAY_TEST_REAL_GIT` is unset).
- [x] `pnpm typecheck` clean.
- [x] `pnpm format:check` clean.
- [ ] CI's `Integration` workflow goes green on this branch (manual `workflow_dispatch` after merge or via `gh workflow run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)