### PR TITLE
feat(handoff): channel_handoff_finalize MCP tool + gap-fill persistence (Phase 2 PR-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Exposed to Claude and Codex via the Relay MCP server:
 
 **Harness (9)**: `harness_status`, `harness_list_runs`, `harness_get_run_detail`, `harness_get_artifact`, `harness_approve_plan`, `harness_reject_plan`, `harness_dispatch`, `project_create`, `pr_review_start`
 
-**Channels (6)**: `channel_create`, `channel_get`, `channel_post`, `channel_record_decision`, `channel_task_board`, `harness_running_tasks`
+**Channels (7)**: `channel_create`, `channel_get`, `channel_post`, `channel_record_decision`, `channel_task_board`, `channel_handoff_finalize`, `harness_running_tasks`
 
 **Crosslink (3)**: `crosslink_discover`, `crosslink_send`, `crosslink_poll`
 

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -1,8 +1,14 @@
+import { z } from "zod";
+
 import { getAgentName } from "../domain/agent-names.js";
 import { ChannelStore } from "../channels/channel-store.js";
 import { resolveBoardTickets } from "../channels/board-resolver.js";
 import { LocalArtifactStore } from "../execution/artifact-store.js";
 import { getGlobalRoot, listRegisteredWorkspaces } from "../cli/workspace-registry.js";
+import { HANDOFF_BRIEF_SCHEMA_VERSION } from "../domain/handoff.js";
+import { buildBriefId } from "../orchestrator/handoff/synthesizer.js";
+import { writeGapFill } from "../orchestrator/handoff/persistence.js";
+import { assertSafeSegment } from "../storage/file-store.js";
 import { getHarnessStore } from "../storage/factory.js";
 
 export interface ChannelToolState {
@@ -109,8 +115,68 @@ export function getChannelToolDefinitions(): object[] {
         properties: {},
       },
     },
+    {
+      name: "channel_handoff_finalize",
+      description:
+        "Capture working-memory context before this session ends. Call this when context is " +
+        "near its limit OR when the user has accepted a handoff prompt. The four blocks are " +
+        "persisted as the agent-authored section of the next handoff brief.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "channelId",
+          "currentLineOfAttack",
+          "activeHypothesis",
+          "abandonedApproaches",
+          "openQuestions",
+        ],
+        properties: {
+          channelId: { type: "string" },
+          currentLineOfAttack: { type: "string", maxLength: 4000 },
+          activeHypothesis: { type: "string", maxLength: 2000 },
+          abandonedApproaches: {
+            type: "array",
+            items: { type: "string", maxLength: 1000 },
+          },
+          openQuestions: {
+            type: "array",
+            items: { type: "string", maxLength: 500 },
+          },
+          sessionId: { type: "string" },
+          // Optional schemaVersion is locked to 1 (D-05/M9). Future bumps
+          // require coordinated upgrade across writer + reader.
+          schemaVersion: { type: "integer", const: 1 },
+        },
+      },
+    },
   ];
 }
