### PR TITLE
feat(budget): Phase 1 PR-1 — schema + RED test scaffolds + spike

### DIFF
--- a/.planning/phases/01-token-usage-telemetry-context-bar/01-SPIKE-A1.md
+++ b/.planning/phases/01-token-usage-telemetry-context-bar/01-SPIKE-A1.md
@@ -1,0 +1,71 @@
+BRANCH=INCONCLUSIVE
+STREAM_FLAG=NONE
+CODEX_VERSION=not installed
+SCHEMA_PATH=fallback-empty-schema
+USAGE_PRESENT=unknown
+
+# A1 spike — Codex `--output-schema` usage extraction
+
+Status: INCONCLUSIVE — `codex` CLI not available in this execution
+environment. Permissions for ad-hoc PATH probing were blocked by the
+sandbox, and the live invocation step (`codex exec --output-schema ...`)
+could therefore not be exercised.
+
+## Goal
+
+Confirm whether `codex exec --output-schema <schema> -o <out>` writes a
+top-level `usage` block into the response file. The answer routes Task 3
+(adapter usage extraction) to one of three branches:
+
+- **Branch A (assumption holds):** `response.json` carries top-level
+  `usage: { input_tokens, cached_input_tokens?, output_tokens }`. Task 3
+  parses it directly. `STREAM_FLAG=NONE`.
+- **Branch B (assumption fails):** `response.json` does NOT carry
+  `usage`. Task 3 must additionally pass a JSONL stream flag (e.g.
+  `--json`) and capture the last `turn.completed.usage`. `STREAM_FLAG=<flag>`.
+- **Branch INCONCLUSIVE:** `codex` CLI unavailable. Task 3 implements
+  Branch A only and emits a stderr warning (`[budget] Codex usage
+  extraction unavailable; bar will not update for this session. Re-run
+  the A1 spike with codex installed to enable telemetry.`) when
+  `parsed.usage` is undefined post-Codex-run. `STREAM_FLAG=NONE`.
+
+This spike file is INCONCLUSIVE per the third bullet. Task 3 (PR-2) will
+implement Branch A with the Codex-unavailable stderr warning. Future
+re-spike (when `codex` is installed in the executor's PATH) should
+overwrite the first 5 lines of this file with the resolved branch.
+
+## Reproduction commands (for re-spike)
+
+When `codex` becomes available, re-run:
+
+```bash
+# Option 1 — use the canonical AgentResultSchema:
+node -e 'import("zod-to-json-schema").then(({zodToJsonSchema}) => import("./dist/domain/agent.js").then(({AgentResultSchema}) => process.stdout.write(JSON.stringify(zodToJsonSchema(AgentResultSchema), null, 2))))' > /tmp/relay-spike-schema.json
+
+codex exec --skip-git-repo-check --sandbox read-only \
+  --output-schema /tmp/relay-spike-schema.json \
+  -o /tmp/relay-spike-response.json \
+  "Return a JSON object with summary='ok', evidence=[], proposedCommands=[], blockers=[]."
+cat /tmp/relay-spike-response.json
+```
+
+If `zod-to-json-schema` is not on the dep tree, the L6 fallback is to
+pass `{}` (empty schema) — that still answers whether `usage` lands in
+the response. Document which path was taken in `SCHEMA_PATH=` above.
+
+## Outcome
+
+INCONCLUSIVE. Per the M2 mitigation, Task 3 in PR-2 will:
+
+1. Implement Branch A only (`response.json` top-level `usage` parse).
+2. After Codex completes, if `parsed.usage` is undefined, emit ONE
+   stderr warning: `[budget] Codex usage extraction unavailable; bar
+   will not update for this session. Re-run the A1 spike with codex
+   installed to enable telemetry.`
+3. The orchestrator (Task 4) guards with `if (result.tokenUsage)`, so a
+   missing usage is a no-op for downstream consumers.
+
+When the executor environment gets `codex` installed, re-running this
+spike + flipping the first 5 lines is sufficient to enable the full
+telemetry path. The Task 3 implementation must remain re-checkable
+against this file (the spike test below greps the documented branch).

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 pub mod tool_activity;
@@ -1491,6 +1492,159 @@ pub fn migrate_legacy_chat(channel_id: &str) {
     let _ = fs::remove_file(&legacy_path);
 }
 
+// --- SessionBudget (Phase 1: per-session token-usage telemetry) ------------
+//
+// Mirror of `src/domain/session-budget.ts`. Same-PR change discipline: any
+// shape change here MUST land alongside a matching TS change (and vice
+// versa). See `AGENTS.md` > "Cross-dashboard contract".
+//
+// On-disk layout: `~/.relay/sessions/<sessionId>/budget.jsonl` — one
+// JSON object per `record()` call, append-only. Each line contains
+// `cumulativeUsed` (post-record total) and an optional `kind`
+// discriminator. The `SessionBudget` snapshot below is computed by
+// `load_session_budget` from the last well-formed line.
+
+/// Discriminator for the three keyspaces under `~/.relay/sessions/`.
+/// Mirrors `SessionKind` in `src/domain/session-budget.ts`.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionKind {
+    Chat,
+    Run,
+    Admin,
+}
+
+impl Default for SessionKind {
+    fn default() -> Self {
+        SessionKind::Admin
+    }
+}
+
+/// Per-session token-budget snapshot. Mirrors `SessionBudget` in
+/// `src/domain/session-budget.ts`. Bumping `schemaVersion` requires a
+/// same-PR TS-side bump and a forward-migration helper for any pre-
+/// existing on-disk lines (CONCERNS.md "Channel state has no
+/// schema-version field anywhere"). Phase 2's handoff briefs depend on
+/// this contract being stable.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionBudget {
+    #[serde(default = "default_session_budget_schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub kind: SessionKind,
+    pub session_id: String,
+    pub used: u64,
+    pub total: u64,
+    pub pct: f64,
+    #[serde(default)]
+    pub last_updated: Option<String>,
+    #[serde(default)]
+    pub model_name: Option<String>,
+}
+
+fn default_session_budget_schema_version() -> u32 {
+    1
+}
+
+impl SessionBudget {
+    pub fn empty(session_id: impl Into<String>, total: u64) -> Self {
+        SessionBudget {
+            schema_version: 1,
+            kind: SessionKind::default(),
+            session_id: session_id.into(),
+            used: 0,
+            total,
+            pct: 0.0,
+            last_updated: None,
+            model_name: None,
+        }
+    }
+}
+
+/// Load the per-session budget snapshot from
+/// `~/.relay/sessions/<sessionId>/budget.jsonl`. Reads the last
+/// well-formed `cumulativeUsed` value; missing/empty file returns
+/// `SessionBudget::empty()`. Hand-edited or torn lines are silently
+/// skipped (research Q7, CONCERNS.md "Cross-language read-during-write
+/// race" — accepted tradeoff).
+pub fn load_session_budget(session_id: &str, total: u64) -> SessionBudget {
+    let path = harness_root()
+        .join("sessions")
+        .join(session_id)
+        .join("budget.jsonl");
+    let Ok(file) = fs::File::open(&path) else {
+        return SessionBudget::empty(session_id, total);
+    };
+    let mut last_cumulative: u64 = 0;
+    let mut last_ts: Option<String> = None;
+    let mut last_kind: SessionKind = SessionKind::default();
+    let mut last_model: Option<String> = None;
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if let Some(c) = value.get("cumulativeUsed").and_then(|v| v.as_u64()) {
+            last_cumulative = c;
+        }
+        if let Some(ts) = value.get("ts").and_then(|v| v.as_str()) {
+            last_ts = Some(ts.to_string());
+        }
+        if let Some(k) = value.get("kind").and_then(|v| v.as_str()) {
+            last_kind = match k {
+                "chat" => SessionKind::Chat,
+                "run" => SessionKind::Run,
+                _ => SessionKind::Admin,
+            };
+        }
+        if let Some(m) = value.get("modelName").and_then(|v| v.as_str()) {
+            last_model = Some(m.to_string());
+        }
+    }
+    let pct = if total == 0 {
+        0.0
+    } else {
+        (last_cumulative as f64 / total as f64) * 100.0
+    };
+    SessionBudget {
+        schema_version: 1,
+        kind: last_kind,
+        session_id: session_id.to_string(),
+        used: last_cumulative,
+        total,
+        pct,
+        last_updated: last_ts,
+        model_name: last_model,
+    }
+}
+
+/// Walk `~/.relay/sessions/<id>/budget.jsonl` files and return one row
+/// per session. Caller filters on `kind == SessionKind::Chat` to drive
+/// the worst-session chip (M3 / M4). Missing/empty `~/.relay/sessions`
+/// returns `Vec::new()` without throwing.
+pub fn list_session_budgets() -> Vec<SessionBudget> {
+    let root = harness_root().join("sessions");
+    let Ok(read) = fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in read.flatten() {
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        // Default ceiling — caller (TS-side or Tauri-side) is responsible
+        // for resolving the actual model context window. Phase 1 surfaces
+        // the file-recorded `cumulativeUsed` directly so downstream UIs
+        // can re-compute pct against the right model.
+        let budget = load_session_budget(&name, 200_000);
+        out.push(budget);
+    }
+    out
+}
+
 // --- Tests -----------------------------------------------------------------
 
 #[cfg(test)]
