### PR TITLE
feat(handoff): threshold listener + handoff-prompt approval kind (Phase 2 PR-3)

### DIFF
--- a/src/approvals/queue.ts
+++ b/src/approvals/queue.ts
@@ -3,6 +3,7 @@ import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises
 import { join } from "node:path";
 
 import { getRelayDir } from "../cli/paths.js";
+import type { HandoffPromptPayload } from "../domain/handoff.js";
 
 /**
  * Kinds of ack-requiring actions AL-7 queues under supervised trust mode.
@@ -18,8 +19,20 @@ import { getRelayDir } from "../cli/paths.js";
  *  - `create-ticket`: produced by AL-6's audit-proposal hook. Payload carries
  *    the proposed ticket body that would otherwise be written directly into
  *    the channel ticket board under god mode.
+ *  - `handoff-prompt`: produced by Phase 2's threshold listener
+ *    (`src/orchestrator/handoff/threshold-listener.ts`) when Phase 1 emits
+ *    a `context_threshold` feed entry with `metadata.threshold === "90"`.
+ *    Payload is `HandoffPromptPayload` from `src/domain/handoff.ts` —
+ *    `thresholdPct` is the parsed-NUMBER form of Phase 1's STRING wire
+ *    field; conversion happens exactly once at the listener boundary (M1).
+ *    Cross-dashboard audit (M10): TUI's `ui.rs` and the GUI's
+ *    `RightPane.tsx` render `record.kind` as an opaque label string and
+ *    pretty-print the payload — neither switches on kind, so widening this
+ *    union is safe without dashboard code changes. The Rust mirror
+ *    (`crates/harness-data/src/lib.rs::ApprovalQueueRecord.kind`) is
+ *    `String`, not an enum, so no Rust widening is needed either.
  */
-export type ApprovalKind = "merge-pr" | "create-ticket";
+export type ApprovalKind = "merge-pr" | "create-ticket" | "handoff-prompt";
 
 /**
  * Approval lifecycle states. Queue records start `pending`; the CLI surface
@@ -68,7 +81,8 @@ export interface CreateTicketPayload {
 /** Union of all payload variants, discriminated by the record's `kind`. */
 export type ApprovalPayload =
   | { kind: "merge-pr"; payload: MergePrPayload }
-  | { kind: "create-ticket"; payload: CreateTicketPayload };
+  | { kind: "create-ticket"; payload: CreateTicketPayload }
+  | { kind: "handoff-prompt"; payload: HandoffPromptPayload };
 
 /**
  * On-disk record shape written to `~/.relay/approvals/<sessionId>/queue.jsonl`.
@@ -92,7 +106,7 @@ export interface ApprovalRecord {
   /** Action kind — see {@link ApprovalKind}. */
   kind: ApprovalKind;
   /** Action payload, discriminated by {@link ApprovalKind}. */
-  payload: MergePrPayload | CreateTicketPayload;
+  payload: MergePrPayload | CreateTicketPayload | HandoffPromptPayload;
   /** ISO-8601 timestamp the record was enqueued. */
   createdAt: string;
   /** Current lifecycle state. */
@@ -116,7 +130,7 @@ export interface ApprovalRecord {
 export interface EnqueueInput {
   sessionId: string;
   kind: ApprovalKind;
-  payload: MergePrPayload | CreateTicketPayload;
+  payload: MergePrPayload | CreateTicketPayload | HandoffPromptPayload;
 }
 
 /**
@@ -129,7 +143,7 @@ export interface EnqueueInput {
 export interface EnqueueAutoApprovedInput {
   sessionId: string;
   kind: ApprovalKind;
-  payload: MergePrPayload | CreateTicketPayload;
+  payload: MergePrPayload | CreateTicketPayload | HandoffPromptPayload;
   /** Who / what auto-approved. Today only `"god-mode"` is defined. */
   autoApprovedBy: "god-mode";
 }
