### PR TITLE
feat(budget): adapter usage + tracker pool + threshold-feed bridge (Phase 1 PR-2)

### DIFF
--- a/docs/design/context-threshold-events.md
+++ b/docs/design/context-threshold-events.md
@@ -1,0 +1,140 @@
+# Context-threshold events on the channel feed
+
+Status: Stable as of Phase 1 (2026-05-09)
+Owner: Relay core
+Target version: 0.7.x
+Related code paths:
+
+- `src/budget/threshold-feed-bridge.ts`
+- `src/budget/token-tracker.ts`
+- `src/budget/session-tracker-pool.ts`
+- `src/orchestrator/orchestrator-v2.ts`
+- `src/channels/channel-store.ts`
+- `crates/harness-data/src/lib.rs` (Rust mirror — `SessionBudget`, `SessionKind`)
+
+## Problem
+
+Phase 2's `rly handoff` planner surfaces a "you're at 90%, want to hand off?" prompt when a chat session is near the model's context-window ceiling. It needs a deterministic, on-disk signal so the planner can subscribe via the existing channel-feed file rather than reaching into orchestrator internals. Phase 1 emits that signal.
+
+## Goals
+
+- Phase 2's planner can subscribe by tailing `~/.relay/channels/<id>/feed.jsonl`.
+- The signal is rising-edge only — re-crossing 90% (e.g. after compaction) does not re-fire within the same session.
+- The signal survives a process restart — `TokenTracker.firedThresholds` replay (token-tracker.ts:404-408) marks already-crossed thresholds on construction so a reload doesn't re-emit them.
+- The same shape works for chat sessions (recorded via `rly chat record-usage`, Phase 1 PR-4) and orchestrator dispatches (recorded by `OrchestratorV2.dispatch`, Phase 1 PR-2).
+
+## Non-goals
+
+- Cross-process locking on `feed.jsonl` writes. The existing append-only contract applies (AGENTS.md: "channel-store.postEntry is append-only"). A torn last line is silently skipped by the Rust reader and recovers on the next render cycle.
+- Re-firing a crossed threshold within the same session — by design, per `TokenTracker.firedThresholds`. Phase 2 must not assume retriggers.
+- Per-tenant or per-workspace filtering. Subscribers filter on `metadata.sessionId` if they want session-scoped semantics.
+
+## Mental model
+
+```
+Adapter (cli-agents.ts)
+    │ extracts result.tokenUsage
+    ▼
+OrchestratorV2.dispatch (or chat record-usage CLI)
+    │ pool.get(sessionId, ceiling, kind).record(in, out)
+    ▼
+TokenTracker
+    │ firedThresholds + onThreshold listeners
+    ▼
+attachThresholdFeed (filter to [75, 90, 95])
+    │ channelStore.postEntry({ type: "status_update", metadata: { kind: "context_threshold", … } })
+    ▼
+~/.relay/channels/<chid>/feed.jsonl
+    │ appended atomically (one entry per crossed threshold per session)
+    ▼
+Phase 2 handoff planner (subscriber)
+```
+
+The wider in-process threshold list (`[50, 60, 75, 85, 90, 95, 100]`, D-01) stays available for in-process subscribers like `RepoAdminSession.handleThresholdEvent` (60% memory-shed cycle). The bridge filters down to `[75, 90, 95]` for the channel-feed surface so chat-session noise is bounded.
+
+## Specs
+
+### Channel-feed entry shape
+
+A threshold crossing emits ONE `ChannelEntry`:
+
+```jsonc
+{
+  "type": "status_update",
+  "fromAgentId": null,
+  "fromDisplayName": "Relay",
+  "content": "Context window at 91% (90% threshold).",
+  "metadata": {
+    "kind": "context_threshold",
+    "schemaVersion": "1",
+    "threshold": "90",
+    "pct": "91.23",
+    "used": "182464",
+    "total": "200000",
+    "sessionId": "sess-1762634000123",
+    "model": "claude-sonnet-4-5",
+  },
+}
+```
+
+All `metadata` values are strings (matches the `ChannelEntry.metadata: Record<string, unknown>` convention; numeric round-trips are the consumer's job). `metadata.pct` is pinned to `/^\d+\.\d{2}$/` by `test/budget/threshold-feed-bridge.test.ts` (M7).
+
+Given a `record()` that crosses 75 / 90 / 95 in one call, the bridge:
+
+- When the crossed threshold is in `[75, 90, 95]`, posts exactly one `status_update` entry with `metadata.kind === "context_threshold"`.
+- When the crossed threshold is outside that subset (e.g. 50, 60, 85, 100), posts nothing — the in-process EventEmitter still fires for in-process subscribers.
+
+Given a process restart over an existing `~/.relay/sessions/<id>/budget.jsonl` whose cumulative is at 80%:
+
+- `TokenTracker` replay marks `[50, 60, 75]` as already-fired (the canonical THRESHOLDS set ≤ resumed pct).
+- A subsequent `record()` that crosses 90% emits one threshold-feed entry with `metadata.threshold === "90"`. 75 does NOT re-fire.
+
+### Phase 2 subscription rule
+
+```ts
+const isContextThreshold90 = (entry: { type: string; metadata?: Record<string, unknown> }) =>
+  entry.type === "status_update" &&
+  entry.metadata?.kind === "context_threshold" &&
+  entry.metadata?.threshold === "90";
+```
+
+Filter `feed.jsonl` lines through that predicate. The `sessionId` field tells you WHICH session crossed; a channel hosting multiple sessions over its lifetime emits one event per (session, threshold) pair.
+
+### Handoff session-id contract (D-03 + M8 sharpening)
+
+A Phase-2 handoff creates a NEW sessionId in the destination provider. The intent is that this session's tracker starts at 0% — but **Phase 1 does not enforce this in code**. Phase 1 guarantees only that `firedThresholds` is replayed from disk for the same sessionId (`src/budget/token-tracker.ts`).
+
+To satisfy the 0%-start requirement, **Phase 2 MUST mint unique sessionIds** that have no pre-existing `~/.relay/sessions/<id>/budget.jsonl`. As a soft guard, `SessionTrackerPool.get` emits `console.warn("[budget] tracker for sessionId X is replaying non-zero state from disk")` if a brand-new sessionId surfaces a non-zero existing budget — but this is a warning, not an error. **Phase 2 owns the uniqueness invariant.**
+
+Subscribers should treat each `(sessionId, threshold)` pair as independent.
+
+### Schema bumps
+
+`metadata.schemaVersion === "1"` is the contract version. Bumping it is a breaking change — coordinate across:
+
+1. `src/budget/threshold-feed-bridge.ts` (the emitter).
+2. `src/domain/session-budget.ts` (the on-disk shape).
+3. `crates/harness-data/src/lib.rs` (the Rust mirror's `default_session_budget_schema_version`).
+4. Phase 2's planner subscription code.
+
+A coordinated bump should also include a forward-migration helper for any pre-existing on-disk lines.
+
+## Implementation plan
+
+Already implemented in Phase 1 PR-2 (this design doc lands in the same PR):
+
+1. `src/budget/threshold-feed-bridge.ts` exports `attachThresholdFeed(tracker, channelId, channelStore, opts)` returning an unsubscribe handle.
+2. `OrchestratorV2.dispatch` calls `attachThresholdFeed` after the first `tokenUsage`-bearing dispatch on a run, capturing the unsubscribe in `thresholdFeedUnsubs`.
+3. `OrchestratorV2.waitForPendingWrites` runs every captured unsubscribe BEFORE `trackerPool.closeAll()` so a final-write listener never fires after the channel store is gone.
+4. `TokenTracker.safeEmitThreshold` awaits any `Promise<void>` returned by an async listener so `tracker.flush()` drains the bridge's `channelStore.postEntry` work — `tests` and the orchestrator's drain rely on that.
+
+Phase 1 PR-4 (later) adds the chat-mode `record-usage` CLI handler that reuses the same bridge for GUI- and TUI-launched chat sessions.
+
+## Open questions
+
+- **Multi-tenant scoping**: today the bridge posts to a single channel id passed at construction. If a future feature wants to fan out the same threshold event to multiple channels (e.g. an org-wide audit channel), the contract is additive — multiple `attachThresholdFeed` calls subscribe independent listeners. No change required here.
+- **Numeric vs string metadata**: `ChannelEntry.metadata` is `Record<string, unknown>` so we could emit numbers. The Phase-2 planner is expected to `parseFloat` the strings already; flipping to numbers would be a `schemaVersion` bump.
+
+## Sign-off
+
+Pending Phase 2 plan-phase confirmation that the documented filter (`type === "status_update" && metadata.kind === "context_threshold" && metadata.threshold === "90"`) matches what the handoff planner subscribes to.

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -9,11 +9,17 @@ import {
   type AgentCapability,
   type FailureClassification,
   type AgentProvider,
+  type TokenUsage,
   type WorkRequest,
 } from "../domain/agent.js";
 import { parsePhasePlan, type PhasePlan } from "../domain/phase-plan.js";
 import { getDisallowedBuiltinsForRole, type AgentRoleName } from "../mcp/role-allowlist.js";
 import type { CommandInvoker } from "./command-invoker.js";
+import {
+  normalizeClaudeUsage,
+  processStreamLine,
+  type StreamParseState,
+} from "./process-stream-line.js";
 
 interface CliAgentOptions {
   id: string;
@@ -90,7 +96,50 @@ interface ParsedProviderResult {
     blockers: string[];
     failureClassification?: FailureClassification;
     phasePlan?: PhasePlan;
+    /**
+     * Per-call token usage extracted by the adapter (Phase 1, Task 3). Set
+     * by the provider-specific parsing path (`obj.usage` on the Claude
+     * `result` event, top-level `usage` on the Codex `response.json`); never
+     * set from the model's response body even if the model echoes a usage
+     * field. Missing usage is non-fatal — callers MUST guard with
+     * `if (result.tokenUsage) { ... }`.
+     */
+    tokenUsage?: TokenUsage;
   };
+}
+
+/**
+ * Stable warning string for the M2 INCONCLUSIVE-branch fallback. Kept as a
+ * module-level constant so the `cli-agents-codex-usage-spike.test.ts` snapshot
+ * test can grep it deterministically and so re-spike work that flips the
+ * branch can repoint the warning at the new failure mode without hunting
+ * through string fragments.
+ */
+const CODEX_USAGE_UNAVAILABLE_WARNING =
+  "[budget] Codex usage extraction unavailable; bar will not update for this session. " +
+  "Re-run the A1 spike with codex installed to enable telemetry.";
+
+/**
+ * Normalize Codex's `response.json` `usage` block (Branch A from the A1
+ * spike). Mirrors {@link normalizeClaudeUsage} but for the OpenAI/Codex
+ * field names — `cached_input_tokens` is the cache hit accounting field.
+ * Cached tokens still occupy the context window, so they sum into
+ * `inputTokens` (same convention as the Claude path).
+ */
+function normalizeCodexUsage(usage: Record<string, unknown>): TokenUsage {
+  const input = numFromUnknown(usage.input_tokens);
+  const cached = numFromUnknown(usage.cached_input_tokens);
+  const result: TokenUsage = {
+    inputTokens: input + cached,
+    outputTokens: numFromUnknown(usage.output_tokens),
+  };
+  if (cached > 0) result.cacheReadTokens = cached;
+  return result;
+}
+
+function numFromUnknown(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return 0;
+  return Math.trunc(value);
 }
 
 /**
@@ -330,11 +379,26 @@ export class CodexCliAgent extends CliAgentBase {
       }
 
       const rawResponse = await readFile(outputPath, "utf8");
+      const responseBody = JSON.parse(rawResponse) as Record<string, unknown>;
 
-      return {
-        rawResponse,
-        parsed: this.normalizePayload(JSON.parse(rawResponse)),
-      };
+      // A1 spike branch INCONCLUSIVE (per `01-SPIKE-A1.md`): Branch A only —
+      // parse a top-level `usage` block from `response.json`. If the field
+      // is absent (older Codex versions, or the spike's documented gap),
+      // emit ONE stderr warning so operators see why the bar is stuck. The
+      // orchestrator (Task 4) guards on `if (result.tokenUsage)` so a
+      // missing usage is a no-op for downstream consumers.
+      const rawUsage = responseBody.usage;
+      let tokenUsage: TokenUsage | undefined;
+      if (rawUsage && typeof rawUsage === "object") {
+        tokenUsage = normalizeCodexUsage(rawUsage as Record<string, unknown>);
+      } else {
+        console.warn(CODEX_USAGE_UNAVAILABLE_WARNING);
+      }
+
+      const parsed = this.normalizePayload(responseBody);
+      if (tokenUsage) parsed.tokenUsage = tokenUsage;
+
+      return { rawResponse, parsed };
     } finally {
       await rm(tempDir, {
         recursive: true,
@@ -409,10 +473,17 @@ export class ClaudeCliAgent extends CliAgentBase {
       throw new Error(result.stderr || result.stdout || "Claude execution failed.");
     }
 
-    return {
-      rawResponse: result.stdout,
-      parsed: this.normalizePayload(JSON.parse(result.stdout)),
-    };
+    const responseBody = JSON.parse(result.stdout) as Record<string, unknown>;
+    const parsed = this.normalizePayload(responseBody);
+    // Claude's `--output-format json` body carries the same `usage` shape as
+    // the streaming `result` event (Anthropic Messages API parity). Treating
+    // it as opaque key/value soup so the parser doesn't break if the API
+    // evolves a new cache-tier field.
+    const rawUsage = responseBody.usage;
+    if (rawUsage && typeof rawUsage === "object") {
+      parsed.tokenUsage = normalizeClaudeUsage(rawUsage as Record<string, unknown>);
+    }
+    return { rawResponse: result.stdout, parsed };
   }
 
   /**
@@ -453,37 +524,14 @@ export class ClaudeCliAgent extends CliAgentBase {
 
     let stdoutBuf = "";
     let stderrBuf = "";
-    let accumText = "";
-    let resultText: string | null = null;
     const onLine = this.onStreamLine!;
-
-    const processLine = (line: string) => {
-      if (!line) return;
-      onLine(line);
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(line);
-      } catch {
-        return;
-      }
-      if (!parsed || typeof parsed !== "object") return;
-      const obj = parsed as Record<string, unknown>;
-      if (obj.type === "assistant") {
-        const msg = obj.message as { content?: unknown } | undefined;
-        const blocks = Array.isArray(msg?.content) ? msg?.content : null;
-        if (!blocks) return;
-        for (const block of blocks) {
-          if (block && typeof block === "object") {
-            const b = block as Record<string, unknown>;
-            if (b.type === "text" && typeof b.text === "string") {
-              accumText += b.text;
-            }
-          }
-        }
-      } else if (obj.type === "result" && typeof obj.result === "string") {
-        resultText = obj.result;
-      }
+    const state: StreamParseState = {
+      accumText: "",
+      resultText: null,
+      capturedUsage: null,
     };
+
+    const consume = (line: string) => processStreamLine(line, state, onLine);
 
     handle.onStdout((chunk) => {
       stdoutBuf += chunk;
@@ -491,7 +539,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       while ((newlineIdx = stdoutBuf.indexOf("\n")) >= 0) {
         const line = stdoutBuf.slice(0, newlineIdx).trim();
         stdoutBuf = stdoutBuf.slice(newlineIdx + 1);
-        if (line) processLine(line);
+        if (line) consume(line);
       }
     });
     handle.onStderr((chunk) => {
@@ -503,20 +551,19 @@ export class ClaudeCliAgent extends CliAgentBase {
       handle.onExit((code) => resolve(code ?? 1));
     });
     const tail = stdoutBuf.trim();
-    if (tail) processLine(tail);
+    if (tail) consume(tail);
 
     if (exitCode !== 0) {
       throw new Error(stderrBuf || stdoutBuf || "Claude execution failed.");
     }
 
-    const raw = resultText ?? accumText;
+    const raw = state.resultText ?? state.accumText;
     if (!raw) {
       throw new Error("Claude stream produced no parseable JSON body.");
     }
-    return {
-      rawResponse: raw,
-      parsed: this.normalizePayload(JSON.parse(raw)),
-    };
+    const parsed = this.normalizePayload(JSON.parse(raw));
+    if (state.capturedUsage) parsed.tokenUsage = state.capturedUsage;
+    return { rawResponse: raw, parsed };
   }
 }
 

--- a/src/agents/process-stream-line.ts
+++ b/src/agents/process-stream-line.ts
@@ -5,9 +5,7 @@ import type { TokenUsage } from "../domain/agent.js";
  * a Claude streaming invocation. Lives in `src/agents/` as a dedicated
  * module so the adapter (`cli-agents.ts`) can `import { processStreamLine
  * } from "./process-stream-line.js"` without growing the monolithic
- * adapter file. PR-2 (Task 3) lifts the existing closure body in
- * `invokeStreaming` into this function verbatim and adds the `obj.usage`
- * capture on the `result` arm.
+ * adapter file.
  */
 export interface StreamParseState {
   accumText: string;
@@ -16,15 +14,79 @@ export interface StreamParseState {
 }
 
 /**
- * **Phase 1 PR-1:** stub. The pure function ships in PR-2 (Task 3); the
- * signature lands in PR-1 so the RED Claude streaming-usage test
- * (`test/agents/cli-agents-claude-usage.test.ts`) compiles against the
- * final shape.
+ * Coerce an unknown value to a non-negative integer. Non-finite / non-numeric
+ * inputs collapse to 0 — the adapter never throws on a malformed `usage` block
+ * because missing usage is non-fatal for callers (Task 3 contract).
+ */
+function num(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return 0;
+  return Math.trunc(value);
+}
+
+/**
+ * Normalize Claude's per-call `usage` payload into Relay's provider-agnostic
+ * {@link TokenUsage}. Cache-read and cache-creation tokens are summed into
+ * `inputTokens` (research Q3 — cache occupies the context window so it
+ * counts against the bar) and surfaced separately for forensics. Treats the
+ * payload as opaque key/value soup — every numeric field defaults to 0 if
+ * missing or malformed.
+ */
+export function normalizeClaudeUsage(usage: Record<string, unknown>): TokenUsage {
+  const input = num(usage.input_tokens);
+  const cacheRead = num(usage.cache_read_input_tokens);
+  const cacheWrite = num(usage.cache_creation_input_tokens);
+  const result: TokenUsage = {
+    inputTokens: input + cacheRead + cacheWrite,
+    outputTokens: num(usage.output_tokens),
+  };
+  if (cacheRead > 0) result.cacheReadTokens = cacheRead;
+  if (cacheWrite > 0) result.cacheWriteTokens = cacheWrite;
+  return result;
+}
+
+/**
+ * Process one stream-json line from a Claude invocation. Mutates `state` in
+ * place — `accumText` accumulates assistant-message text blocks, `resultText`
+ * is set on the final `result` event, and `capturedUsage` is set when the
+ * `result` event carries a top-level `usage` block. Mid-stream
+ * `assistant.message.usage` is intentionally ignored — only the final
+ * `result` event is authoritative (pitfall #2 from research).
+ *
+ * `onLine` receives every raw line so callers can render tool-use activity
+ * live. Lines that fail to parse as JSON, or don't match a recognized event
+ * type, are forwarded to `onLine` and otherwise ignored.
  */
 export function processStreamLine(
-  _line: string,
-  _state: StreamParseState,
-  _onLine: (line: string) => void
+  line: string,
+  state: StreamParseState,
+  onLine: (line: string) => void
 ): void {
-  throw new Error("processStreamLine: not yet implemented (Phase 1 PR-2 / Task 3)");
+  if (!line) return;
+  onLine(line);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== "object") return;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.type === "assistant") {
+    const msg = obj.message as { content?: unknown } | undefined;
+    const blocks = Array.isArray(msg?.content) ? msg?.content : null;
+    if (!blocks) return;
+    for (const block of blocks) {
+      if (block && typeof block === "object") {
+        const b = block as Record<string, unknown>;
+        if (b.type === "text" && typeof b.text === "string") {
+          state.accumText += b.text;
+        }
+      }
+    }
+  } else if (obj.type === "result" && typeof obj.result === "string") {
+    state.resultText = obj.result;
+    if (obj.usage && typeof obj.usage === "object") {
+      state.capturedUsage = normalizeClaudeUsage(obj.usage as Record<string, unknown>);
+    }
+  }
 }

--- a/src/budget/session-tracker-pool.ts
+++ b/src/budget/session-tracker-pool.ts
@@ -1,5 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 import { TokenTracker } from "./token-tracker.js";
 import type { SessionKind } from "../domain/session-budget.js";
+
+/**
+ * Resolve the per-process `~/.relay` directory by reading `HOME` directly
+ * rather than through {@link getRelayDir}. The pool needs to honor a
+ * per-test `process.env.HOME = tmp` override on every `get()` so the M8
+ * disk-probe and the constructed {@link TokenTracker} both target the same
+ * tmp tree. {@link getRelayDir} caches its first answer for the process
+ * lifetime, which would couple unrelated tests via shared state.
+ */
+function relayRootForCurrentEnv(): string {
+  return join(homedir(), ".relay");
+}
 
 /**
  * One-tracker-per-chat-session pool. Construction is lazy: the first
@@ -8,22 +24,97 @@ import type { SessionKind } from "../domain/session-budget.js";
  * Subsequent calls return the same instance — same-process records
  * serialize through the tracker's writeChain (token-tracker.ts:75).
  *
- * **Phase 1 PR-1:** stub. The shape lands in PR-1 so tests + typecheck
- * compile against final types; the implementation lands in PR-2 (Task 4).
- * Calls to `get()` / `closeAll()` throw at runtime so RED tests fail
- * loudly. See `.planning/phases/01-token-usage-telemetry-context-bar/01-PLAN.md`
- * Task 4 for the full implementation contract (M8 soft-warning, etc.).
+ * Per D-02 the pool is keyed by chat sessionId, not channelId — a channel
+ * may host multiple sessions over its lifetime; each gets its own tracker
+ * + budget file. Per D-03 a Phase-2 handoff creates a new sessionId in the
+ * destination provider; that session's tracker starts at 0% (the file is
+ * fresh on disk) — see {@link ../../docs/design/context-threshold-events.md}
+ * for the cross-phase contract.
+ *
+ * **M8 soft-warning:** if a brand-new sessionId surfaces a pre-existing
+ * `budget.jsonl` with non-zero `cumulativeUsed`, log via `console.warn` —
+ * this is most likely a reused id from Phase 2 that violated the 0%-start
+ * guarantee, OR a legitimate same-id resumption (in which case the warning
+ * is harmless). We prefer false positives over silent failures (Phase 2's
+ * planner CI will treat the warning as a contract violation).
  */
 export class SessionTrackerPool {
-  get(_sessionId: string, _ceiling: number, _kind?: SessionKind): TokenTracker {
-    throw new Error("SessionTrackerPool: not yet implemented (Phase 1 PR-2 / Task 4)");
+  private readonly trackers = new Map<string, TokenTracker>();
+
+  /**
+   * Return the tracker for `sessionId`, constructing it on first call and
+   * memoizing for the rest of the process lifetime. `ceiling` is the
+   * model's context-window total in tokens (resolved via
+   * {@link ../domain/model-context-windows.ts resolveContextWindow}); only
+   * the first call's value is honored — subsequent calls get the existing
+   * tracker regardless of the passed ceiling.
+   *
+   * `kind` (default `"admin"`, matching the on-disk back-compat default)
+   * is written onto every appended `BudgetLine` so the Rust + TS readers
+   * can filter chat / run / admin sessions in dashboards.
+   */
+  get(sessionId: string, ceiling: number, kind: SessionKind = "admin"): TokenTracker {
+    let tracker = this.trackers.get(sessionId);
+    if (!tracker) {
+      this.maybeWarnReplay(sessionId);
+      const rootDir = relayRootForCurrentEnv();
+      tracker = new TokenTracker(sessionId, ceiling, { rootDir, kind });
+      this.trackers.set(sessionId, tracker);
+    }
+    return tracker;
   }
 
-  has(_sessionId: string): boolean {
-    throw new Error("SessionTrackerPool: not yet implemented (Phase 1 PR-2 / Task 4)");
+  has(sessionId: string): boolean {
+    return this.trackers.has(sessionId);
   }
 
+  /**
+   * Drain in-flight writes for every tracker and clear the pool. Called
+   * from `OrchestratorV2.run()` cleanup so all `budget.jsonl` writes flush
+   * to disk before the run resolves (mirrors the existing `pendingWrites`
+   * drain pattern). Uses `allSettled` so a single tracker's close failure
+   * doesn't short-circuit the drain.
+   */
   async closeAll(): Promise<void> {
-    throw new Error("SessionTrackerPool: not yet implemented (Phase 1 PR-2 / Task 4)");
+    const all = [...this.trackers.values()];
+    this.trackers.clear();
+    await Promise.allSettled(all.map((t) => t.close()));
+  }
+
+  /**
+   * Probe `~/.relay/sessions/<sessionId>/budget.jsonl` before construction
+   * and log the M8 soft-warning if the file already exists with non-zero
+   * `cumulativeUsed`. Sync IO — runs once per (pool, sessionId) pair on
+   * the first `get()` call. Malformed lines are silently swallowed; the
+   * tracker's own replay handles torn-file recovery.
+   */
+  private maybeWarnReplay(sessionId: string): void {
+    const path = join(relayRootForCurrentEnv(), "sessions", sessionId, "budget.jsonl");
+    if (!existsSync(path)) return;
+    let content: string;
+    try {
+      content = readFileSync(path, "utf8").trim();
+    } catch {
+      return;
+    }
+    if (!content) return;
+    const lines = content.split("\n").filter(Boolean);
+    const lastLine = lines[lines.length - 1];
+    if (!lastLine) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(lastLine);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") return;
+    const cumulative = (parsed as { cumulativeUsed?: unknown }).cumulativeUsed;
+    if (typeof cumulative === "number" && cumulative > 0) {
+      console.warn(
+        `[budget] tracker for sessionId "${sessionId}" is replaying non-zero state ` +
+          `(used=${cumulative}) from disk — if Phase 2 minted this id, the 0% ` +
+          `start guarantee may have been violated.`
+      );
+    }
   }
 }

--- a/src/budget/threshold-feed-bridge.ts
+++ b/src/budget/threshold-feed-bridge.ts
@@ -1,31 +1,96 @@
 import type { ChannelStore } from "../channels/channel-store.js";
-import type { TokenTracker } from "./token-tracker.js";
+import type { ThresholdEvent, TokenTracker } from "./token-tracker.js";
+
+/**
+ * Default subset of the canonical {@link ../budget/token-tracker.js THRESHOLDS}
+ * that this bridge forwards to the channel feed. Other thresholds still fire
+ * on the in-process EventEmitter for in-process subscribers (e.g.
+ * `RepoAdminSession`'s 60% memory-shed cycle in
+ * `src/orchestrator/repo-admin-session.ts`); they are simply not posted to
+ * the channel feed here.
+ *
+ * Phase 2's handoff planner subscribes to `entry.metadata.threshold === "90"`
+ * — see `docs/design/context-threshold-events.md` for the cross-phase
+ * contract.
+ */
+const DEFAULT_POST_THRESHOLDS = [75, 90, 95] as const;
 
 export interface ThresholdFeedOptions {
   /**
    * Subset of `THRESHOLDS` (token-tracker.ts:21) to forward to the channel
-   * feed. Defaults to [75, 90, 95] per the Phase-1 brief. Other thresholds
+   * feed. Defaults to {@link DEFAULT_POST_THRESHOLDS}. Other thresholds
    * still fire on the in-process EventEmitter for in-process subscribers
    * (e.g. RepoAdminSession's 60% memory-shed subscriber); they are simply
    * not posted to the channel feed here.
    */
   postThresholds?: readonly number[];
-  /** Optional model name surfaced in metadata for downstream readers. */
+  /**
+   * Optional model name surfaced as `metadata.model` for downstream
+   * readers. The GUI's worst-session chip displays it so the operator
+   * knows which session crossed.
+   */
   modelName?: string;
 }
 
 /**
- * **Phase 1 PR-1:** stub. The bridge implementation lands in PR-2 (Task 5);
- * the shape + signature ship in PR-1 so RED tests compile. See
- * `.planning/phases/01-token-usage-telemetry-context-bar/01-PLAN.md` Task 5
- * for the contract (filter to [75, 90, 95], `metadata.kind ===
- * "context_threshold"`, M7 pct precision, etc.).
+ * Subscribe a {@link TokenTracker} to the channel feed: every threshold
+ * crossing in {@link ThresholdFeedOptions.postThresholds} (default 75/90/95)
+ * triggers one `status_update` `ChannelEntry` with
+ * `metadata.kind === "context_threshold"`. Returns an unsubscribe handle —
+ * the caller (typically `OrchestratorV2.waitForPendingWrites`) must invoke
+ * it before tearing down the channel store.
+ *
+ * **Stable metadata contract** (Phase 2 handoff subscriber relies on this —
+ * see `docs/design/context-threshold-events.md`):
+ *
+ *   - `kind`: always `"context_threshold"` (the discriminator).
+ *   - `schemaVersion`: `"1"` (string). Bumping requires a coordinated update
+ *     across Phase 1 and Phase 2 codepaths.
+ *   - `threshold`: integer-as-string (`"75"` | `"90"` | `"95"`).
+ *   - `pct`: fixed-2-decimal string matching `/^\d+\.\d{2}$/` (M7 — pinned by
+ *     `test/budget/threshold-feed-bridge.test.ts`).
+ *   - `used` / `total`: token counts, integer-as-string.
+ *   - `sessionId`: the chat sessionId. After a Phase-2 handoff, the
+ *     destination provider gets a NEW sessionId — Phase 2 owns the
+ *     uniqueness invariant (D-03 + M8 sharpening).
+ *   - `model?`: optional, only set when {@link ThresholdFeedOptions.modelName}
+ *     is supplied.
+ *
+ * Best-effort: a channel-post failure logs `[threshold-feed] post failed`
+ * via `console.warn` but never throws — the listener stays attached so a
+ * single transient write failure doesn't break subsequent crossings.
  */
 export function attachThresholdFeed(
-  _tracker: TokenTracker,
-  _channelId: string,
-  _channelStore: ChannelStore,
-  _opts: ThresholdFeedOptions = {}
+  tracker: TokenTracker,
+  channelId: string,
+  channelStore: ChannelStore,
+  opts: ThresholdFeedOptions = {}
 ): () => void {
-  throw new Error("attachThresholdFeed: not yet implemented (Phase 1 PR-2 / Task 5)");
+  const post = new Set<number>(opts.postThresholds ?? DEFAULT_POST_THRESHOLDS);
+  return tracker.onThreshold(async (evt: ThresholdEvent) => {
+    if (!post.has(evt.threshold)) return;
+    const metadata: Record<string, string> = {
+      kind: "context_threshold",
+      schemaVersion: "1",
+      threshold: String(evt.threshold),
+      pct: evt.pct.toFixed(2),
+      used: String(evt.used),
+      total: String(evt.total),
+      sessionId: evt.sessionId,
+    };
+    if (opts.modelName) metadata.model = opts.modelName;
+
+    try {
+      await channelStore.postEntry(channelId, {
+        type: "status_update",
+        fromAgentId: null,
+        fromDisplayName: "Relay",
+        content: `Context window at ${Math.round(evt.pct)}% (${evt.threshold}% threshold).`,
+        metadata,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[threshold-feed] post failed (sessionId=${evt.sessionId}): ${message}`);
+    }
+  });
 }

--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -35,7 +35,17 @@ export type ThresholdEvent = {
   threshold: number;
 };
 
-export type ThresholdListener = (evt: ThresholdEvent) => void;
+/**
+ * Threshold subscriber contract. Return value is ignored UNLESS it is a
+ * thenable, in which case the tracker awaits it inside its write chain so
+ * `flush()` drains async side-effects (e.g. the threshold-feed bridge's
+ * `channelStore.postEntry`). Returning a non-promise value (e.g. an arrow
+ * `() => array.push(...)` that yields the new length) is still permitted
+ * for back-compat with synchronous in-process subscribers like
+ * `RepoAdminSession.handleThresholdEvent` — the value is dropped on the
+ * floor.
+ */
+export type ThresholdListener = (evt: ThresholdEvent) => unknown;
 
 /**
  * One line in `budget.jsonl`. Each `record()` call appends exactly one line
@@ -183,7 +193,9 @@ export class TokenTracker {
       // Fire threshold events before the disk write so listeners observe
       // crossings in the same order they happen in `_used`. Each dispatch
       // is isolated so a throwing listener can't abort the loop or take
-      // down the tracker (record() is a documented void hot path).
+      // down the tracker (record() is a documented void hot path). Async
+      // listeners (e.g. the threshold-feed bridge) are awaited so their
+      // side-effects drain as part of `flush()`.
       for (const threshold of crossed) {
         this.firedThresholds.add(threshold);
         const evt: ThresholdEvent = {
@@ -193,7 +205,7 @@ export class TokenTracker {
           pct: this.pct,
           threshold,
         };
-        this.safeEmitThreshold(evt);
+        await this.safeEmitThreshold(evt);
       }
 
       try {
@@ -338,15 +350,25 @@ export class TokenTracker {
 
   /**
    * Dispatch a threshold event to each subscriber individually. A listener
-   * that throws is logged to `console.warn` and the remaining listeners
-   * still fire — a single bad subscriber can't abort the emit loop or kill
-   * the tracker's void hot path.
+   * that throws (sync) or rejects (async) is logged to `console.warn` and
+   * the remaining listeners still fire — a single bad subscriber can't
+   * abort the emit loop or kill the tracker's void hot path.
+   *
+   * Awaits any `Promise<void>` returned by a listener so async work the
+   * subscriber kicks off (e.g. {@link ../budget/threshold-feed-bridge.js
+   * attachThresholdFeed}'s `channelStore.postEntry`) drains as part of the
+   * tracker's `record()` write-chain. This means {@link flush} drains
+   * those side-effects too — tests and the orchestrator's
+   * `waitForPendingWrites` rely on that ordering.
    */
-  private safeEmitThreshold(evt: ThresholdEvent): void {
+  private async safeEmitThreshold(evt: ThresholdEvent): Promise<void> {
     const listeners = this.emitter.listeners("threshold") as ThresholdListener[];
     for (const listener of listeners) {
       try {
-        listener(evt);
+        const maybe = listener(evt);
+        if (maybe && typeof (maybe as { then?: unknown }).then === "function") {
+          await maybe;
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`TokenTracker: threshold ${evt.threshold} listener threw: ${msg}`);

--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { appendFile, mkdir, readFile, rename } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+import type { SessionKind } from "../domain/session-budget.js";
 import { getRelayDir } from "../cli/paths.js";
 
 /**
@@ -43,12 +44,18 @@ export type ThresholdListener = (evt: ThresholdEvent) => void;
  * forensics, not for replay (the sum is the source of truth, so a
  * hand-edited file that got out of sync on cumulativeUsed still replays
  * correctly).
+ *
+ * `kind` (Phase 1, D-06) is the session-keyspace discriminator
+ * ("chat" | "run" | "admin"). Optional on the line because pre-Phase-1
+ * autonomous-loop files don't carry it; the Rust + TS readers default to
+ * `"admin"` when missing.
  */
 interface BudgetLine {
   ts: string;
   inputTokens: number;
   outputTokens: number;
   cumulativeUsed: number;
+  kind?: SessionKind;
 }
 
 /**
@@ -74,6 +81,13 @@ export class TokenTracker {
   private readonly firedThresholds = new Set<number>();
   private readonly emitter = new EventEmitter();
   private readonly filePath: string;
+  /**
+   * Session-keyspace discriminator (D-06) written onto every appended
+   * `BudgetLine`. `undefined` preserves pre-Phase-1 file shape (used by
+   * `RepoAdminSession` which never passes a kind — the Rust + TS readers
+   * default missing `kind` to `"admin"`).
+   */
+  private readonly kind?: SessionKind;
 
   // Serialize disk IO (replay on construct, append on record, final flush
   // on close). Every public mutator chains its work onto this tail
@@ -90,8 +104,17 @@ export class TokenTracker {
    * @param options.rootDir  Override the `~/.relay` base directory. Tests
    *                   use this with a tmp dir; production callers should
    *                   leave it undefined.
+   * @param options.kind  Session-keyspace discriminator (D-06). Written on
+   *                   every appended `BudgetLine` so the Rust + TS readers
+   *                   can filter chat vs admin sessions. Omit for back-
+   *                   compat with `RepoAdminSession` (the readers default
+   *                   to `"admin"` when missing).
    */
-  constructor(sessionId: string, totalTokens: number, options: { rootDir?: string } = {}) {
+  constructor(
+    sessionId: string,
+    totalTokens: number,
+    options: { rootDir?: string; kind?: SessionKind } = {}
+  ) {
     if (!sessionId) {
       throw new Error("TokenTracker: sessionId is required");
     }
@@ -103,6 +126,7 @@ export class TokenTracker {
 
     this.sessionId = sessionId;
     this._total = totalTokens;
+    this.kind = options.kind;
 
     const root = options.rootDir ?? getRelayDir();
     this.filePath = join(root, "sessions", sessionId, "budget.jsonl");
@@ -178,6 +202,7 @@ export class TokenTracker {
           inputTokens,
           outputTokens,
           cumulativeUsed: this._used,
+          ...(this.kind ? { kind: this.kind } : {}),
         });
       } catch (err) {
         // Disk failure shouldn't take down the autonomous loop — surface

--- a/src/budget/token-tracker.ts
+++ b/src/budget/token-tracker.ts
@@ -12,13 +12,19 @@ import { getRelayDir } from "../cli/paths.js";
  * Exported as a const tuple so callers (AL-3 scheduler, tests) can iterate
  * the canonical list instead of re-declaring it.
  *
- * The `60` entry exists primarily for AL-15's "memory-shed" cycle trigger:
- * each repo-admin session owns its own tracker and subscribes to the 60%
- * crossing to recycle its child process before the context window fills.
- * Other subsystems are free to listen for 60 too; semantics are identical
- * to the other tiers (single emit per upward crossing per tracker).
+ * Subscribers (Phase 1, D-01):
+ *   - `60` → `RepoAdminSession.handleThresholdEvent` (memory-shed cycle,
+ *     AL-15). Unchanged from pre-Phase-1.
+ *   - `75 / 90 / 95` → {@link ../budget/threshold-feed-bridge.ts attachThresholdFeed}
+ *     posts these to the channel feed for chat sessions; Phase 2's handoff
+ *     nudge subscribes to `90` from the feed.
+ *   - `100` → existing overrun signal.
+ *
+ * The Phase-1 widening (D-01) added `75` and `90` so the chat-session feed
+ * has rising-edge events for the GUI / TUI bar's warn (75) and hot (90)
+ * tiers without re-deriving them from `pct` snapshots downstream.
  */
-export const THRESHOLDS = [50, 60, 85, 95, 100] as const;
+export const THRESHOLDS = [50, 60, 75, 85, 90, 95, 100] as const;
 
 export type ThresholdEvent = {
   sessionId: string;

--- a/src/domain/agent.ts
+++ b/src/domain/agent.ts
@@ -124,6 +124,13 @@ export function roleForWork(kind: WorkKind): AgentRole {
   }
 }
 
+export const TokenUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  cacheReadTokens: z.number().int().nonnegative().optional(),
+  cacheWriteTokens: z.number().int().nonnegative().optional(),
+});
+
 export const AgentResultSchema = z.object({
   summary: z.string().min(1),
   evidence: z.array(z.string()),
@@ -131,6 +138,7 @@ export const AgentResultSchema = z.object({
   blockers: z.array(z.string()),
   failureClassification: FailureClassificationSchema.optional(),
   phasePlan: z.unknown().optional(),
+  tokenUsage: TokenUsageSchema.optional(),
 });
 
 export const agentResultJsonSchema = {

--- a/src/orchestrator/dispatch-token-usage.ts
+++ b/src/orchestrator/dispatch-token-usage.ts
@@ -1,0 +1,59 @@
+import type { Agent, AgentResult } from "../domain/agent.js";
+import { resolveContextWindow } from "../domain/model-context-windows.js";
+import { SessionTrackerPool } from "../budget/session-tracker-pool.js";
+
+/**
+ * Wire `agent.run()`'s `tokenUsage` into the per-session tracker pool for
+ * orchestrator dispatches. Best-effort EXCEPT for the missing-model
+ * assertion: that throws so an Opus 4.7 session never gets miscalibrated
+ * against the default 200_000 ceiling (an Opus 4.7 session has a 1M-token
+ * window — defaulting to 200k would mis-render the bar by 5x, and AGENTS.md
+ * explicitly flags silent type drift as a class to refuse).
+ *
+ * Lives in its own module so:
+ *   1. The orchestrator-v2 dispatch site stays small (one import + one
+ *      conditional call).
+ *   2. The Phase 1 RED test
+ *      (`test/orchestrator/orchestrator-v2-token-usage.test.ts`) can
+ *      assert the file exists and exports `dispatchTokenUsageOrThrow` —
+ *      that contract was stamped in PR-1 as the locked surface.
+ *
+ * Returns void — the tracker.record() call is fire-and-forget against the
+ * tracker's internal write chain. Callers that need to know the write hit
+ * disk should await `pool.closeAll()` (the orchestrator does this in its
+ * run-completion drain).
+ */
+export function dispatchTokenUsageOrThrow(input: {
+  pool: SessionTrackerPool;
+  agent: Agent;
+  result: AgentResult;
+  runId: string;
+}): void {
+  const { pool, agent, result, runId } = input;
+  if (!result.tokenUsage) return;
+
+  // Hidden-assumption fix (Phase 1, plan revision iteration 2): hard-throw
+  // when the agent has no model. The legacy fallback to 200_000 would
+  // silently misrender Opus 4.7's 1M window as 5x usage; we'd rather a
+  // loud failure than a wrong bar. Both fields are checked because
+  // CliAgentBase exposes the model on `protected this.model` (not on the
+  // public Agent interface) — `agent.capability.model` is the canonical
+  // surface, but some legacy adapters store it as `agent.model` directly.
+  const cap = agent.capability as { model?: string } | undefined;
+  const model = cap?.model ?? (agent as unknown as { model?: string }).model;
+  if (!model) {
+    throw new Error(
+      `[budget] missing model on agent capability (agentId=${agent.id ?? "unknown"}); ` +
+        `cannot resolve context-window ceiling for runId=${runId}.`
+    );
+  }
+
+  const sessionId = `run-${runId}`;
+  const ceiling = resolveContextWindow(model);
+  const tracker = pool.get(sessionId, ceiling, "run");
+  // `inputTokens` already includes cache-read + cache-write per the
+  // adapter normalizers (research Q3). Pass them as-is — the tracker
+  // sums input + output for cumulative and doesn't care about the
+  // breakdown.
+  tracker.record(result.tokenUsage.inputTokens, result.tokenUsage.outputTokens);
+}

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -549,9 +549,7 @@ export class OrchestratorV2 {
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             if (message.includes("missing model")) throw err;
-            console.warn(
-              `[orchestrator] tracker.record failed (runId=${run.id}): ${message}`
-            );
+            console.warn(`[orchestrator] tracker.record failed (runId=${run.id}): ${message}`);
           }
         }
 

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -1,4 +1,4 @@
-import type { AgentResult, FailureClassification, WorkRequest } from "../domain/agent.js";
+import type { Agent, AgentResult, FailureClassification, WorkRequest } from "../domain/agent.js";
 import {
   tierNeedsApproval,
   tierNeedsDesignDoc,
@@ -25,6 +25,9 @@ import { classifyRequest } from "./classifier.js";
 import { decomposePlanToTickets, buildTicketPlanFromPhases } from "./ticket-decomposer.js";
 import { checkApproval } from "./approval-gate.js";
 import { TicketScheduler } from "./ticket-scheduler.js";
+import { SessionTrackerPool } from "../budget/session-tracker-pool.js";
+import { dispatchTokenUsageOrThrow } from "./dispatch-token-usage.js";
+import { attachThresholdFeed } from "../budget/threshold-feed-bridge.js";
 
 /**
  * Anything the orchestrator can hook into for follow-up enqueueing (PR poller,
@@ -60,6 +63,13 @@ export interface OrchestratorV2Options {
    * calls would break the test path.
    */
   executor?: AgentExecutor;
+  /**
+   * Optional injection point for the per-run {@link SessionTrackerPool}.
+   * Tests may want to provide a pre-seeded pool or assert on the pool's
+   * tracker map directly; production callers should leave this undefined
+   * so the orchestrator constructs a fresh pool per instance.
+   */
+  trackerPool?: SessionTrackerPool;
 }
 
 export class OrchestratorV2 {
@@ -67,6 +77,24 @@ export class OrchestratorV2 {
   private pollerFactory: PollerFactory | null = null;
 
   private readonly executor: AgentExecutor | null;
+
+  /**
+   * Per-session token-budget pool (Phase 1, D-02). Lazily mints one
+   * {@link import("../budget/token-tracker.js").TokenTracker} per
+   * `run-<runId>` session id; each {@link dispatch} call hands the agent's
+   * `result.tokenUsage` to the matching tracker so `~/.relay/sessions/run-
+   * <runId>/budget.jsonl` accumulates a `kind: "run"` line per dispatch.
+   * Drained in {@link waitForPendingWrites} on run completion.
+   */
+  private readonly trackerPool: SessionTrackerPool;
+
+  /**
+   * Per-tracker unsubscribe handles for the threshold-feed bridge. Keyed
+   * by the same `run-<runId>` session id as {@link trackerPool}. Detached
+   * during {@link waitForPendingWrites} BEFORE the pool's `closeAll()` so
+   * a final-write listener doesn't fire after the channel store is gone.
+   */
+  private readonly thresholdFeedUnsubs = new Map<string, () => void>();
 
   /**
    * In-flight best-effort channel writes (postEntry / appendEvent) tracked so
@@ -91,6 +119,7 @@ export class OrchestratorV2 {
     options?: OrchestratorV2Options
   ) {
     this.executor = options?.executor ?? null;
+    this.trackerPool = options?.trackerPool ?? new SessionTrackerPool();
   }
 
   /**
@@ -501,6 +530,31 @@ export class OrchestratorV2 {
       try {
         const result = await agent.run(request);
 
+        // Phase 1 (Task 4 + 5): hand the adapter-extracted token usage to
+        // the per-session tracker pool, then attach the threshold-feed
+        // bridge so 75/90/95 crossings post `status_update` entries to
+        // the channel feed (Phase 2's handoff nudge subscribes to those).
+        // Best-effort EXCEPT for the missing-model assertion inside
+        // `dispatchTokenUsageOrThrow` — that re-throws so the test suite
+        // catches a silent default-200_000 miscalibration on Opus 4.7.
+        if (result.tokenUsage) {
+          try {
+            dispatchTokenUsageOrThrow({
+              pool: this.trackerPool,
+              agent,
+              result,
+              runId: run.id,
+            });
+            this.maybeAttachThresholdFeed(run, agent);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (message.includes("missing model")) throw err;
+            console.warn(
+              `[orchestrator] tracker.record failed (runId=${run.id}): ${message}`
+            );
+          }
+        }
+
         this.recordEvidence(run, {
           phaseId: input.phaseId,
           agentId: agent.id,
@@ -667,12 +721,50 @@ export class OrchestratorV2 {
    * Drain all tracked best-effort writes. Uses `allSettled` so a single
    * failure never short-circuits the drain. Clears the tracker on exit so
    * a second invocation doesn't re-await already-settled promises.
+   *
+   * Phase 1 extension (Task 4 + 5): also detach the threshold-feed bridge
+   * subscriptions and drain {@link trackerPool} so any pending
+   * `budget.jsonl` appends settle before the caller tears down the tmp
+   * artifacts dir. Detach order matters: we run the unsubscribes BEFORE
+   * `closeAll()` so a final write doesn't trip a listener that's about to
+   * lose its channel store.
    */
   private async waitForPendingWrites(): Promise<void> {
+    for (const unsub of this.thresholdFeedUnsubs.values()) {
+      try {
+        unsub();
+      } catch {
+        // Best-effort detach — a failing unsubscribe shouldn't block the
+        // drain. The pool's closeAll() removes all listeners anyway.
+      }
+    }
+    this.thresholdFeedUnsubs.clear();
+    await this.trackerPool.closeAll();
     if (this.pendingWrites.length === 0) return;
     const pending = this.pendingWrites;
     this.pendingWrites = [];
     await Promise.allSettled(pending);
+  }
+
+  /**
+   * Subscribe the run's session tracker to the channel-feed threshold
+   * bridge if (a) the run has a channelId, (b) the channel store is
+   * configured, and (c) we haven't already attached for this session.
+   * Idempotent — repeated dispatches against the same run reuse the
+   * existing subscription.
+   */
+  private maybeAttachThresholdFeed(run: HarnessRun, agent: Agent): void {
+    if (!run.channelId || !this.channelStore) return;
+    const sessionId = `run-${run.id}`;
+    if (this.thresholdFeedUnsubs.has(sessionId)) return;
+    if (!this.trackerPool.has(sessionId)) return;
+    const tracker = this.trackerPool.get(sessionId, 0); // ceiling unused on existing tracker
+    const cap = agent.capability as { model?: string } | undefined;
+    const modelName = cap?.model ?? (agent as unknown as { model?: string }).model;
+    const unsub = attachThresholdFeed(tracker, run.channelId, this.channelStore, {
+      modelName,
+    });
+    this.thresholdFeedUnsubs.set(sessionId, unsub);
   }
 }
 

--- a/test/agents/cli-agents-claude-usage.test.ts
+++ b/test/agents/cli-agents-claude-usage.test.ts
@@ -8,7 +8,7 @@ import { processStreamLine, type StreamParseState } from "../../src/agents/proce
  * closure body in `cli-agents.ts::invokeStreaming` into this function
  * and adds the `obj.usage` capture on the `result` arm.
  */
-describe.todo("processStreamLine — Claude streaming usage capture", () => {
+describe("processStreamLine — Claude streaming usage capture", () => {
   function freshState(): StreamParseState {
     return { accumText: "", resultText: null, capturedUsage: null };
   }

--- a/test/agents/cli-agents-codex-usage-spike.test.ts
+++ b/test/agents/cli-agents-codex-usage-spike.test.ts
@@ -23,7 +23,7 @@ const ADAPTER_PATH = join(process.cwd(), "src", "agents", "cli-agents.ts");
  * Until then, the adapter has no usage parsing at all and the grep
  * fails.
  */
-describe.todo("Codex --output-schema spike snapshot", () => {
+describe("Codex --output-schema spike snapshot", () => {
   it("01-SPIKE-A1.md exists with the 5-line machine-readable header", () => {
     expect(existsSync(SPIKE_PATH)).toBe(true);
     const head = readFileSync(SPIKE_PATH, "utf8").split("\n").slice(0, 5);

--- a/test/agents/cli-agents-codex-usage.test.ts
+++ b/test/agents/cli-agents-codex-usage.test.ts
@@ -65,7 +65,7 @@ function makeWorkRequest(): WorkRequest {
   };
 }
 
-describe.todo("CodexCliAgent — usage extraction (D-07 / Branch A)", () => {
+describe("CodexCliAgent — usage extraction (D-07 / Branch A)", () => {
   let cwd: string;
 
   beforeEach(async () => {

--- a/test/budget/session-tracker-pool.test.ts
+++ b/test/budget/session-tracker-pool.test.ts
@@ -14,7 +14,7 @@ const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
  * the contract is locked at PR-1 review time. All tests fail at runtime
  * until PR-2 implements the body.
  */
-describe.todo("SessionTrackerPool", () => {
+describe("SessionTrackerPool", () => {
   let root: string;
   const originalHome = process.env.HOME;
 

--- a/test/budget/threshold-feed-bridge.test.ts
+++ b/test/budget/threshold-feed-bridge.test.ts
@@ -29,7 +29,7 @@ async function readFeed(channelsDir: string, channelId: string): Promise<FeedEnt
  * stub-throwing `attachThresholdFeed` so this file fails at runtime; PR-2
  * (Task 5) lands the implementation that makes them GREEN.
  */
-describe.todo("attachThresholdFeed", () => {
+describe("attachThresholdFeed", () => {
   let root: string;
   let channelsDir: string;
 

--- a/test/budget/token-tracker.test.ts
+++ b/test/budget/token-tracker.test.ts
@@ -148,12 +148,13 @@ describe("TokenTracker", () => {
       // Replaying does not re-emit 50.
       expect(events).toEqual([]);
 
-      // But a new crossing (to 85) still emits. The resumed state was
+      // But fresh crossings (to 90%) still emit. The resumed state was
       // already at 60%, so 50 and 60 were both marked fired on replay —
-      // only 85 is a fresh crossing this run.
+      // only 75, 85, and 90 are fresh crossings this run (post-D-01 the
+      // canonical THRESHOLDS list includes 75 and 90).
       second.record(300, 0); // now at 900 = 90%
       await second.flush();
-      expect(events.map((e) => e.threshold)).toEqual([85]);
+      expect(events.map((e) => e.threshold)).toEqual([75, 85, 90]);
 
       await second.close();
     });
@@ -206,8 +207,9 @@ describe("TokenTracker", () => {
 
       await second.flush();
 
-      // 50 and 85 already fired in the prior lifetime; they must not fire
-      // again on resume. 95 has not been crossed yet (we're at 90.5%).
+      // Every threshold up through 90 already fired in the prior lifetime
+      // (resumed pct = 90%); they must not re-fire on resume. 95 has not
+      // been crossed yet (we're at 90.5%).
       expect(events).toEqual([]);
       expect(second.used).toBe(905);
 
@@ -304,8 +306,10 @@ describe("TokenTracker", () => {
       };
 
       try {
-        // Cross 50, 60, and 85 in a single record. record() is void and
-        // must not throw even though a listener throws on every dispatch.
+        // Cross 50, 60, 75, 85, and 90 in a single record. record() is
+        // void and must not throw even though a listener throws on every
+        // dispatch. (Post-D-01 the canonical THRESHOLDS list includes 75
+        // and 90 — see token-tracker.ts.)
         expect(() => tracker.record(900, 0)).not.toThrow();
         await tracker.flush();
       } finally {
@@ -313,8 +317,8 @@ describe("TokenTracker", () => {
       }
 
       // Every crossed threshold reached the healthy listeners.
-      expect(secondListenerSeen).toEqual([50, 60, 85]);
-      expect(seen).toEqual([50, 60, 85]);
+      expect(secondListenerSeen).toEqual([50, 60, 75, 85, 90]);
+      expect(seen).toEqual([50, 60, 75, 85, 90]);
 
       // The throwing listener was logged per-threshold (at least one warn
       // per crossed threshold, with the threshold number + error message).
@@ -325,7 +329,7 @@ describe("TokenTracker", () => {
       // A later crossing still fires the remaining thresholds exactly once.
       tracker.record(100, 0); // 1000 → 100%, crosses 95 and 100
       await tracker.flush();
-      expect(secondListenerSeen).toEqual([50, 60, 85, 95, 100]);
+      expect(secondListenerSeen).toEqual([50, 60, 75, 85, 90, 95, 100]);
 
       await tracker.close();
     });

--- a/test/budget/tracker-restart-replay.test.ts
+++ b/test/budget/tracker-restart-replay.test.ts
@@ -17,7 +17,7 @@ const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
  * Task 2 widens the canonical list. Until PR-2 lands the wider THRESHOLDS,
  * the resumed tracker reports `[50, 60]` and this test fails.
  */
-describe.todo("TokenTracker restart-replay (D-01 survives-restart property)", () => {
+describe("TokenTracker restart-replay (D-01 survives-restart property)", () => {
   let root: string;
 
   beforeEach(async () => {

--- a/test/orchestrator/orchestrator-v2-token-usage.test.ts
+++ b/test/orchestrator/orchestrator-v2-token-usage.test.ts
@@ -55,9 +55,8 @@ describe("OrchestratorV2 dispatch — token-usage wiring", () => {
     // agent has no model so a session never gets miscalibrated against
     // the default 200_000 ceiling. An Opus 4.7 session has a 1M-token
     // window — defaulting to 200k would mis-render the bar by 5x.
-    const { dispatchTokenUsageOrThrow } = await import(
-      "../../src/orchestrator/dispatch-token-usage.js"
-    );
+    const { dispatchTokenUsageOrThrow } =
+      await import("../../src/orchestrator/dispatch-token-usage.js");
     expect(dispatchTokenUsageOrThrow).toBeDefined();
 
     const pool = new SessionTrackerPool();

--- a/test/orchestrator/orchestrator-v2-token-usage.test.ts
+++ b/test/orchestrator/orchestrator-v2-token-usage.test.ts
@@ -15,7 +15,7 @@ const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
  * that calls `trackerPool.get(...).record(...)` and writes a
  * `kind: "run"` budget line to `~/.relay/sessions/run-<runId>/budget.jsonl`.
  */
-describe.todo("OrchestratorV2 dispatch — token-usage wiring", () => {
+describe("OrchestratorV2 dispatch — token-usage wiring", () => {
   let root: string;
   const originalHome = process.env.HOME;
 
@@ -51,30 +51,39 @@ describe.todo("OrchestratorV2 dispatch — token-usage wiring", () => {
   });
 
   it("dispatch with an Agent missing capability.model throws a clear error (hidden-assumption fix)", async () => {
-    // This test asserts the contract: the orchestrator's dispatch wiring
-    // (Task 4) hard-throws when the agent has no model so a session
-    // never gets miscalibrated against the default 200_000 ceiling.
-    //
-    // Phase 1 PR-1: the orchestrator wiring isn't in place yet. The
-    // assertion below uses a stub helper that the test re-imports from
-    // PR-2's Task 4 work; until then, the test is RED.
-    // PR-2's Task 4 lands a `dispatch-token-usage.js` helper that the
-    // orchestrator imports for the missing-model hard-throw. PR-1 has
-    // not added it yet, so this dynamic import must fail. The grep
-    // pattern is the contract.
-    let mod: unknown = null;
-    try {
-      mod = await import(
-        // @ts-expect-error PR-2 lands this module; PR-1 stub holds the
-        // RED contract that the import does not yet resolve.
-        "../../src/orchestrator/dispatch-token-usage.js"
-      );
-    } catch {
-      mod = null;
-    }
-    expect(mod).not.toBeNull();
-    expect(
-      (mod as { dispatchTokenUsageOrThrow?: unknown } | null)?.dispatchTokenUsageOrThrow
-    ).toBeDefined();
+    // The orchestrator's dispatch wiring (Task 4) hard-throws when the
+    // agent has no model so a session never gets miscalibrated against
+    // the default 200_000 ceiling. An Opus 4.7 session has a 1M-token
+    // window — defaulting to 200k would mis-render the bar by 5x.
+    const { dispatchTokenUsageOrThrow } = await import(
+      "../../src/orchestrator/dispatch-token-usage.js"
+    );
+    expect(dispatchTokenUsageOrThrow).toBeDefined();
+
+    const pool = new SessionTrackerPool();
+    const agentNoModel = {
+      id: "agent-x",
+      name: "X",
+      provider: "claude" as const,
+      capability: { role: "implementer" as const, specialties: ["general" as const] },
+      run: async () => ({ summary: "n/a", evidence: [], proposedCommands: [], blockers: [] }),
+    };
+
+    expect(() =>
+      dispatchTokenUsageOrThrow({
+        pool,
+        agent: agentNoModel,
+        result: {
+          summary: "ok",
+          evidence: [],
+          proposedCommands: [],
+          blockers: [],
+          tokenUsage: { inputTokens: 100, outputTokens: 50 },
+        },
+        runId: "run-no-model",
+      })
+    ).toThrow(/missing model/);
+
+    await pool.closeAll();
   });
 });


### PR DESCRIPTION
## Summary

- **Task 3** — Provider-side token-usage extraction for Claude (streaming + buffered) and Codex adapters. Lifts `processStreamLine` into a pure exported function, adds `normalizeClaudeUsage` / `normalizeCodexUsage` (cache tokens summed into `inputTokens` per research Q3), and surfaces `AgentResult.tokenUsage` end-to-end. A1 spike resolved INCONCLUSIVE — implements Branch A only and emits ONE `[budget] Codex usage extraction unavailable` stderr warning when `parsed.usage` is undefined post-Codex-run (M2).
- **Task 4** — `SessionTrackerPool` (one-tracker-per-sessionId, M8 soft-warn for non-zero replay on a brand-new sessionId) + `dispatchTokenUsageOrThrow` helper that hard-throws when `agent.capability.model` is missing (the Opus 4.7 5x miscalibration class AGENTS.md flags). Wired into `OrchestratorV2.dispatch` so a successful dispatch with `tokenUsage` writes a `kind: "run"` line to `~/.relay/sessions/run-<runId>/budget.jsonl`. Pool drains in `waitForPendingWrites`.
- **Task 5** — `attachThresholdFeed` bridge filters tracker events to `[75, 90, 95]` and posts `status_update` entries with `metadata.kind === "context_threshold"` matching the Phase-2 `<phase_2_handoff_contract>` block verbatim. Lands `docs/design/context-threshold-events.md` documenting the cross-phase contract (incl. D-03 + M8 sharpening — Phase 1 does not enforce 0% in code; Phase 2 owns the uniqueness invariant). Bridge is wired into `OrchestratorV2.dispatch`; unsubscribes run BEFORE `trackerPool.closeAll()` in `waitForPendingWrites`.

### Deviations from plan

- **THRESHOLDS widening landed here, not in PR-1.** The plan's Task 2 specified widening `[50, 60, 75, 85, 90, 95, 100]` (D-01) in PR-1, but the merged PR-1 (#218) didn't touch `src/budget/token-tracker.ts`. PR-2 needs `75` and `90` in the canonical emit set for the threshold-feed bridge to fire those tiers, so I widened here as part of Task 3's commit and re-pinned the existing `token-tracker.test.ts` assertions for the throwing-listener case (`record(900,0)` now crosses 50/60/75/85/90 instead of just 50/60/85) and the no-reemit-after-restart case (replay at 60% now leaves 75/85/90 to fire on the next crossing instead of just 85). Net assertion change is the listener-isolation count + the resumed-state delta. The `tracker-restart-replay.test.ts` is the M-fix test that explicitly asserts the widened list — converted from `describe.todo` to `describe`, GREEN.
- **`TokenTracker.safeEmitThreshold` now awaits async listeners.** The bridge's `channelStore.postEntry` is genuinely async, and the bridge tests expect `tracker.flush()` to drain the post. Pre-Phase-1 listeners returned `void` synchronously; the new contract is "the tracker awaits any thenable returned by a listener." Listener type widened to `(evt) => unknown` so existing back-compat callers like `(evt) => events.push(evt)` (returns `number`) still typecheck. Documented in the JSDoc.

### LOC

`+763 / -136` across 17 files = ~627 net new LOC. Under the 800-LOC budget. PR-2a/PR-2b L1 contingency NOT triggered.

## CI gates (all green locally)

- `pnpm test` — **1075 passed, 24 skipped, 18 todo** (1117 total). The 18 todos are the cross-PR scaffolds for Tasks 7/9/10/10b/11/12 (PR-3+) — explicitly out of scope for PR-2.
- `pnpm typecheck` — clean.
- `pnpm format:check` — clean.
- `pnpm build` — clean.
- `cargo check --workspace --locked` — green.

## Tests converted from `describe.todo` to `describe`

- `test/agents/cli-agents-claude-usage.test.ts` (3 tests, GREEN)
- `test/agents/cli-agents-codex-usage.test.ts` (3 tests, GREEN — incl. M2 INCONCLUSIVE-branch stderr-warning)
- `test/agents/cli-agents-codex-usage-spike.test.ts` (2 tests, GREEN — spike-snapshot grep against documented branch)
- `test/budget/session-tracker-pool.test.ts` (4 tests, GREEN — incl. M8 soft-warning)
- `test/budget/threshold-feed-bridge.test.ts` (3 tests, GREEN — exact-shape 90 entry + M7 pct precision + M5 distinct sessionIds)
- `test/budget/tracker-restart-replay.test.ts` (2 tests, GREEN — D-01 widening + replay-marks-already-fired)
- `test/orchestrator/orchestrator-v2-token-usage.test.ts` (2 tests, GREEN — pool-records-on-dispatch + missing-model-throws)

Tasks 7/9/10/10b/11/12 stay `describe.todo`:
- `test/cli/chat-record-usage.test.ts` (Task 10 — PR-4)
- `test/cli/print-status-context.test.ts` (Task 11 — PR-4)
- `test/integration/session-budget-end-to-end.test.ts` (depends on Task 10)
- `test/orchestrator/handoff/handoff-cli.test.ts`, `handoff-resume.test.ts` (Phase 2 PR-4 / PR-5)

## Test plan

- [x] `pnpm test` — full suite GREEN (1075 passed, 24 skipped, 18 todo)
- [x] `pnpm typecheck` clean
- [x] `pnpm format:check` clean
- [x] `pnpm build` clean
- [x] `cargo check --workspace --locked` green
- [ ] Live smoke (NOT in CI — gate before tagging): orchestrator dispatch against a real Claude session writes a `kind: "run"` budget line and posts a `context_threshold` entry on the channel feed at 75/90/95. (Requires `HARNESS_LIVE=1` + a `claude` CLI in PATH; deferred to Task 12.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)