@@ -2601,5 +2755,146 @@ mod tests {
         // Don't create the crosslink-session dir at all.
         let sessions = load_crosslink_sessions();
         assert!(sessions.is_empty());
+    }
+
+    // --- SessionBudget (Phase 1) --------------------------------------------
+
+    #[test]
+    fn session_budget_serde_fixture() {
+        // Hand-written camelCase JSON exactly matching what the TS side
+        // serializes. Asserts (M1) that schema_version is the parsed value
+        // — no silent default-fallthrough — and that `kind` round-trips.
+        let json = r#"{"schemaVersion":1,"kind":"chat","sessionId":"sess-x","used":42,"total":200000,"pct":0.021,"lastUpdated":"2026-05-09T00:00:00Z","modelName":"Sonnet 4.5"}"#;
+        let deserialized: SessionBudget =
+            serde_json::from_str(json).expect("fixture must deserialize");
+        assert_eq!(deserialized.schema_version, 1);
+        assert_eq!(deserialized.kind, SessionKind::Chat);
+        assert_eq!(deserialized.session_id, "sess-x");
+        assert_eq!(deserialized.used, 42);
+        assert_eq!(deserialized.total, 200000);
+
+        // Round-trip the other direction — the camelCase boundary holds.
+        let out = serde_json::to_string(&deserialized).expect("round-trip");
+        assert!(out.contains("\"schemaVersion\":1"), "got: {}", out);
+        assert!(out.contains("\"kind\":\"chat\""), "got: {}", out);
+        assert!(out.contains("\"sessionId\":\"sess-x\""), "got: {}", out);
+    }
+
+    #[test]
+    fn session_budget_v2_round_trip() {
+        // M1 drift guard: a hand-written `schemaVersion: 2` line must NOT
+        // silently downgrade to 1. Phase 2 / future schema bumps depend on
+        // the parser preserving the on-disk version.
+        let json = r#"{"schemaVersion":2,"kind":"run","sessionId":"sess-v2","used":10,"total":1000,"pct":1.0}"#;
+        let deserialized: SessionBudget =
+            serde_json::from_str(json).expect("v2 must deserialize");
+        assert_eq!(deserialized.schema_version, 2);
+        assert_eq!(deserialized.kind, SessionKind::Run);
+    }
+
+    #[test]
+    fn session_budget_kind_defaults_to_admin_when_missing() {
+        // Back-compat: pre-Phase-1 budget files have no `kind` field.
+        // Default to Admin so existing autonomous-loop snapshots load.
+        let json = r#"{"schemaVersion":1,"sessionId":"sess-legacy","used":0,"total":200000,"pct":0.0}"#;
+        let deserialized: SessionBudget =
+            serde_json::from_str(json).expect("legacy must deserialize");
+        assert_eq!(deserialized.kind, SessionKind::Admin);
+    }
+
+    #[test]
+    fn session_budget_load_from_jsonl_reads_last_cumulative() {
+        let _guard = scoped_root();
+        let sessions_dir = harness_root().join("sessions").join("sess-x");
+        fs::create_dir_all(&sessions_dir).expect("mkdir");
+        // Three lines — load_session_budget sums what it sees and returns
+        // the LAST `cumulativeUsed`. Each line carries its own kind so
+        // the loader picks up the most recent.
+        let body = "\
+{\"ts\":\"2026-05-09T00:00:00Z\",\"inputTokens\":100,\"outputTokens\":50,\"cumulativeUsed\":150,\"kind\":\"chat\"}
+{\"ts\":\"2026-05-09T00:01:00Z\",\"inputTokens\":200,\"outputTokens\":50,\"cumulativeUsed\":400,\"kind\":\"chat\"}
+{\"ts\":\"2026-05-09T00:02:00Z\",\"inputTokens\":600,\"outputTokens\":0,\"cumulativeUsed\":1000,\"kind\":\"chat\",\"modelName\":\"claude-sonnet-4-5\"}
+";
+        fs::write(sessions_dir.join("budget.jsonl"), body).expect("write");
+
+        let budget = load_session_budget("sess-x", 2000);
+        assert_eq!(budget.used, 1000);
+        assert_eq!(budget.total, 2000);
+        // pct == (used / total) * 100; allow tiny float drift via approx.
+        assert!((budget.pct - 50.0).abs() < 1e-9, "pct was {}", budget.pct);
+        assert_eq!(budget.kind, SessionKind::Chat);
+        assert_eq!(budget.last_updated.as_deref(), Some("2026-05-09T00:02:00Z"));
+        assert_eq!(budget.model_name.as_deref(), Some("claude-sonnet-4-5"));
+    }
+
+    #[test]
+    fn session_budget_load_returns_empty_when_missing() {
+        let _guard = scoped_root();
+        // No file written — loader must return SessionBudget::empty.
+        let budget = load_session_budget("sess-missing", 500);
+        assert_eq!(budget.used, 0);
+        assert_eq!(budget.total, 500);
+        assert_eq!(budget.pct, 0.0);
+        assert_eq!(budget.kind, SessionKind::Admin);
+    }
+
+    #[test]
+    fn session_budget_load_skips_torn_lines() {
+        let _guard = scoped_root();
+        let sessions_dir = harness_root().join("sessions").join("sess-torn");
+        fs::create_dir_all(&sessions_dir).expect("mkdir");
+        // First line good, second line a torn fragment, third line good.
+        // The loader must skip the malformed line and still return the
+        // correct LAST cumulativeUsed from the well-formed tail.
+        let body = "{\"cumulativeUsed\":100,\"kind\":\"chat\"}\n{not json\n{\"cumulativeUsed\":300,\"kind\":\"chat\"}\n";
+        fs::write(sessions_dir.join("budget.jsonl"), body).expect("write");
+        let budget = load_session_budget("sess-torn", 1000);
+        assert_eq!(budget.used, 300);
+    }
+
+    #[test]
+    fn list_session_budgets_returns_empty_when_dir_missing() {
+        let _guard = scoped_root();
+        // Sessions directory does not exist — must return empty without
+        // throwing.
+        let budgets = list_session_budgets();
+        assert!(budgets.is_empty());
+    }
+
+    #[test]
+    fn list_chat_session_budgets_filters_admin() {
+        // M4: list_session_budgets surfaces every session, but the GUI's
+        // worst-session chip is supposed to filter to `kind == Chat`.
+        // The Tauri command (Task 7) does that filter on top; this test
+        // mimics the same filter and confirms an admin-keyed budget is
+        // excluded while a chat-keyed budget surfaces.
+        let _guard = scoped_root();
+        let root = harness_root().join("sessions");
+
+        let chat_dir = root.join("sess-chat");
+        fs::create_dir_all(&chat_dir).expect("mkdir chat");
+        fs::write(
+            chat_dir.join("budget.jsonl"),
+            "{\"cumulativeUsed\":42,\"kind\":\"chat\"}\n",
+        )
+        .expect("write chat");
+
+        let admin_dir = root.join("admin-be");
+        fs::create_dir_all(&admin_dir).expect("mkdir admin");
+        fs::write(
+            admin_dir.join("budget.jsonl"),
+            "{\"cumulativeUsed\":100,\"kind\":\"admin\"}\n",
+        )
+        .expect("write admin");
+
+        let all = list_session_budgets();
+        assert_eq!(all.len(), 2, "list returns every session: {:?}", all);
+
+        let chat_only: Vec<_> = all
+            .into_iter()
+            .filter(|b| matches!(b.kind, SessionKind::Chat))
+            .collect();
+        assert_eq!(chat_only.len(), 1, "filter to chat only");
+        assert_eq!(chat_only[0].session_id, "sess-chat");
     }
 }

--- a/gui/src/components/ContextWindowBar.test.tsx
+++ b/gui/src/components/ContextWindowBar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ContextWindowBar } from "./ContextWindowBar";
+
+/**
+ * RED tests for the `ContextWindowBar` GUI component. PR-1 ships a
+ * `() => null` stub so typecheck passes; PR-3 (Task 7) lands the real
+ * markup, severity classes, and interactive selection.
+ */
+describe("ContextWindowBar", () => {
+  it("renders 'ctx 75%' for used 150_000 / total 200_000 with metric--tokens-warn class", () => {
+    const { container } = render(
+      <ContextWindowBar used={150_000} total={200_000} sessionId="sess-1" model="Sonnet 4.5" />
+    );
+    expect(screen.getByText(/ctx\s*75%/i)).toBeDefined();
+    expect(container.querySelector(".metric--tokens-warn")).toBeTruthy();
+  });
+
+  it("uses metric--tokens-hot for pct >= 90", () => {
+    const { container } = render(
+      <ContextWindowBar used={185_000} total={200_000} sessionId="sess-1" />
+    );
+    expect(container.querySelector(".metric--tokens-hot")).toBeTruthy();
+  });
+
+  it("uses metric--tokens-overrun for pct >= 100", () => {
+    const { container } = render(
+      <ContextWindowBar used={210_000} total={200_000} sessionId="sess-1" />
+    );
+    expect(container.querySelector(".metric--tokens-overrun")).toBeTruthy();
+  });
+});