@@ -168,6 +182,39 @@ function assertValidSessionId(sessionId: string): void {
     throw new Error(
       `approvals queue: invalid sessionId ${JSON.stringify(sessionId)}; ` +
         `expected /^[A-Za-z0-9_-]+$/`
+    );
+  }
+}
+
+/**
+ * Lightweight per-kind payload shape validator. Per Phase 2 PLAN Task 3.1
+ * Step 1: "Add a Zod-or-equivalent validator for `handoff-prompt` payloads
+ * matching `HandoffPromptPayload` shape. Reject unknown payload shapes
+ * loudly." We hand-roll it to avoid pulling Zod into this hot path; the
+ * shape is small and stable. `merge-pr` and `create-ticket` shapes are
+ * left to existing call-site type-checking — this guard exists so that
+ * a misbehaved handoff caller (or a payload that survived a string→number
+ * boundary mistake) blows up at the queue boundary instead of going to
+ * disk and then surprising the dashboards / `rly approve` flow.
+ */
+function assertValidPayloadForKind(
+  kind: ApprovalKind,
+  payload: MergePrPayload | CreateTicketPayload | HandoffPromptPayload
+): void {
+  if (kind !== "handoff-prompt") return;
+  const p = payload as Partial<HandoffPromptPayload>;
+  if (
+    p.schemaVersion !== 1 ||
+    typeof p.channelId !== "string" ||
+    typeof p.sessionId !== "string" ||
+    typeof p.thresholdPct !== "number" ||
+    typeof p.used !== "number" ||
+    typeof p.total !== "number"
+  ) {
+    throw new Error(
+      `approvals queue: invalid handoff-prompt payload ${JSON.stringify(payload)}; ` +
+        `expected { schemaVersion:1, channelId:string, sessionId:string, ` +
+        `thresholdPct:number, used:number, total:number, promptText?:string }`
     );
   }
 }
