### PR TITLE
feat(budget): Phase 1 PR-4 — chat-mode usage hook + rly status active sessions

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use harness_data as data;
-use relay_paths::augmented_child_path;
+use relay_paths::{augmented_child_path, cli_bin};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
@@ -1962,6 +1962,15 @@ fn start_chat(
         let mut final_session_id: Option<String> = None;
         let mut cancelled = false;
         let mut saw_any_stdout_line = false;
+        // D-04 chat-mode parity: capture the per-turn `usage` and `model`
+        // from claude's stream so we can shell out to
+        // `rly chat record-usage` after `child.wait()` resolves below. The
+        // `result` line carries the cumulative usage for the turn; the
+        // `system.init` line carries the model. Holding them in locals is
+        // cheaper than re-parsing the same lines twice.
+        let mut captured_input_tokens: u64 = 0;
+        let mut captured_output_tokens: u64 = 0;
+        let mut captured_model: Option<String> = None;
 
         for line in reader.lines() {
             // Rewind (and anything else that wants to abort a live stream)
@@ -2066,6 +2075,31 @@ fn start_chat(
                     if let Some(sid) = json.get("session_id").and_then(|v| v.as_str()) {
                         final_session_id = Some(sid.to_string());
                     }
+                    // Capture token usage for the chat-record-usage shell-out
+                    // after `child.wait()` resolves. Sum cache_read +
+                    // cache_creation + input_tokens into a single `input`
+                    // figure so the budget line matches what the orchestrator
+                    // adapter records (see `cli-agents-claude-usage.test.ts`).
+                    if let Some(usage) = json.get("usage").and_then(|u| u.as_object()) {
+                        let input = usage
+                            .get("input_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0)
+                            + usage
+                                .get("cache_read_input_tokens")
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0)
+                            + usage
+                                .get("cache_creation_input_tokens")
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0);
+                        let output = usage
+                            .get("output_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        captured_input_tokens = input;
+                        captured_output_tokens = output;
+                    }
                     if accum.is_empty() {
                         if let Some(text) = json.get("result").and_then(|v| v.as_str()) {
                             if !text.is_empty() {
@@ -2093,6 +2127,16 @@ fn start_chat(
                             "chat-event",
                             ChatEvent::Activity { stream_id, text },
                         );
+                    }
+                    // D-04 chat-mode parity: the `system.init` event carries
+                    // the model name. Capture it so the post-turn
+                    // `rly chat record-usage` shell-out can pass `--model`
+                    // and the budget pct is computed against the right
+                    // context-window ceiling.
+                    if json.get("subtype").and_then(|v| v.as_str()) == Some("init") {
+                        if let Some(model) = json.get("model").and_then(|v| v.as_str()) {
+                            captured_model = Some(model.to_string());
+                        }
                     }
                 }
                 Some("rate_limit_event") => {
@@ -2209,6 +2253,42 @@ fn start_chat(
                     claude_session_id: sid.clone(),
                 },
             );
+
+            // D-04 chat-mode parity: shell out to `rly chat record-usage`
+            // exactly once per Claude turn so the GUI's chat session
+            // populates `~/.relay/sessions/<sid>/budget.jsonl` with the
+            // same shape the orchestrator writes (kind="chat" being the
+            // discriminator). The TUI does the equivalent in
+            // `tui/src/main.rs` (Task 10b, PR-3). Fire-and-forget — a
+            // failed record-usage call shouldn't break the chat flow.
+            if captured_input_tokens > 0 || captured_output_tokens > 0 {
+                let input_str = captured_input_tokens.to_string();
+                let output_str = captured_output_tokens.to_string();
+                let mut record_args: Vec<&str> = vec![
+                    "chat",
+                    "record-usage",
+                    "--session",
+                    sid,
+                    "--input",
+                    &input_str,
+                    "--output",
+                    &output_str,
+                    "--kind",
+                    "chat",
+                    "--channel",
+                    &channel_id_thread,
+                ];
+                if let Some(ref m) = captured_model {
+                    record_args.push("--model");
+                    record_args.push(m);
+                }
+                let _ = std::process::Command::new(cli_bin())
+                    .args(&record_args)
+                    .env("PATH", augmented_child_path())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn();
+            }
         }
 
         let _ = app_handle.emit(

--- a/src/cli/chat-record-usage.ts
+++ b/src/cli/chat-record-usage.ts
@@ -1,3 +1,7 @@
+import { ChannelStore } from "../channels/channel-store.js";
+import { TokenTracker } from "../budget/token-tracker.js";
+import { attachThresholdFeed } from "../budget/threshold-feed-bridge.js";
+import { resolveContextWindow } from "../domain/model-context-windows.js";
 import type { SessionKind } from "../domain/session-budget.js";
 
 export interface ChatRecordUsageArgs {
@@ -10,18 +14,41 @@ export interface ChatRecordUsageArgs {
 }
 
 /**
- * Handler for the `rly chat record-usage` CLI subcommand. Mints (or
- * resumes) the session's `TokenTracker`, calls `record(input, output)`,
- * and — when `--channel` is passed — wires the threshold-feed bridge so
- * 75/90/95 crossings post to the channel feed.
+ * Handler for the `rly chat record-usage` CLI subcommand. Mints a fresh
+ * `TokenTracker` for the given session (replay picks up any prior cumulative
+ * total from `~/.relay/sessions/<id>/budget.jsonl`), calls
+ * `record(input, output)`, and — when `--channel` is passed — wires the
+ * threshold-feed bridge so 75/90/95 crossings post to the channel feed.
  *
- * Used by the GUI's chat-event Rust loop and the TUI's chat-event Rust
- * worker (per D-04 chat-mode parity), shelled out via
- * `Command::new(cli_bin())`.
- *
- * **Phase 1 PR-1:** stub. Implementation lands in PR-4 (Task 10). The
- * signature ships in PR-1 so RED tests compile against the final shape.
+ * D-04 (chat-mode parity): used by both the GUI's chat-event Rust loop
+ * (`gui/src-tauri/src/lib.rs`) and the TUI's chat-event Rust worker
+ * (`tui/src/main.rs`), each of which shells out to `rly chat record-usage`
+ * once per Claude turn after `child.wait()` resolves. This keeps the
+ * persistence shape identical to the orchestrator's (modulo the `kind`
+ * discriminator) so a single reader (TS `loadActiveSessions` and Rust
+ * `harness_data::load_session_budget`) handles every dispatch path.
  */
-export async function handleChatRecordUsageCommand(_args: ChatRecordUsageArgs): Promise<void> {
-  throw new Error("handleChatRecordUsageCommand: not yet implemented (Phase 1 PR-4 / Task 10)");
+export async function handleChatRecordUsageCommand(args: ChatRecordUsageArgs): Promise<void> {
+  if (!args.session) {
+    throw new Error("handleChatRecordUsageCommand: session is required");
+  }
+
+  const ceiling = resolveContextWindow(args.model);
+  const tracker = new TokenTracker(args.session, ceiling, { kind: args.kind ?? "chat" });
+
+  let unsubscribe: (() => void) | null = null;
+  if (args.channel) {
+    const channelStore = new ChannelStore();
+    unsubscribe = attachThresholdFeed(tracker, args.channel, channelStore, {
+      modelName: args.model,
+    });
+  }
+
+  try {
+    tracker.record(args.input, args.output);
+    await tracker.flush();
+  } finally {
+    unsubscribe?.();
+    await tracker.close();
+  }
 }

--- a/src/cli/print-status-context.ts
+++ b/src/cli/print-status-context.ts
@@ -1,4 +1,9 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveContextWindow } from "../domain/model-context-windows.js";
 import type { SessionKind } from "../domain/session-budget.js";
+import { getRelayDir } from "./paths.js";
 
 export interface ActiveSessionRow {
   sessionId: string;
@@ -15,21 +20,91 @@ export interface ActiveSessionRow {
  * the rows resolved by `loadActiveSessions()` and returns the printable
  * lines. No `~/.relay/` reads here — keeps the formatter unit-testable.
  *
- * **Phase 1 PR-1:** stub. Implementation lands in PR-4 (Task 11). The
- * shape ships in PR-1 so RED tests compile.
+ * Returns `""` for an empty list so callers can append-then-skip-on-empty
+ * without a separate length check.
  */
-export function formatActiveSessionsBlock(_sessions: ActiveSessionRow[]): string {
-  throw new Error("formatActiveSessionsBlock: not yet implemented (Phase 1 PR-4 / Task 11)");
+export function formatActiveSessionsBlock(sessions: ActiveSessionRow[]): string {
+  if (sessions.length === 0) return "";
+
+  // Worst-percent first so an operator scanning the block sees the most
+  // budget-pressured session at the top.
+  const sorted = [...sessions].sort((a, b) => b.pct - a.pct);
+
+  const lines = ["Active sessions:"];
+  for (const row of sorted) {
+    const usedK = (row.used / 1000).toFixed(0);
+    const totalK = (row.total / 1000).toFixed(0);
+    const channel = row.channelId ? ` (channel: ${row.channelId})` : "";
+    const model = row.model ? ` — ${row.model}` : "";
+    lines.push(
+      `- ${row.sessionId}${channel} ctx ${row.pct.toFixed(0)}% (${usedK}K / ${totalK}K tokens)${model}`
+    );
+  }
+  return lines.join("\n");
 }
 
 /**
  * Walk `~/.relay/sessions/<id>/budget.jsonl` files and resolve the rows
- * that should surface in `rly status`. Filters to `kind === "chat"`;
- * skips malformed individual files (per L3 isolation) and returns `[]`
- * cleanly when the sessions root does not exist.
+ * that should surface in `rly status`. Filters to `kind === "chat"` (M3 /
+ * M4 — admin and orchestrator-run keyspaces are excluded). L3 isolation:
+ * guards against missing root + per-file parse errors so one bad file
+ * doesn't poison the whole list.
  *
- * **Phase 1 PR-1:** stub. Implementation lands in PR-4 (Task 11).
+ * Synchronous: this runs at most once per `rly status` invocation and the
+ * caller already prints synchronously to stdout. Sync IO keeps the surface
+ * simple for tests and matches the rest of the status-print path.
  */
-export function loadActiveSessions(): ActiveSessionRow[] {
-  throw new Error("loadActiveSessions: not yet implemented (Phase 1 PR-4 / Task 11)");
+export function loadActiveSessions(opts?: { maxAgeMs?: number }): ActiveSessionRow[] {
+  const root = join(getRelayDir(), "sessions");
+  if (!existsSync(root)) return []; // L3: missing root → empty, no throw.
+
+  const maxAge = opts?.maxAgeMs ?? 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return [];
+  }
+
+  const rows: ActiveSessionRow[] = [];
+  for (const name of entries) {
+    const file = join(root, name, "budget.jsonl");
+    try {
+      const st = statSync(file);
+      if (now - st.mtimeMs > maxAge) continue;
+
+      const content = readFileSync(file, "utf8");
+      const lastLine = content.trim().split("\n").filter(Boolean).pop();
+      if (!lastLine) continue;
+
+      const parsed = JSON.parse(lastLine);
+      if (parsed.kind !== "chat") continue; // M3 / M4: chat sessions only.
+
+      const used = typeof parsed.cumulativeUsed === "number" ? parsed.cumulativeUsed : 0;
+      const model = typeof parsed.model === "string" ? parsed.model : undefined;
+      const channelId = typeof parsed.channelId === "string" ? parsed.channelId : undefined;
+      const total = resolveContextWindow(model);
+      const pct = total === 0 ? 0 : (used / total) * 100;
+
+      rows.push({
+        sessionId: name,
+        channelId,
+        pct,
+        used,
+        total,
+        model,
+        kind: "chat",
+      });
+    } catch (err) {
+      // L3: per-file error isolation. A single malformed `budget.jsonl`
+      // (e.g. partial flush, hand-edited line) must not block other
+      // sessions from surfacing.
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[budget] skipping malformed session file ${file}: ${message}`);
+      continue;
+    }
+  }
+  return rows;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { handleHandoffCommand } from "./cli/handoff.js";
 import { startDashboard } from "./tui/dashboard.js";
 import { SessionStore } from "./cli/session-store.js";
 import { buildSystemPrompt, resolveChannelRefs, findMcpConfig } from "./cli/chat-context.js";
+import { handleChatRecordUsageCommand } from "./cli/chat-record-usage.js";
 import { rewindApply, rewindSnapshot } from "./cli/chat-rewind.js";
 import { submitApproval } from "./orchestrator/approval-gate.js";
 import { getWorkspaceDir } from "./cli/workspace-registry.js";
@@ -2596,8 +2597,41 @@ async function handleChatCommand(
     return;
   }
 
+  if (sub === "record-usage") {
+    const sessionId = parseNamedArg(args, "--session");
+    const inputArg = parseNamedArg(args, "--input");
+    const outputArg = parseNamedArg(args, "--output");
+    const channelId = parseNamedArg(args, "--channel");
+    const model = parseNamedArg(args, "--model");
+    const kindArg = parseNamedArg(args, "--kind");
+
+    const input = inputArg !== undefined ? Number(inputArg) : NaN;
+    const output = outputArg !== undefined ? Number(outputArg) : NaN;
+
+    if (!sessionId || !Number.isFinite(input) || !Number.isFinite(output)) {
+      console.error(
+        "Usage: rly chat record-usage --session <id> --input <n> --output <n> [--kind chat|run|admin] [--channel <id>] [--model <name>]"
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const kind: "chat" | "run" | "admin" =
+      kindArg === "run" || kindArg === "admin" ? kindArg : "chat";
+
+    await handleChatRecordUsageCommand({
+      session: sessionId,
+      input,
+      output,
+      kind,
+      channel: channelId,
+      model,
+    });
+    return;
+  }
+
   console.error(
-    "Usage: rly chat <system-prompt|resolve-refs|mcp-config|rewind|rewind-snapshot|rewind-apply>"
+    "Usage: rly chat <system-prompt|resolve-refs|mcp-config|rewind|rewind-snapshot|rewind-apply|record-usage>"
   );
   process.exitCode = 1;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { startDashboard } from "./tui/dashboard.js";
 import { SessionStore } from "./cli/session-store.js";
 import { buildSystemPrompt, resolveChannelRefs, findMcpConfig } from "./cli/chat-context.js";
 import { handleChatRecordUsageCommand } from "./cli/chat-record-usage.js";
+import { formatActiveSessionsBlock, loadActiveSessions } from "./cli/print-status-context.js";
 import { rewindApply, rewindSnapshot } from "./cli/chat-rewind.js";
 import { submitApproval } from "./orchestrator/approval-gate.js";
 import { getWorkspaceDir } from "./cli/workspace-registry.js";
@@ -2807,6 +2808,17 @@ async function printStatus(artifactStore: LocalArtifactStore, cwd: string): Prom
   }
 
   console.log("");
+
+  // Active chat sessions block (Phase 1 — REQ-1.6). Reads
+  // `~/.relay/sessions/<id>/budget.jsonl` files filtered to `kind: "chat"`
+  // and surfaces the worst-percent first. Skipped silently when no chat
+  // sessions exist so non-chat operators don't see an empty block.
+  const activeSessions = loadActiveSessions();
+  const activeBlock = formatActiveSessionsBlock(activeSessions);
+  if (activeBlock) {
+    console.log(activeBlock);
+    console.log("");
+  }
 
   if (summary.recentRuns.length === 0) {
     console.log("Recent runs: none");

--- a/test/cli/chat-record-usage.test.ts
+++ b/test/cli/chat-record-usage.test.ts
@@ -6,27 +6,29 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { handleChatRecordUsageCommand } from "../../src/cli/chat-record-usage.js";
+import { __resetRelayDirCacheForTests } from "../../src/cli/paths.js";
 
 const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
 
 /**
- * RED tests for the `rly chat record-usage` CLI subcommand handler. The
- * stub throws in PR-1; PR-4 (Task 10) lands the real implementation that
- * mints/resumes a tracker, calls record(), and (when --channel is passed)
- * wires the threshold-feed bridge.
+ * GREEN in PR-4: real `handleChatRecordUsageCommand` mints a TokenTracker,
+ * calls record(), and (when --channel is passed) wires the threshold-feed
+ * bridge.
  */
-describe.todo("handleChatRecordUsageCommand", () => {
+describe("handleChatRecordUsageCommand", () => {
   let root: string;
   const originalHome = process.env.HOME;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "relay-chat-record-"));
     process.env.HOME = root;
+    __resetRelayDirCacheForTests();
   });
 
   afterEach(async () => {
     if (originalHome) process.env.HOME = originalHome;
     else delete process.env.HOME;
+    __resetRelayDirCacheForTests();
     await rm(root, RM_OPTS);
   });
 

--- a/test/cli/print-status-context.test.ts
+++ b/test/cli/print-status-context.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { __resetRelayDirCacheForTests } from "../../src/cli/paths.js";
 import {
   formatActiveSessionsBlock,
   loadActiveSessions,
@@ -13,10 +14,11 @@ import {
 const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
 
 /**
- * RED tests for the `rly status` Active Sessions block. PR-1 ships the
- * stub-throwing formatters; PR-4 (Task 11) lands the implementations.
+ * GREEN in PR-4: real `formatActiveSessionsBlock` and `loadActiveSessions`
+ * implementations. The formatter is purely deterministic; the loader
+ * filters to `kind === "chat"` (M3 / M4) and isolates malformed files (L3).
  */
-describe.todo("formatActiveSessionsBlock", () => {
+describe("formatActiveSessionsBlock", () => {
   it("renders one line per session with model + ctx pct + used/total", () => {
     const rows: ActiveSessionRow[] = [
       {
@@ -42,18 +44,20 @@ describe.todo("formatActiveSessionsBlock", () => {
   });
 });
 
-describe.todo("loadActiveSessions", () => {
+describe("loadActiveSessions", () => {
   let root: string;
   const originalHome = process.env.HOME;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "relay-status-"));
     process.env.HOME = root;
+    __resetRelayDirCacheForTests();
   });
 
   afterEach(async () => {
     if (originalHome) process.env.HOME = originalHome;
     else delete process.env.HOME;
+    __resetRelayDirCacheForTests();
     await rm(root, RM_OPTS);
   });
 

--- a/test/integration/session-budget-end-to-end.test.ts
+++ b/test/integration/session-budget-end-to-end.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { handleChatRecordUsageCommand } from "../../src/cli/chat-record-usage.js";
+import { __resetRelayDirCacheForTests } from "../../src/cli/paths.js";
 import { SessionBudgetSchema } from "../../src/domain/session-budget.js";
 
 const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
@@ -13,25 +14,24 @@ const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 50 };
 /**
  * M6 — full-chain integration smoke. Wires the chat-record-usage entry
  * point through to the budget.jsonl on disk, then re-reads it via
- * `SessionBudgetSchema` to confirm the round-trip holds end-to-end.
- *
- * RED in PR-1 (handleChatRecordUsageCommand stub throws). Goes GREEN
- * once PR-4 (Task 10) lands the implementation. The Rust-side reader is
- * covered by `crates/harness-data/src/lib.rs::tests::session_budget_*`
- * (already GREEN from Task 6 in this PR).
+ * `SessionBudgetSchema` to confirm the round-trip holds end-to-end. The
+ * Rust-side reader is covered by `crates/harness-data/src/lib.rs::tests::
+ * session_budget_*` (Task 6).
  */
-describe.todo("Session-budget end-to-end (M6)", () => {
+describe("Session-budget end-to-end (M6)", () => {
   let root: string;
   const originalHome = process.env.HOME;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "relay-e2e-budget-"));
     process.env.HOME = root;
+    __resetRelayDirCacheForTests();
   });
 
   afterEach(async () => {
     if (originalHome) process.env.HOME = originalHome;
     else delete process.env.HOME;
+    __resetRelayDirCacheForTests();
     await rm(root, RM_OPTS);
   });
 


### PR DESCRIPTION
## Summary

Phase 1 PR-4 of the per-session token-usage telemetry phase. Replaces the PR-1 stubs in `src/cli/chat-record-usage.ts` and `src/cli/print-status-context.ts` with the real implementations, and wires the GUI shell-out so chat-mode dispatch produces the same `~/.relay/sessions/<sid>/budget.jsonl` shape the orchestrator does (modulo the `kind` discriminator).

### Task 10 — chat-mode parity (\`rly chat record-usage\` + GUI shell-out)
- Real \`handleChatRecordUsageCommand\` mints a \`TokenTracker\`, calls \`record(input, output)\`, and (when \`--channel\` is passed) attaches the threshold-feed bridge so 75/90/95 crossings post to the channel feed.
- New \`rly chat record-usage --session <sid> --input <n> --output <n> [--kind chat|run|admin] [--channel <id>] [--model <name>]\` subcommand wired into \`handleChatCommand\` in \`src/index.ts\`.
- GUI parity: \`gui/src-tauri/src/lib.rs\` chat-event closure now captures per-turn \`usage\` from the \`result\` event and the model from \`system.init\`, then fires \`rly chat record-usage\` once per turn after \`child.wait()\` resolves. Fire-and-forget — a failed record-usage call must not break chat. The TUI shell-out shipped in PR-3 (Task 10b) is now functional end-to-end against this handler.

### Task 11 — \`rly status\` active-sessions block
- Real \`formatActiveSessionsBlock\` renders one line per chat session, sorted worst-percent-first.
- Real \`loadActiveSessions\` walks \`~/.relay/sessions/<id>/budget.jsonl\` files filtered to \`kind === "chat"\` (M3 / M4), with \`existsSync\` root guard + per-file try/catch (L3 isolation — one bad file doesn't poison the list).
- Wired into \`printStatus\` before the \`Recent runs:\` block; skipped silently when no chat sessions exist.

### Tests flipped from \`describe.todo\` to \`describe\`
- \`test/cli/chat-record-usage.test.ts\` — handler writes \`kind: "chat"\` budget line, no-throw without \`--channel\`.
- \`test/cli/print-status-context.test.ts\` — formatter output, missing-root returns \`[]\`, kind filter, malformed-file isolation.
- \`test/integration/session-budget-end-to-end.test.ts\` (M6) — full chain: \`handleChatRecordUsageCommand\` → \`budget.jsonl\` → \`SessionBudgetSchema.parse\` round-trip yields correct \`pct\`.

## CI gates

All green:
- \`pnpm test\` — 1096 passed / 24 skipped
- \`pnpm typecheck\` — clean
- \`pnpm format:check\` — clean
- \`cargo check --workspace --locked\` — clean
- \`cd gui && pnpm build\` — clean

## LOC

~290 lines added across 7 files. Well under the sub-800 budget; close to the plan's ~300 estimate.

## Test plan
- [ ] \`rly chat record-usage --session sess-x --input 100 --output 50\` writes a \`kind: "chat"\` line to \`~/.relay/sessions/sess-x/budget.jsonl\`
- [ ] GUI chat: send a message in a channel, confirm \`~/.relay/sessions/<sid>/budget.jsonl\` populates and the context bar updates
- [ ] \`rly status\` shows the new \`Active sessions:\` block when chat sessions exist; admin / run-keyed budgets are excluded
- [ ] Missing \`~/.relay/sessions/\` returns empty (no throw); a malformed file is skipped with a \`[budget]\` warning while other files still surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)