--- a/gui/src/components/ContextWindowBar.tsx
+++ b/gui/src/components/ContextWindowBar.tsx
@@ -1,0 +1,25 @@
+import { tokenPctSeverity } from "../lib/tokenSeverity";
+
+export interface ContextWindowBarProps {
+  used: number;
+  total: number;
+  sessionId: string;
+  model?: string;
+}
+
+/**
+ * GUI percent-bar React component, severity-colored, polled per
+ * App-level `refreshTick`.
+ *
+ * **Phase 1 PR-1:** stub. Implementation lands in PR-3 (Task 7). The
+ * shape ships in PR-1 so the RED `ContextWindowBar.test.tsx` compiles
+ * against the final props shape. The stub returns null at runtime so
+ * tests that assert on the rendered output go RED loudly.
+ */
+export function ContextWindowBar(_props: ContextWindowBarProps): JSX.Element | null {
+  // Reference tokenPctSeverity so tree-shaking does not strip the
+  // import — Task 7's implementation will use it for the severity
+  // class.
+  void tokenPctSeverity;
+  return null;
+}

--- a/gui/src/lib/modelContextWindows.test.ts
+++ b/gui/src/lib/modelContextWindows.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { MODEL_CONTEXT_WINDOWS } from "./modelContextWindows";
+
+/**
+ * M9 — model-table drift guard. The canonical TS-side table at
+ * `src/domain/model-context-windows.ts` and this GUI-side mirror MUST
+ * stay byte-identical. Vite cannot reach across the workspace boundary
+ * without exposing the orchestrator's path to the GUI bundle, so this
+ * test maintains a hard-coded canonical mapping and asserts the
+ * GUI-side copy matches. PR review owns enforcing the sibling-file
+ * update; this test owns catching it in CI.
+ */
+const CANONICAL_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "claude-sonnet-4-5": 200_000,
+  "claude-opus-4-7": 1_000_000,
+  "claude-haiku-3-5": 200_000,
+  "gpt-5": 200_000,
+  "o3-mini": 200_000,
+};
+
+describe("modelContextWindows GUI mirror (M9 drift guard)", () => {
+  it("matches the canonical orchestrator-side table key-for-key", () => {
+    expect(MODEL_CONTEXT_WINDOWS).toEqual(CANONICAL_MODEL_CONTEXT_WINDOWS);
+  });
+
+  it("each canonical key resolves to the same value in the GUI mirror", () => {
+    for (const [key, value] of Object.entries(CANONICAL_MODEL_CONTEXT_WINDOWS)) {
+      expect(MODEL_CONTEXT_WINDOWS[key]).toBe(value);
+    }
+  });
+
+  // PR-3 (Task 7) extracts a shared `tokenSeverity` util and adds a
+  // re-export from this module so consumers have one import. The
+  // `resolveContextWindow` helper is mirrored too — this assertion
+  // pins the mirror is exposing it. RED until PR-3 lands the
+  // re-export.
+  it("re-exports a `getModelContextWindowSummary` helper for the GUI worst-session chip (PR-3 wiring)", async () => {
+    const mod = await import("./modelContextWindows");
+    // PR-3's Task 7 will add a per-model summary helper that returns
+    // `{ key, value, isDefault }` for the chip's tooltip. Phase 1 PR-1
+    // does not export it; this assertion goes RED until PR-3.
+    expect(
+      (mod as { getModelContextWindowSummary?: unknown }).getModelContextWindowSummary
+    ).toBeDefined();
+  });
+});

--- a/gui/src/lib/modelContextWindows.ts
+++ b/gui/src/lib/modelContextWindows.ts
@@ -1,0 +1,20 @@
+/**
+ * GUI-side mirror of `src/domain/model-context-windows.ts`. Adding a
+ * new model REQUIRES adding it to BOTH files in the same PR; the
+ * sibling test `gui/src/lib/modelContextWindows.test.ts` asserts the
+ * tables stay in sync (drift guard, M9).
+ */
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "claude-sonnet-4-5": 200_000,
+  "claude-opus-4-7": 1_000_000,
+  "claude-haiku-3-5": 200_000,
+  "gpt-5": 200_000,
+  "o3-mini": 200_000,
+};
+
+export const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+export function resolveContextWindow(modelName?: string | null): number {
+  if (!modelName) return DEFAULT_CONTEXT_WINDOW;
+  return MODEL_CONTEXT_WINDOWS[modelName] ?? DEFAULT_CONTEXT_WINDOW;
+}

--- a/gui/src/lib/tokenSeverity.ts
+++ b/gui/src/lib/tokenSeverity.ts
@@ -1,0 +1,18 @@
+/**
+ * Map context-window pct (0-100+) to a CSS severity tier.
+ * Mirrors the original implementation from
+ * `gui/src/components/AutonomousSessionHeader.tsx` —
+ * extracted here so `ContextWindowBar` and the worst-session chip
+ * share the named export rather than copy-pasting the ladder.
+ *
+ * Phase 1 PR-3 (Task 7) will refactor `AutonomousSessionHeader` to
+ * import from here instead of holding its own copy.
+ */
+export type TokenSeverity = "ok" | "warn" | "hot" | "overrun";
+
+export function tokenPctSeverity(pct: number): TokenSeverity {
+  if (pct >= 100) return "overrun";
+  if (pct >= 90) return "hot";
+  if (pct >= 75) return "warn";
+  return "ok";
+}

--- a/src/agents/process-stream-line.ts
+++ b/src/agents/process-stream-line.ts
@@ -1,0 +1,30 @@
+import type { TokenUsage } from "../domain/agent.js";
+
+/**
+ * Mutable state passed between successive `processStreamLine` calls during
+ * a Claude streaming invocation. Lives in `src/agents/` as a dedicated
+ * module so the adapter (`cli-agents.ts`) can `import { processStreamLine
+ * } from "./process-stream-line.js"` without growing the monolithic
+ * adapter file. PR-2 (Task 3) lifts the existing closure body in
+ * `invokeStreaming` into this function verbatim and adds the `obj.usage`
+ * capture on the `result` arm.
+ */
+export interface StreamParseState {
+  accumText: string;
+  resultText: string | null;
+  capturedUsage: TokenUsage | null;
+}
+
+/**
+ * **Phase 1 PR-1:** stub. The pure function ships in PR-2 (Task 3); the
+ * signature lands in PR-1 so the RED Claude streaming-usage test
+ * (`test/agents/cli-agents-claude-usage.test.ts`) compiles against the
+ * final shape.
+ */
+export function processStreamLine(
+  _line: string,
+  _state: StreamParseState,
+  _onLine: (line: string) => void
+): void {
+  throw new Error("processStreamLine: not yet implemented (Phase 1 PR-2 / Task 3)");
+}

--- a/src/budget/session-tracker-pool.ts
+++ b/src/budget/session-tracker-pool.ts
@@ -1,0 +1,29 @@
+import { TokenTracker } from "./token-tracker.js";
+import type { SessionKind } from "../domain/session-budget.js";
+
+/**
+ * One-tracker-per-chat-session pool. Construction is lazy: the first
+ * `get(sessionId, ceiling)` call mints the tracker (which immediately
+ * starts replaying any prior `~/.relay/sessions/<sessId>/budget.jsonl`).
+ * Subsequent calls return the same instance — same-process records
+ * serialize through the tracker's writeChain (token-tracker.ts:75).
+ *
+ * **Phase 1 PR-1:** stub. The shape lands in PR-1 so tests + typecheck
+ * compile against final types; the implementation lands in PR-2 (Task 4).
+ * Calls to `get()` / `closeAll()` throw at runtime so RED tests fail
+ * loudly. See `.planning/phases/01-token-usage-telemetry-context-bar/01-PLAN.md`
+ * Task 4 for the full implementation contract (M8 soft-warning, etc.).
+ */
+export class SessionTrackerPool {
+  get(_sessionId: string, _ceiling: number, _kind?: SessionKind): TokenTracker {
+    throw new Error("SessionTrackerPool: not yet implemented (Phase 1 PR-2 / Task 4)");
+  }
+
+  has(_sessionId: string): boolean {
+    throw new Error("SessionTrackerPool: not yet implemented (Phase 1 PR-2 / Task 4)");
+  }
+
+  async closeAll(): Promise<void> {
+    throw new Error("SessionTrackerPool: not yet implemented (Phase 1 PR-2 / Task 4)");
+  }
+}

--- a/src/budget/threshold-feed-bridge.ts
+++ b/src/budget/threshold-feed-bridge.ts
@@ -1,0 +1,31 @@
+import type { ChannelStore } from "../channels/channel-store.js";
+import type { TokenTracker } from "./token-tracker.js";
+
+export interface ThresholdFeedOptions {
+  /**
+   * Subset of `THRESHOLDS` (token-tracker.ts:21) to forward to the channel
+   * feed. Defaults to [75, 90, 95] per the Phase-1 brief. Other thresholds
+   * still fire on the in-process EventEmitter for in-process subscribers
+   * (e.g. RepoAdminSession's 60% memory-shed subscriber); they are simply
+   * not posted to the channel feed here.
+   */
+  postThresholds?: readonly number[];
+  /** Optional model name surfaced in metadata for downstream readers. */
+  modelName?: string;
+}
+
+/**
+ * **Phase 1 PR-1:** stub. The bridge implementation lands in PR-2 (Task 5);
+ * the shape + signature ship in PR-1 so RED tests compile. See
+ * `.planning/phases/01-token-usage-telemetry-context-bar/01-PLAN.md` Task 5
+ * for the contract (filter to [75, 90, 95], `metadata.kind ===
+ * "context_threshold"`, M7 pct precision, etc.).
+ */
+export function attachThresholdFeed(
+  _tracker: TokenTracker,
+  _channelId: string,
+  _channelStore: ChannelStore,
+  _opts: ThresholdFeedOptions = {}
+): () => void {
+  throw new Error("attachThresholdFeed: not yet implemented (Phase 1 PR-2 / Task 5)");
+}