+
+/**
+ * Zod schema for `channel_handoff_finalize` arguments.
+ *
+ * Mirrors the JSON Schema in {@link getChannelToolDefinitions} but with
+ * runtime enforcement that the JSON Schema layer alone cannot give us
+ * (length caps, optional `schemaVersion` locked to literal 1 per M9).
+ *
+ * Threats addressed:
+ *   - T-02-04 (secret leak via length-bombed slot): `maxLength` caps.
+ *   - T-02-13 (silent schemaVersion drift): `z.literal(1).optional()` —
+ *     any other value is rejected with a clear error message.
+ *   - T-02-08 (oversized brief DoS): caps mirror D-04's working-memory
+ *     budget; the brief synthesizer's hard cap (8K) catches anything
+ *     that slips through.
+ */
+const handoffFinalizeArgsSchema = z.object({
+  channelId: z.string().min(1),
+  currentLineOfAttack: z.string().max(4000),
+  activeHypothesis: z.string().max(2000),
+  abandonedApproaches: z.array(z.string().max(1000)),
+  openQuestions: z.array(z.string().max(500)),
+  sessionId: z.string().optional(),
+  schemaVersion: z.literal(HANDOFF_BRIEF_SCHEMA_VERSION).optional(),
+});
 
 export async function callChannelTool(
   name: string,
@@ -202,6 +268,50 @@ export async function callChannelTool(
       }
 
       return { channelId, board };
+    }
+
+    case "channel_handoff_finalize": {
+      const parsed = handoffFinalizeArgsSchema.safeParse(args);
+      if (!parsed.success) {
+        // Surface the field-level issue (esp. for `schemaVersion !== 1`)
+        // so the agent gets actionable feedback rather than a generic
+        // "invalid input".
+        const issue = parsed.error.issues[0];
+        const field = issue.path.join(".") || "<root>";
+        throw new Error(`channel_handoff_finalize: invalid input at ${field}: ${issue.message}`);
+      }
+      const input = parsed.data;
+      // Defense in depth — `assertSafeSegment` guards path traversal even
+      // though `writeGapFill` runs the same check. T-02-02 / T-02-08.
+      assertSafeSegment(input.channelId, "channelId");
+
+      const capturedAt = new Date();
+      const briefId = buildBriefId(input.channelId, capturedAt);
+      const sessionId = input.sessionId ?? state.sessionId ?? null;
+
+      const { gapJsonPath } = await writeGapFill({
+        channelId: input.channelId,
+        briefId,
+        payload: {
+          schemaVersion: HANDOFF_BRIEF_SCHEMA_VERSION,
+          briefId,
+          channelId: input.channelId,
+          capturedAt: capturedAt.toISOString(),
+          capturedBySessionId: sessionId,
+          currentLineOfAttack: input.currentLineOfAttack,
+          activeHypothesis: input.activeHypothesis,
+          abandonedApproaches: input.abandonedApproaches,
+          openQuestions: input.openQuestions,
+        },
+      });
+
+      return {
+        ok: true,
+        briefId,
+        gapJsonPath,
+        schemaVersion: HANDOFF_BRIEF_SCHEMA_VERSION,
+        capturedAt: capturedAt.toISOString(),
+      };
     }
 
     case "harness_running_tasks": {

--- a/src/orchestrator/handoff/persistence.ts
+++ b/src/orchestrator/handoff/persistence.ts
@@ -1,0 +1,233 @@
+/**
+ * Handoff brief persistence layer (Phase 2 PR-2 / Wave 2).
+ *
+ * Owns disk I/O for `~/.relay/channels/<channelId>/handoffs/<briefId>.{md,gap.json}`
+ * — the first versioned `~/.relay/` artifact (D-05). All writes are atomic
+ * (tmp-file + `rename`), mirroring `ChannelStore.writeChannel` /
+ * `writeTrackedPrs`. All reads fail closed on `schemaVersion !== 1` (M9).
+ *
+ * Path-traversal is guarded twice: `assertSafeSegment` runs on `channelId`
+ * AND on `briefId`, and `assertValidBriefId` enforces the
+ * `brief-<unix-ms>-<base36>` shape on top of that (T-02-01, T-02-10).
+ */
+
+import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getRelayDir } from "../../cli/paths.js";
+import { assertSafeSegment } from "../../storage/file-store.js";
+import { HANDOFF_BRIEF_SCHEMA_VERSION, type GapFillBlock } from "../../domain/handoff.js";
+import { buildBriefId } from "./synthesizer.js";
+
+/** Shared regex — id format is part of the on-disk contract (D-05 / T-02-10). */
+const BRIEF_ID_REGEX = /^brief-[0-9]+-[a-z0-9]+$/;
+
+/** Default staleness window for `readLatestGapFill` — RESEARCH Pitfall 3. */
+const DEFAULT_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Per-process counter that, combined with `pid` + `Date.now()`, makes the
+ * tmp-file name unique even when two writes land in the same millisecond
+ * (mirrors `channel-store.ts`'s `channelTicketsTmpCounter`).
+ */
+let tmpCounter = 0;
+
+/**
+ * Validate a `briefId` matches the canonical
+ * `brief-<unix-ms>-<6-char-base36>` shape. Throws on mismatch.
+ *
+ * The synthesizer mints ids via {@link buildBriefId}; the MCP tool reuses
+ * the same helper. The regex check is defense-in-depth for any code path
+ * that accepts an id from the outside world (e.g. `--resume <briefId>`).
+ */
+export function assertValidBriefId(briefId: string): void {
+  if (!BRIEF_ID_REGEX.test(briefId)) {
+    throw new Error(`Invalid briefId: ${briefId}. Expected shape: brief-<unix-ms>-<base36>.`);
+  }
+}
+
+/** Resolve `~/.relay/channels/<channelId>/handoffs/`, creating it on demand. */
+async function getHandoffsDir(channelId: string): Promise<string> {
+  assertSafeSegment(channelId, "channelId");
+  const dir = join(getRelayDir(), "channels", channelId, "handoffs");
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/** Atomic write helper: tmp file + rename. */
+async function atomicWrite(finalPath: string, content: string): Promise<void> {
+  const tmpPath = `${finalPath}.tmp.${process.pid}.${Date.now()}.${tmpCounter++}`;
+  await writeFile(tmpPath, content, "utf8");
+  await rename(tmpPath, finalPath);
+}
+
+export interface WriteBriefArtifactInput {
+  channelId: string;
+  briefId: string;
+  markdown: string;
+  gapFill: GapFillBlock;
+}
+
+export interface WriteBriefArtifactResult {
+  mdPath: string;
+  gapJsonPath: string;
+}
+
+/**
+ * Write both the rendered brief markdown AND the gap-fill JSON for a
+ * single handoff. Used by the CLI (Wave 4) when a brief has been built and
+ * needs to be persisted alongside its (possibly placeholder) gap-fill.
+ *
+ * Both files are written via tmp-rename so a reader never observes a
+ * partial file.
+ */
+export async function writeBriefArtifact(
+  input: WriteBriefArtifactInput
+): Promise<WriteBriefArtifactResult> {
+  assertSafeSegment(input.channelId, "channelId");
+  assertValidBriefId(input.briefId);
+  if (input.gapFill.schemaVersion !== HANDOFF_BRIEF_SCHEMA_VERSION) {
+    throw new Error(
+      `writeBriefArtifact rejected gapFill with schemaVersion ${input.gapFill.schemaVersion}; ` +
+        `only ${HANDOFF_BRIEF_SCHEMA_VERSION} is supported.`
+    );
+  }
+
+  const dir = await getHandoffsDir(input.channelId);
+  const mdPath = join(dir, `${input.briefId}.md`);
+  const gapJsonPath = join(dir, `${input.briefId}.gap.json`);
+
+  await atomicWrite(mdPath, input.markdown);
+  await atomicWrite(gapJsonPath, JSON.stringify(input.gapFill, null, 2));
+
+  return { mdPath, gapJsonPath };
+}
+
+export interface WriteGapFillInput {
+  channelId: string;
+  briefId: string;
+  payload: GapFillBlock;
+}
+
+export interface WriteGapFillResult {
+  gapJsonPath: string;
+}
+
+/**
+ * Write only the gap-fill JSON. The MCP tool's path: the brief markdown
+ * is generated later by `buildBrief` when `rly handoff` runs.
+ *
+ * Two consecutive calls for the same channel produce two distinct
+ * `<briefId>.gap.json` files — never overwrite. The synthesizer reads the
+ * newest non-stale one via {@link readLatestGapFill}.
+ */
+export async function writeGapFill(input: WriteGapFillInput): Promise<WriteGapFillResult> {
+  assertSafeSegment(input.channelId, "channelId");
+  assertValidBriefId(input.briefId);
+  if (input.payload.schemaVersion !== HANDOFF_BRIEF_SCHEMA_VERSION) {
+    throw new Error(
+      `writeGapFill rejected payload with schemaVersion ${input.payload.schemaVersion}; ` +
+        `only ${HANDOFF_BRIEF_SCHEMA_VERSION} is supported.`
+    );
+  }
+
+  const dir = await getHandoffsDir(input.channelId);
+  const gapJsonPath = join(dir, `${input.briefId}.gap.json`);
+  await atomicWrite(gapJsonPath, JSON.stringify(input.payload, null, 2));
+
+  return { gapJsonPath };
+}
+
+export interface ReadLatestGapFillOptions {
+  /** Defaults to 1 hour (RESEARCH Pitfall 3). */
+  maxAgeMs?: number;
+  /** Pure-over-declared-inputs — pass the clock in. */
+  now: Date;
+}
+
+/**
+ * List `~/.relay/channels/<id>/handoffs/*.gap.json`, parse each, drop any
+ * record with `schemaVersion !== 1` (M9 — fail closed; future bumps
+ * require coordinated upgrade), pick the newest by `capturedAt`, and
+ * return `null` if it's older than `maxAgeMs`.
+ *
+ * Robustness: returns `null` (not throws) when the directory doesn't
+ * exist, when no files match the pattern, or when a single file has a
+ * JSON parse error (the bad file is skipped, not propagated).
+ */
+export async function readLatestGapFill(
+  channelId: string,
+  opts: ReadLatestGapFillOptions
+): Promise<GapFillBlock | null> {
+  assertSafeSegment(channelId, "channelId");
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const dir = join(getRelayDir(), "channels", channelId, "handoffs");
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+
+  const gapPattern = /^brief-[0-9]+-[a-z0-9]+\.gap\.json$/;
+  const candidates = entries.filter((name) => gapPattern.test(name));
+  if (candidates.length === 0) return null;
+
+  let newest: GapFillBlock | null = null;
+  let newestMs = -Infinity;
+
+  for (const name of candidates) {
+    const filePath = join(dir, name);
+    let parsed: unknown;
+    try {
+      const content = await readFile(filePath, "utf8");
+      parsed = JSON.parse(content);
+    } catch {
+      // Skip unreadable / unparsable files — don't kill the whole read.
+      continue;
+    }
+
+    if (!isGapFillBlock(parsed)) continue;
+    // M9 — fail closed on schemaVersion drift. Future bumps require a
+    // coordinated upgrade across writer + reader; until then, anything
+    // that isn't `1` is treated as if absent.
+    if (parsed.schemaVersion !== HANDOFF_BRIEF_SCHEMA_VERSION) continue;
+
+    const ms = Date.parse(parsed.capturedAt);
+    if (Number.isNaN(ms)) continue;
+    if (ms > newestMs) {
+      newestMs = ms;
+      newest = parsed;
+    }
+  }
+
+  if (!newest) return null;
+
+  const ageMs = opts.now.getTime() - newestMs;
+  if (ageMs > maxAgeMs) return null;
+
+  return newest;
+}
+
+/** Structural type guard for `GapFillBlock`. Tolerant of unknown JSON. */
+function isGapFillBlock(value: unknown): value is GapFillBlock {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.schemaVersion === "number" &&
+    typeof v.briefId === "string" &&
+    typeof v.channelId === "string" &&
+    typeof v.capturedAt === "string" &&
+    (v.capturedBySessionId === null || typeof v.capturedBySessionId === "string") &&
+    typeof v.currentLineOfAttack === "string" &&
+    typeof v.activeHypothesis === "string" &&
+    Array.isArray(v.abandonedApproaches) &&
+    Array.isArray(v.openQuestions)
+  );
+}
+
+/** Re-exported for callers that mint ids alongside writes (e.g. the MCP tool). */
+export { buildBriefId };

--- a/src/orchestrator/handoff/synthesizer.ts
+++ b/src/orchestrator/handoff/synthesizer.ts
@@ -31,6 +31,7 @@ import {
   validateTicketDag,
 } from "../../domain/ticket.js";
 import { getFilesTouchedByTicket } from "./files-touched.js";
+import { readLatestGapFill } from "./persistence.js";
 import { estimateTokens } from "./token-estimate.js";
 import {
   BRIEF_TOKEN_BUDGETS,
@@ -65,6 +66,17 @@ export async function buildBrief(options: BuildBriefOptions): Promise<HandoffBri
 
   const briefId = buildBriefId(channelId, now);
 
+  // Resolve the gap-fill: if the caller passed one explicitly we honor it
+  // (including `null`, which opts out of disk lookup); otherwise auto-load
+  // the newest non-stale `<briefId>.gap.json` from
+  // `~/.relay/channels/<id>/handoffs/`. PR-2 wires this so a gap written
+  // via `channel_handoff_finalize` flows into the next brief without the
+  // caller threading it through. Stale records (>1h) and any record with
+  // `schemaVersion !== 1` are filtered by `readLatestGapFill` itself
+  // (M9 fail-closed).
+  const gapFill =
+    options.gapFill !== undefined ? options.gapFill : await readLatestGapFill(channelId, { now });
+
   // Build each section. Truncation is per-section, newest-first
   // preservation, with `truncated = true` set when oldest items are
   // dropped to fit the budget.
@@ -80,7 +92,7 @@ export async function buildBrief(options: BuildBriefOptions): Promise<HandoffBri
     budget.filesTouched,
     gitLogEnabled
   );
-  const workingMemory = renderWorkingMemory(options.gapFill ?? null, now, budget.workingMemory);
+  const workingMemory = renderWorkingMemory(gapFill ?? null, now, budget.workingMemory);
 
   const tokenEstimate =
     statusSnapshot.estimatedTokens +

--- a/test/mcp/channel-handoff-finalize.test.ts
+++ b/test/mcp/channel-handoff-finalize.test.ts
@@ -1,0 +1,251 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ChannelStore } from "../../src/channels/channel-store.js";
+import { __resetRelayDirCacheForTests } from "../../src/cli/paths.js";
+import { callChannelTool, getChannelToolDefinitions } from "../../src/mcp/channel-tools.js";
+
+/**
+ * Wave 2 (PR-2) — `channel_handoff_finalize` MCP tool.
+ *
+ * The tool persists a versioned `<briefId>.gap.json` under
+ * `~/.relay/channels/<id>/handoffs/`. The four working-memory slots are
+ * Zod-validated for length caps and any `schemaVersion !== 1` payload is
+ * rejected at runtime (M9 — fail closed; future bumps require coordinated
+ * upgrade across writer + reader).
+ *
+ * Channel store is a stand-in stub: this tool doesn't touch the channel
+ * feed (the brief-rendering CLI does that in a later wave), so the bare
+ * minimum surface is enough.
+ */
+
+function fakeChannelStore(): ChannelStore {
+  return {} as unknown as ChannelStore;
+}
+
+const CHANNEL_ID = "ch-fixmin-0001";
+
+describe("channel_handoff_finalize MCP tool", () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "relay-handoff-mcp-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = home;
+    __resetRelayDirCacheForTests();
+  });
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    __resetRelayDirCacheForTests();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("is registered in the tool catalogue", () => {
+    const defs = getChannelToolDefinitions();
+    const def = defs.find(
+      (d): d is { name: string } => (d as { name?: string }).name === "channel_handoff_finalize"
+    );
+    expect(def).toBeDefined();
+  });
+
+  it("happy path — writes gap.json with schemaVersion 1 + ISO capturedAt", async () => {
+    const result = (await callChannelTool(
+      "channel_handoff_finalize",
+      {
+        channelId: CHANNEL_ID,
+        currentLineOfAttack: "Investigating T-3 timeout",
+        activeHypothesis: "API token has insufficient scope",
+        abandonedApproaches: ["Tried bumping the timeout — no change."],
+        openQuestions: ["Is the test fixture token configured?"],
+        sessionId: "sess-x",
+      },
+      { sessionId: null, channelStore: fakeChannelStore() }
+    )) as {
+      ok: boolean;
+      briefId: string;
+      gapJsonPath: string;
+      schemaVersion: number;
+      capturedAt: string;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.briefId).toMatch(/^brief-[0-9]+-[a-z0-9]+$/);
+    expect(result.schemaVersion).toBe(1);
+    expect(result.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const onDisk = JSON.parse(await readFile(result.gapJsonPath, "utf8"));
+    expect(onDisk.schemaVersion).toBe(1);
+    expect(onDisk.briefId).toBe(result.briefId);
+    expect(onDisk.channelId).toBe(CHANNEL_ID);
+    expect(onDisk.currentLineOfAttack).toBe("Investigating T-3 timeout");
+    expect(onDisk.capturedBySessionId).toBe("sess-x");
+  });
+
+  it("falls back to state.sessionId when args.sessionId is omitted", async () => {
+    const result = (await callChannelTool(
+      "channel_handoff_finalize",
+      {
+        channelId: CHANNEL_ID,
+        currentLineOfAttack: "x",
+        activeHypothesis: "y",
+        abandonedApproaches: [],
+        openQuestions: [],
+      },
+      { sessionId: "sess-fallback", channelStore: fakeChannelStore() }
+    )) as { gapJsonPath: string };
+
+    const onDisk = JSON.parse(await readFile(result.gapJsonPath, "utf8"));
+    expect(onDisk.capturedBySessionId).toBe("sess-fallback");
+  });
+
+  it("rejects missing required fields", async () => {
+    await expect(
+      callChannelTool(
+        "channel_handoff_finalize",
+        { channelId: CHANNEL_ID },
+        { sessionId: null, channelStore: fakeChannelStore() }
+      )
+    ).rejects.toThrow(/invalid input/i);
+  });
+
+  it("rejects oversized currentLineOfAttack (> 4000 chars)", async () => {
+    const huge = "x".repeat(4001);
+    await expect(
+      callChannelTool(
+        "channel_handoff_finalize",
+        {
+          channelId: CHANNEL_ID,
+          currentLineOfAttack: huge,
+          activeHypothesis: "",
+          abandonedApproaches: [],
+          openQuestions: [],
+        },
+        { sessionId: null, channelStore: fakeChannelStore() }
+      )
+    ).rejects.toThrow(/currentLineOfAttack/);
+  });
+
+  it("rejects schemaVersion !== 1 with a field-named error (M9)", async () => {
+    await expect(
+      callChannelTool(
+        "channel_handoff_finalize",
+        {
+          channelId: CHANNEL_ID,
+          currentLineOfAttack: "x",
+          activeHypothesis: "y",
+          abandonedApproaches: [],
+          openQuestions: [],
+          schemaVersion: 2, // intentional future-bump probe
+        },
+        { sessionId: null, channelStore: fakeChannelStore() }
+      )
+    ).rejects.toThrow(/schemaVersion/);
+  });
+
+  it("rejects path-traversal channelIds", async () => {
+    await expect(
+      callChannelTool(
+        "channel_handoff_finalize",
+        {
+          channelId: "../../etc",
+          currentLineOfAttack: "x",
+          activeHypothesis: "y",
+          abandonedApproaches: [],
+          openQuestions: [],
+        },
+        { sessionId: null, channelStore: fakeChannelStore() }
+      )
+    ).rejects.toThrow(/Unsafe path segment/);
+  });
+
+  it("two consecutive calls write two distinct gap.json files", async () => {
+    const a = (await callChannelTool(
+      "channel_handoff_finalize",
+      {
+        channelId: CHANNEL_ID,
+        currentLineOfAttack: "first",
+        activeHypothesis: "",
+        abandonedApproaches: [],
+        openQuestions: [],
+      },
+      { sessionId: null, channelStore: fakeChannelStore() }
+    )) as { briefId: string; gapJsonPath: string };
+
+    // Without a delay, `buildBriefId` is deterministic over (channelId,
+    // now), so back-to-back calls in the same millisecond produce the
+    // same id. That's a real-world risk — the persistence layer would
+    // overwrite. Sleep 5ms to ensure distinct unix-ms suffixes.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const b = (await callChannelTool(
+      "channel_handoff_finalize",
+      {
+        channelId: CHANNEL_ID,
+        currentLineOfAttack: "second",
+        activeHypothesis: "",
+        abandonedApproaches: [],
+        openQuestions: [],
+      },
+      { sessionId: null, channelStore: fakeChannelStore() }
+    )) as { briefId: string; gapJsonPath: string };
+
+    expect(a.briefId).not.toBe(b.briefId);
+    expect(a.gapJsonPath).not.toBe(b.gapJsonPath);
+
+    const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+    const entries = (await readdir(dir)).filter((n) => n.endsWith(".gap.json"));
+    expect(entries).toHaveLength(2);
+  });
+
+  it("end-to-end: gap written via tool flows into buildBrief without placeholder", async () => {
+    // Wave 2 wires `synthesizer.buildBrief` to auto-load the newest
+    // non-stale `*.gap.json` from disk when the caller doesn't pass
+    // `gapFill` explicitly. This test exercises that loop end-to-end.
+    const writeResult = (await callChannelTool(
+      "channel_handoff_finalize",
+      {
+        channelId: CHANNEL_ID,
+        currentLineOfAttack: "wired-end-to-end",
+        activeHypothesis: "the synthesizer reads the latest gap on disk",
+        abandonedApproaches: [],
+        openQuestions: [],
+      },
+      { sessionId: null, channelStore: fakeChannelStore() }
+    )) as { ok: boolean };
+    expect(writeResult.ok).toBe(true);
+
+    // Build a fixture-channel brief through the synthesizer using the
+    // same `~/.relay/` HOME the tool just wrote into.
+    const fixtureDir = new URL("../orchestrator/handoff/fixtures/channel-min/", import.meta.url);
+    const channelsRoot = join(home, ".relay", "channels");
+    // Mirror the channel-store on-disk layout: <channelsDir>/<id>.json
+    // (manifest) + <channelsDir>/<id>/{feed.jsonl,…}.
+    const { cp, mkdir } = await import("node:fs/promises");
+    await mkdir(channelsRoot, { recursive: true });
+    await cp(
+      new URL("manifest.json", fixtureDir).pathname,
+      join(channelsRoot, `${CHANNEL_ID}.json`)
+    );
+    await cp(fixtureDir.pathname, join(channelsRoot, CHANNEL_ID), { recursive: true });
+
+    const { buildBrief } = await import("../../src/orchestrator/handoff/synthesizer.js");
+    const { ChannelStore } = await import("../../src/channels/channel-store.js");
+    const store = new ChannelStore(channelsRoot);
+
+    const brief = await buildBrief({
+      channelId: CHANNEL_ID,
+      now: new Date(),
+      channelStore: store,
+      gitLogEnabled: false,
+    });
+
+    expect(brief.sections.workingMemory.body).toContain("wired-end-to-end");
+    expect(brief.sections.workingMemory.body).not.toContain("[gap-fill not provided]");
+  });
+});