@@ -248,6 +295,7 @@ export class ApprovalsQueue {
    */
   async enqueue(input: EnqueueInput): Promise<ApprovalRecord> {
     assertValidSessionId(input.sessionId);
+    assertValidPayloadForKind(input.kind, input.payload);
     const record: ApprovalRecord = {
       id: this.idFactory(),
       sessionId: input.sessionId,
@@ -281,6 +329,7 @@ export class ApprovalsQueue {
    */
   async enqueueAutoApproved(input: EnqueueAutoApprovedInput): Promise<ApprovalRecord> {
     assertValidSessionId(input.sessionId);
+    assertValidPayloadForKind(input.kind, input.payload);
     const stamp = new Date(this.clock()).toISOString();
     const record: ApprovalRecord = {
       id: this.idFactory(),

--- a/src/orchestrator/handoff/threshold-listener.ts
+++ b/src/orchestrator/handoff/threshold-listener.ts
@@ -1,0 +1,221 @@
+/**
+ * Phase 2 PR-3: 90% context-threshold listener.
+ *
+ * Watches a channel's `feed.jsonl` (via `ChannelStore.readFeed`) for the
+ * Phase 1 `context_threshold` contract — `entry.type === "status_update"`,
+ * `entry.metadata.kind === "context_threshold"`,
+ * `entry.metadata.schemaVersion === "1"`,
+ * `entry.metadata.sessionId === <our session>`,
+ * `entry.metadata.threshold === "90"` — and enqueues exactly one
+ * `ApprovalsQueue` record of `kind: "handoff-prompt"` per (sessionId,
+ * threshold) crossing. The user then approves / rejects via the existing
+ * AL-7 / AL-8 surfaces (`rly approve <id>` / `rly reject <id>`); rejection
+ * is a no-op terminal state and the running session simply continues.
+ *
+ * Phase 1 → Phase 2 contract surface (inherited verbatim from Phase 1
+ * PLAN's `<phase_2_handoff_contract>` block — see Phase 2 PLAN's
+ * `<phase_2_handoff_contract_inherited_from_phase_1>`):
+ *   - All `metadata` values arrive as STRINGS on the wire. Per M1, this
+ *     module is the ONLY place that converts `metadata.threshold` /
+ *     `metadata.pct` / `metadata.used` / `metadata.total` to numbers, and
+ *     the conversion happens exactly once at the listener boundary.
+ *   - Crossings are single-emit per (sessionId, threshold). In-process
+ *     dedup uses an in-memory `Set<string>` keyed `<sessionId>::<threshold>`;
+ *     restart-idempotency seeds that set from the existing approvals queue
+ *     by reading `approvalsQueue.list(sessionId)` and filtering
+ *     `kind === "handoff-prompt"` in JS. Per H1, the actual signature is
+ *     `list(sessionId)` (positional, no `{ kind, sessionId }` shape).
+ *   - The listener does NOT import from `src/budget/`. Phase 2 owns the
+ *     handoff UX; Phase 1 owns telemetry. The contract is read via the
+ *     channel feed.
+ *
+ * Self-loop disjointness (L6): if the listener ever posts its own
+ * follow-up signaling entries to the same channel feed, those carry
+ * `metadata.handoffPrompt: true` (NOT `metadata.kind: "context_threshold"`).
+ * The poll predicate filters on `metadata.kind === "context_threshold"`,
+ * so the listener cannot match its own posts. The two predicates are
+ * disjoint by construction — there is no self-loop, and we can post
+ * freely without filtering our own writes.
+ */
+
+import type { ApprovalsQueue } from "../../approvals/queue.js";
+import type { ChannelStore } from "../../channels/channel-store.js";
+import type { ChannelEntry } from "../../domain/channel.js";
+import type { HandoffPromptPayload } from "../../domain/handoff.js";
+import { HANDOFF_BRIEF_SCHEMA_VERSION } from "../../domain/handoff.js";
+
+/**
+ * Default poll interval for the threshold listener (M8).
+ *
+ * 5s default: context crossings are minutes-scale (token budgets are
+ * 100K-1M), not sub-second. Tests pass `pollIntervalMs: 50` to keep
+ * wall-clock under 200ms. Tradeoff: a 5s lag between Phase 1 emitting a
+ * `context_threshold` entry and the user seeing the prompt is
+ * acceptable; reducing this to 1s would 5× the readdir/readFile load on
+ * a 5-session orchestrator with no UX benefit.
+ */
+export const DEFAULT_HANDOFF_THRESHOLD_POLL_MS = 5000;
+
+export interface AttachHandoffThresholdListenerOptions {
+  channelStore: ChannelStore;
+  approvalsQueue: ApprovalsQueue;
+  /** Channel whose feed.jsonl is polled for context_threshold entries. */
+  channelId: string;
+  /**
+   * Session id this listener subscribes to. The poll predicate filters
+   * `entry.metadata.sessionId === sessionId` so two listeners on the
+   * same channel feed (different sessions) do not cross-fire. Asserted
+   * by `threshold-listener.test.ts`'s H2b two-session test.
+   */
+  sessionId: string;
+  /** Default {@link DEFAULT_HANDOFF_THRESHOLD_POLL_MS}. */
+  pollIntervalMs?: number;
+}
+
+export interface HandoffThresholdSubscription {
+  /** Stop polling and release the timer. Idempotent. */
+  unsubscribe: () => void;
+}
+
+/**
+ * Attach a feed-polling listener that converts Phase 1 90%-threshold
+ * crossings into AL-7 handoff-prompt approvals.
+ *
+ * Returns a subscription handle whose `unsubscribe()` clears the poll
+ * timer. The timer is `unref()`'d so the listener never holds the
+ * process open by itself.
+ *
+ * Errors during poll are swallowed and logged via `console.warn`
+ * (best-effort): a transient `readFeed` failure must not crash the
+ * orchestrator's autonomous loop.
+ */
+export function attachHandoffThresholdListener(
+  options: AttachHandoffThresholdListenerOptions
+): HandoffThresholdSubscription {
+  const { channelStore, approvalsQueue, channelId, sessionId } = options;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_HANDOFF_THRESHOLD_POLL_MS;
+
+  // In-process dedup. Keyed `<sessionId>::<threshold-as-string>`. The
+  // outer `<sessionId>` partition is redundant for a single listener
+  // (we filter feed entries to our session above) but cheap, and it
+  // means a future shared-listener refactor inherits the right key
+  // shape without churn. Per H1: the payload contract has NO
+  // `entryId` field; restart dedup is by (sessionId, threshold) only.
+  const seenCrossings = new Set<string>();
+  const crossingKey = (sid: string, thresholdStr: string): string => `${sid}::${thresholdStr}`;
+
+  // Restart-idempotency seed (H1): fetch existing approvals for this
+  // session, filter to `kind === "handoff-prompt"` in JS, and seed the
+  // in-process Set with each record's `(sessionId, thresholdPct)`. After
+  // an orchestrator restart, the process re-attaches the listener, the
+  // seed runs once, and any prior 90% crossing for this session is
+  // already known — the next poll will not re-enqueue.
+  let seededPromise: Promise<void> | null = null;
+  const ensureSeeded = (): Promise<void> => {
+    if (seededPromise) return seededPromise;
+    seededPromise = (async () => {
+      try {
+        const existing = await approvalsQueue.list(sessionId);
+        for (const rec of existing) {
+          if (rec.kind !== "handoff-prompt") continue;
+          // payload.thresholdPct is a NUMBER (M1); the in-memory key
+          // tracks the wire-format STRING form so feed predicates and
+          // dedup keys agree byte-for-byte. `"90"` and `90`.toString()
+          // are both `"90"` — safe.
+          const payload = rec.payload as HandoffPromptPayload;
+          seenCrossings.add(crossingKey(rec.sessionId, String(payload.thresholdPct)));
+        }
+      } catch (err) {
+        console.warn(
+          `[handoff-threshold-listener] seedThresholds failed: ${(err as Error).message}`
+        );
+      }
+    })();
+    return seededPromise;
+  };
+
+  let stopped = false;
+
+  const poll = async (): Promise<void> => {
+    if (stopped) return;
+    await ensureSeeded();
+    let entries: ChannelEntry[];
+    try {
+      entries = await channelStore.readFeed(channelId);
+    } catch (err) {
+      console.warn(`[handoff-threshold-listener] readFeed failed: ${(err as Error).message}`);
+      return;
+    }
+
+    for (const entry of entries) {
+      if (stopped) return;
+      // Phase 1 contract predicate. Five conjuncts kept on separate
+      // lines so a future contract-version bump shows a clean diff. Note
+      // that this predicate is DISJOINT from the listener's own follow-up
+      // posts (which would carry `metadata.handoffPrompt: true`, not
+      // `metadata.kind: "context_threshold"`) — see L6 in the module
+      // docstring; no self-loop.
+      const md = entry.metadata as Record<string, unknown> | undefined;
+      if (!md) continue;
+      if (entry.type !== "status_update") continue;
+      if (md.kind !== "context_threshold") continue;
+      if (md.schemaVersion !== "1") continue; // T-02-12: schema-version drift fails closed
+      if (md.sessionId !== sessionId) continue;
+      if (md.threshold !== "90") continue;
+
+      const thresholdStr = String(md.threshold);
+      const key = crossingKey(sessionId, thresholdStr);
+      if (seenCrossings.has(key)) continue;
+      seenCrossings.add(key);
+
+      // M1: STRING→NUMBER conversion happens HERE, exactly once per
+      // crossing. No other code path coerces these wire fields.
+      const thresholdPct = Number(md.threshold);
+      const used = Number(md.used);
+      const total = Number(md.total);
+      const pct = Number(md.pct);
+
+      const channelIdMeta = typeof md.channelId === "string" ? md.channelId : channelId;
+      const promptText = `Context at ${pct}% — consider running \`rly handoff\` to brief a fresh session before the window fills up.`;
+
+      const payload: HandoffPromptPayload = {
+        schemaVersion: HANDOFF_BRIEF_SCHEMA_VERSION,
+        channelId: channelIdMeta,
+        sessionId,
+        thresholdPct,
+        used,
+        total,
+        promptText,
+      };
+
+      try {
+        await approvalsQueue.enqueue({ sessionId, kind: "handoff-prompt", payload });
+      } catch (err) {
+        // Roll back the dedup mark so a transient enqueue failure does
+        // not silently swallow this crossing — the next poll retries.
+        seenCrossings.delete(key);
+        console.warn(`[handoff-threshold-listener] enqueue failed: ${(err as Error).message}`);
+      }
+    }
+  };
+
+  // Fire one immediate poll so a feed entry that landed before attach
+  // is picked up without waiting a full interval. Errors swallowed
+  // (poll handles them internally).
+  void poll();
+
+  const handle = setInterval(() => {
+    void poll();
+  }, pollIntervalMs);
+  // Don't keep the event loop alive on the listener's behalf. The
+  // owning autonomous loop (or test harness) controls process lifetime.
+  if (typeof handle.unref === "function") handle.unref();
+
+  return {
+    unsubscribe: () => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(handle);
+    },
+  };
+}

--- a/test/orchestrator/handoff/threshold-listener.test.ts
+++ b/test/orchestrator/handoff/threshold-listener.test.ts
@@ -1,41 +1,293 @@
 /**
- * RED test scaffold — turns GREEN in Wave 3 / PR-3 when
- * `src/orchestrator/handoff/threshold-listener.ts` lands.
+ * Phase 2 PR-3: 90% threshold listener tests.
  *
- * Per Phase 2 PLAN Task 0.1 Step 5: this scaffold encodes the success
- * criteria for the threshold listener. Tests intentionally fail at
- * import time until the listener module is created.
+ * Wires a tmp ~/.relay/, instantiates `ChannelStore` + `ApprovalsQueue`,
+ * posts the Phase 1-shaped `context_threshold` feed entries, and asserts
+ * the listener:
+ *   - Enqueues exactly one `kind: "handoff-prompt"` approval per crossing
+ *     with `payload.thresholdPct === 90` (NUMBER, not the wire STRING).
+ *   - Dedupes within-process re-posts (D-03).
+ *   - Filters non-90 thresholds.
+ *   - Does NOT cross-fire between sessions (H2b defense in depth).
+ *   - Stops polling on `unsubscribe()`.
+ *   - Survives orchestrator restart without double-enqueueing
+ *     (`approvalsQueue.list(sessionId)` seeds the in-memory dedup Set).
  */
 
-import { describe, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-describe.todo("attachHandoffThresholdListener — wired in Wave 3", () => {
-  it("enqueues a single handoff-prompt approval on a threshold === '90' feed entry", () => {
-    // - Create tmp ~/.relay/, instantiate ChannelStore + ApprovalsQueue.
-    // - Post a Phase-1-shaped context_threshold entry with threshold === "90", sessionId === "sess-x".
-    // - attachHandoffThresholdListener({ channelStore, approvalsQueue, channelId, sessionId: "sess-x", pollIntervalMs: 50 }).
-    // - Await ~200ms.
-    // - Expect approvalsQueue.list("sess-x") filtered by kind === "handoff-prompt" to have length 1.
-    // - Expect payload.thresholdPct === 90 (NUMBER, not "90") — pinpoints the M1 conversion at the boundary.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ApprovalsQueue } from "../../../src/approvals/queue.js";
+import { ChannelStore } from "../../../src/channels/channel-store.js";
+import {
+  attachHandoffThresholdListener,
+  DEFAULT_HANDOFF_THRESHOLD_POLL_MS,
+} from "../../../src/orchestrator/handoff/threshold-listener.js";
+import type { HandoffPromptPayload } from "../../../src/domain/handoff.js";
+
+const POLL_MS = 30;
+const WAIT_MS = 200;
+
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface ThresholdMetadataInput {
+  sessionId: string;
+  threshold?: string;
+  pct?: string;
+  used?: string;
+  total?: string;
+  schemaVersion?: string;
+}
+
+async function postContextThreshold(
+  store: ChannelStore,
+  channelId: string,
+  meta: ThresholdMetadataInput
+): Promise<void> {
+  await store.postEntry(channelId, {
+    type: "status_update",
+    fromAgentId: null,
+    fromDisplayName: "system",
+    content: `context-threshold ${meta.threshold ?? "90"}% crossed`,
+    metadata: {
+      kind: "context_threshold",
+      schemaVersion: meta.schemaVersion ?? "1",
+      threshold: meta.threshold ?? "90",
+      pct: meta.pct ?? "91.23",
+      used: meta.used ?? "182000",
+      total: meta.total ?? "200000",
+      sessionId: meta.sessionId,
+      channelId,
+    },
+  });
+}
+
+describe("attachHandoffThresholdListener", () => {
+  let root: string;
+  let channelsDir: string;
+  let store: ChannelStore;
+  let queue: ApprovalsQueue;
+  let channelId: string;
+  let unsubs: Array<() => void>;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "handoff-threshold-"));
+    channelsDir = join(root, "channels");
+    store = new ChannelStore(channelsDir);
+    queue = new ApprovalsQueue({ rootDir: root });
+    const ch = await store.createChannel({ name: "fixture", description: "" });
+    channelId = ch.channelId;
+    unsubs = [];
   });
 
-  it("does NOT re-enqueue when an identical 90% entry is posted for the same session (D-03 dedup)", () => {
-    // Posts the same metadata twice; expects exactly one approval.
+  afterEach(async () => {
+    for (const u of unsubs) {
+      try {
+        u();
+      } catch {
+        /* noop */
+      }
+    }
+    await rm(root, { recursive: true, force: true });
   });
 
-  it("filters out threshold === '75' entries (only 90% triggers)", () => {
-    // Posts a threshold:"75" entry; expects no approval.
+  it("enqueues a single handoff-prompt approval on a threshold === '90' feed entry", async () => {
+    await postContextThreshold(store, channelId, { sessionId: "sess-x" });
+
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(sub.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(1);
+    const payload = records[0].payload as HandoffPromptPayload;
+    // M1 pinpoint: NUMBER, not wire STRING "90".
+    expect(payload.thresholdPct).toBe(90);
+    expect(typeof payload.thresholdPct).toBe("number");
+    expect(payload.used).toBe(182000);
+    expect(payload.total).toBe(200000);
+    expect(payload.sessionId).toBe("sess-x");
+    expect(payload.channelId).toBe(channelId);
+    expect(payload.schemaVersion).toBe(1);
   });
 
-  it("two distinct sessionIds both crossing 90% enqueue independent approvals (H2b defense in depth)", () => {
-    // Subscribes one listener per sessionId; posts a 90% entry for each; expects ONE approval per session.
+  it("does NOT re-enqueue when an identical 90% entry is posted for the same session (D-03 dedup)", async () => {
+    await postContextThreshold(store, channelId, { sessionId: "sess-x" });
+
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(sub.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    // Post a second identical entry; the listener has already seen
+    // (sessionId, "90") so the dedup Set must prevent a second enqueue.
+    await postContextThreshold(store, channelId, { sessionId: "sess-x", pct: "92.5" });
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(1);
   });
 
-  it("unsubscribe() stops the poll loop", () => {
-    // After unsubscribe, posting another match must not enqueue.
+  it("filters out threshold === '75' entries (only 90% triggers)", async () => {
+    await postContextThreshold(store, channelId, {
+      sessionId: "sess-x",
+      threshold: "75",
+      pct: "75.0",
+    });
+
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(sub.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(0);
   });
 
-  it("survives orchestrator restart without double-enqueueing (seedThresholds via approvalsQueue.list)", () => {
-    // Pre-place a handoff-prompt approval for (sess-x, 90); attach a fresh listener; expects no new approval.
+  it("ignores entries with mismatched sessionId (no cross-session leakage)", async () => {
+    await postContextThreshold(store, channelId, { sessionId: "sess-other" });
+
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(sub.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(0);
+  });
+
+  it("two distinct sessionIds both crossing 90% enqueue independent approvals (H2b defense in depth)", async () => {
+    await postContextThreshold(store, channelId, { sessionId: "sess-A", pct: "91.0" });
+    await postContextThreshold(store, channelId, { sessionId: "sess-B", pct: "92.0" });
+
+    const subA = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-A",
+      pollIntervalMs: POLL_MS,
+    });
+    const subB = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-B",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(subA.unsubscribe, subB.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    const apprA = (await queue.list("sess-A")).filter((r) => r.kind === "handoff-prompt");
+    const apprB = (await queue.list("sess-B")).filter((r) => r.kind === "handoff-prompt");
+    expect(apprA).toHaveLength(1);
+    expect(apprB).toHaveLength(1);
+    expect((apprA[0].payload as HandoffPromptPayload).sessionId).toBe("sess-A");
+    expect((apprB[0].payload as HandoffPromptPayload).sessionId).toBe("sess-B");
+  });
+
+  it("unsubscribe() stops the poll loop", async () => {
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    sub.unsubscribe();
+
+    await postContextThreshold(store, channelId, { sessionId: "sess-x" });
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(0);
+  });
+
+  it("survives orchestrator restart without double-enqueueing (seed via approvalsQueue.list)", async () => {
+    // Pretend a prior listener-run already enqueued the handoff-prompt
+    // approval. After the orchestrator restarts and re-attaches the
+    // listener, the seed step (approvalsQueue.list(sessionId) filtered to
+    // kind === "handoff-prompt") MUST mark (sess-x, 90) as already seen so
+    // the next poll does not re-enqueue.
+    await queue.enqueue({
+      sessionId: "sess-x",
+      kind: "handoff-prompt",
+      payload: {
+        schemaVersion: 1,
+        channelId,
+        sessionId: "sess-x",
+        thresholdPct: 90,
+        used: 182000,
+        total: 200000,
+      },
+    });
+    await postContextThreshold(store, channelId, { sessionId: "sess-x" });
+
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(sub.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(1); // still only the seeded one
+  });
+
+  it("filters out entries with mismatched schemaVersion (T-02-12 fail-closed)", async () => {
+    await postContextThreshold(store, channelId, {
+      sessionId: "sess-x",
+      schemaVersion: "2",
+    });
+
+    const sub = attachHandoffThresholdListener({
+      channelStore: store,
+      approvalsQueue: queue,
+      channelId,
+      sessionId: "sess-x",
+      pollIntervalMs: POLL_MS,
+    });
+    unsubs.push(sub.unsubscribe);
+
+    await wait(WAIT_MS);
+
+    const records = (await queue.list("sess-x")).filter((r) => r.kind === "handoff-prompt");
+    expect(records).toHaveLength(0);
+  });
+
+  it("exports DEFAULT_HANDOFF_THRESHOLD_POLL_MS = 5000 per M8", () => {
+    expect(DEFAULT_HANDOFF_THRESHOLD_POLL_MS).toBe(5000);
   });
 });


### PR DESCRIPTION
## Summary

Wave 3 of the Phase 2 handoff command + brief synthesizer phase. Subscribes (read-only) to Phase 1's `context_threshold` channel-feed contract and surfaces the 90% nudge through the existing AL-7 approval queue.

- **`ApprovalKind` extension.** Widened to `"merge-pr" | "create-ticket" | "handoff-prompt"` in `src/approvals/queue.ts`. Added a hand-rolled `assertValidPayloadForKind` that rejects malformed `HandoffPromptPayload` at the queue boundary (per Step 1 of the plan).
- **Cross-dashboard audit (M10) — no widening implementation needed.** Findings:
  - `gui/src/components/RightPane.tsx` renders `{r.kind}` as an opaque label string — no switch on kind.
  - `tui/src/ui.rs` renders `r.kind` as a padded label (line 832, 1512, 1921) and pretty-prints `rec.payload` (line 1911) — no switch on kind.
  - `crates/harness-data/src/lib.rs::ApprovalQueueRecord.kind` is `String`, not an enum.
  - The `ApprovalKind` widening therefore renders correctly across all dashboards with no code changes. Documented inline in the `ApprovalKind` JSDoc; PR-5 docs will reference this.
- **`src/orchestrator/handoff/threshold-listener.ts`** — new `attachHandoffThresholdListener({ channelStore, approvalsQueue, channelId, sessionId, pollIntervalMs? })`. Polls the channel feed via `ChannelStore.readFeed`, filters on the Phase 1 contract predicate, dedupes in-process by `(sessionId, threshold)`, seeds restart-idempotency from `approvalsQueue.list(sessionId)` (positional per H1) filtered to `kind === "handoff-prompt"` in JS. Default `pollIntervalMs = DEFAULT_HANDOFF_THRESHOLD_POLL_MS = 5000` (M8). STRING→NUMBER conversion of `metadata.threshold` / `pct` / `used` / `total` happens exactly once at the listener boundary (M1).
- **Self-loop disjointness (L6).** Listener's contract predicate requires `metadata.kind === "context_threshold"`; any future follow-up posts carry `metadata.handoffPrompt: true`. Disjoint by construction. Code-comment makes this explicit.
- **Tests.** Converted `test/orchestrator/handoff/threshold-listener.test.ts` from `describe.todo` to a live 9-test suite, including the H2b defense-in-depth two-session-independence test, T-02-12 schema-version drift fail-closed, and restart-idempotency seeding.

## Out of scope (per task spec)

- `rly handoff` CLI command — PR-4
- Brief seeding new sessions, `--save` / `--resume` modes — PR-4
- Docs / integration tests in `describe.skip` — PR-5
- Any actual GUI/TUI widening implementation — N/A; the audit shows no widening is required

## Phase 1 PR-2 coordination

Phase 1 PR-2 (the producer of `kind: "context_threshold"` channel-feed entries) is being executed in parallel. This PR's tests simulate the Phase 1 feed-entry shape verbatim per the inherited contract block. Integration becomes live once PR-2 lands; no additional changes are expected here.

## CI gates

- `pnpm typecheck` — clean
- `pnpm test` — 1056 passed | 24 skipped | 37 todo (1117 total)
- `pnpm test test/orchestrator/handoff/threshold-listener.test.ts` — 9/9 pass
- `pnpm format:check` — all matched files use Prettier code style
- `cargo check --workspace --locked` — clean

Net diff: **+551 LOC** (well under 800).

## Test plan

- [ ] `pnpm test test/orchestrator/handoff/threshold-listener.test.ts` shows 9 passing
- [ ] `pnpm test test/approvals/queue.test.ts` still passes (24 tests, none should regress on `ApprovalKind` widening)
- [ ] `pnpm typecheck`, `pnpm format:check`, `cargo check --workspace --locked` all green
- [ ] Manual smoke: enqueue a `handoff-prompt` approval and run `rly pending-approvals --json` to confirm the new kind serializes / renders without dashboard breakage (deferred to PR-5 audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)