--- a/src/cli/chat-record-usage.ts
+++ b/src/cli/chat-record-usage.ts
@@ -1,0 +1,27 @@
+import type { SessionKind } from "../domain/session-budget.js";
+
+export interface ChatRecordUsageArgs {
+  session: string;
+  input: number;
+  output: number;
+  kind?: SessionKind;
+  model?: string;
+  channel?: string;
+}
+
+/**
+ * Handler for the `rly chat record-usage` CLI subcommand. Mints (or
+ * resumes) the session's `TokenTracker`, calls `record(input, output)`,
+ * and — when `--channel` is passed — wires the threshold-feed bridge so
+ * 75/90/95 crossings post to the channel feed.
+ *
+ * Used by the GUI's chat-event Rust loop and the TUI's chat-event Rust
+ * worker (per D-04 chat-mode parity), shelled out via
+ * `Command::new(cli_bin())`.
+ *
+ * **Phase 1 PR-1:** stub. Implementation lands in PR-4 (Task 10). The
+ * signature ships in PR-1 so RED tests compile against the final shape.
+ */
+export async function handleChatRecordUsageCommand(_args: ChatRecordUsageArgs): Promise<void> {
+  throw new Error("handleChatRecordUsageCommand: not yet implemented (Phase 1 PR-4 / Task 10)");
+}

--- a/src/cli/print-status-context.ts
+++ b/src/cli/print-status-context.ts
@@ -1,0 +1,35 @@
+import type { SessionKind } from "../domain/session-budget.js";
+
+export interface ActiveSessionRow {
+  sessionId: string;
+  channelId?: string;
+  pct: number;
+  used: number;
+  total: number;
+  model?: string;
+  kind?: SessionKind;
+}
+
+/**
+ * Pure formatter for the `Active sessions:` block in `rly status`. Takes
+ * the rows resolved by `loadActiveSessions()` and returns the printable
+ * lines. No `~/.relay/` reads here — keeps the formatter unit-testable.
+ *
+ * **Phase 1 PR-1:** stub. Implementation lands in PR-4 (Task 11). The
+ * shape ships in PR-1 so RED tests compile.
+ */
+export function formatActiveSessionsBlock(_sessions: ActiveSessionRow[]): string {
+  throw new Error("formatActiveSessionsBlock: not yet implemented (Phase 1 PR-4 / Task 11)");
+}
+
+/**
+ * Walk `~/.relay/sessions/<id>/budget.jsonl` files and resolve the rows
+ * that should surface in `rly status`. Filters to `kind === "chat"`;
+ * skips malformed individual files (per L3 isolation) and returns `[]`
+ * cleanly when the sessions root does not exist.
+ *
+ * **Phase 1 PR-1:** stub. Implementation lands in PR-4 (Task 11).
+ */
+export function loadActiveSessions(): ActiveSessionRow[] {
+  throw new Error("loadActiveSessions: not yet implemented (Phase 1 PR-4 / Task 11)");
+}

--- a/src/domain/agent.ts
+++ b/src/domain/agent.ts
@@ -65,6 +65,23 @@ export interface WorkRequest {
   priorEvidence: string[];
 }
 
+/**
+ * Per-call token usage extracted from a CLI adapter's streaming/buffered
+ * output. The shape is provider-agnostic: `inputTokens` already includes
+ * any cache-read / cache-write tokens (research Q3 — cache occupies the
+ * window). Cache breakdowns are surfaced separately for forensics.
+ *
+ * Populated by `cli-agents.ts` adapter parsing in Phase 1 PR-2 (Task 3);
+ * the type ships in PR-1 so RED tests + the orchestrator wiring (Task 4)
+ * can reference it without typecheck breaks.
+ */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
 export interface AgentResult {
   summary: string;
   evidence: string[];
@@ -74,6 +91,8 @@ export interface AgentResult {
   phasePlan?: PhasePlan;
   ticketPlan?: TicketPlan;
   rawResponse?: string;
+  /** Provider token usage for this call, if the adapter extracted it. */
+  tokenUsage?: TokenUsage;
 }
 
 export interface Agent {

--- a/src/domain/model-context-windows.ts
+++ b/src/domain/model-context-windows.ts
@@ -1,0 +1,48 @@
+/**
+ * Hard-coded per-model context-window ceilings as of 2026-05-09. Sources:
+ *   - Claude: support.claude.com/en/articles/8606395
+ *   - Codex / OpenAI: docs.onlinetool.cc/codex (varies by deployed model)
+ *
+ * Add new entries when models ship; missing keys fall back to a conservative
+ * 200_000 with a stderr warning so the operator knows their bar may be off.
+ * Mirrored at `gui/src/lib/modelContextWindows.ts` (same keys / values).
+ * `gui/src/lib/modelContextWindows.test.ts` asserts the two copies stay in
+ * sync (drift guard, M9). Adding a new entry here REQUIRES adding it
+ * there in the same PR.
+ */
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "claude-sonnet-4-5": 200_000,
+  "claude-opus-4-7": 1_000_000,
+  "claude-haiku-3-5": 200_000,
+  "gpt-5": 200_000,
+  "o3-mini": 200_000,
+};
+
+export const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+const warnedModels = new Set<string>();
+
+/**
+ * Resolve the context-window ceiling for a given model. Returns
+ * `DEFAULT_CONTEXT_WINDOW` (200_000) for unknown / missing models, and
+ * writes a one-line `[budget]` stderr warning so operators notice the
+ * bar may be miscalibrated. The warning is deduped per process via
+ * `warnedModels`.
+ */
+export function resolveContextWindow(modelName?: string | null): number {
+  if (!modelName) return DEFAULT_CONTEXT_WINDOW;
+  const known = MODEL_CONTEXT_WINDOWS[modelName];
+  if (typeof known === "number") return known;
+  if (!warnedModels.has(modelName)) {
+    warnedModels.add(modelName);
+    console.warn(
+      `[budget] Unknown model "${modelName}"; assuming ${DEFAULT_CONTEXT_WINDOW.toLocaleString()}-token context window.`
+    );
+  }
+  return DEFAULT_CONTEXT_WINDOW;
+}
+
+/** Test helper — reset the per-process dedup cache so warnings re-fire. */
+export function __resetWarnedModelsForTests(): void {
+  warnedModels.clear();
+}

--- a/src/domain/session-budget.ts
+++ b/src/domain/session-budget.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+/**
+ * Schema version for SessionBudget. Bumping this requires a same-PR Rust
+ * mirror update (`crates/harness-data/src/lib.rs::SessionBudget::schema_version`)
+ * AND a forward-migration helper for any pre-existing on-disk lines.
+ *
+ * Phase 2's handoff brief artifacts depend on this contract being stable —
+ * if you bump it, surface the change in the Phase 2 plan's revision_context.
+ */
+export const SESSION_BUDGET_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Discriminator for the three keyspaces under `~/.relay/sessions/`:
+ *   - "chat":  chat-mode sessions (recorded via `rly chat record-usage`)
+ *   - "run":   orchestrator dispatches (recorded by OrchestratorV2.dispatch)
+ *   - "admin": autonomous-loop admin sessions (existing keyspace under
+ *              `admin-<alias>`); default when missing for back-compat
+ *              with files that pre-date Phase 1.
+ *
+ * `list_chat_session_budgets()` and `loadActiveSessions()` filter on
+ * `kind === "chat"` to avoid surfacing autonomous noise in the
+ * worst-session chip / `rly status` block.
+ */
+export const SessionKindSchema = z.enum(["chat", "run", "admin"]);
+export type SessionKind = z.infer<typeof SessionKindSchema>;
+
+/**
+ * `SessionBudget` is the on-disk + cross-dashboard shape for per-session
+ * token-budget snapshots. Mirrored at
+ * `crates/harness-data/src/lib.rs::SessionBudget` — same-PR change
+ * discipline (AGENTS.md > "Cross-dashboard contract").
+ */
+export const SessionBudgetSchema = z.object({
+  schemaVersion: z.literal(SESSION_BUDGET_SCHEMA_VERSION),
+  kind: SessionKindSchema.default("admin"),
+  sessionId: z.string().min(1),
+  used: z.number().int().nonnegative(),
+  total: z.number().int().positive(),
+  pct: z.number(),
+  lastUpdated: z.string().optional(),
+  modelName: z.string().optional(),
+});
+
+export type SessionBudget = z.infer<typeof SessionBudgetSchema>;

--- a/test/agents/cli-agents-claude-usage.test.ts
+++ b/test/agents/cli-agents-claude-usage.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { processStreamLine, type StreamParseState } from "../../src/agents/process-stream-line.js";
+
+/**
+ * RED tests for the Claude streaming-usage extraction. PR-1 ships the
+ * stub-throwing `processStreamLine`; PR-2 (Task 3) lifts the existing
+ * closure body in `cli-agents.ts::invokeStreaming` into this function
+ * and adds the `obj.usage` capture on the `result` arm.
+ */
+describe("processStreamLine — Claude streaming usage capture", () => {
+  function freshState(): StreamParseState {
+    return { accumText: "", resultText: null, capturedUsage: null };
+  }
+
+  it("captures `usage` from the `result` event with cache tokens summed into inputTokens", () => {
+    const state = freshState();
+    const line = JSON.stringify({
+      type: "result",
+      result: "ok",
+      usage: {
+        input_tokens: 1500,
+        output_tokens: 250,
+        cache_read_input_tokens: 3000,
+      },
+    });
+    processStreamLine(line, state, () => {});
+    expect(state.capturedUsage).toBeDefined();
+    expect(state.capturedUsage?.inputTokens).toBe(1500 + 3000);
+    expect(state.capturedUsage?.outputTokens).toBe(250);
+    expect(state.capturedUsage?.cacheReadTokens).toBe(3000);
+  });
+
+  it("ignores mid-stream `assistant` events that carry usage (only `result` is authoritative)", () => {
+    const state = freshState();
+    const assistantLine = JSON.stringify({
+      type: "assistant",
+      message: { usage: { input_tokens: 999, output_tokens: 999 } },
+    });
+    processStreamLine(assistantLine, state, () => {});
+    expect(state.capturedUsage).toBeNull();
+  });
+
+  it("captures `usage` even when cache_creation_input_tokens is present (sums into inputTokens)", () => {
+    const state = freshState();
+    const line = JSON.stringify({
+      type: "result",
+      result: "ok",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 200,
+      },
+    });
+    processStreamLine(line, state, () => {});
+    expect(state.capturedUsage?.inputTokens).toBe(100 + 200);
+    expect(state.capturedUsage?.cacheWriteTokens).toBe(200);
+  });
+});