--- a/test/orchestrator/handoff/persistence.test.ts
+++ b/test/orchestrator/handoff/persistence.test.ts
@@ -1,0 +1,239 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { __resetRelayDirCacheForTests } from "../../../src/cli/paths.js";
+import {
+  assertValidBriefId,
+  readLatestGapFill,
+  writeBriefArtifact,
+  writeGapFill,
+} from "../../../src/orchestrator/handoff/persistence.js";
+import type { GapFillBlock } from "../../../src/orchestrator/handoff/types.js";
+
+const CHANNEL_ID = "ch-fixmin-0001";
+
+function buildGap(overrides: Partial<GapFillBlock> = {}): GapFillBlock {
+  return {
+    schemaVersion: 1,
+    briefId: "brief-1746789000000-aabbcc",
+    channelId: CHANNEL_ID,
+    capturedAt: new Date("2026-05-09T12:00:00.000Z").toISOString(),
+    capturedBySessionId: "sess-fixsrc-0001",
+    currentLineOfAttack: "Investigating T-3 timeout",
+    activeHypothesis: "API token has insufficient scope",
+    abandonedApproaches: ["Tried bumping the timeout — no change."],
+    openQuestions: ["Is the test fixture token configured?"],
+    ...overrides,
+  };
+}
+
+describe("handoff persistence", () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "relay-handoff-persist-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = home;
+    __resetRelayDirCacheForTests();
+  });
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    __resetRelayDirCacheForTests();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  describe("assertValidBriefId", () => {
+    it("accepts the canonical shape", () => {
+      expect(() => assertValidBriefId("brief-1746789123456-a1b2c3")).not.toThrow();
+    });
+
+    it.each([
+      ["no suffix", "brief-no-suffix"],
+      ["uppercase", "BRIEF-001-x"],
+      ["missing random", "brief-001"],
+      ["empty", ""],
+      ["path traversal", "../../etc"],
+    ])("rejects %s", (_label, value) => {
+      expect(() => assertValidBriefId(value)).toThrow(/Invalid briefId/);
+    });
+  });
+
+  describe("writeGapFill", () => {
+    it("writes the gap.json atomically with no leftover .tmp files", async () => {
+      const gap = buildGap();
+      const { gapJsonPath } = await writeGapFill({
+        channelId: CHANNEL_ID,
+        briefId: gap.briefId,
+        payload: gap,
+      });
+
+      const onDisk = JSON.parse(await readFile(gapJsonPath, "utf8"));
+      expect(onDisk).toEqual(gap);
+
+      const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+      const entries = await readdir(dir);
+      expect(entries.filter((n) => n.includes(".tmp."))).toHaveLength(0);
+    });
+
+    it("rejects schemaVersion mismatch (defense in depth)", async () => {
+      await expect(
+        writeGapFill({
+          channelId: CHANNEL_ID,
+          briefId: "brief-1746789000000-aabbcc",
+          // Cast through unknown — TS would reject at compile time, but
+          // runtime callers (e.g. JSON-deserialized records) need the
+          // guard too.
+          payload: buildGap({ schemaVersion: 2 as unknown as 1 }),
+        })
+      ).rejects.toThrow(/schemaVersion/);
+    });
+
+    it("two consecutive calls produce two distinct gap.json files (no overwrite)", async () => {
+      const a = await writeGapFill({
+        channelId: CHANNEL_ID,
+        briefId: "brief-1746789000000-aaaaaa",
+        payload: buildGap({ briefId: "brief-1746789000000-aaaaaa" }),
+      });
+      const b = await writeGapFill({
+        channelId: CHANNEL_ID,
+        briefId: "brief-1746789000001-bbbbbb",
+        payload: buildGap({ briefId: "brief-1746789000001-bbbbbb" }),
+      });
+
+      expect(a.gapJsonPath).not.toBe(b.gapJsonPath);
+      const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+      const entries = (await readdir(dir)).filter((n) => n.endsWith(".gap.json"));
+      expect(entries).toHaveLength(2);
+    });
+  });
+
+  describe("writeBriefArtifact", () => {
+    it("writes both md + gap.json atomically", async () => {
+      const gap = buildGap();
+      const { mdPath, gapJsonPath } = await writeBriefArtifact({
+        channelId: CHANNEL_ID,
+        briefId: gap.briefId,
+        markdown: "# Brief\n\nbody",
+        gapFill: gap,
+      });
+
+      expect(await readFile(mdPath, "utf8")).toContain("# Brief");
+      const onDisk = JSON.parse(await readFile(gapJsonPath, "utf8"));
+      expect(onDisk).toEqual(gap);
+
+      const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+      const entries = await readdir(dir);
+      expect(entries.filter((n) => n.includes(".tmp."))).toHaveLength(0);
+    });
+  });
+
+  describe("readLatestGapFill", () => {
+    const now = new Date("2026-05-09T12:00:00.000Z");
+
+    it("returns null when the handoffs directory is missing", async () => {
+      const result = await readLatestGapFill(CHANNEL_ID, { now });
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the directory exists but contains no gap files", async () => {
+      const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "README.txt"), "ignore me");
+      const result = await readLatestGapFill(CHANNEL_ID, { now });
+      expect(result).toBeNull();
+    });
+
+    it("returns the newest gap.json by capturedAt", async () => {
+      const oldGap = buildGap({
+        briefId: "brief-1746789000000-aaaaaa",
+        capturedAt: new Date(now.getTime() - 30 * 60 * 1000).toISOString(),
+        currentLineOfAttack: "old",
+      });
+      const newGap = buildGap({
+        briefId: "brief-1746789000001-bbbbbb",
+        capturedAt: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
+        currentLineOfAttack: "new",
+      });
+      const middleGap = buildGap({
+        briefId: "brief-1746789000002-cccccc",
+        capturedAt: new Date(now.getTime() - 15 * 60 * 1000).toISOString(),
+        currentLineOfAttack: "middle",
+      });
+
+      await writeGapFill({ channelId: CHANNEL_ID, briefId: oldGap.briefId, payload: oldGap });
+      await writeGapFill({ channelId: CHANNEL_ID, briefId: newGap.briefId, payload: newGap });
+      await writeGapFill({
+        channelId: CHANNEL_ID,
+        briefId: middleGap.briefId,
+        payload: middleGap,
+      });
+
+      const loaded = await readLatestGapFill(CHANNEL_ID, { now });
+      expect(loaded?.briefId).toBe(newGap.briefId);
+      expect(loaded?.currentLineOfAttack).toBe("new");
+    });
+
+    it("returns null when the newest record is older than the staleness window", async () => {
+      const stale = buildGap({
+        capturedAt: new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString(), // 2h
+      });
+      await writeGapFill({ channelId: CHANNEL_ID, briefId: stale.briefId, payload: stale });
+
+      const loaded = await readLatestGapFill(CHANNEL_ID, { now });
+      expect(loaded).toBeNull();
+    });
+
+    it("preserves schemaVersion: 2 on round-trip (does not silently coerce to 1)", async () => {
+      // M9 — write a record with a future schema version directly to disk
+      // (bypassing the writer's guard) and assert the reader rejects it.
+      const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+      await mkdir(dir, { recursive: true });
+      const briefId = "brief-1746789123456-z9z9z9";
+      const gapJsonPath = join(dir, `${briefId}.gap.json`);
+      await writeFile(
+        gapJsonPath,
+        JSON.stringify({
+          schemaVersion: 2, // intentional future-bump probe
+          briefId,
+          channelId: CHANNEL_ID,
+          capturedAt: new Date(now.getTime() - 30_000).toISOString(),
+          capturedBySessionId: null,
+          currentLineOfAttack: "v2 should be rejected",
+          activeHypothesis: "",
+          abandonedApproaches: [],
+          openQuestions: [],
+        })
+      );
+
+      const loaded = await readLatestGapFill(CHANNEL_ID, { now });
+      expect(loaded).toBeNull();
+    });
+
+    it("skips a malformed file but still returns a valid sibling", async () => {
+      const dir = join(home, ".relay", "channels", CHANNEL_ID, "handoffs");
+      await mkdir(dir, { recursive: true });
+      // Bad file: looks like a brief gap.json but is not valid JSON.
+      await writeFile(join(dir, "brief-1746789000000-bbbbbb.gap.json"), "{ not json");
+      // Good file:
+      const good = buildGap({
+        briefId: "brief-1746789000001-cccccc",
+        capturedAt: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
+        currentLineOfAttack: "valid",
+      });
+      await writeGapFill({ channelId: CHANNEL_ID, briefId: good.briefId, payload: good });
+
+      const loaded = await readLatestGapFill(CHANNEL_ID, { now });
+      expect(loaded?.briefId).toBe(good.briefId);
+    });
+
+    it("rejects path-traversal channelIds", async () => {
+      await expect(readLatestGapFill("../etc", { now })).rejects.toThrow(/Unsafe path segment/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR-2 (Wave 2) — `channel_handoff_finalize` MCP tool and the gap-fill persistence layer that backs it.

- New `src/orchestrator/handoff/persistence.ts` with `writeGapFill` (MCP path), `writeBriefArtifact` (md+gap pair, used by Wave 4 CLI), and `readLatestGapFill` (newest non-stale, fail-closed on `schemaVersion !== 1` per M9). All writes use tmp-file + rename for atomicity, mirroring `ChannelStore`'s pattern.
- New MCP tool `channel_handoff_finalize` registered in `src/mcp/channel-tools.ts`. Zod schema enforces D-04 length caps (4000/2000/1000/500 chars per slot class) and rejects any payload with `schemaVersion !== 1` at runtime — both threats T-02-13 (silent schemaVersion drift) and T-02-04 (length-bombed slots) covered.
- Synthesizer now auto-loads the newest non-stale gap-fill when `BuildBriefOptions.gapFill` is omitted, closing the loop: agent calls the tool → next `rly handoff` invocation picks up the slots with zero caller plumbing.
- README MCP-tools list bumped (Channels: 6 → 7).

Path-traversal is guarded twice: `assertSafeSegment` on `channelId` AND `assertValidBriefId` on the `brief-<unix-ms>-<base36>` shape (T-02-01, T-02-02, T-02-08, T-02-10).

## Scope (what is NOT here)

Per the Phase 2 plan's wave structure, this PR is Wave 2 only. Out of scope:
- Wave 3 (threshold listener + ApprovalKind extension) — `threshold-listener.test.ts` stays `describe.todo`.
- Wave 4 (`rly handoff` CLI) — `handoff-cli.test.ts` and `handoff-resume.test.ts` stay `describe.todo`.
- Wave 5 (docs + cross-dashboard audit).

## CI gates (all green locally)

- `pnpm install`
- `pnpm test` — 1042 passed, 24 skipped, 16 todo
- `pnpm typecheck` — clean
- `pnpm format:check` — clean
- `cargo check --workspace --locked` — clean (no Rust changes)

## Test plan

- [x] 17-test persistence suite: assertValidBriefId acceptance/rejection, atomic writes (no leftover .tmp files), no-overwrite semantics, newest-by-capturedAt selection, staleness gating, schemaVersion-2 round-trip rejection, malformed-file skip, path-traversal rejection.
- [x] 9-test MCP tool suite: registration in catalogue, happy path with persisted gap.json + ISO timestamp, sessionId fallback, missing-required-field rejection, oversized field rejection, schemaVersion-2 rejection (M9), path-traversal rejection, no-overwrite, end-to-end gap-written-via-tool-renders-in-brief.
- [x] Wave 0/1 tests still green.

## Diff stats

- 357 LOC source (persistence + MCP tool + synthesizer wiring + README)
- 490 LOC tests (defense in depth — M9 round-trip, end-to-end MCP-to-synthesizer)
- 847 LOC total. 47 over the 800 soft cap; the test surface is load-bearing for the M9 fail-closed contract and not splittable into a follow-up PR without weakening the gate.