--- a/test/agents/cli-agents-codex-usage-spike.test.ts
+++ b/test/agents/cli-agents-codex-usage-spike.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SPIKE_PATH = join(
+  process.cwd(),
+  ".planning",
+  "phases",
+  "01-token-usage-telemetry-context-bar",
+  "01-SPIKE-A1.md"
+);
+
+const ADAPTER_PATH = join(process.cwd(), "src", "agents", "cli-agents.ts");
+
+/**
+ * Spike-snapshot test: parses the machine-readable header of
+ * `01-SPIKE-A1.md` and asserts that the adapter's Codex parsing branch
+ * matches the documented BRANCH=. Future re-spikes (when codex becomes
+ * available) flip the header; this test holds Task 3 honest.
+ *
+ * RED in PR-1: PR-2's Task 3 implements the documented Codex parsing.
+ * Until then, the adapter has no usage parsing at all and the grep
+ * fails.
+ */
+describe("Codex --output-schema spike snapshot", () => {
+  it("01-SPIKE-A1.md exists with the 5-line machine-readable header", () => {
+    expect(existsSync(SPIKE_PATH)).toBe(true);
+    const head = readFileSync(SPIKE_PATH, "utf8").split("\n").slice(0, 5);
+    expect(head[0]).toMatch(/^BRANCH=(A|B|INCONCLUSIVE)$/);
+    expect(head[1]).toMatch(/^STREAM_FLAG=/);
+    expect(head[2]).toMatch(/^CODEX_VERSION=/);
+    expect(head[3]).toMatch(/^SCHEMA_PATH=/);
+    expect(head[4]).toMatch(/^USAGE_PRESENT=/);
+  });
+
+  it("Task 3's adapter implements the documented branch", () => {
+    expect(existsSync(SPIKE_PATH)).toBe(true);
+    const head = readFileSync(SPIKE_PATH, "utf8").split("\n").slice(0, 5);
+    const branchLine = head[0] ?? "";
+    const branch = branchLine.replace(/^BRANCH=/, "");
+    const adapter = readFileSync(ADAPTER_PATH, "utf8");
+
+    if (branch === "A" || branch === "INCONCLUSIVE") {
+      // Branch A or INCONCLUSIVE: expect a top-level `usage` parse on
+      // the response body. Task 3 lifts this in PR-2.
+      expect(adapter).toMatch(/normalizeCodexUsage|response\.usage|response\["usage"\]|\.usage/);
+    }
+    if (branch === "B") {
+      // Branch B: expect the JSONL stream parse with `turn.completed`.
+      expect(adapter).toMatch(/turn\.completed|turn_completed/);
+    }
+    if (branch === "INCONCLUSIVE") {
+      // M2: when INCONCLUSIVE the adapter MUST emit a stderr warning
+      // when usage is missing post-Codex-run.
+      expect(adapter).toMatch(/Codex usage extraction unavailable/);
+    }
+  });
+});

--- a/test/agents/cli-agents-codex-usage.test.ts
+++ b/test/agents/cli-agents-codex-usage.test.ts
@@ -1,0 +1,149 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CodexCliAgent } from "../../src/agents/cli-agents.js";
+import type {
+  CommandInvocation,
+  CommandInvoker,
+  CommandResult,
+} from "../../src/agents/command-invoker.js";
+import type { AgentResult, WorkRequest } from "../../src/domain/agent.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * Codex `--output-schema` usage extraction. RED in PR-1: PR-2 (Task 3)
+ * adds the `usage` parse to `CodexCliAgent.invokeProvider`. The
+ * `STREAM_FLAG=NONE` warning case is gated on the spike's INCONCLUSIVE
+ * branch (see `01-SPIKE-A1.md`).
+ */
+class FakeOutputSchemaInvoker implements CommandInvoker {
+  readonly invocations: CommandInvocation[] = [];
+
+  constructor(private readonly responseBody: unknown) {}
+
+  async exec(invocation: CommandInvocation): Promise<CommandResult> {
+    this.invocations.push(invocation);
+    // Codex CLI writes its response JSON to the path passed via `-o
+    // <out>`. The adapter then reads that file. Find the `-o` arg and
+    // synthesize the file there.
+    const oIdx = invocation.args.indexOf("-o");
+    if (oIdx >= 0) {
+      const outputPath = invocation.args[oIdx + 1];
+      if (outputPath) {
+        await writeFile(outputPath, JSON.stringify(this.responseBody));
+      }
+    }
+    return {
+      stdout: JSON.stringify(this.responseBody),
+      stderr: "",
+      exitCode: 0,
+    };
+  }
+}
+
+function makeWorkRequest(): WorkRequest {
+  return {
+    runId: "run-codex-usage",
+    phaseId: "phase-1",
+    kind: "implement_phase",
+    specialty: "general",
+    title: "codex usage extraction",
+    objective: "extract usage from response.json",
+    acceptanceCriteria: [],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    context: [],
+    artifactContext: [],
+    attempt: 1,
+    maxAttempts: 3,
+    priorEvidence: [],
+  };
+}
+
+describe("CodexCliAgent — usage extraction (D-07 / Branch A)", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "relay-codex-usage-"));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, RM_OPTS);
+  });
+
+  it("populates AgentResult.tokenUsage from response.json top-level usage block", async () => {
+    const invoker = new FakeOutputSchemaInvoker({
+      summary: "ok",
+      evidence: [],
+      proposedCommands: [],
+      blockers: [],
+      usage: { input_tokens: 800, output_tokens: 120 },
+    });
+    const agent = new CodexCliAgent({
+      id: "codex-1",
+      name: "Codex",
+      provider: "codex",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd,
+      invoker: invoker as unknown as CommandInvoker,
+    });
+
+    const result = (await agent.run(makeWorkRequest())) as AgentResult;
+    expect(result.tokenUsage).toBeDefined();
+    expect(result.tokenUsage?.inputTokens).toBe(800);
+    expect(result.tokenUsage?.outputTokens).toBe(120);
+  });
+
+  it("does not throw when usage is missing (older Codex versions)", async () => {
+    const invoker = new FakeOutputSchemaInvoker({
+      summary: "ok",
+      evidence: [],
+      proposedCommands: [],
+      blockers: [],
+    });
+    const agent = new CodexCliAgent({
+      id: "codex-2",
+      name: "Codex",
+      provider: "codex",
+      capability: { role: "implementer", specialties: ["general"] },
+      cwd,
+      invoker: invoker as unknown as CommandInvoker,
+    });
+
+    const result = (await agent.run(makeWorkRequest())) as AgentResult;
+    expect(result.tokenUsage).toBeUndefined();
+  });
+
+  it("emits a [budget] stderr warning when usage is unavailable post-Codex-run (M2 INCONCLUSIVE branch)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const invoker = new FakeOutputSchemaInvoker({
+        summary: "ok",
+        evidence: [],
+        proposedCommands: [],
+        blockers: [],
+      });
+      const agent = new CodexCliAgent({
+        id: "codex-3",
+        name: "Codex",
+        provider: "codex",
+        capability: { role: "implementer", specialties: ["general"] },
+        cwd,
+        invoker: invoker as unknown as CommandInvoker,
+      });
+
+      await agent.run(makeWorkRequest());
+      const calls = warn.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((m) => /\[budget\].*Codex usage extraction unavailable/.test(m))).toBe(
+        true
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/test/budget/session-tracker-pool.test.ts
+++ b/test/budget/session-tracker-pool.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SessionTrackerPool } from "../../src/budget/session-tracker-pool.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * RED tests for `SessionTrackerPool`. The pool's implementation lands in
+ * PR-2 (Task 4); this file ships in PR-1 with `vi.fn`-based assertions so
+ * the contract is locked at PR-1 review time. All tests fail at runtime
+ * until PR-2 implements the body.
+ */
+describe("SessionTrackerPool", () => {
+  let root: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-pool-"));
+    process.env.HOME = root;
+  });
+
+  afterEach(async () => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(root, RM_OPTS);
+  });
+
+  it("returns the same TokenTracker instance for the same sessionId", () => {
+    const pool = new SessionTrackerPool();
+    const a = pool.get("sess-1", 1000);
+    const b = pool.get("sess-1", 1000);
+    expect(a).toBe(b);
+  });
+
+  it("returns distinct trackers for different sessionIds", () => {
+    const pool = new SessionTrackerPool();
+    const a = pool.get("sess-a", 1000);
+    const b = pool.get("sess-b", 1000);
+    expect(a).not.toBe(b);
+  });
+
+  it("closeAll() flushes all trackers and clears the map", async () => {
+    const pool = new SessionTrackerPool();
+    pool.get("sess-1", 1000);
+    pool.get("sess-2", 1000);
+    expect(pool.has("sess-1")).toBe(true);
+    expect(pool.has("sess-2")).toBe(true);
+    await pool.closeAll();
+    expect(pool.has("sess-1")).toBe(false);
+    expect(pool.has("sess-2")).toBe(false);
+  });
+
+  it("emits an M8 soft-warning when a brand-new sessionId surfaces a non-zero existing budget", async () => {
+    // Pre-write a budget.jsonl with non-zero cumulativeUsed under the
+    // tmp HOME — when get() is called for this "brand-new" session the
+    // pool should warn (Phase 2 handoff 0%-start contract violation).
+    const sessionsDir = join(root, ".relay", "sessions", "sess-replay");
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(
+      join(sessionsDir, "budget.jsonl"),
+      JSON.stringify({
+        ts: "2026-05-09T00:00:00Z",
+        inputTokens: 100,
+        outputTokens: 50,
+        cumulativeUsed: 150,
+      }) + "\n"
+    );
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const pool = new SessionTrackerPool();
+      pool.get("sess-replay", 1000);
+      const calls = warn.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((m) => /\[budget\].*replaying non-zero state/i.test(m))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/test/budget/threshold-feed-bridge.test.ts
+++ b/test/budget/threshold-feed-bridge.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { attachThresholdFeed } from "../../src/budget/threshold-feed-bridge.js";
+import { TokenTracker } from "../../src/budget/token-tracker.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+interface FeedEntry {
+  type: string;
+  metadata: Record<string, string>;
+  content: string;
+}
+
+async function readFeed(channelsDir: string, channelId: string): Promise<FeedEntry[]> {
+  const text = await readFile(join(channelsDir, channelId, "feed.jsonl"), "utf8");
+  return text
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as FeedEntry);
+}
+
+/**
+ * RED tests for the 75/90/95 threshold-feed bridge. PR-1 ships the
+ * stub-throwing `attachThresholdFeed` so this file fails at runtime; PR-2
+ * (Task 5) lands the implementation that makes them GREEN.
+ */
+describe("attachThresholdFeed", () => {
+  let root: string;
+  let channelsDir: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-bridge-"));
+    channelsDir = join(root, "channels");
+  });
+
+  afterEach(async () => {
+    await rm(root, RM_OPTS);
+  });
+
+  it("posts exactly one status_update entry when crossing 90%, with the documented metadata shape", async () => {
+    const store = new ChannelStore(channelsDir);
+    const tracker = new TokenTracker("sess-1", 1000, { rootDir: root });
+    attachThresholdFeed(tracker, "ch-1", store, { modelName: "claude-sonnet-4-5" });
+    tracker.record(900, 0); // crosses 75 + 85 + 90 thresholds at once
+    await tracker.flush();
+
+    const entries = await readFeed(channelsDir, "ch-1");
+    const events = entries.filter(
+      (e) => e.type === "status_update" && e.metadata.kind === "context_threshold"
+    );
+    const ninety = events.find((e) => e.metadata.threshold === "90");
+    expect(ninety, "expected a 90 threshold entry").toBeDefined();
+    expect(ninety?.metadata).toMatchObject({
+      kind: "context_threshold",
+      schemaVersion: "1",
+      threshold: "90",
+      sessionId: "sess-1",
+      model: "claude-sonnet-4-5",
+    });
+    // M7 — pin pct precision to two decimal places so future drift to
+    // toFixed(3) is caught.
+    expect(ninety?.metadata.pct).toMatch(/^\d+\.\d{2}$/);
+  });
+
+  it("does not post for thresholds outside [75, 90, 95]", async () => {
+    const store = new ChannelStore(channelsDir);
+    const tracker = new TokenTracker("sess-quiet", 1000, { rootDir: root });
+    attachThresholdFeed(tracker, "ch-quiet", store);
+    tracker.record(600, 0); // crosses 50 + 60 only — neither in [75, 90, 95]
+    await tracker.flush();
+
+    let entries: FeedEntry[];
+    try {
+      entries = await readFeed(channelsDir, "ch-quiet");
+    } catch {
+      entries = [];
+    }
+    const events = entries.filter((e) => e.metadata?.kind === "context_threshold");
+    expect(events).toHaveLength(0);
+  });
+
+  it("M5: two trackers with distinct sessionIds emit distinct feed entries", async () => {
+    const store = new ChannelStore(channelsDir);
+    const a = new TokenTracker("sess-a", 1000, { rootDir: root });
+    const b = new TokenTracker("sess-b", 1000, { rootDir: root });
+    attachThresholdFeed(a, "ch-multi", store);
+    attachThresholdFeed(b, "ch-multi", store);
+    a.record(900, 0);
+    b.record(900, 0);
+    await a.flush();
+    await b.flush();
+
+    const entries = await readFeed(channelsDir, "ch-multi");
+    const ninety = entries.filter(
+      (e) => e.metadata?.kind === "context_threshold" && e.metadata?.threshold === "90"
+    );
+    const sessionIds = new Set(ninety.map((e) => e.metadata.sessionId));
+    expect(sessionIds.size).toBe(2);
+    expect(sessionIds.has("sess-a")).toBe(true);
+    expect(sessionIds.has("sess-b")).toBe(true);
+  });
+});

--- a/test/budget/tracker-restart-replay.test.ts
+++ b/test/budget/tracker-restart-replay.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { THRESHOLDS, TokenTracker } from "../../src/budget/token-tracker.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * Survives-restart property — automated proof for the must-have truth
+ * "Telemetry survives a process restart" (Task 12 step 7 #1, M-fix).
+ *
+ * RED in PR-1 because Phase 1 widens THRESHOLDS to include `75` (D-01) —
+ * the assertion "firedThresholds includes [50, 60, 75]" can only hold once
+ * Task 2 widens the canonical list. Until PR-2 lands the wider THRESHOLDS,
+ * the resumed tracker reports `[50, 60]` and this test fails.
+ */
+describe("TokenTracker restart-replay (D-01 survives-restart property)", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-restart-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, RM_OPTS);
+  });
+
+  it("THRESHOLDS includes the 7-element [50, 60, 75, 85, 90, 95, 100] list (D-01)", () => {
+    // RED until PR-2 / Task 2 widens THRESHOLDS to include 75 + 90.
+    expect([...THRESHOLDS]).toEqual([50, 60, 75, 85, 90, 95, 100]);
+  });
+
+  it("resumes cumulative usage AND already-fired thresholds across a process restart", async () => {
+    const sessionId = "sess-restart";
+    const ceiling = 200_000;
+
+    // Phase 1: record up to 75% (150_000 / 200_000).
+    const t1 = new TokenTracker(sessionId, ceiling, { rootDir: root });
+    t1.record(150_000, 0);
+    await t1.flush();
+    await t1.close();
+
+    // Phase 2: new tracker over the same on-disk file. Should resume
+    // cumulative usage AND mark every crossed threshold (50, 60, 75) as
+    // already-fired so they do NOT re-emit.
+    const captured: number[] = [];
+    const t2 = new TokenTracker(sessionId, ceiling, { rootDir: root });
+    t2.onThreshold((evt) => captured.push(evt.threshold));
+    // Wait for the constructor's replay to drain.
+    await t2.flush();
+
+    expect(t2.used).toBe(150_000);
+
+    // Now record enough additional tokens to cross 85% (170_000 / 200_000).
+    // This triggers the threshold check loop. With the widened (D-01)
+    // threshold list, 75 is already fired from replay so it does NOT
+    // re-emit; only 85 should fire. With the pre-D-01 list (no 75),
+    // replay would not have marked 75 as fired (it's not in the list),
+    // and 85 would still fire — but the assertion below also checks
+    // that 75 is NOT among the fired thresholds, which only holds once
+    // the wider list is in place AND replay marks 75 from history.
+    t2.record(20_000, 0);
+    await t2.flush();
+
+    expect(captured).toContain(85);
+    // 75 must NOT re-fire — D-01 widens the list AND replay marks it.
+    expect(captured).not.toContain(75);
+    await t2.close();
+  });
+});

--- a/test/cli/chat-record-usage.test.ts
+++ b/test/cli/chat-record-usage.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleChatRecordUsageCommand } from "../../src/cli/chat-record-usage.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * RED tests for the `rly chat record-usage` CLI subcommand handler. The
+ * stub throws in PR-1; PR-4 (Task 10) lands the real implementation that
+ * mints/resumes a tracker, calls record(), and (when --channel is passed)
+ * wires the threshold-feed bridge.
+ */
+describe("handleChatRecordUsageCommand", () => {
+  let root: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-chat-record-"));
+    process.env.HOME = root;
+  });
+
+  afterEach(async () => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(root, RM_OPTS);
+  });
+
+  it("writes a budget.jsonl line with kind: 'chat' when --kind chat is passed", async () => {
+    await handleChatRecordUsageCommand({
+      session: "sess-chat-1",
+      input: 1500,
+      output: 250,
+      kind: "chat",
+    });
+
+    const path = join(root, ".relay", "sessions", "sess-chat-1", "budget.jsonl");
+    expect(existsSync(path)).toBe(true);
+    const text = await readFile(path, "utf8");
+    const lastLine = text.trim().split("\n").filter(Boolean).pop();
+    expect(lastLine).toBeDefined();
+    const parsed = JSON.parse(lastLine!);
+    expect(parsed.cumulativeUsed).toBe(1500 + 250);
+    expect(parsed.kind).toBe("chat");
+  });
+
+  it("does not throw when called without --channel (no bridge wiring)", async () => {
+    await expect(
+      handleChatRecordUsageCommand({
+        session: "sess-no-channel",
+        input: 10,
+        output: 5,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/cli/print-status-context.test.ts
+++ b/test/cli/print-status-context.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  formatActiveSessionsBlock,
+  loadActiveSessions,
+  type ActiveSessionRow,
+} from "../../src/cli/print-status-context.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * RED tests for the `rly status` Active Sessions block. PR-1 ships the
+ * stub-throwing formatters; PR-4 (Task 11) lands the implementations.
+ */
+describe("formatActiveSessionsBlock", () => {
+  it("renders one line per session with model + ctx pct + used/total", () => {
+    const rows: ActiveSessionRow[] = [
+      {
+        sessionId: "sess-abc",
+        channelId: "ch-1",
+        pct: 76,
+        used: 152_000,
+        total: 200_000,
+        model: "Sonnet 4.5",
+        kind: "chat",
+      },
+    ];
+    const out = formatActiveSessionsBlock(rows);
+    expect(out).toMatch(/sess-abc/);
+    expect(out).toMatch(/ch-1/);
+    expect(out).toMatch(/76%/);
+    expect(out).toMatch(/Sonnet 4\.5/);
+  });
+
+  it("returns an empty (or 'no active sessions') block on empty input", () => {
+    const out = formatActiveSessionsBlock([]);
+    expect(out).toBeDefined();
+  });
+});
+
+describe("loadActiveSessions", () => {
+  let root: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-status-"));
+    process.env.HOME = root;
+  });
+
+  afterEach(async () => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(root, RM_OPTS);
+  });
+
+  it("returns [] when ~/.relay/sessions/ does not exist (L3 isolation)", () => {
+    // No sessions dir under root/.relay/. Must return empty without throwing.
+    const result = loadActiveSessions();
+    expect(result).toEqual([]);
+  });
+
+  it("filters out kind=run and kind=admin budgets, surfaces only kind=chat (M3 + M4)", async () => {
+    const sessionsRoot = join(root, ".relay", "sessions");
+    await mkdir(join(sessionsRoot, "sess-chat"), { recursive: true });
+    await writeFile(
+      join(sessionsRoot, "sess-chat", "budget.jsonl"),
+      JSON.stringify({ cumulativeUsed: 100, kind: "chat" }) + "\n"
+    );
+    await mkdir(join(sessionsRoot, "run-x"), { recursive: true });
+    await writeFile(
+      join(sessionsRoot, "run-x", "budget.jsonl"),
+      JSON.stringify({ cumulativeUsed: 100, kind: "run" }) + "\n"
+    );
+    await mkdir(join(sessionsRoot, "admin-y"), { recursive: true });
+    await writeFile(
+      join(sessionsRoot, "admin-y", "budget.jsonl"),
+      JSON.stringify({ cumulativeUsed: 100, kind: "admin" }) + "\n"
+    );
+
+    const rows = loadActiveSessions();
+    expect(rows.map((r) => r.sessionId)).toEqual(["sess-chat"]);
+  });
+
+  it("isolates a malformed session file so other sessions still surface (L3)", async () => {
+    const sessionsRoot = join(root, ".relay", "sessions");
+    await mkdir(join(sessionsRoot, "sess-good"), { recursive: true });
+    await writeFile(
+      join(sessionsRoot, "sess-good", "budget.jsonl"),
+      JSON.stringify({ cumulativeUsed: 50, kind: "chat" }) + "\n"
+    );
+    await mkdir(join(sessionsRoot, "sess-bad"), { recursive: true });
+    await writeFile(join(sessionsRoot, "sess-bad", "budget.jsonl"), "{ malformed line\n");
+
+    const rows = loadActiveSessions();
+    expect(rows.find((r) => r.sessionId === "sess-good")).toBeDefined();
+  });
+});

--- a/test/domain/session-budget.test.ts
+++ b/test/domain/session-budget.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SESSION_BUDGET_SCHEMA_VERSION,
+  SessionBudgetSchema,
+  type SessionBudget,
+} from "../../src/domain/session-budget.js";
+
+/**
+ * Schema-shape RED tests for `SessionBudget`. These ride on the Task 2
+ * implementation that lands in the same PR-1 bundle (per H2 fix), so
+ * they go GREEN at PR-1 merge for the round-trip + back-compat cases.
+ *
+ * The intentionally-failing case (currently RED) is the cross-language
+ * round-trip with a non-camelCase JSON line — this test asserts that
+ * the schema rejects snake_case payloads, which it does, BUT a marker
+ * test below intentionally expects a behavior that lands in PR-2 (the
+ * `version: 2` clear error message) so the file has at least one
+ * runtime FAIL until PR-2 ships the migration helper.
+ */
+describe("SessionBudgetSchema", () => {
+  it("round-trips a fully-populated chat budget", () => {
+    const original: SessionBudget = {
+      schemaVersion: SESSION_BUDGET_SCHEMA_VERSION,
+      kind: "chat",
+      sessionId: "sess-1",
+      used: 42,
+      total: 200_000,
+      pct: 0.021,
+      lastUpdated: "2026-05-09T00:00:00Z",
+      modelName: "claude-sonnet-4-5",
+    };
+    const wire = JSON.stringify(original);
+    const parsed = SessionBudgetSchema.parse(JSON.parse(wire));
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.kind).toBe("chat");
+    expect(parsed.sessionId).toBe("sess-1");
+    expect(parsed.used).toBe(42);
+    expect(parsed.total).toBe(200_000);
+  });
+
+  it("defaults `kind` to `admin` when missing (back-compat for legacy budget files)", () => {
+    const parsed = SessionBudgetSchema.parse({
+      schemaVersion: 1,
+      sessionId: "sess-legacy",
+      used: 0,
+      total: 200_000,
+      pct: 0,
+    });
+    expect(parsed.kind).toBe("admin");
+  });
+
+  it("rejects schemaVersion === 0", () => {
+    expect(() =>
+      SessionBudgetSchema.parse({
+        schemaVersion: 0,
+        kind: "chat",
+        sessionId: "sess-x",
+        used: 0,
+        total: 1000,
+        pct: 0,
+      })
+    ).toThrow();
+  });
+
+  it("rejects missing schemaVersion entirely", () => {
+    expect(() =>
+      SessionBudgetSchema.parse({
+        kind: "chat",
+        sessionId: "sess-x",
+        used: 0,
+        total: 1000,
+        pct: 0,
+      })
+    ).toThrow();
+  });
+
+  // M1 — drift guard. PR-1 schema is `z.literal(1)`, so v2 fails parse.
+  // The intent of this test is to assert that the error message contains
+  // the word "schemaVersion" so future readers can grep for it. Currently
+  // zod throws a generic literal-mismatch — this test will go RED until
+  // PR-2's Task 5 work adds a custom .refine() with a clear message.
+  // M1 — drift guard. PR-1 schema is `z.literal(1)`, so v2 fails parse.
+  // The intent of this test is to assert that the error message clearly
+  // calls out a future migration path (e.g.
+  // "schemaVersion 2 not supported — bump migration helper"). Currently
+  // zod throws a generic literal-mismatch — this test will go RED until
+  // PR-2's Task 5 work adds a custom `.refine()` with a clear message
+  // pointing operators at the migration helper.
+  it("rejects schemaVersion === 2 with a clear migration-helper message", () => {
+    let err: unknown;
+    try {
+      SessionBudgetSchema.parse({
+        schemaVersion: 2,
+        kind: "chat",
+        sessionId: "sess-x",
+        used: 0,
+        total: 1000,
+        pct: 0,
+      });
+    } catch (e) {
+      err = e;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    // Future migration helper should surface a hint like "migration" /
+    // "supported" so operators understand what to do. zod's default
+    // literal-mismatch message does not contain these words — RED
+    // until PR-2 adds the custom refinement.
+    expect(message).toMatch(/migration|not supported|forward-migrat/i);
+  });
+});

--- a/test/integration/session-budget-end-to-end.test.ts
+++ b/test/integration/session-budget-end-to-end.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleChatRecordUsageCommand } from "../../src/cli/chat-record-usage.js";
+import { SessionBudgetSchema } from "../../src/domain/session-budget.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * M6 — full-chain integration smoke. Wires the chat-record-usage entry
+ * point through to the budget.jsonl on disk, then re-reads it via
+ * `SessionBudgetSchema` to confirm the round-trip holds end-to-end.
+ *
+ * RED in PR-1 (handleChatRecordUsageCommand stub throws). Goes GREEN
+ * once PR-4 (Task 10) lands the implementation. The Rust-side reader is
+ * covered by `crates/harness-data/src/lib.rs::tests::session_budget_*`
+ * (already GREEN from Task 6 in this PR).
+ */
+describe("Session-budget end-to-end (M6)", () => {
+  let root: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-e2e-budget-"));
+    process.env.HOME = root;
+  });
+
+  afterEach(async () => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(root, RM_OPTS);
+  });
+
+  it("chat record-usage → budget.jsonl → re-read with SessionBudgetSchema yields the expected pct", async () => {
+    await handleChatRecordUsageCommand({
+      session: "sess-e2e",
+      input: 100_000,
+      output: 50_000,
+      kind: "chat",
+      model: "claude-sonnet-4-5",
+    });
+
+    const path = join(root, ".relay", "sessions", "sess-e2e", "budget.jsonl");
+    expect(existsSync(path)).toBe(true);
+
+    const text = await readFile(path, "utf8");
+    const lastLine = text.trim().split("\n").filter(Boolean).pop();
+    expect(lastLine).toBeDefined();
+    const parsed = JSON.parse(lastLine!);
+
+    expect(parsed.cumulativeUsed).toBe(150_000);
+    expect(parsed.kind).toBe("chat");
+
+    // Build a SessionBudget snapshot from the last line and validate the
+    // schema. This is the exact shape the Rust reader (Task 6) produces
+    // on its side, so this assert pins the cross-language contract.
+    const snapshot = SessionBudgetSchema.parse({
+      schemaVersion: 1,
+      kind: parsed.kind,
+      sessionId: "sess-e2e",
+      used: parsed.cumulativeUsed,
+      total: 200_000,
+      pct: (parsed.cumulativeUsed / 200_000) * 100,
+      lastUpdated: parsed.ts,
+      modelName: "claude-sonnet-4-5",
+    });
+    expect(snapshot.pct).toBeCloseTo(75, 5);
+  });
+});

--- a/test/orchestrator/orchestrator-v2-token-usage.test.ts
+++ b/test/orchestrator/orchestrator-v2-token-usage.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SessionTrackerPool } from "../../src/budget/session-tracker-pool.js";
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
+
+/**
+ * RED tests for the orchestrator → tracker pool wiring. PR-1 ships
+ * stubs; PR-2 (Task 4) lands the real `OrchestratorV2.dispatch` block
+ * that calls `trackerPool.get(...).record(...)` and writes a
+ * `kind: "run"` budget line to `~/.relay/sessions/run-<runId>/budget.jsonl`.
+ */
+describe("OrchestratorV2 dispatch — token-usage wiring", () => {
+  let root: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "relay-orch-budget-"));
+    process.env.HOME = root;
+  });
+
+  afterEach(async () => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(root, RM_OPTS);
+  });
+
+  it("a successful dispatch with tokenUsage records into the pool and writes kind: 'run'", async () => {
+    // Drive the public contract through the pool directly — this is the
+    // same hot path the orchestrator's dispatch will exercise in PR-2.
+    // RED in PR-1 because SessionTrackerPool.get throws.
+    const pool = new SessionTrackerPool();
+    const tracker = pool.get("run-test-1", 200_000, "run");
+    tracker.record(1500, 250);
+    await tracker.flush();
+
+    expect(tracker.used).toBeGreaterThan(0);
+    const path = join(root, ".relay", "sessions", "run-test-1", "budget.jsonl");
+    expect(existsSync(path)).toBe(true);
+    const text = await readFile(path, "utf8");
+    const lastLine = text.trim().split("\n").filter(Boolean).pop();
+    expect(lastLine).toBeDefined();
+    const parsed = JSON.parse(lastLine!);
+    expect(parsed.cumulativeUsed).toBeGreaterThan(0);
+    expect(parsed.kind).toBe("run");
+  });
+
+  it("dispatch with an Agent missing capability.model throws a clear error (hidden-assumption fix)", async () => {
+    // This test asserts the contract: the orchestrator's dispatch wiring
+    // (Task 4) hard-throws when the agent has no model so a session
+    // never gets miscalibrated against the default 200_000 ceiling.
+    //
+    // Phase 1 PR-1: the orchestrator wiring isn't in place yet. The
+    // assertion below uses a stub helper that the test re-imports from
+    // PR-2's Task 4 work; until then, the test is RED.
+    // PR-2's Task 4 lands a `dispatch-token-usage.js` helper that the
+    // orchestrator imports for the missing-model hard-throw. PR-1 has
+    // not added it yet, so this dynamic import must fail. The grep
+    // pattern is the contract.
+    let mod: unknown = null;
+    try {
+      mod = await import(
+        // @ts-expect-error PR-2 lands this module; PR-1 stub holds the
+        // RED contract that the import does not yet resolve.
+        "../../src/orchestrator/dispatch-token-usage.js"
+      );
+    } catch {
+      mod = null;
+    }
+    expect(mod).not.toBeNull();
+    expect(
+      (mod as { dispatchTokenUsageOrThrow?: unknown } | null)?.dispatchTokenUsageOrThrow
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

PR-1 of Relay's per-session token-usage telemetry phase. Lands the
canonical `SessionBudget` schema (TS + Rust), the model context-window
table, the A1 Codex spike (INCONCLUSIVE), and 11 RED test scaffolds
that lock the contract for PR-2 → PR-5.

Plan: `.planning/phases/01-token-usage-telemetry-context-bar/01-PLAN.md`.
Per the wave structure: PR-1 = Tasks 0 + 1 + 2 + 6.

- **Task 1 (commit 1):** `01-SPIKE-A1.md` — INCONCLUSIVE because `codex`
  CLI was unavailable in the executor sandbox. Header is machine-
  readable so PR-2 can grep the branch deterministically.
- **Task 2 + 6 (commit 2):** `SessionBudget` zod schema + Rust mirror
  with `#[serde(rename_all = "camelCase")]`, `SessionKind` discriminator,
  `schemaVersion: 1`, model context-window table + GUI mirror,
  `TokenUsage` type on `AgentResult`. Closes the H1 schema-drift
  class for PR review.
- **Task 0 (commit 3):** 11 RED test files + 6 stub modules. Each test
  file has at least one runtime FAIL (per L4 per-file grep). Stubs
  throw at runtime so RED is loud; signatures are final so PR-2 → PR-5
  fill in bodies without re-shaping APIs.

## Base branch

This PR targets `chore/gsd-planning-init` (PR #216) so it has access
to `.planning/`. GitHub will auto-retarget to `main` when #216 merges.

## CI gates

| Gate | Result |
|------|--------|
| `pnpm install` | pass |
| `pnpm typecheck` | pass |
| `pnpm format:check` | pass |
| `pnpm test` | RED for 25 wave-0 tests across 11 files (expected); 996 existing tests still pass; 24 skipped |
| `cargo check --workspace --locked` | pass |
| `cargo test -p harness-data session_budget` | 8 tests pass (M1 v2 drift guard, fixture round-trip, kind back-compat default, load-from-jsonl, missing-dir + torn-line + list_chat_session_budgets_filters_admin) |

## Deviations from plan

- **LOC budget overage.** Plan estimated PR-1 at ~750 LOC. Actual
  diff is **+1728 LOC across 26 files** — ~2.3× the estimate. Driven
  almost entirely by Task 0's 11 test files (~1100 LOC of test code).
  The plan's revision iteration 2 added M1/M5/M6/M7/M8/M9 + an
  integration test + a restart-replay test + a spike test + GUI tests
  on top of the original Task 0 scope without re-walking the LOC
  estimate. Reducing further would require dropping required test
  coverage. Reviewer should decide whether to accept this PR as-is or
  split into PR-1a (schema + spike) + PR-1b (test scaffolds). I
  stopped before opening to flag, per the user's stop-condition;
  pushing for visibility, NOT requesting merge until reviewed.
- **A1 spike INCONCLUSIVE.** `codex` CLI not on PATH in the executor
  sandbox; documented per M2 mitigation, no blocker for downstream
  work.

## Test plan

- [ ] Re-run `pnpm install && pnpm typecheck && pnpm format:check`
- [ ] Re-run `pnpm test` and confirm exactly 25 RED failures spread
      across the 11 wave-0 test files (`test/budget/*.test.ts`,
      `test/agents/cli-agents-{claude,codex}-usage*.test.ts`,
      `test/orchestrator/orchestrator-v2-token-usage.test.ts`,
      `test/cli/{print-status-context,chat-record-usage}.test.ts`,
      `test/domain/session-budget.test.ts`,
      `test/integration/session-budget-end-to-end.test.ts`)
- [ ] Re-run `cd gui && pnpm test ContextWindowBar modelContextWindows`
      and confirm 4 RED failures (3 in `ContextWindowBar.test.tsx`,
      1 in `modelContextWindows.test.ts`)
- [ ] Re-run `cargo check --workspace --locked` and
      `cargo test -p harness-data session_budget` (8 tests pass)
- [ ] Confirm `01-SPIKE-A1.md`'s first 5 lines exactly match the
      `BRANCH=...`, `STREAM_FLAG=...`, `CODEX_VERSION=...`,
      `SCHEMA_PATH=...`, `USAGE_PRESENT=...` machine-readable header
- [ ] Decide whether to accept the LOC overage or split into 1a / 1b