### PR TITLE
docs(04): plan Phase 4 — project readiness surface

### DIFF
--- a/.planning/phases/04-project-readiness-surface/04-01-PLAN.md
+++ b/.planning/phases/04-project-readiness-surface/04-01-PLAN.md
@@ -1,0 +1,282 @@
+---
+phase: 04-project-readiness-surface
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/domain/repo-admin-state.ts
+  - test/domain/repo-admin-state.test.ts
+  - crates/harness-data/src/lib.rs
+  - src/orchestrator/repo-admin-session.ts
+  - test/orchestrator/repo-admin-session.test.ts
+autonomous: true
+requirements:
+  - SURFACE-06
+  - WORKER-06
+
+must_haves:
+  truths:
+    - "TS exports `RepoAdminState` type + zod schema + `STALE_HEARTBEAT_MS` constant from `src/domain/repo-admin-state.ts`."
+    - "Rust exports `RepoAdminState` enum + `derive_state(&CrosslinkSession, now_ms) -> RepoAdminState` + `STALE_HEARTBEAT_MS` + `is_pid_alive(pid: u32) -> bool` + `group_by_admin(&[CrosslinkSession]) -> Vec<AdminWithWorkers>` from `crates/harness-data/src/lib.rs`."
+    - "TS `deriveRepoAdminState(session | null, nowMs, isProcessAlive)` returns same four states as Rust given identical inputs (parity table)."
+    - "`RepoAdminSession._state` is renamed to `_processState` everywhere it is referenced (mechanical rename, no behavior change)."
+    - "Wire format is kebab-case: `disconnected | booting | ready | stale`. Old session.json files without `readyAt` deserialize cleanly and map to `booting` (when alive) or `stale` (when not)."
+  artifacts:
+    - path: "src/domain/repo-admin-state.ts"
+      provides: "RepoAdminState type + RepoAdminStateSchema (zod) + STALE_HEARTBEAT_MS + deriveRepoAdminState(session, nowMs, isProcessAlive)"
+      contains: "export type RepoAdminState"
+    - path: "crates/harness-data/src/lib.rs"
+      provides: "RepoAdminState enum + derive_state + group_by_admin + is_pid_alive + STALE_HEARTBEAT_MS (mirrors TS)"
+      contains: "pub enum RepoAdminState"
+    - path: "test/domain/repo-admin-state.test.ts"
+      provides: "Truth-table tests for deriveRepoAdminState covering all four states (disconnected, booting, ready, stale) + parity with Rust."
+      contains: "deriveRepoAdminState"
+  key_links:
+    - from: "src/domain/repo-admin-state.ts STALE_HEARTBEAT_MS"
+      to: "src/crosslink/store.ts:19 STALE_HEARTBEAT_MS"
+      via: "shared constant (TS imports from new domain module; store.ts re-exports for back-compat or imports)"
+      pattern: "STALE_HEARTBEAT_MS"
+    - from: "crates/harness-data RepoAdminState (kebab-case wire format)"
+      to: "src/domain/repo-admin-state.ts RepoAdminStateSchema (zod string union)"
+      via: "byte-for-byte string equality on the four wire values"
+      pattern: "\"disconnected\"|\"booting\"|\"ready\"|\"stale\""
+---
+
+<objective>
+Define the canonical four-state enum `RepoAdminState = "disconnected" | "booting" | "ready" | "stale"` in both TS (`src/domain/repo-admin-state.ts`) and Rust (`crates/harness-data/src/lib.rs`) with byte-compatible wire format. Land the pure `derive_state(session, now)` function as the single source of truth — every downstream surface (Wave 3 hook, Wave 4 TUI/GUI, Wave 5 CLI) calls into this same function. Bundle the deferred `_state → _processState` rename to eliminate the lexical collision with `RepoAdminState.ready`.
+
+Purpose: Phase 3's lesson is "alive ≠ ready" — Phase 4's equivalent is "one definition of state, used identically everywhere." This plan ships the contract. Every other Phase 4 plan consumes it.
+
+Output: Two type files in sync, a Rust pure function with tests, a TS pure function with tests, and a clean naming surface for the rest of the phase.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-project-readiness-surface/04-CONTEXT.md
+@.planning/phases/04-project-readiness-surface/04-RESEARCH.md
+@.planning/phases/04-project-readiness-surface/04-PATTERNS.md
+@.planning/phases/03-repo-admin-readiness-handshake/03-SUMMARY.md
+@AGENTS.md
+
+<interfaces>
+<!-- Phase 3 disk shape that this plan derives state FROM. Source: 03-SUMMARY.md + crates/harness-data/src/lib.rs:600-621. -->
+
+From src/crosslink/types.ts (Phase 3):
+```typescript
+// CrosslinkSessionSchema includes:
+//   readyAt: z.string().optional()
+//   readyKind: z.enum(["admin", "worker"]).optional()
+//   lastHeartbeat: z.string()
+//   pid: z.number()
+//   channelId: z.string().optional()
+```
+
+From crates/harness-data/src/lib.rs (Phase 3, lines 600-621):
+```rust
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CrosslinkSession {
+    pub session_id: String,
+    pub pid: u32,
+    pub last_heartbeat: String,
+    pub channel_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_kind: Option<String>,
+    // ... other fields
+}
+
+pub fn load_crosslink_sessions() -> Vec<CrosslinkSession> { /* lines 633-652, read-only */ }
+```
+
+From src/crosslink/store.ts:19 (existing):
+```typescript
+const STALE_HEARTBEAT_MS = 120_000;
+```
+
+From src/orchestrator/repo-admin-session.ts:90 (the rename target):
+```typescript
+// Currently named `_state`; refers to PROCESS spawn state, not agent readiness.
+// Phase 3 SUMMARY follow-up #1: rename to `_processState`.
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add `RepoAdminState` TS type, zod schema, and pure `deriveRepoAdminState` function with RED→GREEN tests</name>
+  <read_first>
+    - src/domain/repo-admin-state.ts (target — will be created)
+    - test/domain/repo-admin-state.test.ts (target — will be created)
+    - src/crosslink/types.ts (analog: zod enum pattern, lines 26-28; ReadyKindSchema)
+    - src/crosslink/store.ts:19 (existing STALE_HEARTBEAT_MS constant — Phase 4 takes ownership)
+    - src/crosslink/hook.ts:161-167 (analog: existing `isProcessAlive(pid)` via `process.kill(pid, 0)`)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md lines 218-252 (Pattern 1: state derivation as pure function) and lines 425-443 (TS mirror sketch)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/domain/repo-admin-state.ts" section
+  </read_first>
+  <files>src/domain/repo-admin-state.ts, test/domain/repo-admin-state.test.ts</files>
+  <action>
+    Create `src/domain/repo-admin-state.ts` exporting:
+      - `RepoAdminStateSchema = z.enum(["disconnected", "booting", "ready", "stale"])`
+      - `type RepoAdminState = z.infer<typeof RepoAdminStateSchema>`
+      - `STALE_HEARTBEAT_MS = 120_000` (re-exports the same numeric value as `src/crosslink/store.ts:19`; the store.ts version should `import { STALE_HEARTBEAT_MS } from "../domain/repo-admin-state.js"` to remove duplication — touch one line in store.ts to switch to the import per D-06 single-source-of-truth)
+      - `deriveRepoAdminState(session: { pid: number; lastHeartbeat: string; readyAt?: string | null } | null, nowMs: number, isProcessAlive: (pid: number) => boolean): RepoAdminState`
+    Derivation branch order (must match Rust byte-for-byte per D-06): null session → `"disconnected"`; not alive OR (`nowMs - parseISO(lastHeartbeat)` > `STALE_HEARTBEAT_MS`) → `"stale"`; `readyAt` present → `"ready"`; else `"booting"`.
+
+    Write `test/domain/repo-admin-state.test.ts` with the full truth table (per RESEARCH §"Wave 0 Gaps" + 04-PATTERNS.md test pattern):
+      - null session → disconnected
+      - alive + fresh heartbeat + no readyAt → booting
+      - alive + fresh heartbeat + readyAt set → ready
+      - alive + heartbeat older than STALE_HEARTBEAT_MS → stale
+      - dead pid + fresh heartbeat → stale
+      - readyAt present but pid dead → stale (precedence: stale wins over ready, matching Rust)
+    Inject `isProcessAlive` as a parameter (do NOT import the real one — keep the function pure for scripted-mode tests). No file IO.
+
+    NO fenced code blocks elsewhere in the file. Use kebab-case wire values only.
+  </action>
+  <verify>
+    <automated>pnpm test test/domain/repo-admin-state.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - File `src/domain/repo-admin-state.ts` exists and exports `RepoAdminState`, `RepoAdminStateSchema`, `STALE_HEARTBEAT_MS`, `deriveRepoAdminState`.
+    - `pnpm test test/domain/repo-admin-state.test.ts` passes with at least 6 cases covering the truth table.
+    - `pnpm typecheck` passes.
+    - `grep -n "STALE_HEARTBEAT_MS" src/crosslink/store.ts` shows the constant is imported from the new domain module (not re-declared) — exactly one definition site survives.
+    - `pnpm test` runs the full suite green (no regressions in crosslink-store or hook tests after the constant move).
+  </acceptance_criteria>
+  <done>TS enum + schema + pure derivation function shipped with truth-table tests; STALE_HEARTBEAT_MS deduplicated.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Mirror `RepoAdminState` in `crates/harness-data` with `derive_state`, `is_pid_alive`, `group_by_admin`, and Rust tests</name>
+  <read_first>
+    - crates/harness-data/src/lib.rs (target — EXTEND). Specifically:
+      - lines 600-621 (CrosslinkSession struct pattern)
+      - lines 633-652 (load_crosslink_sessions read-only enumerator)
+      - lines 660-668 (TicketProvider four-value enum + serde rename pattern)
+      - lines 2676-2767 (Phase 3 serde + load tests — analog for new Phase 4 tests)
+    - crates/harness-data/Cargo.toml (confirm available deps: serde, serde_json; check for `nix` or `libc` for kill syscall)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md lines 218-252 (Pattern 1 Rust sketch) + Assumption A5 + Pitfall #3 (must NOT call discoverSessions)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "crates/harness-data/src/lib.rs EXTEND" section (lines 76-156)
+    - src/domain/repo-admin-state.ts (from Task 1 — the TS mirror this Rust impl must match byte-for-byte)
+  </read_first>
+  <files>crates/harness-data/src/lib.rs</files>
+  <action>
+    Append to `crates/harness-data/src/lib.rs`:
+
+      1. `pub enum RepoAdminState { Disconnected, Booting, Ready, Stale }` with derives `Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq` and `#[serde(rename_all = "kebab-case")]`. CLOSED enum — do NOT add `#[serde(other)] Unknown` (per 04-PATTERNS.md, the four states are exhaustive).
+      2. `pub const STALE_HEARTBEAT_MS: i64 = 120_000;` (mirrors TS).
+      3. `pub fn is_pid_alive(pid: u32) -> bool` — implement via `libc::kill(pid as i32, 0)` returning `0` (or use `nix::sys::signal::kill(pid, None).is_ok()` if `nix` is already a workspace dep — check Cargo.toml first; prefer the existing dep, add `libc` if neither exists since `libc` is already transitive). 4-line impl. Returns false on any errno other than `EPERM` (EPERM means process exists but we lack signal permission — alive).
+      4. `pub fn derive_state(session: &CrosslinkSession, now_ms: i64) -> RepoAdminState` — branch order from Task 1 mapped to Rust: parse `last_heartbeat` via `chrono::DateTime::parse_from_rfc3339` (check whether `chrono` is already in `harness-data` deps; if not, parse manually via `time` crate or fall back to a tiny RFC3339 parser — RESEARCH does not mandate chrono). Aged-heartbeat OR not-alive → Stale; `ready_at.is_some()` → Ready; else Booting. Note (doc comment): Disconnected is NEVER returned by this function — it is decided at the channel-rendering layer when no `CrosslinkSession` exists for a `repoAssignment[i]`.
+      5. `pub struct AdminWithWorkers { pub admin: CrosslinkSession, pub workers: Vec<CrosslinkSession> }` and `pub fn group_by_admin(sessions: &[CrosslinkSession]) -> Vec<AdminWithWorkers>` — groups sessions by `ready_kind`: each session whose `ready_kind == Some("admin")` (or `None`, treated as admin per Phase 3 default) becomes an `AdminWithWorkers.admin`; sessions whose `ready_kind == Some("worker")` are placed under the admin sharing the same `channel_id`. Empty workers list is the common case (Phase 5 fills it). Stable ordering: admins sorted by `session_id` ascending; workers sorted by `session_id` within each admin.
+
+    Add `#[cfg(test)]` block with these tests (per 04-PATTERNS.md Wave 0 Gaps):
+      - `derive_state_returns_stale_when_pid_dead`
+      - `derive_state_returns_stale_when_heartbeat_aged` (use a known-bogus pid like 0 to force alive=false, OR mock by passing in a synthetic session with future-now offset)
+      - `derive_state_returns_ready_when_ready_at_set`
+      - `derive_state_returns_booting_when_alive_no_ready_at`
+      - `repo_admin_state_serde_roundtrip_kebab_case` (asserts all four variants serialize to "disconnected" | "booting" | "ready" | "stale")
+      - `group_by_admin_returns_admins_with_empty_workers` (forward-compat for WORKER-06: feed in 2 admin sessions, assert two AdminWithWorkers entries with empty workers Vec)
+      - `group_by_admin_nests_worker_under_admin_with_same_channel_id` (synthesise 1 admin + 1 worker on same channel_id; assert the worker lands under the admin)
+
+    Use `#[serde(rename_all = "kebab-case")]` on the enum (NOT `snake_case` per 04-PATTERNS.md — wire format is `"disconnected"` not `"dis_connected"`).
+  </action>
+  <verify>
+    <automated>cargo test -p harness-data derive_state group_by_admin repo_admin_state</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo test -p harness-data derive_state` shows ≥4 derive_state tests passing.
+    - `cargo test -p harness-data group_by_admin` shows ≥2 grouping tests passing.
+    - `cargo test -p harness-data repo_admin_state_serde_roundtrip_kebab_case` passes (asserts kebab-case wire format).
+    - `cargo check --workspace --locked` green.
+    - `cargo test --workspace` green (Phase 3's 70 prior tests must still pass; new tests add to the count, no regression).
+    - `grep -c "RepoAdminState" crates/harness-data/src/lib.rs` (filtered with `grep -v '^//'` to skip comments) ≥ 4 (enum decl + derive_state return type + group_by_admin internal use + tests).
+  </acceptance_criteria>
+  <done>Rust enum + derive_state + is_pid_alive + group_by_admin shipped with tests; harness-data workspace builds and tests green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Rename `RepoAdminSession._state` → `_processState` (Phase 3 deferred follow-up; resolves lexical collision with new `RepoAdminState`)</name>
+  <read_first>
+    - src/orchestrator/repo-admin-session.ts (target — full file; identify every `_state` usage on the `RepoAdminSession` type/object only — DO NOT rename unrelated `state` variables in other modules)
+    - test/orchestrator/repo-admin-session.test.ts (target — update assertions to use new field name)
+    - .planning/phases/03-repo-admin-readiness-handshake/03-SUMMARY.md "Open follow-ups" #1 (the deferred rename; ~50 LOC mechanical)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Pitfall #1 (lines 345-352 — recommends bundling rename into Phase 4 Wave 1)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "Naming check" reference under "Closed enum, named consistently TS↔Rust"
+  </read_first>
+  <files>src/orchestrator/repo-admin-session.ts, test/orchestrator/repo-admin-session.test.ts</files>
+  <action>
+    Mechanical rename per Phase 3 SUMMARY follow-up #1 (decision D-Plan-3 in this plan: BUNDLED into Wave 1 per RESEARCH recommendation):
+
+      1. In `src/orchestrator/repo-admin-session.ts`, locate every reference to the `_state` field on the `RepoAdminSession` type/interface AND every read/write of that field (`.repo-admin-session.ts` line ~90 per CONTEXT.md). Rename the field to `_processState`. Update type definitions, constructors, getters/setters, and any internal references. The semantics are unchanged — it still tracks process spawn lifecycle.
+      2. Use `git grep -nw _state src/orchestrator/repo-admin-session.ts` to find every site (the `-w` word boundary avoids matching `_state` substrings in unrelated identifiers).
+      3. Also `git grep -nw "RepoAdminSession" src/ test/` and verify no consumer reads `._state` externally — if any do, update them.
+      4. Update `test/orchestrator/repo-admin-session.test.ts` to assert `._processState` instead.
+      5. Add a one-line doc comment on the renamed field: `/** Process spawn state (spawning | spawned | exited). NOT the agent-asserted readiness signal — for that, see CrosslinkSession.readyAt and RepoAdminState in src/domain/repo-admin-state.ts. */`
+
+    NO behavior changes. NO drive-by reformats (per AGENTS.md). Diff should be field rename + comment + test updates, nothing else.
+  </action>
+  <verify>
+    <automated>pnpm test test/orchestrator/repo-admin-session.test.ts && git grep -nw _state src/orchestrator/repo-admin-session.ts | grep -v '^//' | wc -l</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/orchestrator/repo-admin-session.test.ts` passes.
+    - `pnpm typecheck` passes (proves all consumers of `RepoAdminSession._state` were also updated).
+    - `git grep -nw "_state" src/orchestrator/repo-admin-session.ts | grep -v '^//'` returns 0 matches (every uncommented `_state` reference renamed; doc comments may mention the old name historically).
+    - `git grep -nw "_processState" src/orchestrator/repo-admin-session.ts | wc -l` ≥ 3 (field decl, at least one read, at least one write).
+    - `pnpm test` full suite green — no regressions.
+  </acceptance_criteria>
+  <done>Field renamed; tests updated; lexical collision with `RepoAdminState.ready` eliminated.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | This plan is pure type definitions + a mechanical rename. No trust boundaries are crossed; no new attack surface introduced. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-01 | Tampering | `RepoAdminState` wire format drift between TS and Rust | mitigate | Both sides use the same four kebab-case strings (`disconnected | booting | ready | stale`). Test in Task 1 asserts TS schema accepts exactly those four; test in Task 2 asserts Rust serializes to those four. Any future change requires both PRs to land in the same commit per AGENTS.md cross-dashboard rule. |
+| T-04-02 | DoS | `is_pid_alive` on a hostile/non-existent PID | accept | `kill(pid, 0)` is a syscall that returns immediately; no network, no fs. Worst case: errno EINVAL for nonsense PIDs, returns false, derive_state maps to Stale. No amplification possible. |
+| T-04-03 | Information Disclosure | TS `_state → _processState` rename leaks internal lifecycle name into agent-visible logs | accept | The field is internal to the orchestrator; not serialized to disk, not surfaced to agents. Pure refactor. |
+</threat_model>
+
+<verification>
+- `pnpm typecheck` GREEN (TS types align across new module + renames).
+- `pnpm test test/domain/repo-admin-state.test.ts test/orchestrator/repo-admin-session.test.ts` GREEN.
+- `pnpm test` full suite GREEN (no regressions from constant move or rename).
+- `cargo test -p harness-data` shows new `derive_state*`, `group_by_admin*`, `repo_admin_state_serde*` tests passing (≥7 new cases).
+- `cargo check --workspace --locked` GREEN.
+- `cargo test --workspace` GREEN (Phase 3's 70 tests still pass).
+- `pnpm format:check` GREEN.
+- `grep -c "STALE_HEARTBEAT_MS" src/crosslink/store.ts src/domain/repo-admin-state.ts | grep -v '^#'` — exactly one declaration in `src/domain/repo-admin-state.ts`, with `src/crosslink/store.ts` importing from it.
+- `git grep -nw "_state" src/orchestrator/repo-admin-session.ts | grep -v '^//'` returns 0.
+</verification>
+
+<success_criteria>
+- TS + Rust both export the four-state enum with identical wire format (verified by serde-roundtrip test in Rust + zod schema test in TS).
+- `derive_state` is the single source of truth for state mapping — no other surface in Phase 4 will re-derive (enforced by code review in Waves 3-5).
+- `_state → _processState` rename complete; doc comment distinguishes process state from agent readiness; Phase 3 follow-up #1 closed.
+- `group_by_admin` lands forward-compat for Phase 5 / WORKER-06: today returns admins with empty `workers` Vec; Phase 5 will populate it without schema churn.
+- All gates (typecheck, test, build, cargo check, cargo test, format:check) GREEN.
+</success_criteria>
+
+<output>
+After completion, no SUMMARY file yet — Phase SUMMARY lands in plan 05. Pass the four-state enum + `derive_state` contract forward to plan 02 (hook generator + install) and plans 03-04 (rendering surfaces).
+</output>

--- a/.planning/phases/04-project-readiness-surface/04-02-PLAN.md
+++ b/.planning/phases/04-project-readiness-surface/04-02-PLAN.md
@@ -1,0 +1,363 @@
+---
+phase: 04-project-readiness-surface
+plan: 02
+type: execute
+wave: 2
+depends_on: [01]
+files_modified:
+  - src/crosslink/session-start-hook-content.ts
+  - test/crosslink/session-start-hook-content.test.ts
+  - src/crosslink/hook.ts
+  - test/crosslink/hook.test.ts
+  - src/channels/channel-store.ts
+  - test/channels/channel-store-watermark.test.ts
+autonomous: true
+requirements:
+  - SURFACE-01
+
+must_haves:
+  truths:
+    - "`formatSessionStartContext({ channelName, repoStates, newFeedEntries? })` returns a deterministic ~5-15 line text block when given a valid input, including: a header line `[Relay] Channel: <name> (<N> repos)`, one `glyph alias state (detail)` line per repo (per D-03), and an optional `Feed: N new entries...` tail when `newFeedEntries > 0`."
+    - "`generateSessionStartHookScripts()` writes `~/.relay/crosslink/hooks/session-start.sh` (chmod 755) + `~/.relay/crosslink/hooks/session-start.mjs` and returns their paths."
+    - "The generated `session-start.mjs` script: (a) resolves active channel via `RELAY_CHANNEL_ID` env OR `cwd`-prefix match against `Channel.repoAssignments[].repoPath` (per D-02), (b) reads raw `~/.relay/crosslink-session/*.json` via direct fs (NEVER `discoverSessions()`), (c) computes `RepoAdminState` per repo via a TS-inlined mirror of `deriveRepoAdminState` from plan 01, (d) prints formatted output to stdout, (e) exits 0 on success AND on any failure path (graceful no-op)."
+    - "The `Feed: N new entries` tail is GATED on `mySession !== null` (mySession is the CrosslinkSession matching `process.env.RELAY_SESSION_ID`). For user-launched / non-Relay-spawned Claude/Codex sessions where `RELAY_SESSION_ID` is unset, the tail is OMITTED entirely; the header + per-repo state lines still render."
+    - "The inlined `.mjs` state-derivation logic is verified byte-equivalent to TS `deriveRepoAdminState` via a behavioral-equivalence test running both against the same 4-state truth-table fixture (closes the inlined-duplication gap)."
+    - "`CrosslinkSession.lastSeenFeedIdx?: number` is added to the TS schema and Rust mirror with `.optional()` / `#[serde(default)]`; the hook advances this watermark by atomic-rename write at the end of a successful run."
+    - "`CrosslinkStore.advanceFeedWatermark(sessionId, idx)` is monotonic — never advances backward."
+  artifacts:
+    - path: "src/crosslink/session-start-hook-content.ts"
+      provides: "Pure formatter `formatSessionStartContext` + glyph/detail helpers; no IO"
+      contains: "export function formatSessionStartContext"
+    - path: "src/crosslink/hook.ts"
+      provides: "Extended with `generateSessionStartHookScripts()` + `buildSessionStartShellScript` + `buildSessionStartNodeScript` (sibling to existing `generateHookScripts`)"
+      contains: "export async function generateSessionStartHookScripts"
+    - path: "src/channels/channel-store.ts"
+      provides: "Existing ChannelStore extended with `advanceFeedWatermark(sessionId, idx)` writing to `CrosslinkSession.lastSeenFeedIdx` (atomic rename, monotonic, idempotent)"
+      contains: "advanceFeedWatermark"
+  key_links:
+    - from: "src/crosslink/session-start-hook-content.ts formatSessionStartContext"
+      to: "src/domain/repo-admin-state.ts RepoAdminState type"
+      via: "RepoState input shape imports RepoAdminState"
+      pattern: "import.*RepoAdminState"
+    - from: "src/crosslink/hook.ts buildSessionStartNodeScript"
+      to: "src/domain/repo-admin-state.ts deriveRepoAdminState"
+      via: "the generated node script INLINES the derivation logic (string-template) since the script runs standalone without imports — must match plan-01 logic byte-for-byte"
+      pattern: "STALE_HEARTBEAT_MS"
+    - from: "generated session-start.mjs node script"
+      to: "~/.relay/crosslink-session/*.json (raw fs read, NOT discoverSessions)"
+      via: "readdir + readFile + JSON.parse per Pitfall #3"
+      pattern: "readdir|readFile"
+---
+
+<objective>
+Land the SessionStart hook generator + the pure formatter that produces the hook's stdout output. The generator emits a shell + node script pair under `~/.relay/crosslink/hooks/` (sibling to the existing `generateHookScripts()` UserPromptSubmit pair). The generated node script: resolves the active channel via env-or-cwd (D-02), reads raw session records (NEVER via `discoverSessions()` per Pitfall #3), derives state via an inlined mirror of plan-01's logic, formats per D-03, and exits 0 always.
+
+Also add the `lastSeenFeedIdx` watermark (D-04 — decision D-Plan-4: KEEP) as an optional field on `CrosslinkSession` so the hook can emit the `Feed: N new entries` tail.
+
+Purpose: This is the agent-visible surface of Phase 4. Every Claude or Codex session opened in a Relay-channel-rooted directory will see the project's repo states inline at first turn.
+
+Output: A pure formatter (vitest-friendly), a script generator (extends existing hook.ts pattern), watermark plumbing in CrosslinkStore + schema.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-project-readiness-surface/04-CONTEXT.md
+@.planning/phases/04-project-readiness-surface/04-RESEARCH.md
+@.planning/phases/04-project-readiness-surface/04-PATTERNS.md
+@AGENTS.md
+
+<interfaces>
+<!-- Existing hook generator pattern (the analog this plan extends). Source: src/crosslink/hook.ts lines 6-99 -->
+
+From src/crosslink/hook.ts (existing — analog this plan mirrors):
+```typescript
+export async function generateHookScripts(): Promise<{
+  shellScriptPath: string;
+  nodeScriptPath: string;
+}>;
+
+// Internal builders:
+function buildShellScript(nodeScriptPath: string): string;  // exec node + redirect stderr
+function buildNodeScript(relayDir: string): string;          // baked RELAY_DIR template
+
+// Existing hooks dir convention:
+//   ~/.relay/crosslink/hooks/check-messages.{sh,mjs}
+// Phase 4 sibling emits:
+//   ~/.relay/crosslink/hooks/session-start.{sh,mjs}
+```
+
+From src/cli/print-status-context.ts:26-44 (formatter analog):
+```typescript
+export function formatActiveSessionsBlock(sessions: ActiveSessionRow[]): string {
+  if (sessions.length === 0) return "";
+  // ... build lines[] ... return lines.join("\n");
+}
+```
+
+From src/domain/channel.ts (consumed for cwd resolution, per D-02):
+```typescript
+// Channel.repoAssignments: Array<{ alias: string; repoPath: string; workspaceId: string }>
+// Channel.status: "active" | "archived" | ...
+// Channel.updatedAt: string (ISO)  // tie-break for cwd resolution per RESEARCH Pattern 4
+```
+
+From src/crosslink/types.ts (Phase 3 — adding `lastSeenFeedIdx` here):
+```typescript
+// CrosslinkSessionSchema (Phase 3) — extend with:
+//   lastSeenFeedIdx: z.number().int().nonnegative().optional()
+```
+
+From src/domain/repo-admin-state.ts (plan 01):
+```typescript
+export type RepoAdminState = "disconnected" | "booting" | "ready" | "stale";
+export const STALE_HEARTBEAT_MS = 120_000;
+export function deriveRepoAdminState(
+  session: { pid: number; lastHeartbeat: string; readyAt?: string | null } | null,
+  nowMs: number,
+  isProcessAlive: (pid: number) => boolean
+): RepoAdminState;
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Pure formatter `formatSessionStartContext` + tests (shape per D-03, glyphs per D-07)</name>
+  <read_first>
+    - src/crosslink/session-start-hook-content.ts (target — will be created)
+    - test/crosslink/session-start-hook-content.test.ts (target — will be created)
+    - src/cli/print-status-context.ts:26-44 (analog: `formatActiveSessionsBlock` — same empty-list contract, same line-building style)
+    - src/domain/repo-admin-state.ts (consumed: `RepoAdminState` type)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-03 (sample shape) + D-07 (glyph rules: ready muted, booting yellow, stale red, disconnected dimmed)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md lines 445-473 (formatter sketch) + Pattern 3 (plain stdout — works for both Claude + Codex)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/crosslink/session-start-hook-content.ts" section
+  </read_first>
+  <files>src/crosslink/session-start-hook-content.ts, test/crosslink/session-start-hook-content.test.ts</files>
+  <action>
+    Create `src/crosslink/session-start-hook-content.ts` exporting:
+
+      - `interface RepoState { alias: string; state: RepoAdminState; adminAlias?: string; bootingSinceMs?: number }`
+      - `function glyphFor(state: RepoAdminState): string` — returns `"●"` for ready, `"○"` for booting, `"×"` for stale, `"·"` for disconnected (per 04-PATTERNS.md D-07 color mapping, glyph column only — colors are surface-specific).
+      - `function detailFor(repo: RepoState, nowMs: number): string` — for ready: `(admin: <adminAlias>)` if present, else `""`; for booting: `(since <human-readable-relative-time> ago)` from `bootingSinceMs`; for stale: `(stale)`; for disconnected: `""`. Relative-time helper: < 60s = "Ns", < 60m = "Nm", else "Nh". Inline, no date-fns.
+      - `function formatSessionStartContext(input: { channelName: string; repoStates: RepoState[]; newFeedEntries?: number; nowMs?: number }): string` — returns `""` if `repoStates.length === 0` (empty contract per analog). Otherwise: header line `[Relay] Channel: <name> (<N> repos)`, one indented line per repo `  <glyph> <alias padEnd 14> <state><detail>`, then conditional `Feed: <n> new entries since you were last here. Use \`rly status\` for detail.` tail when `newFeedEntries !== undefined && newFeedEntries > 0`. Lines joined with `\n`.
+
+    Write `test/crosslink/session-start-hook-content.test.ts` with these cases (assert structural shape per AGENTS.md "no snapshot tests" — split lines + assert per-line predicates, NOT one giant `toEqual` on a frozen string):
+      1. Empty `repoStates` → returns `""`.
+      2. 3-repo channel with mixed states (1 ready, 1 booting, 1 disconnected) → produces 4 lines: header + 3 repo lines. Assert each line contains the expected glyph + state string.
+      3. Watermark tail present when `newFeedEntries === 4` → last line starts with `"Feed: 4 new entries"`.
+      4. Watermark tail absent when `newFeedEntries === 0` OR `undefined` → no `Feed:` line.
+      5. Booting detail formats `(since 2m ago)` for a `bootingSinceMs` of 130_000.
+      6. Stale glyph is `×` and state text is `"stale"` (verifies D-07 emphasis is via glyph+state-string, color is per-surface).
+      7. The output contains NO imperative language (no occurrences of "MUST", "ATTENTION", "do not") — per RESEARCH anti-pattern (avoid prompt-injection triggers). Assert via `expect(output).not.toMatch(/\b(MUST|ATTENTION)\b/)`.
+
+    NO IO. NO Date.now() inside the formatter — accept `nowMs` as input so tests are deterministic.
+  </action>
+  <verify>
+    <automated>pnpm test test/crosslink/session-start-hook-content.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/crosslink/session-start-hook-content.test.ts` passes with ≥7 cases.
+    - `pnpm typecheck` passes.
+    - `grep -v '^//' src/crosslink/session-start-hook-content.ts | grep -c 'fs\\.' ` returns 0 (no IO imports — pure function).
+    - `grep -v '^//' src/crosslink/session-start-hook-content.ts | grep -c 'Date.now' ` returns 0 (no implicit time — `nowMs` is parameter).
+  </acceptance_criteria>
+  <done>Pure, deterministic formatter shipped with tests. Output shape matches D-03 verbatim. No prompt-injection-prone phrasing.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Extend `src/crosslink/hook.ts` with `generateSessionStartHookScripts()` + tests for graceful no-op + cwd resolution</name>
+  <read_first>
+    - src/crosslink/hook.ts (target — EXTEND, full file). Specifically:
+      - lines 6-32 (`generateHookScripts` — sibling pattern this task mirrors)
+      - lines 34-47 (`buildShellScript` — shell wrapper pattern)
+      - lines 49-99 (`buildNodeScript` — baked-RELAY_DIR template pattern; lines 71-96 specifically — raw fs read of crosslink-session, no discoverSessions)
+      - lines 98-100 (`if (!mySession) process.exit(0)` graceful no-op pattern)
+      - lines 161-167 (`isProcessAlive` pattern)
+      - line 178 (`main().catch(() => process.exit(0))`)
+    - test/crosslink/hook.test.ts (existing — find existing test conventions; will be extended in same file or with new sibling file `test/crosslink/session-start-hook.test.ts` — prefer NEW sibling file to keep diff focused)
+    - src/domain/channel.ts (consumed: Channel.repoAssignments[].repoPath; Channel.status; Channel.updatedAt)
+    - src/channels/channel-store.ts (consumed: `listChannels()` for cwd reverse-lookup)
+    - src/crosslink/session-start-hook-content.ts (from Task 1 — INLINE the formatter into the generated script via string-template; same approach as existing `buildNodeScript`)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-02 (active channel resolution: env first, cwd second, graceful no-op third)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Pattern 4 (cwd reverse lookup with most-recent-updatedAt tie-break) + Pitfall #3 (NEVER call discoverSessions from the script) + Pitfall #6 (< 100ms target — read ONLY the resolved channel's files)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/crosslink/hook.ts EXTEND" section
+  </read_first>
+  <files>src/crosslink/hook.ts, test/crosslink/hook.test.ts</files>
+  <action>
+    Extend `src/crosslink/hook.ts`:
+
+      1. Add `export async function generateSessionStartHookScripts(): Promise<{ shellScriptPath: string; nodeScriptPath: string }>`. Mirrors `generateHookScripts()` (lines 6-32) exactly: ensures `~/.relay/crosslink/hooks/` exists, writes `session-start.sh` + `session-start.mjs`, chmod 755 the shell file, returns both paths.
+
+      2. Add `function buildSessionStartShellScript(nodeScriptPath: string): string` — copy of `buildShellScript` (lines 34-47); only the inner exec path changes (to `session-start.mjs`).
+
+      3. Add `function buildSessionStartNodeScript(relayDir: string): string` — returns the Node script as a string template. Behavior of the generated script:
+          - Read stdin (JSON from Claude/Codex). Parse defensively — empty stdin is OK (some Codex versions don't pipe stdin to SessionStart).
+          - Resolve active channel:
+              (a) If `process.env.RELAY_CHANNEL_ID` is set → read `~/.relay/channels/<id>/channel.json`. If file missing → fall through to (b).
+              (b) Else: enumerate `~/.relay/channels/*/channel.json`, filter to `status === "active"`, pick those whose `repoAssignments[].repoPath` is exactly `cwd` (from stdin JSON or `process.cwd()`) OR a prefix `cwd.startsWith(ra.repoPath + "/")`. Tie-break by `updatedAt` descending (most-recent wins) per RESEARCH Pattern 4.
+              (c) If neither resolves → `process.exit(0)` with empty stdout (graceful no-op per D-02).
+          - Read raw `~/.relay/crosslink-session/*.json` via `readdir + readFile` (NEVER call `discoverSessions` — verified Pitfall #3). Filter to records where `channelId === resolvedChannel.channelId`.
+          - INLINE the state derivation (DO NOT import from `repo-admin-state.ts` — the script must be self-contained for the node hook). Inline body: bake `STALE_HEARTBEAT_MS = 120_000`; inline `isProcessAlive(pid)` from lines 161-167; inline the same branch order from plan 01 Task 1.
+          - For each `repoAssignment` in `resolvedChannel.repoAssignments`:
+              * Find the matching `CrosslinkSession` (by `repoAlias` field on session, or fallback to no match → `"disconnected"`).
+              * If found → `state = derive(session, Date.now())`; if not → `state = "disconnected"`.
+              * Capture `adminAlias` for the agent (from `session.alias` or similar — the script needs this for the `(admin: <alias>)` detail per D-03). If the field name varies, inline a best-effort fallback chain.
+              * For `booting`, compute `bootingSinceMs = Date.now() - parseISO(session.registeredAt || session.lastHeartbeat)`.
+          - Compute `newFeedEntries` (D-04 watermark — covered fully in Task 3):
+              * Resolve `mySession`: find the CrosslinkSession matching `process.env.RELAY_SESSION_ID` (if set AND a record exists). For user-launched (non-Relay-spawned) `claude` / `codex` sessions, `RELAY_SESSION_ID` is unset → `mySession === null`.
+              * **GATE: If `mySession === null`, OMIT the `Feed:` tail entirely** (do NOT compute or render `newFeedEntries`). The rest of the hook output (header + per-repo state lines) still renders. Rationale: without a `mySession.lastSeenFeedIdx` watermark to subtract against, the count would always equal the full feed length (every user-launched session start would emit a noisy "Feed: N new entries" message). Skipping the tail is the honest behavior.
+              * If `mySession !== null`:
+                - Read `~/.relay/channels/<id>/feed.jsonl` → count lines (per Pitfall #4 tolerance, skip torn last line silently — `.split('\n').filter(Boolean).length`).
+                - Subtract `mySession.lastSeenFeedIdx ?? 0`.
+                - After rendering succeeds, advance the watermark via atomic-rename write of `<sid>.json` (best-effort — failures swallowed; this is the only WRITE the hook ever does).
+          - INLINE the `formatSessionStartContext` logic from Task 1 into the script. Yes, this is duplication; the alternative (bundling) is more complex. Tests in Task 1 cover the formatter; an end-to-end test in this task covers the inlined version. Keep both versions byte-equivalent — add a code comment in `buildSessionStartNodeScript` saying "Mirror of formatSessionStartContext; keep in sync."
+          - Print to stdout (plain text, per RESEARCH Pattern 3 — works for both Claude SessionStart and Codex SessionStart). Exit 0.
+          - Wrap top-level in `try/catch` — any error → exit 0 with empty stdout (Pitfall #2 graceful no-op).
+
+      4. NEW test file `test/crosslink/session-start-hook.test.ts`:
+          - `generateSessionStartHookScripts writes both files under ~/.relay/crosslink/hooks/` (mock relayDir to tmpdir).
+          - `generated script is executable (chmod 755)` (assert via `fs.statSync().mode & 0o111`).
+          - `generated node script body contains the four state strings` (assert via `expect(script).toMatch(/"ready"/)` etc — proves inlined derivation made it into the output).
+          - `generated node script body contains "STALE_HEARTBEAT_MS = 120_000"` — mirror constant verified inline.
+          - `generated node script body does NOT contain "discoverSessions"` — Pitfall #3 enforcement at the script-template level.
+          - END-TO-END test that EXECUTES the generated script against a tmpdir-rooted `~/.relay/` fixture (set RELAY_DIR via env, or template literal): write a synthetic `channels/oauth/channel.json`, a `crosslink-session/sid1.json` (alive + readyAt), a `crosslink-session/sid2.json` (alive + no readyAt), run the script with `RELAY_CHANNEL_ID=oauth`, capture stdout, assert:
+              * stdout contains `"[Relay] Channel: oauth"`.
+              * stdout contains `"ready"` exactly once (the first repo).
+              * stdout contains `"booting"` exactly once (the second repo).
+              * exit code is 0.
+              * Run the script a second time with `RELAY_CHANNEL_ID` UNSET and `cwd` set to one of the repo paths — assert stdout still resolves the channel.
+              * Run the script with `RELAY_CHANNEL_ID=does-not-exist` and `cwd` outside any channel — assert stdout is empty AND exit code is 0 (graceful no-op).
+          - **NEW: `Feed: tail is OMITTED when RELAY_SESSION_ID is unset`** — fixture: a channel with `feed.jsonl` containing 5 entries; run the generated script with `RELAY_CHANNEL_ID=oauth` and `RELAY_SESSION_ID` UNSET; capture stdout; assert `expect(stdout).not.toMatch(/^Feed:/m)` AND `expect(stdout).not.toMatch(/new entries since/)`. The header + per-repo state lines MUST still render (assert `expect(stdout).toMatch(/^\[Relay\] Channel:/m)`).
+          - **NEW: `Feed: tail RENDERS when RELAY_SESSION_ID matches an existing session and there are new entries`** — same fixture as above, but write a CrosslinkSession `sid1.json` with `lastSeenFeedIdx: 2` matching `RELAY_SESSION_ID=sid1`; run with both env vars; assert stdout contains `"Feed: 3 new entries"` (5 total − 2 seen).
+          - **NEW: BEHAVIORAL EQUIVALENCE TEST** — closes the inlined-formatter duplication gap (WARNING #3). Test name: `generated_mjs_formatter_matches_TS_deriveRepoAdminState_for_all_4_states`. Body:
+              * Build the 4-state truth-table fixture used by plan 01 Task 2's `deriveRepoAdminState` test (call it `STATE_FIXTURE`): an array of `{ session, nowMs, expectedState }` covering ready, booting, stale-by-heartbeat, stale-by-dead-pid, and the no-session/disconnected case.
+              * For each fixture entry: construct a minimal channel + session disk fixture, run the generated `session-start.mjs` via `child_process.execFileSync("node", [scriptPath], { env: { RELAY_DIR: tmpDir, RELAY_CHANNEL_ID: "fix" }, input: "{}" })`, parse the state word out of stdout (it's the third whitespace-separated token on each per-repo line: `<glyph> <alias> <state>...`).
+              * In the SAME test, import `deriveRepoAdminState` from `src/domain/repo-admin-state.ts` and call it directly with the same `session, nowMs, isProcessAlive` inputs.
+              * Assert the state word from stdout EQUALS the string returned by `deriveRepoAdminState` for every fixture entry. This proves the inlined `.mjs` derivation is byte-equivalent to the TS reference and would catch any future drift in the inlined branch order, the `STALE_HEARTBEAT_MS` constant, or the `isProcessAlive` shim.
+
+    Reuse existing helpers — DO NOT re-implement `safeReaddir` or `isProcessAlive` if hook.ts already inlines them. Mirror exactly.
+  </action>
+  <verify>
+    <automated>pnpm test test/crosslink/session-start-hook.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/crosslink/session-start-hook.test.ts` passes including the end-to-end execution test.
+    - `pnpm typecheck` GREEN.
+    - `grep -c "discoverSessions" src/crosslink/hook.ts | grep -v '^//' ` — no new uncommented occurrences (existing hook may reference it; the new generator MUST NOT).
+    - The generated script body contains literally `"disconnected"`, `"booting"`, `"ready"`, `"stale"` (verified by Task 2's test).
+    - **Feed-tail gate verified:** the test `Feed: tail is OMITTED when RELAY_SESSION_ID is unset` GREEN; stdout from a non-Relay-spawned session start has no line matching `/^Feed:/m`.
+    - **Feed-tail render verified:** the test `Feed: tail RENDERS when RELAY_SESSION_ID matches an existing session and there are new entries` GREEN; stdout contains the exact substring `"Feed: 3 new entries"` for the (5 entries − watermark 2) fixture.
+    - **Behavioral equivalence verified:** the test `generated_mjs_formatter_matches_TS_deriveRepoAdminState_for_all_4_states` GREEN; the state word emitted by the inlined `.mjs` formatter equals the string returned by `deriveRepoAdminState` for every entry in the 4-state truth-table fixture (covers ready / booting / stale-by-heartbeat / stale-by-dead-pid / disconnected). This closes the inlined-duplication gap (any future drift in the inlined branch order, the `STALE_HEARTBEAT_MS` constant, or the `isProcessAlive` shim is caught here, not at runtime).
+    - Generated script wall-clock target (informational, not a gate): < 100ms in the end-to-end test for a 3-repo channel — log timing in the test but don't fail on it (per Pitfall #6, this is the budget).
+    - `pnpm test` full suite GREEN.
+  </acceptance_criteria>
+  <done>SessionStart hook generator emits a working node script. End-to-end test proves: channel resolution (env + cwd), raw fs read of sessions, state derivation, plain-stdout output, graceful no-op on miss.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Watermark plumbing — add `lastSeenFeedIdx` to TS schema + Rust mirror + `CrosslinkStore.advanceFeedWatermark`</name>
+  <read_first>
+    - src/crosslink/types.ts (target — EXTEND CrosslinkSessionSchema with optional `lastSeenFeedIdx`)
+    - src/crosslink/store.ts (target — EXTEND with `advanceFeedWatermark`). Specifically:
+      - existing `updateHeartbeat` (atomic rename pattern + monotonic guard)
+      - existing `updateReadiness` (Phase 3 monotonic-once-set sibling; identical shape this task mirrors)
+    - crates/harness-data/src/lib.rs (target — add `pub last_seen_feed_idx: Option<u64>` field to `CrosslinkSession` with `#[serde(default, skip_serializing_if = "Option::is_none")]`)
+    - test/crosslink/channel-store-watermark.test.ts (target — will be created)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-04 (snapshot only; watermark is droppable; field-on-record per RESEARCH A4)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md A4 (watermark shape recommendation) + Pitfall #4 (torn last line in feed.jsonl)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "Schema versioning + back-compat" and "Atomic-rename file writes" sections
+  </read_first>
+  <files>src/crosslink/types.ts, src/crosslink/store.ts, crates/harness-data/src/lib.rs, test/crosslink/channel-store-watermark.test.ts</files>
+  <action>
+    1. **TS schema** (`src/crosslink/types.ts`): add `lastSeenFeedIdx: z.number().int().nonnegative().optional()` to `CrosslinkSessionSchema`. Place adjacent to `readyAt`/`readyKind` for visual grouping. NO schemaVersion bump (additive optional field — Phase 1's back-compat convention).
+
+    2. **TS write site** (`src/crosslink/store.ts`): add `async advanceFeedWatermark(sessionId: string, idx: number): Promise<{ ok: boolean; idx: number } | null>` to `CrosslinkStore`. Shape mirrors `updateReadiness` (Phase 3):
+        - Returns `null` for unknown sessionId.
+        - Reads current `<sid>.json`, computes `newIdx = Math.max(idx, current.lastSeenFeedIdx ?? 0)` (MONOTONIC — never goes backward).
+        - Writes via atomic rename (tmp file + `rename`) — reuse the existing pattern from `updateHeartbeat` and `updateReadiness`.
+        - Idempotent: calling with the same or smaller idx returns the current value, no disk write.
+
+    3. **Rust mirror** (`crates/harness-data/src/lib.rs`): in `pub struct CrosslinkSession`, add:
+       ```
+       #[serde(default, skip_serializing_if = "Option::is_none")]
+       pub last_seen_feed_idx: Option<u64>,
+       ```
+       Place adjacent to `ready_at`/`ready_kind`. Add a Rust test `parses_session_with_watermark` and `parses_session_without_watermark` (back-compat) to the existing `#[cfg(test)]` block — mirror Phase 3's serde-roundtrip tests at lines 2676-2767.
+
+    4. **Tests** (`test/crosslink/channel-store-watermark.test.ts`):
+        - `advanceFeedWatermark sets the field on a fresh session` — write a session, call advance(sid, 5), read back, assert `lastSeenFeedIdx === 5`.
+        - `advanceFeedWatermark is monotonic — does not go backward` — call advance(sid, 5), then advance(sid, 3), assert still 5.
+        - `advanceFeedWatermark is idempotent — repeat call with same idx is a no-op write` — call advance twice with idx=5, assert (informational) mtime unchanged OR just assert the second call returns the same idx. Strict mtime is platform-dependent; prefer just-assert-return.
+        - `advanceFeedWatermark returns null for unknown sessionId`.
+        - `back-compat: legacy session.json without lastSeenFeedIdx deserializes cleanly` — write a pre-Phase-4 shaped session JSON to disk, load it, assert no schema error.
+
+    Use the existing tmpdir-rooted store helper from Phase 3 tests (`test/crosslink-store.test.ts` shows the pattern).
+
+    NO drive-by reformats. NO changes to `updateHeartbeat` or `updateReadiness` semantics.
+  </action>
+  <verify>
+    <automated>pnpm test test/crosslink/channel-store-watermark.test.ts && cargo test -p harness-data parses_session_with_watermark parses_session_without_watermark</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/crosslink/channel-store-watermark.test.ts` passes with ≥5 cases.
+    - `cargo test -p harness-data parses_session_with_watermark parses_session_without_watermark` shows 2 tests passing.
+    - `pnpm typecheck` GREEN; `cargo check --workspace --locked` GREEN.
+    - `grep -n "last_seen_feed_idx" crates/harness-data/src/lib.rs` shows the field declared with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
+    - `grep -n "lastSeenFeedIdx" src/crosslink/types.ts` shows the field declared as `.optional()`.
+    - Phase 3 tests still pass: `pnpm test test/crosslink-store.test.ts` GREEN (no regressions in updateHeartbeat or updateReadiness).
+    - Note in hook (Task 2): the inlined node script reads `lastSeenFeedIdx` from `mySession` when matching `process.env.RELAY_SESSION_ID`. If RELAY_SESSION_ID is unset, no watermark advance — the hook still renders, watermark just doesn't advance (acceptable best-effort behavior).
+  </acceptance_criteria>
+  <done>Watermark field shipped in both TS and Rust with back-compat. Store has a monotonic advancer. Hook (Task 2) can now emit "Feed: N new entries" honestly.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Hook stdout → Agent context | The hook writes plain text into the agent's first turn. Untrusted content (channel names, repo aliases sourced from disk) could in principle be crafted to bias the agent. |
+| stdin (JSON from Claude/Codex) → hook script | Adapter-provided JSON. Must be parsed defensively. |
+| `~/.relay/crosslink-session/*.json` → hook script | Disk-provided JSON. Already a Relay trust boundary; same defensive parsing as existing hook. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-04 | Tampering | Prompt injection via hook output (channel/alias contains imperative text) | mitigate | Formatter uses factual phrasing only — header + per-repo state line + count tail. NO imperative words. Test 7 in Task 1 asserts `expect(output).not.toMatch(/\b(MUST\|ATTENTION)\b/)`. Cited from Claude Code docs in 04-RESEARCH.md anti-patterns. |
+| T-04-05 | Tampering | Malicious `channel.json` or `session.json` crashes the hook | mitigate | All file reads wrapped in try/catch per Pitfall #4 + existing `safeReaddir` pattern from src/crosslink/hook.ts:71-96. End-to-end test in Task 2 includes a "channel does not exist" branch and asserts exit 0. |
+| T-04-06 | DoS | Hook reads too many files → multi-second startup → user sees Claude/Codex as sluggish | mitigate | Per Pitfall #6: resolve channel FIRST, read ONLY that channel's session records via `channelId` filter on the raw fs walk. Target wall-clock < 100ms. Task 2 logs timing (informational, not a gate). |
+| T-04-07 | Tampering | Watermark race (two hook invocations advance same session's lastSeenFeedIdx concurrently) | accept | Last-writer-wins via atomic rename. Best-effort counter per D-04; an off-by-one on "N new entries" is acceptable per Pitfall #4 reasoning. |
+| T-04-08 | Information Disclosure | Hook injects channel name into a session that didn't originate in Relay (user runs `claude` in a random dir that happens to match a repo prefix) | accept | This is the DESIGNED behavior per D-02 (cwd reverse lookup). The injected context only reveals Relay state for repos the user has explicitly connected to a channel — which is already on their disk. No cross-user leakage. |
+</threat_model>
+
+<verification>
+- `pnpm typecheck` GREEN.
+- `pnpm test test/crosslink/session-start-hook-content.test.ts test/crosslink/session-start-hook.test.ts test/crosslink/channel-store-watermark.test.ts` GREEN (≥15 new cases total).
+- `cargo test -p harness-data` GREEN, with 2 new watermark serde tests.
+- `pnpm test` full suite GREEN (no regressions in existing hook tests, store tests, channel-store tests).
+- `pnpm format:check` GREEN.
+- `grep -c "discoverSessions" src/crosslink/hook.ts | grep -v '^//' ` shows no new uncommented references in the new generator code.
+- End-to-end script execution (in Task 2) demonstrates: env resolution → cwd fallback → graceful no-op, all observable via stdout + exit code.
+</verification>
+
+<success_criteria>
+- A Claude or Codex agent opened in a Relay-channel directory sees the project's repo states injected at first turn (verified end-to-end in Task 2 test).
+- Hook degrades to silent no-op outside Relay channels (verified — exit 0, empty stdout).
+- Watermark plumbing in place; "Feed: N new entries" count is honest when RELAY_SESSION_ID is threaded.
+- Single source of truth for state derivation is preserved: the inlined node-script logic is commented as a mirror of plan 01's `deriveRepoAdminState`; any future change requires touching both (enforced by code review + the script's "must contain STALE_HEARTBEAT_MS = 120_000" test).
+- Pitfall #3 (NEVER call discoverSessions) enforced at the script-template level by a grep test.
+</success_criteria>
+
+<output>
+After completion, hook generator + formatter + watermark all green. Plan 03 (install integration) wires this generator into `rly install` for Claude AND Codex.
+</output>

--- a/.planning/phases/04-project-readiness-surface/04-03-PLAN.md
+++ b/.planning/phases/04-project-readiness-surface/04-03-PLAN.md
@@ -1,0 +1,358 @@
+---
+phase: 04-project-readiness-surface
+plan: 03
+type: execute
+wave: 3
+depends_on: [02]
+files_modified:
+  - src/install/manifest.ts
+  - src/install/installer.ts
+  - src/cli/install.ts
+  - src/install/codex-toml.ts
+  - test/install/manifest-hooks.test.ts
+  - test/install/install-session-start.test.ts
+  - test/install/codex-toml.test.ts
+autonomous: true
+requirements:
+  - SURFACE-01
+  - SURFACE-02
+  - SURFACE-07
+
+must_haves:
+  truths:
+    - "`rly install` writes the SessionStart hook entry into `~/.claude/settings.json` (idempotent merge, atomic rename) under matcher tag `relay-channel-readiness`."
+    - "`rly install` writes the SessionStart hook entry into `~/.codex/hooks.json` (same matcher tag, identical shape) AND ensures `[features].hooks = true` is present in `~/.codex/config.toml`."
+    - "`rly install --check` reports drift on EITHER hook file if the user manually edited the entry — using the existing `installed.json` manifest extended with a `hooks` block (no schemaVersion bump; additive optional field)."
+    - "On a Codex CLI < v0.130 (or codex not installed), `rly install` writes the config anyway, logs a single-line note `[rly install] Codex hooks require Codex CLI v0.130+ (detected: <version>|not-found). Writing config anyway; will activate on upgrade.`, and exits 0 (fail-soft per D-Plan-1)."
+    - "Re-running `rly install` is idempotent: byte-for-byte same content in both target files; manifest sha entries unchanged."
+    - "User-configured pre-existing hooks in `~/.claude/settings.json` or `~/.codex/hooks.json` are PRESERVED — only entries tagged `matcher === 'relay-channel-readiness'` are touched."
+  artifacts:
+    - path: "src/install/manifest.ts"
+      provides: "Extended `InstallManifest` with optional `hooks?: Partial<Record<HookTarget, HookRecord>>` block (`HookTarget = 'claude' | 'codex'`; `HookRecord = { sha: string; installedAt: string; command: string }`); `markHookInstalled`, `getHookRecord`, `diffHook`, `reportHookDrift` helpers."
+      contains: "hooks?:"
+    - path: "src/install/installer.ts"
+      provides: "Extended with `installSessionStartHooks({ relayDir, claude, codex }, opts)` — generates scripts via plan-02's `generateSessionStartHookScripts`, writes Claude + Codex config files, marks manifest entries."
+      contains: "installSessionStartHooks"
+    - path: "src/install/codex-toml.ts"
+      provides: "`ensureCodexFeatureFlag(flag, value)` — idempotent TOML merge that preserves comments + unrelated keys; atomic rename write."
+      contains: "ensureCodexFeatureFlag"
+    - path: "src/cli/install.ts"
+      provides: "Extended `handleInstallCommand` to invoke `installSessionStartHooks` after existing surface installs; `--check` reports hook drift alongside surface drift."
+      contains: "installSessionStartHooks"
+  key_links:
+    - from: "src/cli/install.ts handleInstallCommand"
+      to: "src/install/installer.ts installSessionStartHooks"
+      via: "function call from install command, post-surfaces"
+      pattern: "installSessionStartHooks"
+    - from: "src/install/installer.ts installSessionStartHooks"
+      to: "src/crosslink/hook.ts generateSessionStartHookScripts (plan 02)"
+      via: "generates the scripts then writes the config entries that reference their paths"
+      pattern: "generateSessionStartHookScripts"
+    - from: "src/install/installer.ts installSessionStartHooks"
+      to: "src/install/codex-toml.ts ensureCodexFeatureFlag"
+      via: "after writing hooks.json, also touches config.toml feature flag"
+      pattern: "ensureCodexFeatureFlag"
+---
+
+<objective>
+Wire `rly install` to drop the SessionStart hooks into BOTH `~/.claude/settings.json` AND `~/.codex/hooks.json` (idempotent JSON merge, atomic rename), enable Codex's `[features].hooks = true` feature flag in `~/.codex/config.toml` (idempotent TOML merge), and extend the install manifest with a `hooks` block so `rly install --check` reports drift on either hook file.
+
+Decision on Open Question #1 (Codex version probe): probe `codex --version`, log a one-line note if < v0.130 or not installed, write config anyway (fail-soft). This honors the four-surface parity promise (SURFACE-02) even on older Codex installations — the config activates automatically on upgrade.
+
+Purpose: Without install integration, the hook generator from plan 02 produces files that no agent reads. This plan closes the gap from "generator exists" to "agent sees Relay state on every Claude/Codex session start."
+
+Output: Manifest extension, two writer paths (Claude + Codex), one TOML helper, drift-detection hooks, and integration tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-project-readiness-surface/04-CONTEXT.md
+@.planning/phases/04-project-readiness-surface/04-RESEARCH.md
+@.planning/phases/04-project-readiness-surface/04-PATTERNS.md
+@.planning/phases/04-project-readiness-surface/04-02-PLAN.md
+@AGENTS.md
+
+<interfaces>
+<!-- Existing install manifest pattern. Source: src/install/manifest.ts lines 12-192 -->
+
+From src/install/manifest.ts:
+```typescript
+interface InstallManifest {
+  schemaVersion: 1;
+  surfaces: Partial<Record<Surface, SurfaceRecord>>;
+  // Phase 4 ADDITIVE:
+  // hooks?: Partial<Record<HookTarget, HookRecord>>;
+}
+
+interface SurfaceRecord {
+  sha: string;
+  installedAt: string;
+  // ... existing fields
+}
+
+async function writeManifest(manifest: InstallManifest): Promise<void>;  // atomic rename pattern lines 64-69
+function diffSurface(installed: SurfaceRecord | undefined, source: { sha: string }): SurfaceState;
+function reportDrift(manifest: InstallManifest, sources: Record<Surface, { sha: string }>): DriftReport;
+```
+
+From src/install/installer.ts:
+```typescript
+// installSurface (lines 130-176): the shape for atomic per-surface install
+// 1. Read source SHA + current installed record
+// 2. If matches → skip with "already at vX"
+// 3. Otherwise: build/write + markInstalled()
+```
+
+From src/cli/install.ts:
+```typescript
+// handleInstallCommand (lines 132-164): argv parsing + dispatch
+// --check flag: existing flow that reports surface drift; Phase 4 extends to also report hook drift
+```
+
+From src/crosslink/hook.ts (plan 02):
+```typescript
+export async function generateSessionStartHookScripts(): Promise<{
+  shellScriptPath: string;
+  nodeScriptPath: string;
+}>;
+```
+
+Target external files (PRESERVE unrelated user config):
+- `~/.claude/settings.json` — JSON, may have user-configured `hooks.UserPromptSubmit`, `hooks.PreToolUse`, etc.
+- `~/.codex/hooks.json` — JSON, same shape as Claude per RESEARCH (Codex v0.130+ I/O).
+- `~/.codex/config.toml` — TOML, may have `[features]`, `[model]`, comments. NO regex edits.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Codex TOML helper — `ensureCodexFeatureFlag(flag, value)` with comment-preserving merge</name>
+  <read_first>
+    - src/install/codex-toml.ts (target — will be created)
+    - test/install/codex-toml.test.ts (target — will be created)
+    - package.json (check if a TOML parser is already installed — `@iarna/toml` is the prevalent Node TOML library; `smol-toml` is leaner. Prefer whatever ships with the existing repo; if none, add `@iarna/toml` as a dev dep ONLY if not already present)
+    - src/install/manifest.ts:64-69 (atomic rename write pattern this task mirrors)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Pitfall #5 (Codex feature flag opt-in; legacy `codex_hooks` deprecated for `hooks`) + Code Example at lines 496-514 (sketch) + Runtime State Inventory entry on `~/.codex/config.toml`
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "No Analog Found" table — `~/.codex/config.toml` writer is net-new; use parsed-AST approach, NOT regex
+  </read_first>
+  <files>src/install/codex-toml.ts, test/install/codex-toml.test.ts</files>
+  <action>
+    First, `grep -r "iarna/toml\\|smol-toml\\|@ltd/j-toml" package.json src/` to discover what's already available. If a TOML parser is already installed, use it. If not, prefer `@iarna/toml` (most widely used, comment-preserving AST is acceptable trade for the simplicity of the API) — add to `dependencies` (NOT devDependencies, since install runs at runtime). Note the addition in the install task output for the reviewer.
+
+    Create `src/install/codex-toml.ts` exporting:
+
+      - `async function ensureCodexFeatureFlag(flag: string, value: boolean): Promise<{ changed: boolean; path: string }>`. Semantics:
+        1. Path: `join(homedir(), ".codex", "config.toml")`.
+        2. If file does not exist → create with content `[features]\n${flag} = ${value}\n` (no existing data to preserve).
+        3. If file exists → read raw, parse via TOML library, set `parsed.features = parsed.features ?? {}; parsed.features[flag] = value`. If the parsed value already equals `value` → return `{ changed: false, path }` (idempotent, no write).
+        4. Serialize back to TOML, write via atomic rename (tmp + `rename` per `manifest.ts:64-69`).
+        5. Return `{ changed: true, path }`.
+        6. **Comment preservation:** since `@iarna/toml` does NOT preserve comments through round-trip (most TOML libs don't), document the limitation in a JSDoc comment on the function: "Round-trip via TOML parser does not preserve user comments in modified sections. If `~/.codex/config.toml` has user comments and the [features] section is touched, comments in the [features] section will be lost. Comments in other sections are preserved by virtue of section-level identity." Add a check: if the file contains a `# ` comment line inside the `[features]` section pre-write, log a single-line warning to stderr "[rly install] Note: comments in [features] section of ~/.codex/config.toml may be reformatted." Acceptable trade per RESEARCH "No Analog Found" — full-fidelity TOML editing is out of scope.
+
+    Create `test/install/codex-toml.test.ts`:
+      1. `creates config.toml with [features] when file is absent` — point at tmpdir, call, assert file exists with expected content.
+      2. `idempotent: returns changed:false on second call with same value` — call twice, second call returns `{ changed: false }`.
+      3. `preserves other sections + their keys` — write a fixture with `[model]\nname = "gpt-5"\n[features]\nother = true\n` to tmpdir, call `ensureCodexFeatureFlag("hooks", true)`, read back, assert `[model].name === "gpt-5"` AND `[features].other === true` AND `[features].hooks === true`.
+      4. `updates existing feature flag from false to true` — pre-write `[features]\nhooks = false`, call, assert now true and returned `changed: true`.
+      5. `atomic write — no partial file on failure` — informational: hard to test rename atomicity portably; instead assert the tmp file does NOT survive after a successful write (`fs.existsSync(target + '.' + pid + '.tmp')` is false).
+      6. `legacy codex_hooks key is NOT touched` — pre-write `[features]\ncodex_hooks = true` (deprecated per RESEARCH), call `ensureCodexFeatureFlag("hooks", true)`, assert both keys now present and unchanged (we do not migrate legacy; deprecation message is logged elsewhere).
+  </action>
+  <verify>
+    <automated>pnpm test test/install/codex-toml.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/install/codex-toml.test.ts` passes with ≥6 cases.
+    - `pnpm typecheck` GREEN.
+    - `package.json` reflects the TOML library dep (if a new one was added). If `@iarna/toml` was added, it is in `dependencies` (NOT devDependencies) — install runs at user-runtime.
+    - The helper is idempotent (case 2 verifies).
+    - Other sections / keys preserved (case 3 verifies).
+  </acceptance_criteria>
+  <done>TOML helper with idempotency + preservation of unrelated keys + atomic-rename write.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Manifest extension — `hooks` block + drift detection helpers</name>
+  <read_first>
+    - src/install/manifest.ts (target — EXTEND). Specifically:
+      - lines 12-39 (`InstallManifest` interface + `SurfaceRecord`)
+      - lines 36-40 (`isManifest` predicate — must remain forward-compat to old shape)
+      - lines 64-69 (`writeManifest` atomic-rename write pattern)
+      - lines 144-192 (`diffSurface` + `reportDrift` — the shape this task mirrors for hooks)
+    - test/install/manifest-hooks.test.ts (target — will be created)
+    - test/install/manifest.test.ts (existing — check shape; will be touched only via the back-compat case where a Phase-3-shaped manifest still parses)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/install/manifest.ts EXTEND" section + "Schema versioning + back-compat" pattern
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Don't Hand-Roll table "Hook installation drift detection" row
+  </read_first>
+  <files>src/install/manifest.ts, test/install/manifest-hooks.test.ts</files>
+  <action>
+    In `src/install/manifest.ts`:
+
+      1. Add types:
+         - `type HookTarget = "claude" | "codex"`.
+         - `interface HookRecord { sha: string; installedAt: string; command: string }` — `sha` is sha256 of the GENERATED script body (deterministic given a fixed `relayDir`); `installedAt` is ISO; `command` is the path written into the config (`~/.relay/crosslink/hooks/session-start.sh`).
+      2. Extend `InstallManifest`:
+         ```
+         interface InstallManifest {
+           schemaVersion: 1;            // unchanged — additive field
+           surfaces: Partial<Record<Surface, SurfaceRecord>>;
+           hooks?: Partial<Record<HookTarget, HookRecord>>;
+         }
+         ```
+      3. Update `isManifest` predicate to ACCEPT manifests with or without `hooks` (forward-compat — Phase-3-shaped manifests must still parse). Specifically: do NOT require `hooks` to be present.
+      4. Add helpers (mirror surface counterparts):
+         - `function getHookRecord(manifest: InstallManifest, target: HookTarget): HookRecord | undefined`.
+         - `async function markHookInstalled(target: HookTarget, sha: string, command: string): Promise<void>` — reads manifest, sets `manifest.hooks[target] = { sha, installedAt: new Date().toISOString(), command }`, writes via `writeManifest` (existing atomic rename).
+         - `function diffHook(installed: HookRecord | undefined, source: { sha: string }): SurfaceState` — same vocabulary as `diffSurface`: `"fresh"` (no installed record), `"current"` (sha match), `"behind"` (sha differs). Reuse the existing `SurfaceState` type — naming is identical because the user-facing semantics are.
+         - `function reportHookDrift(manifest: InstallManifest, sources: Partial<Record<HookTarget, { sha: string }>>): { target: HookTarget; state: SurfaceState }[]` — mirrors `reportDrift` shape for parallel use in `install.ts --check`.
+
+    `test/install/manifest-hooks.test.ts`:
+      1. `back-compat: parses Phase-3-shaped manifest with no hooks field` — write a manifest like `{ schemaVersion: 1, surfaces: { cli: { sha: "abc", installedAt: "..." } } }`, parse, assert no error AND `getHookRecord(m, "claude") === undefined`.
+      2. `markHookInstalled writes the record + persists to disk` — call mark, re-read manifest, assert `hooks.claude.sha === <expected>`.
+      3. `markHookInstalled is idempotent on the manifest level` — calling twice with the same sha persists the latest `installedAt` only, no other state changes.
+      4. `diffHook returns 'fresh' when no record exists`, `'current' when sha matches`, `'behind' when sha differs`.
+      5. `reportHookDrift covers both targets independently` — Claude installed, Codex not → returns `[{ target: "claude", state: "current" }, { target: "codex", state: "fresh" }]` (or equivalent).
+      6. `writing a manifest with hooks does NOT break old `rly install --check`` — informational/regression: read back the just-written manifest with `isManifest`, assert true.
+  </action>
+  <verify>
+    <automated>pnpm test test/install/manifest-hooks.test.ts test/install/manifest.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/install/manifest-hooks.test.ts` passes with ≥6 cases.
+    - `pnpm test test/install/manifest.test.ts` (existing) still passes — back-compat verified.
+    - `pnpm typecheck` GREEN.
+    - `grep -n "schemaVersion: 1" src/install/manifest.ts` shows the version unchanged (additive only).
+    - `grep -n "hooks?:" src/install/manifest.ts` shows the field is OPTIONAL.
+  </acceptance_criteria>
+  <done>Manifest extended with optional hooks block; drift helpers shipped; back-compat verified.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Wire `rly install` to write Claude + Codex hook entries + integration tests + version probe</name>
+  <read_first>
+    - src/install/installer.ts (target — EXTEND). Specifically lines 130-176 (`installSurface` shape — per-target install with manifest update)
+    - src/cli/install.ts (target — EXTEND). Specifically lines 132-164 (`handleInstallCommand` argv + dispatch + --check flow)
+    - test/install/install-session-start.test.ts (target — will be created)
+    - src/crosslink/hook.ts (plan 02 — `generateSessionStartHookScripts`)
+    - src/install/codex-toml.ts (Task 1 — `ensureCodexFeatureFlag`)
+    - src/install/manifest.ts (Task 2 — `markHookInstalled`, `diffHook`, `reportHookDrift`)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-02 (graceful degradation) + Claude's Discretion #1 (Codex hook surface — DECIDED in this plan: write unconditionally + version note)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md lines 475-514 (idempotent merge sketches for both files) + Pitfall #5 (Codex feature flag) + Open Question #1 recommendation (write anyway, log note)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/cli/install.ts EXTEND" + "Hook config writes" sections
+  </read_first>
+  <files>src/install/installer.ts, src/cli/install.ts, test/install/install-session-start.test.ts</files>
+  <action>
+    In `src/install/installer.ts`:
+
+      Add `export async function installSessionStartHooks(opts?: { skipCodex?: boolean; logger?: (line: string) => void }): Promise<{ claude: HookRecord; codex: HookRecord | null }>`. Steps:
+
+        1. Call `generateSessionStartHookScripts()` (plan 02) → get `{ shellScriptPath, nodeScriptPath }`.
+        2. Compute `scriptSha` = sha256 of the GENERATED `session-start.mjs` body content (read the file from disk after generation). This is the manifest's drift key.
+        3. **Codex version probe** (Open Question #1 — decision: probe + log + write):
+           - Run `spawnSync("codex", ["--version"], { encoding: "utf8", timeout: 2000 })`.
+           - On success, parse version via regex `/(\d+)\.(\d+)\.(\d+)/`. If `< 0.130`, log a note via `opts.logger ?? console.error`: `"[rly install] Codex hooks require Codex CLI v0.130+ (detected: <ver>). Writing config anyway; will activate on upgrade."`
+           - On spawn failure (codex not on PATH), log: `"[rly install] Codex CLI not found on PATH. Writing hook config anyway; will activate when Codex is installed and v0.130+."`
+           - In EITHER failure case, continue with the Codex write unless `opts.skipCodex === true`.
+        4. **Write Claude config** (`~/.claude/settings.json`):
+           - `readJsonSafe(path, { hooks: {} })` (helper — implement inline if it doesn't exist; existing `safeReadJson` may be present in repo, grep first).
+           - `existing.hooks ??= {}; existing.hooks.SessionStart ??= []`.
+           - Filter out any entry with `matcher === "relay-channel-readiness"`.
+           - Push `{ matcher: "relay-channel-readiness", hooks: [{ type: "command", command: shellScriptPath, timeout: 30 }] }` (the shell script wraps the node script — this is the existing pattern; matches `getClaudeHookConfig` in `hook.ts:182-193`).
+           - Write via atomic rename (`tmp + rename` — reuse pattern from `manifest.ts:64-69`).
+           - Call `markHookInstalled("claude", scriptSha, shellScriptPath)`.
+        5. **Write Codex config** (`~/.codex/hooks.json`) — same shape, same matcher tag, same atomic rename. Then call `ensureCodexFeatureFlag("hooks", true)` (Task 1).
+           - On success: `markHookInstalled("codex", scriptSha, shellScriptPath)`.
+           - If `skipCodex === true`, skip Codex entirely.
+        6. Return `{ claude: HookRecord, codex: HookRecord | null }` (null when skipped).
+
+    In `src/cli/install.ts`:
+
+      Extend `handleInstallCommand` argv (lines 38-63 pattern):
+        - Add `--skip-codex` flag (parsed into `ParsedArgs`).
+        - After the existing surface-install loop, call `await installSessionStartHooks({ skipCodex: parsed.skipCodex })` (unless `--check`).
+        - In `--check` flow: call `reportHookDrift(manifest, { claude: { sha: scriptSha }, codex: { sha: scriptSha } })` and print each target with its state in the same format the existing surface drift report uses. Add to the existing summary output.
+
+    `test/install/install-session-start.test.ts` (end-to-end, tmpdir-rooted):
+
+      Set up: a tmpdir as `HOME`, point `~/.relay/`, `~/.claude/`, `~/.codex/` all there. Use existing test helpers from Phase 1 / Phase 3 install tests (find via grep first).
+
+      Cases:
+        1. **`installs Claude hook entry on a fresh system`** — call `installSessionStartHooks()`, read `~/.claude/settings.json`, assert it contains an entry with matcher === "relay-channel-readiness" and `hooks[0].command` is the shell script path.
+        2. **`installs Codex hook entry + feature flag on a fresh system`** — read `~/.codex/hooks.json` assert SessionStart entry present; read `~/.codex/config.toml`, assert `[features].hooks = true`.
+        3. **`preserves user-configured pre-existing hooks`** — pre-write `~/.claude/settings.json` with `{ hooks: { UserPromptSubmit: [{ matcher: "user-thing", hooks: [...] }] } }`. Call install. Assert UserPromptSubmit entry unchanged AND SessionStart entry now also present.
+        4. **`idempotent: re-running install does not duplicate entries`** — call install twice; assert SessionStart has exactly ONE entry with matcher === "relay-channel-readiness" (verifies the filter-out-our-tag-before-push semantic).
+        5. **`replaces only Relay's own matcher entry on re-run with new sha`** — call install, then mutate the script path artificially (simulate a regenerated script), call install again, assert the SessionStart array still has exactly one Relay entry but with the new command path.
+        6. **`drift detection: edited hooks.json reports as 'behind'`** — call install, then manually delete the Relay entry from `~/.claude/settings.json` and write it back. Run `rly install --check` (via `handleInstallCommand(["--check"])`), capture output, assert it reports Claude hook as drifted (or "fresh" if record exists but file no longer matches). Acceptance: the term in output is "behind" or "drifted" — assert via regex.
+        7. **`Codex version < v0.130: writes anyway + logs note`** — stub `spawnSync` to return `{ stdout: "codex 0.128.0\n" }`. Capture logger output via `opts.logger`. Assert the warning line is present AND `~/.codex/hooks.json` is still written.
+        8. **`Codex not on PATH: writes anyway + logs note`** — stub `spawnSync` to throw ENOENT. Assert config written, logger note about "not found" present.
+        9. **`--skip-codex flag skips Codex writes`** — call install with `{ skipCodex: true }`. Assert Claude is written, Codex hooks.json is NOT written, config.toml NOT touched, `codex` manifest entry is null.
+        10. **`manifest records hook sha for drift detection`** — call install, read `installed.json`, assert `hooks.claude.sha` is a 64-char hex string.
+
+    Logging output must respect existing Relay logger conventions (find via grep — likely a single `console.log` / `console.error` or a small custom logger).
+  </action>
+  <verify>
+    <automated>pnpm test test/install/install-session-start.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/install/install-session-start.test.ts` passes with ≥10 cases.
+    - `pnpm test test/install/manifest-hooks.test.ts test/install/codex-toml.test.ts` continue passing.
+    - `pnpm test` full suite GREEN (no regressions in any existing install test).
+    - `pnpm typecheck` GREEN.
+    - Manual `rly install --check` on a freshly-installed system reports both `claude` AND `codex` hook entries as `current` (verified by case 6 indirectly).
+    - The Codex version probe is fail-soft: case 8 proves it.
+    - `grep -c "relay-channel-readiness" src/install/installer.ts | grep -v '^//' ` ≥ 2 (matcher tag referenced for both writes; filter-out-on-push semantic).
+  </acceptance_criteria>
+  <done>`rly install` writes both hook configs idempotently; manifest tracks drift; Codex version probe is fail-soft; user-configured hooks preserved. SURFACE-01, SURFACE-02, SURFACE-07 substantially complete from the install side.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| `rly install` (Relay) → `~/.claude/settings.json` (Claude config) | Relay writes into Claude's config file. User trusts Relay to not nuke their other hooks. |
+| `rly install` → `~/.codex/hooks.json` and `~/.codex/config.toml` | Same trust. |
+| `rly install` → child process `codex --version` | Untrusted CLI invocation (in theory). Bounded by 2s timeout + ENOENT-safe spawn. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-09 | Tampering | Install overwrites user's pre-existing Claude/Codex hooks | mitigate | Filter-out-only-our-matcher-tag semantic + atomic rename. Tested in case 3 (preserves UserPromptSubmit entries). |
+| T-04-10 | Tampering | TOML round-trip silently drops user comments in `[features]` section | accept | Documented limitation in `ensureCodexFeatureFlag` JSDoc + stderr warning when comments detected. Acceptable per RESEARCH "No Analog Found" trade. |
+| T-04-11 | DoS | `codex --version` hangs indefinitely → blocks install | mitigate | `spawnSync` with 2-second timeout. ENOENT and timeout both produce a logged note + continue. |
+| T-04-12 | Spoofing | Symlink attack on `~/.claude/settings.json` (attacker pre-creates symlink to elsewhere) | accept | Same trust boundary as the rest of Relay's `~/.relay/` writes. Pre-Relay user already had write access to their own home. Not a new attack class. |
+| T-04-13 | Information Disclosure | Manifest stores SHA of generated script — not sensitive | accept | SHAs are not secrets. Standard practice for drift detection. |
+</threat_model>
+
+<verification>
+- All three test files (`codex-toml.test.ts`, `manifest-hooks.test.ts`, `install-session-start.test.ts`) pass with ≥6 + ≥6 + ≥10 cases respectively.
+- `pnpm test` full suite GREEN.
+- `pnpm typecheck` GREEN.
+- `pnpm format:check` GREEN.
+- Re-running install is idempotent (case 4 verifies).
+- User-configured hooks preserved (case 3 verifies).
+- Codex version probe fails soft (cases 7 + 8 verify).
+- `rly install --check` reports hook drift alongside surface drift (case 6 verifies).
+</verification>
+
+<success_criteria>
+- A user running `rly install` on a fresh system gets working SessionStart hooks for BOTH Claude and Codex (assuming Codex ≥ v0.130; older versions get the config but a friendly note about activation-on-upgrade).
+- Repeated `rly install` calls produce identical bytes in both target files (idempotent).
+- `rly install --check` detects manual edits to either hook file.
+- The Codex feature flag (`[features].hooks = true`) is set without trashing the user's `~/.codex/config.toml`.
+- All four SURFACE-01, SURFACE-02, SURFACE-07 requirements are now covered from the install side; rendering surfaces in plans 04 + 05 complete the loop.
+</success_criteria>
+
+<output>
+After completion, install integration green. Plans 04 (TUI + GUI rendering) and 05 (CLI + SUMMARY) consume the state-derivation contract from plan 01 and the hook script paths recorded in the manifest by this plan.
+</output>

--- a/.planning/phases/04-project-readiness-surface/04-04-PLAN.md
+++ b/.planning/phases/04-project-readiness-surface/04-04-PLAN.md
@@ -1,0 +1,448 @@
+---
+phase: 04-project-readiness-surface
+plan: 04
+type: execute
+wave: 2
+depends_on: [01]
+files_modified:
+  - tui/src/main.rs
+  - tui/src/ui.rs
+  - gui/src-tauri/src/lib.rs
+  - gui/src/api.ts
+  - gui/src/types.ts
+  - gui/src/components/ChannelHeader.tsx
+  - gui/src/components/RepoChipRow.tsx
+  - gui/src/styles.css
+autonomous: true
+requirements:
+  - SURFACE-03
+  - SURFACE-04
+  - SURFACE-06
+  - SURFACE-07
+  - WORKER-06
+
+must_haves:
+  truths:
+    - "TUI sidebar (or per-channel drill-in) shows one state badge per repo assignment, sourced from `harness_data::derive_state` (NOT a TUI-side re-derivation). Glyph + color per D-07: ready=muted, booting=yellow ○, stale=red ×, disconnected=dim ·."
+    - "TUI consumes `load_crosslink_sessions()` (NOT `discoverSessions`) on every render tick — verified by absence of any `discoverSessions` import in `tui/`."
+    - "TUI cache shape is `HashMap<ChannelId, Vec<AdminWithWorkers>>` populated by `harness_data::group_by_admin` (NOT a flat `Vec<(Alias, RepoAdminState)>`). Sidebar renderer iterates admins → nested workers, so when Phase 5 emits worker sessions they auto-render under their spawning admin (WORKER-06)."
+    - "State→presentation mapping lives in a single pure helper `state_visual(state) -> (glyph: char, color: Color, word: &'static str)` with a Rust unit test covering all four variants (ready/booting/stale/disconnected)."
+    - "GUI ChannelHeader.tsx (or sibling RepoChipRow.tsx) renders a per-repo state badge alongside the existing chip — sourced from a new Tauri command `load_repo_admin_states(channelId)` returning `Vec<(alias, RepoAdminState)>`."
+    - "GUI Tauri command computes states via `harness_data::derive_state` — same Rust function the TUI uses (single source of truth)."
+    - "Closing and reopening either dashboard shows the same state (verified by the absence of any in-process cache layer — backends read disk on every Tauri call / every TUI tick)."
+    - "Workers (Phase 5 / WORKER-06) render nested under their admin via `group_by_admin` — today produces an empty workers list per admin without crashing; tomorrow it just works when Phase 5 writes worker session records."
+  artifacts:
+    - path: "tui/src/main.rs"
+      provides: "App refresh tick loads sessions via `load_crosslink_sessions()`, groups them per channel via `harness_data::group_by_admin`, and caches `HashMap<ChannelId, Vec<AdminWithWorkers>>` in App state for the next render frame. WORKER-06 forward-compat: workers nest under admins by construction; today the worker Vec is empty per admin."
+      contains: "group_by_admin"
+    - path: "tui/src/ui.rs"
+      provides: "Per-repo state column rendered in the channel drill-in section of `draw_sidebar` (or sibling pane). Uses Span::styled with D-07 color mapping."
+      contains: "RepoAdminState"
+    - path: "gui/src-tauri/src/lib.rs"
+      provides: "`#[tauri::command] load_repo_admin_states(channel_id: String) -> Result<Vec<(String, RepoAdminState)>, String>` and `load_channel_admins_grouped(channel_id) -> Result<Vec<AdminWithWorkers>, String>` (for WORKER-06 forward-compat)."
+      contains: "load_repo_admin_states"
+    - path: "gui/src/components/ChannelHeader.tsx"
+      provides: "State badge row rendered under the channel header — one badge per repo assignment, sourced from the Tauri command."
+      contains: "loadRepoAdminStates"
+    - path: "gui/src/styles.css"
+      provides: "`.state-ready .state-booting .state-stale .state-disconnected` CSS classes mapping to D-07 colors."
+      contains: ".state-ready"
+  key_links:
+    - from: "tui/src/main.rs App refresh"
+      to: "harness_data::derive_state"
+      via: "for each session loaded, compute state on the spot — no caching across ticks"
+      pattern: "derive_state"
+    - from: "gui/src-tauri/src/lib.rs load_repo_admin_states"
+      to: "harness_data::load_crosslink_sessions + derive_state"
+      via: "Tauri command body calls both Rust helpers — never re-derives"
+      pattern: "load_crosslink_sessions"
+    - from: "gui/src/components/ChannelHeader.tsx"
+      to: "gui/src/api.ts (Tauri invoke shim)"
+      via: "invoke('load_repo_admin_states', { channelId })"
+      pattern: "invoke.*load_repo_admin_states"
+---
+
+<objective>
+Wire the state-derivation contract from plan 01 into the two graphical surfaces — TUI and GUI. Both consume `harness_data::derive_state` (Rust). The TUI extends its existing sidebar / channel-row rendering with a state column. The GUI adds a Tauri command + a state-badge row under each channel header. Both surfaces filter to `status === "active"` channels per D-01.
+
+Forward-compat for WORKER-06: surface grouping uses `group_by_admin()` so when Phase 5 starts emitting worker sessions, they render under their spawning admin without any rendering-layer change.
+
+Purpose: This plan closes SURFACE-03 (TUI) and SURFACE-04 (GUI). After this lands, two of the four surfaces are observable end-to-end.
+
+Output: Read-path additions to TUI App + render code; one new Tauri command + one React component change; CSS for D-07 color mapping.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-project-readiness-surface/04-CONTEXT.md
+@.planning/phases/04-project-readiness-surface/04-RESEARCH.md
+@.planning/phases/04-project-readiness-surface/04-PATTERNS.md
+@.planning/phases/04-project-readiness-surface/04-01-PLAN.md
+@.planning/codebase/ARCHITECTURE.md
+@.planning/codebase/STRUCTURE.md
+@AGENTS.md
+
+<interfaces>
+<!-- From plan 01 (Wave 1). These are the SHARED contracts consumed by both TUI and GUI. -->
+
+From crates/harness-data/src/lib.rs (Phase 4 plan 01 + Phase 3):
+```rust
+pub enum RepoAdminState { Disconnected, Booting, Ready, Stale }
+// serde: kebab-case strings
+
+pub fn derive_state(session: &CrosslinkSession, now_ms: i64) -> RepoAdminState;
+pub fn load_crosslink_sessions() -> Vec<CrosslinkSession>;
+pub fn group_by_admin(sessions: &[CrosslinkSession]) -> Vec<AdminWithWorkers>;
+pub fn is_pid_alive(pid: u32) -> bool;
+
+pub struct AdminWithWorkers {
+    pub admin: CrosslinkSession,
+    pub workers: Vec<CrosslinkSession>,
+}
+
+// Channel.repoAssignments[].repoAlias provides the alias label for each repo.
+```
+
+From tui/src/main.rs (existing):
+```rust
+// App struct holds `app.channels: Vec<Channel>` loaded from harness_data.
+// Refresh tick already exists (poll loop) — Phase 4 adds a sibling
+// `app.admins_by_channel: HashMap<ChannelId, Vec<AdminWithWorkers>>`
+// populated by calling `harness_data::group_by_admin` on the sessions
+// loaded for each channel. Sidebar renderer iterates admins, then nested
+// workers (today: empty Vec; Phase 5 fills it). This matches the GUI's
+// `load_channel_admins_grouped` Tauri command shape and closes WORKER-06's
+// forward-compat requirement on the TUI side without future code changes.
+```
+
+From tui/src/ui.rs (existing — lines 175-298 `draw_sidebar`):
+```rust
+// Per-channel ListItem rendering with iterated `repo_assignments`.
+// Existing icon/color match at lines 235-241 — Phase 4 mirrors structure.
+```
+
+From gui/src-tauri/src/lib.rs (existing):
+```rust
+// Tauri commands follow pattern:
+//   #[tauri::command] fn name(args) -> Result<T, String> {
+//     // call harness_data::load_*
+//   }
+// Phase 4 adds load_repo_admin_states + load_channel_admins_grouped.
+```
+
+From gui/src/components/ChannelHeader.tsx (existing lines 95-112):
+```typescript
+// Existing agent-stack badge row renders members.
+// Phase 4 adds a sibling row keyed on repoAssignments + computed states.
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: TUI — load + render per-repo state column via grouped admin cache (WORKER-06 forward-compat)</name>
+  <read_first>
+    - tui/src/main.rs (target — EXTEND). Specifically:
+      - App struct + refresh tick (find via `grep -n "load_channels\\|fn refresh\\|fn tick\\|pub struct App" tui/src/main.rs`)
+      - existing consumers of `harness_data::load_*` in main.rs
+    - tui/src/ui.rs (target — EXTEND). Specifically:
+      - lines 175-298 (`draw_sidebar` — channel list iteration)
+      - lines 230-255 (per-repo agent rendering — the precedent for state column)
+      - lines 235-241 (icon/color match — direct precedent for state→color mapping)
+    - crates/harness-data/src/lib.rs (consumed: `RepoAdminState`, `derive_state`, `load_crosslink_sessions`, `group_by_admin`, `AdminWithWorkers`)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-06 + D-07 (state vocabulary + color mapping)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Pattern 4 + anti-pattern "Re-deriving state in each consumer" + WORKER-06 forward-compat constraint
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "tui/src/ui.rs EXTEND" + "tui/src/main.rs EXTEND" sections
+  </read_first>
+  <files>tui/src/main.rs, tui/src/ui.rs</files>
+  <action>
+    First, `grep -n "load_channels\\|load_crosslink_sessions\\|fn refresh\\|pub struct App" tui/src/main.rs` to find:
+      (a) the App struct definition (and its existing `channels: Vec<Channel>` or similar field),
+      (b) the refresh/tick function where channels are reloaded each cycle.
+
+    1. **App state extension — grouped cache** (`tui/src/main.rs`):
+       - Add `pub admins_by_channel: std::collections::HashMap<String, Vec<harness_data::AdminWithWorkers>>` to App struct, keyed by `channelId`. The Vec is the output of `harness_data::group_by_admin` filtered to that channel's sessions. NOTE: this is NOT a flat `Vec<(Alias, RepoAdminState)>`. WORKER-06 requires nested admin→workers grouping at the cache layer so the renderer can iterate `admin → admin.workers` without future code changes when Phase 5 ships.
+       - In the refresh function, after channels are loaded:
+         ```rust
+         let now_ms = current_unix_millis();  // use existing util or std::time::SystemTime
+         let sessions = harness_data::load_crosslink_sessions();
+         for ch in &app.channels {
+             let ch_sessions: Vec<_> = sessions.iter()
+                 .filter(|s| s.channel_id.as_deref() == Some(&ch.channel_id))
+                 .cloned()
+                 .collect();
+             let grouped: Vec<harness_data::AdminWithWorkers> =
+                 harness_data::group_by_admin(&ch_sessions);
+             app.admins_by_channel.insert(ch.channel_id.clone(), grouped);
+         }
+         ```
+       - States are derived from `admin.admin` (and per-worker via `admin.workers[i]`) inside the renderer using `harness_data::derive_state(session, now_ms)`. The cache stores SESSIONS (grouped), not pre-computed state strings — this avoids state-staleness between cache write and render.
+       - For repo assignments that have NO matching admin session in the channel, the renderer falls back to `RepoAdminState::Disconnected` (the channel's `repo_assignments` list is the source of truth for "which repos should appear"; sessions tell us state for the ones with admins).
+       - NO caching of derived states across ticks beyond the per-tick sessions cache. Each refresh recomputes (SURFACE-07: no in-process cache of derived state).
+
+    2. **`state_visual` pure helper — extracted for unit testing** (`tui/src/ui.rs`):
+       - Add a private (or `pub(crate)`) free function with NO external dependencies on `App` or render state:
+         ```rust
+         use ratatui::style::Color;
+         use harness_data::RepoAdminState;
+
+         pub(crate) fn state_visual(state: RepoAdminState) -> (char, Color, &'static str) {
+             match state {
+                 RepoAdminState::Ready        => ('●', Color::DarkGray, "ready"),         // muted per D-07
+                 RepoAdminState::Booting      => ('○', Color::Yellow,   "booting"),       // warning
+                 RepoAdminState::Stale        => ('×', Color::Red,      "stale"),         // error
+                 RepoAdminState::Disconnected => ('·', Color::DarkGray, "disconnected"),  // dimmed
+             }
+         }
+         ```
+         The state words MUST match the kebab-case wire format from plan 01 (`"disconnected"`, `"booting"`, `"ready"`, `"stale"`) — same vocabulary as the hook and CLI per D-06.
+
+    3. **TUI render — iterate admin then workers** (`tui/src/ui.rs`):
+       - In `draw_sidebar` (or the channel drill-in renderer), after rendering each channel header line, iterate `app.admins_by_channel.get(&channel.channel_id)`:
+         - For each `AdminWithWorkers` entry:
+             * Render one indented line for the admin: use its repo alias (find via the admin session's `repo_alias` field or look up via `channel.repo_assignments`), compute state via `harness_data::derive_state(&admin.admin, now_ms)`, format via `state_visual(state)`.
+             * Then iterate `admin.workers` (today: empty Vec; Phase 5 fills it) and render one further-indented line per worker with the same `state_visual` mapping. This block lands today as a no-op (zero workers) and starts rendering automatically when Phase 5 writes worker session records — WORKER-06 closed without future code changes.
+         - For each `repo_assignment` in `channel.repo_assignments` that has NO matching admin in `admins_by_channel`, emit a `disconnected` line using `state_visual(RepoAdminState::Disconnected)`.
+       - Use `Span::styled(format!("{glyph} "), Style::default().fg(color))` + `Span::styled(format!("{alias:<14}"), Style::default())` + `Span::styled(word, Style::default().fg(color))` per the existing `draw_sidebar` precedent at lines 235-241.
+
+    4. **Rust unit test for `state_visual`** — REQUIRED acceptance criterion (mapping coverage for all 4 variants):
+       - In `tui/src/ui.rs` add a `#[cfg(test)] mod tests` block (or in a sibling `tests/` if `ui.rs` already has one — `grep -n "#\[cfg(test)\]" tui/src/ui.rs` first).
+       - Test name: `state_visual_covers_all_four_variants`. Body:
+         ```rust
+         #[test]
+         fn state_visual_covers_all_four_variants() {
+             use harness_data::RepoAdminState::*;
+             use ratatui::style::Color;
+
+             assert_eq!(state_visual(Ready),        ('●', Color::DarkGray, "ready"));
+             assert_eq!(state_visual(Booting),      ('○', Color::Yellow,   "booting"));
+             assert_eq!(state_visual(Stale),        ('×', Color::Red,      "stale"));
+             assert_eq!(state_visual(Disconnected), ('·', Color::DarkGray, "disconnected"));
+         }
+         ```
+       - If `tui/` doesn't have a test setup at all (`grep -n "#\[cfg(test)\]\|#\[test\]" tui/src/`), add one — this is the smallest possible test module and the mapping is the lowest-risk-to-test logic in Phase 4.
+
+    5. **Verify NO `discoverSessions` import**:
+       - `grep -rn "discover_sessions\\|discoverSessions" tui/` → expect 0 matches in any file (Pitfall #3 enforcement). If a match exists, replace with `load_crosslink_sessions`.
+  </action>
+  <verify>
+    <automated>cargo check -p tui --locked && cargo build -p tui --locked && cargo test -p tui state_visual_covers_all_four_variants && (test -z "$(grep -rn 'discover_sessions' tui/ | grep -v target)" || (echo 'discover_sessions found in tui/ - violates Pitfall #3'; exit 1))</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo check -p tui --locked` GREEN.
+    - `cargo build -p tui --locked` GREEN.
+    - `cargo test -p tui state_visual_covers_all_four_variants` GREEN — all four state variants asserted to map to the expected `(glyph, color, word)` triple.
+    - `cargo test -p tui` (full crate) GREEN — no regressions.
+    - **TUI cache shape verified:** `grep -n "admins_by_channel.*HashMap<.*Vec<.*AdminWithWorkers>" tui/src/main.rs` returns ≥ 1 match (the cache field declaration). The flat `repo_states: HashMap<.*, Vec<(.*, RepoAdminState)>>` shape MUST NOT appear.
+    - **Sidebar render iterates admin→workers:** `grep -c "\.workers" tui/src/ui.rs` ≥ 1 (the renderer touches `admin.workers` even if today it's empty).
+    - **`state_visual` is a pure free function:** `grep -n "fn state_visual" tui/src/ui.rs` returns exactly one declaration; its signature is `(RepoAdminState) -> (char, Color, &'static str)` (or `pub(crate)` equivalent).
+    - `grep -rn "discover_sessions\\|discoverSessions" tui/` returns 0 matches (Pitfall #3 enforcement).
+    - `grep -c "RepoAdminState" tui/src/ui.rs` ≥ 4 (one match arm per variant in `state_visual`).
+    - `grep -c "group_by_admin\\|load_crosslink_sessions" tui/src/main.rs` ≥ 2.
+    - Manual smoke (not gated, informational): run `cargo run -p tui` in a worktree with a known channel, visually confirm state column renders with the admin row + (empty today) worker block — record observation as a SUMMARY checkpoint for plan 05.
+  </acceptance_criteria>
+  <done>TUI shows a state badge per repo in channel drill-in via the grouped admin cache (admin→workers iteration, today's workers Vec is empty per admin). State derivation is the shared `harness_data::derive_state`. `state_visual` mapping helper is unit-tested across all 4 variants. No in-process cache of derived state. No `discoverSessions`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: GUI Tauri commands — `load_repo_admin_states` + `load_channel_admins_grouped`</name>
+  <read_first>
+    - gui/src-tauri/src/lib.rs (target — EXTEND). Find existing `#[tauri::command]` functions via `grep -n "#\\[tauri::command\\]" gui/src-tauri/src/lib.rs` and identify the pattern they follow (likely Result<T, String>).
+    - crates/harness-data/src/lib.rs (consumed: `RepoAdminState`, `derive_state`, `load_crosslink_sessions`, `group_by_admin`, `AdminWithWorkers`)
+    - gui/src-tauri/Cargo.toml (verify `harness_data` is already a workspace dep; per 04-PATTERNS.md it should be)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Architectural Responsibility Map entry "derive_state() consumed by GUI"
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "gui/src-tauri/src/lib.rs EXTEND" section
+  </read_first>
+  <files>gui/src-tauri/src/lib.rs</files>
+  <action>
+    In `gui/src-tauri/src/lib.rs`:
+
+      1. Add `RepoAdminState` to the serde-exported types. If the file uses `#[derive(serde::Serialize)]` on a wrapper struct or re-exports `harness_data` types directly, follow the existing convention. The four wire values from plan 01 (`"disconnected" | "booting" | "ready" | "stale"`) must serialize through to the JS side unchanged.
+
+      2. Add `#[tauri::command] fn load_repo_admin_states(channel_id: String) -> Result<Vec<(String, harness_data::RepoAdminState)>, String>`:
+         ```
+         let channel = harness_data::load_channel(&channel_id).map_err(|e| e.to_string())?;
+         let sessions = harness_data::load_crosslink_sessions();
+         let now_ms = std::time::SystemTime::now()
+             .duration_since(std::time::UNIX_EPOCH)
+             .map(|d| d.as_millis() as i64)
+             .unwrap_or(0);
+         let mut out = Vec::new();
+         for ra in &channel.repo_assignments {
+             let sess = sessions.iter().find(|s|
+                 s.channel_id.as_deref() == Some(&channel_id)
+                 && /* same repo-match predicate as TUI task 1 */
+             );
+             let state = match sess {
+                 Some(s) => harness_data::derive_state(s, now_ms),
+                 None => harness_data::RepoAdminState::Disconnected,
+             };
+             out.push((ra.repo_alias.clone(), state));
+         }
+         Ok(out)
+         ```
+         The repo-match predicate MUST be identical to the TUI's (task 1). Extract as a small helper in `harness_data` IF the predicate is non-trivial; if it's a one-liner (`session.repo_alias == ra.repo_alias`), inline both sides.
+
+      3. Add `#[tauri::command] fn load_channel_admins_grouped(channel_id: String) -> Result<Vec<harness_data::AdminWithWorkers>, String>`:
+         - Load all sessions, filter to `channel_id == channel_id`, call `harness_data::group_by_admin(&filtered)`, return.
+         - Forward-compat for WORKER-06: today returns admins with empty workers Vec; Phase 5 fills it. The frontend can render the nested structure starting today.
+
+      4. Register BOTH commands in the Tauri `Builder::default().invoke_handler(tauri::generate_handler![...])` block — find via `grep -n "generate_handler!" gui/src-tauri/src/lib.rs`.
+
+      5. **Legacy GUI reader bug** noted in Phase 3 SUMMARY follow-up #2 (`gui/src-tauri/src/lib.rs:2810-2861, :2916-2970` reads the legacy `~/.relay/crosslink/sessions/` path for SIGTERM matching). Phase 4 ONLY touches the NEW commands; do NOT fix that bug here (out of scope; tracked as Phase 3 follow-up). Add a code comment near the new commands: `// Phase 4 commands read via harness_data::load_crosslink_sessions which targets the current ~/.relay/crosslink-session/ path (Phase 3 SUMMARY follow-up #2 covers the legacy SIGTERM path bug separately).`
+
+      6. **Unit test in harness-data** (since GUI doesn't have a rust test setup for tauri commands): add to `crates/harness-data/src/lib.rs` test module (or piggyback on plan 01's test additions if landed together): no new tests needed if plan 01's `group_by_admin` tests cover the grouping; just ensure plan 01's tests are passing. If the repo-match predicate ends up in `harness_data`, add a unit test for it there.
+  </action>
+  <verify>
+    <automated>cd gui/src-tauri && cargo check --locked && cargo build --locked</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cd gui/src-tauri && cargo check --locked` GREEN.
+    - `cd gui/src-tauri && cargo build --locked` GREEN.
+    - `grep -c "#\\[tauri::command\\]" gui/src-tauri/src/lib.rs` increases by exactly 2 versus pre-Phase-4 baseline.
+    - `grep -c "load_repo_admin_states\\|load_channel_admins_grouped" gui/src-tauri/src/lib.rs` ≥ 4 (2 declarations + 2 references in `generate_handler!`).
+    - `grep -c "derive_state\\|load_crosslink_sessions\\|group_by_admin" gui/src-tauri/src/lib.rs` ≥ 3.
+    - No new references to `discoverSessions` or the legacy `~/.relay/crosslink/sessions/` path.
+  </acceptance_criteria>
+  <done>Two new Tauri commands shipped; both consume the shared `harness_data` derivation; forward-compat grouping in place for Phase 5.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: GUI frontend — state badge row in ChannelHeader.tsx + API shim + CSS</name>
+  <read_first>
+    - gui/src/api.ts (target — EXTEND with `loadRepoAdminStates`, `loadChannelAdminsGrouped`)
+    - gui/src/types.ts (target — EXTEND with `RepoAdminState` string-union type matching Rust kebab-case)
+    - gui/src/components/ChannelHeader.tsx (target — EXTEND). Specifically:
+      - lines 95-112 (`agent-stack` badge row — analog this task mirrors)
+    - gui/src/components/RepoChipRow.tsx (existing — Phase 4 may either extend OR leave alone; per 04-PATTERNS.md it's the secondary analog. Default: ADD a state badge inside RepoChipRow next to the chip, keeping the new rendering visually integrated with the existing repo display).
+    - gui/src/styles.css (target — EXTEND with `.state-ready / .state-booting / .state-stale / .state-disconnected`)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-07 (color mapping per state)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "gui/src/components/ChannelHeader.tsx EXTEND" section
+  </read_first>
+  <files>gui/src/api.ts, gui/src/types.ts, gui/src/components/ChannelHeader.tsx, gui/src/components/RepoChipRow.tsx, gui/src/styles.css</files>
+  <action>
+    1. **Types** (`gui/src/types.ts`):
+       - Add `export type RepoAdminState = "disconnected" | "booting" | "ready" | "stale";`
+       - Add `export interface AdminWithWorkers { admin: CrosslinkSession; workers: CrosslinkSession[] }` (CrosslinkSession type already exists in this file from Phase 3 — extend if needed; mirror the field set from Rust including `lastSeenFeedIdx?: number` from plan 02).
+
+    2. **API shim** (`gui/src/api.ts`):
+       - Add `export async function loadRepoAdminStates(channelId: string): Promise<Array<[string, RepoAdminState]>> { return invoke("load_repo_admin_states", { channelId }); }`
+       - Add `export async function loadChannelAdminsGrouped(channelId: string): Promise<AdminWithWorkers[]> { return invoke("load_channel_admins_grouped", { channelId }); }`
+
+    3. **ChannelHeader.tsx**:
+       - Inside the component, add a state hook + effect:
+         ```
+         const [repoStates, setRepoStates] = useState<Array<[string, RepoAdminState]>>([]);
+         useEffect(() => {
+           let cancelled = false;
+           const tick = async () => {
+             const states = await loadRepoAdminStates(channel.channelId);
+             if (!cancelled) setRepoStates(states);
+           };
+           tick();
+           const id = setInterval(tick, /* same refresh interval as existing channel pollers — find via grep */);
+           return () => { cancelled = true; clearInterval(id); };
+         }, [channel.channelId]);
+         ```
+         Find the existing polling interval via `grep -n "setInterval\\|refreshTick" gui/src/components/ChannelHeader.tsx gui/src/components/Sidebar.tsx` and match it (likely 1000-2000ms).
+       - Add the state-badge row beneath the existing `agent-stack` row (or wherever fits the visual hierarchy):
+         ```jsx
+         <div className="repo-state-stack">
+           {repoStates.map(([alias, state]) => (
+             <span
+               key={alias}
+               className={`repo-state-badge state-${state}`}
+               title={`${alias}: ${state}`}
+               data-state={state}
+             >
+               {alias}
+             </span>
+           ))}
+         </div>
+         ```
+       - Per D-01: filter the channel list parent component (likely `Sidebar.tsx` — check) to `status === "active"` if it does not already. If it ALREADY filters, leave alone.
+
+    4. **RepoChipRow.tsx** (optional integration):
+       - If RepoChipRow.tsx is rendered for the same channel, add a small state-badge next to each chip using the same prop or via a parallel data-fetch. To keep diff bounded, EITHER:
+         (a) Extend RepoChipRow with a new prop `states: Record<string, RepoAdminState>` and render a small `.state-dot` next to each chip; the parent (ChannelHeader) passes `states` down, OR
+         (b) Leave RepoChipRow alone; only ChannelHeader's repo-state-stack carries the visual signal.
+       - Recommend (a) — minimal change, visually integrated. If the prop drilling becomes ugly, fall back to (b) and document the choice in the SUMMARY.
+
+    5. **CSS** (`gui/src/styles.css`):
+       - Add four classes mapping to D-07 colors (use existing palette tokens if any exist — find via `grep -n "color:\\|--accent" gui/src/styles.css`):
+         ```css
+         .state-ready        { color: var(--text-muted, #888); }                      /* baseline, muted */
+         .state-booting      { color: var(--warn-yellow, #cca050); background: rgba(204,160,80,0.08); border: 1px solid rgba(204,160,80,0.25); border-radius: 3px; padding: 0 4px; }
+         .state-stale        { color: var(--error-red, #cc4848); background: rgba(204,72,72,0.10); border: 1px solid rgba(204,72,72,0.30); border-radius: 3px; padding: 0 4px; }
+         .state-disconnected { color: var(--text-faint, #555); opacity: 0.55; }
+         .repo-state-stack   { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; font-size: 11px; }
+         .repo-state-badge   { font-family: var(--font-mono); }
+         ```
+         Use existing CSS variable names if the project already defines them (grep first; fall back to literals only if not).
+
+    6. **Frontend test**:
+       - Add `gui/src/components/ChannelHeader.test.tsx` (if a test setup exists — check `cd gui && cat package.json` for vitest/jest/playwright). If a `gui/src/components/*.test.tsx` analog exists, mirror it; render ChannelHeader with a mocked `loadRepoAdminStates` returning `[["ui-repo", "ready"], ["sdk-repo", "booting"]]`, assert two `.repo-state-badge` elements present with classes `state-ready` and `state-booting`. If `gui/` has NO React test setup, skip this — manual smoke at SUMMARY time covers it.
+  </action>
+  <verify>
+    <automated>cd gui && pnpm typecheck && (test -f gui/src/components/ChannelHeader.test.tsx && pnpm test gui/src/components/ChannelHeader.test.tsx || echo 'No GUI test setup — skip')</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cd gui && pnpm typecheck` GREEN.
+    - `cd gui && pnpm build` GREEN (Vite production build succeeds with new code).
+    - `grep -c "loadRepoAdminStates\\|RepoAdminState" gui/src/components/ChannelHeader.tsx gui/src/api.ts gui/src/types.ts` ≥ 4.
+    - `grep -c "state-ready\\|state-booting\\|state-stale\\|state-disconnected" gui/src/styles.css` ≥ 4 (one CSS rule per state).
+    - If a frontend test was added: `cd gui && pnpm test ChannelHeader` GREEN.
+    - Manual smoke (informational, recorded in plan 05 SUMMARY): launch the Tauri app, open a channel with mixed states, visually confirm badges render with D-07 colors.
+  </acceptance_criteria>
+  <done>GUI renders a per-repo state badge under each channel header. Color/glyph per D-07. Source is the shared Rust derivation via Tauri command. Forward-compat command for WORKER-06 also shipped.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Tauri command response → React frontend | Backend-computed state strings flow to UI. No new untrusted boundary — same trust as existing Tauri commands. |
+| TUI render → terminal | Rust-formatted strings; same as existing TUI output. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-14 | Tampering | TUI or GUI renders STATE differently than the hook (drift) | mitigate | Both call into `harness_data::derive_state`. Plan 01's truth-table tests prevent silent regressions. Acceptance criteria in this plan require ZERO `discoverSessions` references in tui/ or gui/src-tauri/. |
+| T-04-15 | DoS | TUI refresh tick reads all sessions on every poll → slow on huge channels | accept | Existing TUI tick already does this; Phase 4 adds at most one extra `load_crosslink_sessions` call per tick (microsecond scale for typical 1-10 session counts). |
+| T-04-16 | Information Disclosure | GUI exposes admin alias in tooltip text | accept | Admin aliases are user-chosen labels, not secrets. Same exposure level as existing UI. |
+</threat_model>
+
+<verification>
+- `cargo check -p tui --locked` GREEN; `cargo build -p tui --locked` GREEN.
+- `cd gui/src-tauri && cargo check --locked && cargo build --locked` GREEN.
+- `cd gui && pnpm typecheck && pnpm build` GREEN.
+- `cargo test -p harness-data` continues passing (plan 01's tests still cover the contract).
+- `grep -rn "discover_sessions\\|discoverSessions" tui/ gui/src-tauri/` returns 0 matches (Pitfall #3 enforcement at the system level).
+- `pnpm test` full TS suite GREEN.
+- Manual smoke deferred to plan 05 (`SUMMARY` checkpoint — same precedent as Phase 3).
+</verification>
+
+<success_criteria>
+- TUI shows a state badge column per repo on channel drill-in; vocabulary matches the hook's (`ready | booting | stale | disconnected`).
+- GUI shows a state badge row under each channel header; same vocabulary; D-07 color/intensity mapping applied via CSS classes.
+- Both surfaces read fresh disk state on every refresh tick — no in-process cache (SURFACE-07).
+- `group_by_admin` Tauri command shipped for WORKER-06 forward-compat (workers will nest under admins when Phase 5 fills the worker session shape).
+- No `discoverSessions` import anywhere in `tui/` or `gui/src-tauri/`.
+- Architectural invariant preserved: state derivation lives in ONE place (`harness_data::derive_state`); all consumers call into it.
+</success_criteria>
+
+<output>
+After completion, TUI + GUI green. Plan 05 lands `rly status` channel block + `rly channel show <id>` command + manual smoke + 04-SUMMARY.
+</output>

--- a/.planning/phases/04-project-readiness-surface/04-05-PLAN.md
+++ b/.planning/phases/04-project-readiness-surface/04-05-PLAN.md
@@ -1,0 +1,475 @@
+---
+phase: 04-project-readiness-surface
+plan: 05
+type: execute
+wave: 5
+depends_on: [01, 02, 03, 04]
+files_modified:
+  - src/cli/print-status-context.ts
+  - src/cli/channel-show.ts
+  - src/index.ts
+  - test/cli/print-status-context.test.ts
+  - test/cli/channel-show.test.ts
+  - .planning/phases/04-project-readiness-surface/04-SUMMARY.md
+autonomous: false
+requirements:
+  - SURFACE-05
+  - SURFACE-06
+  - SURFACE-07
+
+must_haves:
+  truths:
+    - "`rly status` prints a `Channels:` block listing each active channel with its repo-state roll-up (one repo per line, state vocabulary identical to TUI + hook)."
+    - "`rly channel show <channelId|name>` (and alias `rly project show <channelId|name>`) prints a detailed per-channel view: repo states + recent feed entries + admin sessions. Alias equivalence is locked by an automated test (Task 2 case 8) — either a unit-level dispatch-table import assertion OR a subprocess test asserting byte-identical stdout for both invocations."
+    - "Both commands read raw via `loadChannelStates()` (new TS sibling — direct readdir/readFile of `~/.relay/`); NEVER call `discoverSessions()`."
+    - "Empty / no-channels output: `rly status` prints no `Channels:` block at all (parity with existing `formatActiveSessionsBlock` empty contract)."
+    - "Manual smoke confirms end-to-end: hook fires for live Claude session, TUI + GUI + CLI all render the same state words for the same channel."
+    - "04-SUMMARY.md captures wave-by-wave PR boundaries, verification gates GREEN, Phase 5 handoff notes (worker rendering already nested via group_by_admin), deferred follow-ups (cmux pane refs, legacy GUI reader bug from Phase 3 SUMMARY #2)."
+  artifacts:
+    - path: "src/cli/print-status-context.ts"
+      provides: "Extended with `formatChannelStatesBlock(rows)` + `loadChannelStates()` — pure formatter paired with an isolated IO loader, mirroring `formatActiveSessionsBlock` + `loadActiveSessions`."
+      contains: "formatChannelStatesBlock"
+    - path: "src/cli/channel-show.ts"
+      provides: "NEW — `handleChannelShowCommand(args): Promise<number>` parses `<channelId|name>`, loads channel + sessions + feed tail, renders detailed view."
+      contains: "handleChannelShowCommand"
+    - path: "src/index.ts"
+      provides: "`rly status` integration site extended; `rly channel show` and alias `rly project show` registered as subcommands."
+      contains: "channel-show"
+    - path: ".planning/phases/04-project-readiness-surface/04-SUMMARY.md"
+      provides: "Phase SUMMARY following Phase 3 SUMMARY template — wave-by-wave PRs, verification gates, handoff contract for Phase 5, deferred items."
+      contains: "Phase 4 Summary"
+  key_links:
+    - from: "src/cli/print-status-context.ts loadChannelStates"
+      to: "~/.relay/channels/* + ~/.relay/crosslink-session/* (raw fs read)"
+      via: "direct readdirSync + readFileSync — NOT discoverSessions"
+      pattern: "readdirSync.*channels|readFileSync"
+    - from: "src/cli/channel-show.ts handleChannelShowCommand"
+      to: "src/domain/repo-admin-state.ts deriveRepoAdminState"
+      via: "per-repo state computation using the shared TS derivation"
+      pattern: "deriveRepoAdminState"
+    - from: "src/index.ts printStatus"
+      to: "src/cli/print-status-context.ts formatChannelStatesBlock"
+      via: "block append after Active sessions block, per src/index.ts:2816-2821 precedent"
+      pattern: "formatChannelStatesBlock"
+---
+
+<objective>
+Close the loop on Phase 4 by landing the CLI surface (`rly status` channel block + `rly channel show <id>` + alias `rly project show <id>`), running the manual smoke test that validates end-to-end live behavior across all four surfaces, and writing the phase SUMMARY.
+
+Decision on Open Question #2 (CLI command shape): SHIP both `rly channel show` (canonical, per D-01 channel-IS-project) AND `rly project show` as an alias that dispatches to the same handler — deprecation-friendly if "project" is later introduced as a first-class entity.
+
+Decision on Open Question #4 (cmux integration): DEFER. Captured as a follow-up in 04-SUMMARY.
+
+Purpose: SURFACE-05 is the last unrendered surface. After this plan, all four surfaces (hook, TUI, GUI, CLI) read the same disk state through the same `derive_state` function (Rust) or its TS mirror (`deriveRepoAdminState`).
+
+Output: CLI block + new subcommand + alias + manual smoke + 04-SUMMARY.md. This plan contains the only checkpoint in Phase 4 (the manual smoke).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-project-readiness-surface/04-CONTEXT.md
+@.planning/phases/04-project-readiness-surface/04-RESEARCH.md
+@.planning/phases/04-project-readiness-surface/04-PATTERNS.md
+@.planning/phases/04-project-readiness-surface/04-01-PLAN.md
+@.planning/phases/04-project-readiness-surface/04-02-PLAN.md
+@.planning/phases/04-project-readiness-surface/04-03-PLAN.md
+@.planning/phases/04-project-readiness-surface/04-04-PLAN.md
+@.planning/phases/03-repo-admin-readiness-handshake/03-SUMMARY.md
+@AGENTS.md
+
+<interfaces>
+<!-- Existing CLI block pattern. Source: src/cli/print-status-context.ts lines 26-110 -->
+
+From src/cli/print-status-context.ts:
+```typescript
+// formatActiveSessionsBlock(sessions): empty → ""; otherwise multi-line block
+// loadActiveSessions({ maxAgeMs? }): walks ~/.relay/sessions/, returns rows
+// L3 isolation: try/catch per file, skip malformed
+```
+
+From src/index.ts:2816-2821 (the wire-up site):
+```typescript
+const activeSessions = loadActiveSessions();
+const activeBlock = formatActiveSessionsBlock(activeSessions);
+if (activeBlock) { console.log(activeBlock); console.log(""); }
+// Phase 4 extends: same pattern, append Channels: block.
+```
+
+From src/cli/install.ts:132-164 (argv handler pattern that channel-show.ts mirrors).
+
+From src/domain/repo-admin-state.ts (plan 01):
+```typescript
+export type RepoAdminState = "disconnected" | "booting" | "ready" | "stale";
+export function deriveRepoAdminState(...): RepoAdminState;
+```
+
+From plan 02: hook script (already installed via plan 03) emits per-session feed-watermark advance.
+From plan 04: TUI + GUI render the same state vocabulary.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: `rly status` channel-states block — `formatChannelStatesBlock` + `loadChannelStates` + wire-up</name>
+  <read_first>
+    - src/cli/print-status-context.ts (target — EXTEND). Specifically:
+      - lines 26-44 (`formatActiveSessionsBlock` — empty contract + line-building style)
+      - lines 57-110 (`loadActiveSessions` — sync IO + per-file try/catch isolation pattern)
+    - src/index.ts (target — EXTEND at the wire-up site around line 2816-2821)
+    - test/cli/print-status-context.test.ts (existing — extend with channel-states cases)
+    - src/channels/channel-store.ts (consumed: `listChannels()` — find via grep)
+    - src/domain/repo-admin-state.ts (plan 01 — `deriveRepoAdminState` + `STALE_HEARTBEAT_MS`)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md D-01 (channel IS the project; filter to `status === "active"`) + D-06 + D-07
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Code Examples lines 516-532 (formatter sketch)
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/cli/print-status-context.ts EXTEND" section
+  </read_first>
+  <files>src/cli/print-status-context.ts, src/index.ts, test/cli/print-status-context.test.ts</files>
+  <action>
+    In `src/cli/print-status-context.ts`:
+
+      1. Add types:
+         ```typescript
+         export interface ChannelRepoRow {
+           alias: string;
+           state: RepoAdminState;
+           adminAlias?: string;
+         }
+         export interface ChannelStateRow {
+           channelId: string;
+           name: string;
+           repos: ChannelRepoRow[];
+         }
+         ```
+
+      2. Add `export function formatChannelStatesBlock(rows: ChannelStateRow[]): string`:
+         - Empty contract: `if (rows.length === 0) return "";`
+         - Header line: `"Channels:"`.
+         - Per channel: `"- ${ch.name} (${ch.repos.length} repos)"`.
+         - Per repo: `"    ${alias.padEnd(12)} ${state}${adminAlias ? \" admin=\" + adminAlias : \"\"}"`.
+         - Lines joined with `\n`. No trailing newline.
+
+      3. Add `export function loadChannelStates(opts?: { onlyActive?: boolean }): ChannelStateRow[]` (defaults `onlyActive: true` per D-01):
+         - Read `~/.relay/channels/` directory via `readdirSync` (mirror `loadActiveSessions`).
+         - For each entry, try to read `<id>/channel.json` (skip if missing).
+         - Skip channels where `status !== "active"` when `onlyActive: true`.
+         - Read `~/.relay/crosslink-session/*.json` ONCE (outside the channels loop) — direct `readdirSync + readFileSync + JSON.parse`, try/catch per file. DO NOT call `discoverSessions`. Cache the parsed list.
+         - For each channel × each `repoAssignments[i]`:
+           * Find matching session by `channelId === channel.channelId && session.repoAlias === ra.repoAlias` (use the same predicate as TUI + GUI from plan 04).
+           * Compute state via `deriveRepoAdminState(session, Date.now(), isProcessAlive)` (`isProcessAlive` is the inline pattern from `src/crosslink/hook.ts:161-167` — import or copy a tiny helper; if there's no existing exported helper, add `export function isProcessAlive(pid: number): boolean` to `src/domain/repo-admin-state.ts` and use it here).
+           * Capture `adminAlias` from session if state is `ready` or `booting` (presentation detail per D-03).
+         - Return `ChannelStateRow[]`, sorted by `channel.updatedAt` descending (most recently active first).
+         - L3 isolation per file (skip malformed, console.warn once on parse error per existing pattern lines 100-107).
+
+      4. In `src/index.ts` at the wire-up site (after the existing `formatActiveSessionsBlock` block — find via `grep -n "formatActiveSessionsBlock" src/index.ts`):
+         ```typescript
+         const channelStates = loadChannelStates();
+         const channelBlock = formatChannelStatesBlock(channelStates);
+         if (channelBlock) { console.log(channelBlock); console.log(""); }
+         ```
+         Same shape as the existing block append.
+
+      5. Extend `test/cli/print-status-context.test.ts`:
+         - `formatChannelStatesBlock returns "" when rows is empty`.
+         - `formatChannelStatesBlock renders one line per channel + indented lines per repo`.
+         - `formatChannelStatesBlock uses kebab-case state words` (parity with hook + TUI + GUI per D-06).
+         - `loadChannelStates filters out non-active channels by default` — write 2 channel fixtures, one `status: "active"` and one `status: "archived"`, assert only the active one appears.
+         - `loadChannelStates derives disconnected for repoAssignments with no matching session`.
+         - `loadChannelStates skips malformed channel.json silently` (write a torn fixture).
+         - `loadChannelStates does not call discoverSessions` — assert via spying that no such function is invoked (or simpler: spy on the underlying `CrosslinkStore.discoverSessions` if it's importable, expect zero calls). If spying is hard, instead use a grep-level test in Task 4 verification.
+
+    Use tmpdir-rooted fixtures (existing pattern from `loadActiveSessions` tests).
+  </action>
+  <verify>
+    <automated>pnpm test test/cli/print-status-context.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/cli/print-status-context.test.ts` passes including ≥6 new channel-states cases plus existing active-sessions cases unchanged.
+    - `pnpm typecheck` GREEN.
+    - `grep -c "discoverSessions" src/cli/print-status-context.ts | grep -v '^//' ` returns 0 (no new references; Pitfall #3 enforcement).
+    - `grep -c "formatChannelStatesBlock\\|loadChannelStates" src/index.ts` ≥ 2 (wire-up site present).
+    - Running `rly status` with no active channels prints no `Channels:` block (empty contract verified).
+    - Running `rly status` with active channels prints `Channels:` block with same state vocabulary as TUI/hook.
+  </acceptance_criteria>
+  <done>`rly status` now shows a channel-states block. Vocabulary matches all other surfaces.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: `rly channel show <id|name>` subcommand + `rly project show` alias</name>
+  <read_first>
+    - src/cli/channel-show.ts (target — will be created)
+    - test/cli/channel-show.test.ts (target — will be created)
+    - src/cli/install.ts:38-63, :132-164 (argv parsing + dispatch pattern this task mirrors)
+    - src/index.ts (target — REGISTER both subcommands; find existing subcommand registration via `grep -n "case \"status\"\\|argv\\[2\\]" src/index.ts`)
+    - src/channels/channel-store.ts (consumed: `listChannels`; check for a `findChannelByIdOrName` helper — if absent, implement inline)
+    - src/cli/print-status-context.ts (Task 1 — reuse `loadChannelStates` filtered to a single channel, OR factor out a sibling `loadChannelStateForChannel(channelId)` if the filtering is awkward)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md Claude's Discretion #2 (CLI command shape — DECIDED: ship `rly channel show` canonical + `rly project show` alias)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md Open Question #2 recommendation
+    - .planning/phases/04-project-readiness-surface/04-PATTERNS.md "src/cli/channel-show.ts" section
+  </read_first>
+  <files>src/cli/channel-show.ts, test/cli/channel-show.test.ts, src/index.ts</files>
+  <action>
+    Create `src/cli/channel-show.ts`:
+
+      ```typescript
+      // imports: loadChannelStates (or a sibling helper for single-channel),
+      // ChannelStore for listChannels + readFeed (recent entries), etc.
+
+      export interface ChannelShowOptions { json?: boolean; feedTail?: number }
+
+      export async function handleChannelShowCommand(args: string[]): Promise<number> {
+        // 1. Parse args:
+        //    - First positional: channelIdOrName (required; if absent, print usage + return 2)
+        //    - --json: emit JSON instead of human-readable
+        //    - --feed-tail=N: number of recent feed entries (default 5)
+        //    - --help / -h: print usage + return 0
+        // 2. Resolve channel:
+        //    - listChannels() → find by exact channelId match first, then by name (case-insensitive).
+        //    - If multiple name matches, prefer status === "active", then most-recent updatedAt.
+        //    - If no match → print "Channel not found: <id>" to stderr, return 1.
+        // 3. Load sessions raw (NOT via discoverSessions — direct readdirSync of ~/.relay/crosslink-session/).
+        // 4. For each repoAssignment, compute state via deriveRepoAdminState.
+        // 5. Read recent feed entries via ChannelStore.readFeed (or direct readFileSync of feed.jsonl with try/catch).
+        //    Take last N entries (default 5).
+        // 6. Render:
+        //    - JSON mode: { channelId, name, status, repos: [{alias, state, adminAlias?}], recentFeed: [...] }
+        //    - Human mode:
+        //        Channel: <name> (<channelId>)
+        //        Status: <status>
+        //        Repos (N):
+        //          <alias>      <state>  admin=<alias>?
+        //          ...
+        //        Recent feed (last N):
+        //          [<timestamp>] <type>: <one-line summary>
+        //          ...
+        // 7. Return 0.
+      }
+      ```
+
+      Wire into `src/index.ts`:
+        - In the argv dispatch (find existing pattern via grep), add case `"channel"` with subcommand `"show"`: `await handleChannelShowCommand(argv.slice(3))`.
+        - Add alias case `"project"` with subcommand `"show"`: same dispatch — `await handleChannelShowCommand(argv.slice(3))`. Note in a code comment: `// Alias for rly channel show (D-01: channel IS the project).`
+        - Update any usage/help output to mention both forms.
+
+    Tests (`test/cli/channel-show.test.ts`):
+      1. `usage error when no args` — call `handleChannelShowCommand([])`, expect return 2, stderr mentions "usage".
+      2. `prints channel details for valid id` — set up tmpdir fixture with one channel + 2 sessions (one ready, one booting), call, capture stdout, assert:
+         * Contains `"Channel:"` + channel name.
+         * Contains `"ready"` and `"booting"` exactly once each.
+      3. `not found returns 1` — call with `"does-not-exist"`, expect return 1.
+      4. `JSON mode emits parseable JSON` — `--json` flag, parse stdout, assert shape `{ channelId, name, repos: [...] }`.
+      5. `respects --feed-tail=2` — write feed.jsonl with 5 entries, call with `--feed-tail=2`, assert exactly 2 feed lines rendered.
+      6. `does NOT call discoverSessions` — same approach as Task 1 case 7.
+      7. `resolves by name when channelId is not an id-shaped string` — set up channel with name `oauth-rollout` and id `ch-abc123`, call with `"oauth-rollout"`, assert resolution succeeds and channel id `"ch-abc123"` appears in output.
+      8. `rly project show dispatches to the same handler as rly channel show` — **REQUIRED, NON-SKIPPABLE.** Pick exactly ONE of the two options below and implement it; the test must run and pass:
+
+         **Option A — Unit-level dispatch import (preferred when a dispatch table exists):**
+           - Open `src/index.ts` (or `src/cli/index.ts` if dispatch lives there) and identify the subcommand dispatch site (find via `grep -n "case \"channel\"\\|case \"project\"\\|registerCommand\\|argv\\[2\\]" src/index.ts`).
+           - If dispatch uses a lookup table (e.g., `const COMMANDS = { channel: { show: handleChannelShowCommand }, project: { show: handleChannelShowCommand } }`), import that table in the test and assert `expect(COMMANDS.project.show).toBe(COMMANDS.channel.show)` — same function reference, not a re-wrapped closure.
+           - If dispatch is a `switch` statement, refactor the two arms to delegate to one shared helper `dispatchChannelShow(args)` and export it; the test imports `dispatchChannelShow` and asserts both arms call it (use a vitest spy).
+
+         **Option B — Subprocess byte-identical stdout (use when Option A's refactor is undesirable):**
+           - In the test, after `pnpm build` has produced `dist/`, write a tmpdir channel fixture, then run `child_process.execFileSync("node", ["dist/index.js", "channel", "show", channelId], { cwd: tmpProjectDir, env: { ...process.env, RELAY_DIR: tmpRelayDir } })` and capture its stdout.
+           - Repeat with `["dist/index.js", "project", "show", channelId]` — same env, same channelId.
+           - Assert `expect(projectStdout).toBe(channelStdout)` — strict byte equality. Also assert both runs exit 0.
+           - The test MUST gate on `pnpm build` having been run; if `dist/index.js` does not exist, the test fails (NOT skips) with a clear message instructing the runner to `pnpm build` first.
+
+         Document the chosen option in a code comment at the top of the test case (e.g., `// Option A: dispatch table import — see 04-05-PLAN.md Task 2 case 8.`). The test MUST NOT be marked `.skip` or `.todo`; if neither option fits the codebase's actual structure, surface the conflict in the SUMMARY follow-ups (do not silently drop the assertion).
+  </action>
+  <verify>
+    <automated>pnpm test test/cli/channel-show.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pnpm test test/cli/channel-show.test.ts` passes with ≥8 cases.
+    - **Case 8 (alias dispatch equivalence) is NOT marked `.skip` or `.todo`** — verified via `grep -E "(it|test)\\.(skip|todo)" test/cli/channel-show.test.ts` returning 0 matches in the channel-show test file. The chosen option (A or B) is documented in a code comment at the top of the test case.
+    - `pnpm typecheck` GREEN.
+    - `pnpm build` GREEN.
+    - `grep -c "discoverSessions" src/cli/channel-show.ts | grep -v '^//' ` returns 0.
+    - `grep -c "handleChannelShowCommand" src/index.ts` ≥ 2 (one for `channel show`, one for `project show` alias).
+    - Manual: `rly channel show <known-channel-id>` produces human-readable output; `rly project show <known-channel-id>` produces byte-identical output.
+    - `rly channel show --help` prints usage; exits 0.
+  </acceptance_criteria>
+  <done>Canonical `rly channel show` subcommand + `rly project show` alias both shipping; state vocabulary matches all surfaces; JSON mode supported for downstream tooling.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Manual smoke — end-to-end live verification across all four surfaces</name>
+  <what-built>
+    Phase 4 ships four surfaces (SessionStart hook injected at Claude/Codex first turn, TUI state column, GUI state badge row, `rly status` + `rly channel show` CLI) all reading the same `~/.relay/` disk state via `harness_data::derive_state`. Plans 01-04 verified each surface in isolation via tests; this checkpoint verifies they agree on the SAME channel under live conditions.
+  </what-built>
+  <how-to-verify>
+    Prerequisites:
+      - You're in a worktree on the Phase 4 branch.
+      - `pnpm build && pnpm install` has been run; `cargo build --workspace` has been run.
+      - `~/.relay/installed.json` reflects Phase 4 hook entries (run `rly install` if not — it's idempotent).
+      - At least one Codex CLI installation; if v0.130+, all the better; if older, you'll see the friendly install note and the hook config will be present but inactive.
+
+    Steps:
+
+      1. **Set up a fresh channel:**
+         - Run `rly` (interactive TUI) OR use existing channels.
+         - Pick a channel with ≥2 repos. Note its `channelId` and human name.
+
+      2. **CLI smoke:**
+         - Run `rly status`. Confirm the `Channels:` block appears with your channel + repo states.
+         - Run `rly channel show <channelId>`. Confirm detailed output: per-repo states, recent feed entries.
+         - Run `rly project show <channelId>`. Confirm byte-identical output to the previous step.
+         - Verify state vocabulary: `disconnected | booting | ready | stale` — these EXACT words appear.
+
+      3. **TUI smoke:**
+         - Run `rly` (or `tui`-launching wrapper). Navigate to the chosen channel.
+         - Confirm a state column appears alongside each repo with the same words from step 2.
+         - Confirm color/glyph per D-07: ready muted, booting yellow ○, stale red ×, disconnected dim ·.
+
+      4. **GUI smoke:**
+         - Launch the desktop app (`pnpm tauri dev` or the built binary).
+         - Open the same channel. Confirm state badges render under the channel header with same vocabulary + D-07 colors.
+         - Close + reopen the channel — confirm state words are identical (no in-process cache).
+
+      5. **Hook smoke (highest leverage):**
+         - In one of the channel's repo directories, run `RELAY_CHANNEL_ID=<channelId> claude` (or `codex` if v0.130+).
+         - At first turn, paste a prompt like "What channel am I on?" — the agent's response should reference the injected context (e.g., it knows the channel name + repo states without you typing them).
+         - Verify: the context block in the agent's first message includes `[Relay] Channel: <name>` and per-repo state lines matching the CLI's output from step 2.
+         - Re-run with `RELAY_CHANNEL_ID` UNSET and `cwd` set to one of the repo paths — same channel should resolve via cwd-prefix lookup.
+         - Run `claude` (no env, no channel-matching cwd) in `/tmp` — confirm NO Relay context is injected (graceful no-op).
+
+      6. **State transition smoke (the Phase 3 acceptance pair):**
+         - Spawn a fresh repo-admin via `rly` for a new repo in the channel.
+         - Run `rly channel show <id>` within ~5 seconds — confirm new repo shows `booting`.
+         - Wait for the admin to call `agent_ready` (per Phase 3 contract — visible on the channel feed as `metadata.kind: agent_ready`).
+         - Re-run `rly channel show <id>` — confirm state flipped to `ready`.
+         - Confirm TUI + GUI agree on the same transition.
+
+      7. **Stale smoke:**
+         - Kill the repo-admin process (`kill -9 <pid>` or close its cmux pane).
+         - Wait > 120 seconds (the STALE_HEARTBEAT_MS threshold).
+         - Re-run `rly channel show <id>` — confirm state flipped to `stale` (NOT to `disconnected` — the assignment still exists).
+         - Verify the session record is STILL on disk (`ls ~/.relay/crosslink-session/`) — Pitfall #3 enforcement: stale ≠ deleted.
+
+    Record observations into 04-SUMMARY.md (Task 4). If any step fails, surface the gap as a Phase 4 follow-up rather than blocking the SUMMARY; note the discrepancy explicitly.
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe issues (specific step + observed vs expected). Issues become Phase 4 follow-up items in the SUMMARY.</resume-signal>
+</task>
+
+<task type="auto">
+  <name>Task 4: Write 04-SUMMARY.md — wave-by-wave PRs, gates, handoff, follow-ups</name>
+  <read_first>
+    - .planning/phases/03-repo-admin-readiness-handshake/03-SUMMARY.md (template — Phase 4 SUMMARY mirrors this shape)
+    - .planning/phases/04-project-readiness-surface/04-01-PLAN.md through 04-04-PLAN.md (capture what landed per plan)
+    - .planning/phases/04-project-readiness-surface/04-CONTEXT.md Deferred Ideas section (capture which deferred items remain deferred + which got pulled in)
+    - .planning/phases/04-project-readiness-surface/04-RESEARCH.md "Open Questions" (each one needs a one-line answer in the SUMMARY)
+    - Task 3 observations (manual smoke results — capture verbatim or summarize)
+    - $HOME/.claude/get-shit-done/templates/summary.md (the canonical SUMMARY template)
+  </read_first>
+  <files>.planning/phases/04-project-readiness-surface/04-SUMMARY.md</files>
+  <action>
+    Create `04-SUMMARY.md` mirroring Phase 3 SUMMARY shape:
+
+      Sections (in order):
+        1. **Frontmatter**: `phase: 04-project-readiness-surface`, `status: implemented`, `written: <today>`, `manual_smoke: verified|deferred|partial` based on Task 3 outcome.
+        2. **Goal achieved**: One-paragraph statement: "Four surfaces (SessionStart hook, TUI, GUI, CLI) now render the same `RepoAdminState` for every channel by consuming `harness_data::derive_state` (Rust) or its TS mirror. State vocabulary `disconnected | booting | ready | stale` is identical across surfaces. `rly install` drops hooks for both Claude AND Codex with drift detection."
+        3. **What landed** (sub-sections per plan):
+           - **Schema + state derivation (Plan 01):** `RepoAdminState` enum (TS zod + Rust serde kebab-case); `derive_state` + `group_by_admin` in `harness-data`; `_state → _processState` rename closes Phase 3 follow-up #1.
+           - **Hook generator + watermark (Plan 02):** `generateSessionStartHookScripts`; pure formatter `formatSessionStartContext`; `CrosslinkSession.lastSeenFeedIdx` + `advanceFeedWatermark`.
+           - **Install integration (Plan 03):** `installSessionStartHooks` writes Claude + Codex configs idempotently; `ensureCodexFeatureFlag` for `[features].hooks = true`; manifest extended with `hooks` block + drift detection.
+           - **TUI + GUI rendering (Plan 04):** TUI state column in sidebar; GUI Tauri command `load_repo_admin_states` + `load_channel_admins_grouped` (forward-compat for WORKER-06); React `repo-state-stack` row with D-07 CSS classes.
+           - **CLI + manual smoke + SUMMARY (Plan 05):** `formatChannelStatesBlock` in `rly status`; `rly channel show <id>` + `rly project show` alias; manual smoke observations.
+        4. **Wave-by-wave PR boundaries** (table matching Phase 3 SUMMARY format):
+           | Wave | LOC | Title |
+           | 1 (scaffolds) | TBD | feat(domain): RepoAdminState enum + derive_state + _state→_processState rename |
+           | 2 (hook generator) | TBD | feat(crosslink): SessionStart hook generator + lastSeenFeedIdx watermark |
+           | 3 (install) | TBD | feat(install): wire SessionStart hooks for Claude + Codex with drift detection |
+           | 4 (TUI + GUI) | TBD | feat(tui/gui): per-repo state column + state badge row |
+           | 5 (CLI + SUMMARY) | TBD | feat(cli): rly status channel block + rly channel show subcommand |
+           Note: LOC values are filled in from `git diff --stat main...HEAD` at SUMMARY-writing time.
+        5. **Verification gates** (table — same shape as Phase 3 SUMMARY):
+           | Gate | Result |
+           |------|--------|
+           | pnpm typecheck | GREEN |
+           | pnpm test (full suite, scripted mode) | <N passed, 0 failed, X skipped> |
+           | pnpm format:check | GREEN |
+           | pnpm build | GREEN |
+           | cargo check --workspace --locked | GREEN |
+           | cargo test --workspace | GREEN |
+        6. **New tests added by this phase** — bullet list per test file added (mirror Phase 3 SUMMARY).
+        7. **Manual smoke results** — record outcome of Task 3 step-by-step. If any step had partial success, note it here. State whether SURFACE-06 (four states distinguishable in all surfaces) is verified live.
+        8. **Phase handoff contract — confirmed live for Phase 5**:
+           - State-derivation contract: `harness_data::derive_state` + `group_by_admin` exposed.
+           - Worker forward-compat: GUI command `load_channel_admins_grouped` and Rust `group_by_admin` already nest workers under admins; Phase 5 just needs to emit `CrosslinkSession.readyKind === "worker"` records and the surfaces auto-render them.
+           - Hook entries are tagged `matcher === "relay-channel-readiness"` — Phase 5 worker spawn does NOT need its own hook entry.
+        9. **Open follow-ups** — bullets:
+           - cmux pane integration (deferred — Open Question #4; UI-level "open external app" call).
+           - Phase 3 SUMMARY follow-up #2: legacy GUI reader path bug at `gui/src-tauri/src/lib.rs:2810-2861, :2916-2970` still reads the deprecated `~/.relay/crosslink/sessions/` path. Out of scope for Phase 4. Suggested fix in a small follow-up PR.
+           - `lastSeenFeedIdx` watermark cost-vs-value review: if reviewer feels the "N new entries" tail is noise, the field can be dropped in a one-line follow-up PR (per D-04 droppable).
+           - Codex < v0.130: install writes config; users on older Codex must `codex --version` upgrade before hooks activate. Documented in `rly install` note + 04-SUMMARY.
+           - Manual smoke step 5 (live `codex` test): may be deferred if Codex < v0.130 is the only available version in the dev env — log status here.
+
+    Apply the SUMMARY template at `$HOME/.claude/get-shit-done/templates/summary.md` if available (read first). Fill in actual LOC counts via `git diff --stat $(git merge-base main HEAD)..HEAD --shortstat`.
+  </action>
+  <verify>
+    <automated>test -f .planning/phases/04-project-readiness-surface/04-SUMMARY.md && grep -c "Wave\\|Gate\\|follow-up\\|handoff" .planning/phases/04-project-readiness-surface/04-SUMMARY.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `.planning/phases/04-project-readiness-surface/04-SUMMARY.md` exists.
+    - Frontmatter contains `phase`, `status`, `written`, `manual_smoke`.
+    - Contains "Wave-by-wave PR boundaries" table with 5 waves.
+    - Contains "Verification gates" table with at least 6 gates.
+    - Contains "Phase handoff contract — confirmed live for Phase 5" section.
+    - Contains "Open follow-ups" section listing cmux deferral + Phase 3 follow-up #2 reference + watermark cost-vs-value note.
+    - Records the manual smoke outcome verbatim from Task 3.
+    - All five RESEARCH "Open Questions" answered with a one-line decision recorded in the SUMMARY (Codex version probe, channel-show alias, rename bundling, watermark in/out, cmux defer).
+    - All 8 phase requirement IDs (SURFACE-01 → SURFACE-07 + WORKER-06) mentioned in the SUMMARY with their landing wave noted.
+  </acceptance_criteria>
+  <done>Phase 4 SUMMARY committed; Phase 5 has a clean handoff contract; deferred items captured.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | CLI commands read disk + format; no new untrusted boundary. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-17 | Tampering | `loadChannelStates` reads `~/.relay/` recursively → could be slow on very large channel counts | accept | L3 isolation per file + sync IO; same scaling characteristics as existing `loadActiveSessions`. If a user has >1000 channels, `rly status` may take >1s — acceptable per the existing Phase 1 precedent. |
+| T-04-18 | Tampering | `rly channel show` resolves name → channel; collision between two channels with same name | mitigate | Resolution prefers exact channelId match first; falls back to name with most-recent updatedAt tie-break (Task 2 step 2). Documented. |
+| T-04-19 | DoS | `--feed-tail=N` with huge N reads entire feed.jsonl | accept | feed.jsonl is bounded by channel lifetime; even multi-MB files parse in ms. No user input flows into a subprocess. |
+</threat_model>
+
+<verification>
+- `pnpm test test/cli/print-status-context.test.ts test/cli/channel-show.test.ts` GREEN.
+- `pnpm test` full suite GREEN.
+- `pnpm typecheck && pnpm format:check && pnpm build` GREEN.
+- `cargo check --workspace --locked && cargo test --workspace` GREEN.
+- `grep -rn "discover_sessions\\|discoverSessions" src/cli/ tui/ gui/src-tauri/ src/crosslink/hook.ts` → 0 NEW uncommented references (Pitfall #3 enforced system-wide for Phase 4 code paths).
+- Manual smoke (Task 3) ran and recorded outcomes — gates ON CHECKPOINT, not on full pass.
+- `04-SUMMARY.md` exists and answers all five RESEARCH Open Questions + lists all 8 requirement IDs.
+</verification>
+
+<success_criteria>
+- All four Phase 4 surfaces (hook, TUI, GUI, CLI) live and rendering identical state words for the same channel.
+- All 8 phase requirement IDs satisfied: SURFACE-01..SURFACE-07 + WORKER-06.
+- Single source of truth for state derivation enforced across the codebase: `harness_data::derive_state` (Rust) + `deriveRepoAdminState` (TS mirror) are the only state computation sites.
+- `discoverSessions` is NOT referenced by any Phase 4 read path (system-wide grep test).
+- 04-SUMMARY.md captures wave PRs, verification gates, handoff contract for Phase 5, and Phase 4 follow-ups.
+- Manual smoke run AND recorded — even if any step is deferred (e.g., Codex < v0.130), the deferral is logged in SUMMARY.
+</success_criteria>
+
+<output>
+After completion:
+- Commit and push 04-SUMMARY.md.
+- Phase 4 closes.
+- STATE.md should be updated (orchestrator's job, not this plan's): Phase 4 → completed, Phase 5 → unblocked.
+</output>

--- a/.planning/phases/04-project-readiness-surface/04-PATTERNS.md
+++ b/.planning/phases/04-project-readiness-surface/04-PATTERNS.md
@@ -1,0 +1,647 @@
+# Phase 4: Project readiness surface - Pattern Map
+
+**Mapped:** 2026-05-11
+**Files analyzed:** 14 (8 NEW, 6 EXTEND)
+**Analogs found:** 14 / 14 — every Phase 4 surface has a precedented twin in shipped Phase 1/3 code.
+
+Phase 4 is a **composition phase**. Every primitive (readiness flag, channel structure, hook scaffolding, install manifest, drift detection, channel-feed reader, TUI sidebar render, GUI channel header, `rly status` block) already exists. Patterns below tell each plan which precedent to copy.
+
+## Skills / Project Conventions
+
+Checked `.claude/skills/` and `.agents/skills/` — **neither directory exists**. Project conventions live in `CLAUDE.md` → `AGENTS.md` (referenced but not loaded here; planner reads). Phase-specific conventions surface through the analogs themselves: sub-800 LOC PRs, TS/Rust mirror in same PR, `#[serde(default)]` for back-compat, no in-process cache across surfaces.
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| **NEW** `src/domain/repo-admin-state.ts` | domain type / state derivation (TS mirror) | pure transform | `src/crosslink/types.ts` (zod enum + type) + `src/lifecycle/types.ts` (string-union state enum + transition table) | exact |
+| **EXTEND** `crates/harness-data/src/lib.rs` (RepoAdminState + derive_state + group_by_admin) | domain type / state derivation (Rust authoritative) | pure transform | Same file lines 600-652 (`CrosslinkSession` + `load_crosslink_sessions`) + lines 660-668 (`TicketProvider` four-value enum with `serde(rename_all)`) | exact |
+| **EXTEND** `src/crosslink/hook.ts` (add `generateSessionStartHookScripts()`) | hook generator | file I/O (write generated scripts) | `src/crosslink/hook.ts::generateHookScripts()` lines 6-32 + `buildShellScript` + `buildNodeScript` | exact (same file, sibling fn) |
+| **NEW** `src/crosslink/session-start-hook-content.ts` | utility / pure formatter | pure transform | `src/cli/print-status-context.ts::formatActiveSessionsBlock` lines 26-44 | exact |
+| **EXTEND** `src/cli/install.ts` + new install step | install integration | file I/O (idempotent JSON merge) | `src/install/installer.ts::installSurface` + `src/install/manifest.ts::markInstalled` + `writeManifest` atomic-rename pattern | role-match (new file write target, same idempotent pattern) |
+| **EXTEND** `src/install/manifest.ts` (add `hooks: { claude, codex }` block) | install integration / manifest schema | file I/O | Same file: `SurfaceRecord` / `InstallManifest` / `diffSurface` / `reportDrift` lines 12-192 | exact (same file, additive field) |
+| **EXTEND** `src/cli/print-status-context.ts` (add `formatChannelStatesBlock`) | CLI rendering | pure transform | Same file: `formatActiveSessionsBlock` + `loadActiveSessions` lines 26-110 | exact |
+| **NEW** `src/cli/channel-show.ts` (rly channel show subcommand handler) | CLI rendering / argv handler | pure transform + read | `src/cli/install.ts::handleInstallCommand` lines 132-164 (argv → parseArgs → dispatch) | role-match |
+| **EXTEND** `tui/src/ui.rs` (state column in sidebar) | TUI rendering | pure transform of state → styled spans | Same file: `draw_sidebar` lines 175-298 (specifically the icon/color match block lines 235-241) | exact |
+| **EXTEND** `tui/src/main.rs` (load + cache session state on tick) | TUI state load | file I/O (per-tick) | Existing `app.channels` load pattern (calls `load_channels()`) — to be confirmed by planner; precedent: any existing `harness_data::load_*` consumer in `main.rs` | role-match |
+| **EXTEND** `gui/src/components/ChannelHeader.tsx` (state badge row) | GUI rendering | request-response (Tauri cmd) | Same file lines 95-112 (agent-stack badge stack) + `RepoChipRow.tsx` chip pattern | exact |
+| **EXTEND** `gui/src-tauri/src/lib.rs` (new Tauri cmd returning `Vec<(repo, RepoAdminState)>`) | GUI bridge / backend cmd | request-response | Existing Tauri commands in `gui/src-tauri/src/lib.rs` (planner to confirm exact analog; pattern: `#[tauri::command] fn foo() -> Result<T, String>` calling `harness_data::load_*`) | role-match |
+| **EXTEND** Hook-installed `~/.claude/settings.json` (managed by install) | live service config | file I/O (idempotent merge) | Existing `getClaudeHookConfig` in `src/crosslink/hook.ts` lines 182-193 — but only emits the *shape*; Phase 4 writes it from `rly install` | partial (shape exists; writer is new) |
+| **EXTEND** `~/.codex/hooks.json` + `~/.codex/config.toml` (`[features].hooks=true`) | live service config | file I/O (idempotent merge) | No existing Codex config writer in repo. Closest analog: `src/install/manifest.ts::writeManifest` atomic-rename pattern (lines 64-69) | role-match (no exact analog; pattern is "idempotent merge + atomic rename") |
+
+## Pattern Assignments
+
+### `src/domain/repo-admin-state.ts` (NEW — domain type / pure transform)
+
+**Analog:** `src/crosslink/types.ts` (zod enum precedent) + `src/lifecycle/types.ts` (string-union state enum).
+
+**Imports pattern** (from `src/crosslink/types.ts` line 1):
+```ts
+import { z } from "zod";
+```
+
+**Enum schema pattern** (from `src/crosslink/types.ts` lines 26-28, 22-24):
+```ts
+export const ReadyKindSchema = z.enum(["admin", "worker"]);
+export type ReadyKind = z.infer<typeof ReadyKindSchema>;
+// Phase 4: same shape, four values.
+// export const RepoAdminStateSchema = z.enum(["disconnected", "booting", "ready", "stale"]);
+// export type RepoAdminState = z.infer<typeof RepoAdminStateSchema>;
+```
+
+**Pure transform pattern** (target shape; mirror of Rust `derive_state` — see RESEARCH.md line 432 for the canonical TS mirror sketch):
+```ts
+// Match the Rust impl byte-for-byte in branch order. STALE_HEARTBEAT_MS
+// mirrors the const in src/crosslink/store.ts:19.
+export const STALE_HEARTBEAT_MS = 120_000;
+
+export function deriveRepoAdminState(
+  session: { pid: number; lastHeartbeat: string; readyAt?: string | null } | null,
+  nowMs: number,
+  isProcessAlive: (pid: number) => boolean
+): RepoAdminState { /* ... */ }
+```
+
+**Liveness-check pattern** (from `src/crosslink/hook.ts` lines 161-167):
+```ts
+function isProcessAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+```
+
+---
+
+### `crates/harness-data/src/lib.rs` EXTEND (RepoAdminState + derive_state + group_by_admin)
+
+**Analog:** same file. `CrosslinkSession` block (lines 600-621) for the type pattern; `TicketProvider` (lines 660-668) for the four-value enum + serde rename pattern; `load_crosslink_sessions` (lines 633-652) for the read-only enumerator pattern.
+
+**Type pattern** (from same file lines 600-621):
+```rust
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CrosslinkSession {
+    pub session_id: String,
+    pub pid: u32,
+    // ...
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_kind: Option<String>,
+}
+```
+
+**Four-value enum pattern** (from same file lines 660-668 — `TicketProvider`):
+```rust
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TicketProvider {
+    Relay,
+    Linear,
+    None,
+    #[serde(other)]
+    Unknown,
+}
+// Phase 4 RepoAdminState: same shape, use rename_all = "kebab-case"
+// (matches the canonical wire shape "disconnected" | "booting" | "ready" | "stale").
+// Do NOT include #[serde(other)] — the enum is closed.
+```
+
+**Read-only enumerator pattern** (from same file lines 633-652 — `load_crosslink_sessions`):
+```rust
+pub fn load_crosslink_sessions() -> Vec<CrosslinkSession> {
+    let dir = harness_root().join("crosslink-session");
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&dir) else { return out; };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+        let Ok(raw) = std::fs::read_to_string(&path) else { continue; };
+        if let Ok(session) = serde_json::from_str::<CrosslinkSession>(&raw) {
+            out.push(session);
+        }
+    }
+    out
+}
+```
+
+**Pure derivation pattern** (Phase 4 addition; see RESEARCH.md Pattern 1):
+```rust
+pub const STALE_HEARTBEAT_MS: i64 = 120_000;
+
+pub fn derive_state(session: &CrosslinkSession, now_ms: i64) -> RepoAdminState {
+    let alive = is_pid_alive(session.pid);
+    let hb = parse_iso(&session.last_heartbeat).unwrap_or(0);
+    if !alive || now_ms - hb > STALE_HEARTBEAT_MS { return RepoAdminState::Stale; }
+    if session.ready_at.is_some() { return RepoAdminState::Ready; }
+    RepoAdminState::Booting
+}
+// Note: Disconnected is decided at the channel level (no CrosslinkSession
+// for that repo assignment); derive_state is never called with `None`.
+```
+
+**Test pattern** (from same file lines 2676-2767 — Phase 3 added serde + load tests):
+```rust
+#[test]
+fn parses_phase3_session_with_ready_fields() { /* ... */ }
+#[test]
+fn parses_legacy_session_without_ready_fields() { /* ... */ }
+#[test]
+fn load_crosslink_sessions_returns_valid_rows_skips_malformed() { /* ... */ }
+// Phase 4 adds:
+// derive_state_returns_stale_when_pid_dead
+// derive_state_returns_stale_when_heartbeat_aged
+// derive_state_returns_ready_when_ready_at_set
+// derive_state_returns_booting_when_alive_no_ready_at
+// group_by_admin_groups_workers_under_admin (forward-compat empty case)
+```
+
+---
+
+### `src/crosslink/hook.ts` EXTEND — `generateSessionStartHookScripts()`
+
+**Analog:** same file, `generateHookScripts()` lines 6-32 (sibling generator).
+
+**Generator entry pattern** (lines 6-32):
+```ts
+export async function generateHookScripts(): Promise<{
+  shellScriptPath: string;
+  nodeScriptPath: string;
+}> {
+  const relayDir = getRelayDir();
+  const hooksDir = join(relayDir, "crosslink", "hooks");
+  await mkdir(hooksDir, { recursive: true });
+
+  const shellScriptPath = join(hooksDir, "check-messages.sh");
+  const nodeScriptPath = join(hooksDir, "check-messages.mjs");
+
+  await writeFile(shellScriptPath, buildShellScript(nodeScriptPath));
+  await chmod(shellScriptPath, 0o755);
+  await writeFile(nodeScriptPath, buildNodeScript(relayDir));
+
+  return { shellScriptPath, nodeScriptPath };
+}
+// Phase 4: sibling generateSessionStartHookScripts() emitting
+// session-start.{sh,mjs} in the same hooksDir.
+```
+
+**Shell-wrapper pattern** (lines 34-47):
+```ts
+function buildShellScript(nodeScriptPath: string): string {
+  return `#!/bin/bash
+NODE="$(which node 2>/dev/null)"
+if [ -z "$NODE" ]; then exit 0; fi
+"$NODE" "${nodeScriptPath}" 2>/dev/null
+`;
+}
+```
+
+**Node-script-baked-relay-dir pattern** (lines 49-64):
+```ts
+function buildNodeScript(relayDir: string): string {
+  return `#!/usr/bin/env node
+import { readdir, readFile, writeFile, rename } from "node:fs/promises";
+import { join } from "node:path";
+
+const RELAY_DIR = ${JSON.stringify(relayDir)};
+const SESSIONS_DIR = join(RELAY_DIR, "crosslink-session");
+// ...
+`;
+}
+```
+
+**Graceful no-op pattern** (lines 71-99 — critical Phase 4 invariant per Pitfall #2):
+```ts
+async function main() {
+  // ... resolve mySession from env or PID chain ...
+  if (!mySession) { process.exit(0); }
+  // ... emit context only on success path ...
+}
+main().catch(() => process.exit(0));
+```
+
+**Raw fs session-read pattern** (lines 71-96 — Phase 4 reuses this; do NOT call `discoverSessions()` per Pitfall #3):
+```ts
+const sessions = await safeReaddir(SESSIONS_DIR);
+for (const file of sessions) {
+  if (!file.endsWith(".json")) continue;
+  try {
+    const raw = JSON.parse(await readFile(join(SESSIONS_DIR, file), "utf8"));
+    // Phase 4: filter raw.channelId === resolvedChannelId
+  } catch { /* skip malformed */ }
+}
+```
+
+---
+
+### `src/crosslink/session-start-hook-content.ts` (NEW — pure formatter)
+
+**Analog:** `src/cli/print-status-context.ts::formatActiveSessionsBlock` (lines 26-44).
+
+**Pure formatter contract** (lines 26-44):
+```ts
+export function formatActiveSessionsBlock(sessions: ActiveSessionRow[]): string {
+  if (sessions.length === 0) return "";
+  const sorted = [...sessions].sort((a, b) => b.pct - a.pct);
+  const lines = ["Active sessions:"];
+  for (const row of sorted) {
+    const usedK = (row.used / 1000).toFixed(0);
+    const totalK = (row.total / 1000).toFixed(0);
+    const channel = row.channelId ? ` (channel: ${row.channelId})` : "";
+    const model = row.model ? ` — ${row.model}` : "";
+    lines.push(`- ${row.sessionId}${channel} ctx ${row.pct.toFixed(0)}% ...`);
+  }
+  return lines.join("\n");
+}
+```
+
+**Phase 4 application:**
+- Input: `{ channelName, repoStates: RepoState[], newFeedEntries?: number }`.
+- Empty contract: returns `""` when no repos (caller skips append).
+- Sorting: stable presentation; "ready" baseline → mute, "booting" / "stale" emphasized per D-07.
+- Glyphs (`●` / `○`) live in the formatter — RESEARCH.md Pattern 3.
+- **No IO** — keeps it vitest-friendly in scripted mode.
+
+---
+
+### `src/install/manifest.ts` EXTEND — `hooks: { claude, codex }` manifest block
+
+**Analog:** same file. `SurfaceRecord` / `InstallManifest` / `markInstalled` / `diffSurface`.
+
+**Schema-bump pattern** (lines 21-39):
+```ts
+interface InstallManifest {
+  schemaVersion: 1;
+  surfaces: Partial<Record<Surface, SurfaceRecord>>;
+  // Phase 4 ADDITIVE: hooks?: Partial<Record<HookTarget, HookRecord>>
+  // - additive means schemaVersion stays at 1 (older readers ignore the field)
+  // - HookRecord mirrors SurfaceRecord: { sha, installedAt, command }
+}
+```
+
+**Atomic-rename write pattern** (lines 64-69):
+```ts
+async function writeManifest(manifest: InstallManifest): Promise<void> {
+  const target = manifestPath();
+  const tmp = `${target}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  await rename(tmp, target);
+}
+// Phase 4 reuses this for ~/.claude/settings.json + ~/.codex/hooks.json
+// idempotent merge writes.
+```
+
+**Drift detection pattern** (lines 144-192 — `diffSurface` + `reportDrift`):
+```ts
+export type SurfaceState = "fresh" | "current" | "behind";
+// Phase 4: identical state vocabulary for hook entries.
+// "fresh" — never installed (don't nudge)
+// "current" — installed sha matches generator output
+// "behind" — installed sha differs from generator output
+```
+
+**Forward-compat invariant** (lines 36-40): `isManifest` returns false for unrecognized shape; emptyManifest resets. Phase 4's `hooks` field MUST be optional so a manifest written by an old `rly install` still passes the predicate.
+
+---
+
+### `src/cli/install.ts` EXTEND — wire SessionStart hooks for Claude + Codex
+
+**Analog:** same file (`handleInstallCommand` lines 132-164) + `src/install/installer.ts::installSurface` lines 130-182.
+
+**Argv-parse + dispatch pattern** (`install.ts` lines 38-63):
+```ts
+function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { surfaces: [], check: false, force: false, ... };
+  for (const raw of args) {
+    if (raw === "--help" || raw === "-h") parsed.help = true;
+    else if (raw === "--check") parsed.check = true;
+    // ...
+  }
+  return parsed;
+}
+```
+
+**Per-surface install pattern** (`installer.ts` lines 130-176 — the shape Phase 4's hook-install step copies):
+```ts
+// 1. Read source version + current installed record.
+// 2. If matches source SHA → skip with "already at vX".
+// 3. Otherwise: run build/write, mark installed via markInstalled().
+// 4. Atomic per-surface so partial install still records what succeeded.
+```
+
+**Idempotent JSON merge pattern** (Phase 4 addition; RESEARCH.md lines 477-493 for the canonical sketch):
+```ts
+// 1. readJsonSafe(claudeSettingsPath, { hooks: {} }) — missing file → skeleton
+// 2. existing.hooks.SessionStart ??= []
+// 3. Filter out entries with matcher === "relay-channel-readiness" (own tag)
+// 4. Push fresh entry with current scriptPath + timeout
+// 5. writeJsonAtomic (tmp + rename — manifest.ts:64-69 pattern)
+```
+
+**Codex feature-flag toggle** (no existing analog; net-new but minimal):
+```ts
+// Read ~/.codex/config.toml (or treat absent as empty)
+// Ensure [features] section has hooks = true
+// Idempotent merge — preserve other keys (use a TOML parser, not regex)
+// Atomic rename
+// Surface a one-line "[rly install] Enabled Codex hooks feature flag." note
+// Per Pitfall #5: legacy key codex_hooks is DEPRECATED — write `hooks`.
+```
+
+---
+
+### `src/cli/print-status-context.ts` EXTEND — `formatChannelStatesBlock`
+
+**Analog:** same file (lines 26-110 — `formatActiveSessionsBlock` + `loadActiveSessions`).
+
+**Two-function pair pattern**:
+- `formatChannelStatesBlock(rows)` — pure formatter, vitest-friendly. Empty list → `""`.
+- `loadChannelStates()` — sync IO walk of `~/.relay/channels/` + `~/.relay/crosslink-session/`. Wraps each file read in try/catch (L3 isolation per lines 100-107).
+
+**Empty-block contract** (line 27):
+```ts
+if (sessions.length === 0) return "";
+// Callers do `if (block) { console.log(block); console.log(""); }`
+// — see src/index.ts:2816-2821 for the integration site Phase 4 extends.
+```
+
+**Synchronous IO + per-file isolation pattern** (lines 57-110):
+```ts
+export function loadActiveSessions(opts?: { maxAgeMs?: number }): ActiveSessionRow[] {
+  const root = join(getRelayDir(), "sessions");
+  if (!existsSync(root)) return [];     // L3: missing root → empty
+  // ...
+  for (const name of entries) {
+    try { /* parse last line */ } catch (err) {
+      console.warn(`[budget] skipping malformed session file ${file}: ...`);
+      continue;
+    }
+  }
+}
+// Phase 4 channel-states variant walks `channels/<id>/channel.json`
+// + `crosslink-session/*.json` with the same try/catch shell.
+```
+
+**Wire-up site** (`src/index.ts` lines 2816-2821):
+```ts
+const activeSessions = loadActiveSessions();
+const activeBlock = formatActiveSessionsBlock(activeSessions);
+if (activeBlock) { console.log(activeBlock); console.log(""); }
+// Phase 4: identical block-append after Active sessions:
+//   const channelStates = loadChannelStates();
+//   const channelBlock = formatChannelStatesBlock(channelStates);
+//   if (channelBlock) { console.log(channelBlock); console.log(""); }
+```
+
+---
+
+### `src/cli/channel-show.ts` (NEW — if planner picks `rly channel show <id>`)
+
+**Analog:** `src/cli/install.ts::handleInstallCommand` (lines 132-164) for argv parse + dispatch shape.
+
+**Subcommand handler signature**:
+```ts
+export async function handleChannelShowCommand(args: string[]): Promise<number> {
+  // 1. parse args (channelId | --json | --help) — same shape as install.ts:38-63
+  // 2. Resolve channel by id or name via ChannelStore.listChannels()
+  // 3. Load CrosslinkSession records for that channel via raw fs read
+  //    (DO NOT call discoverSessions — see Pitfall #3)
+  // 4. derive_state per repo
+  // 5. Render via formatChannelStatesBlock (same pure formatter)
+  // 6. Return 0 on success, 1 on channel-not-found, 2 on argv error
+}
+```
+
+**Per RESEARCH.md Open Question #2 recommendation:** make `rly channel show` the canonical subcommand; alias `rly project show` to the same handler for deprecation-friendly future-proofing. Both planner's call per CONTEXT.md Claude's Discretion.
+
+---
+
+### `tui/src/ui.rs` EXTEND — state column on channel drill-in
+
+**Analog:** same file (`draw_sidebar` lines 175-298, specifically the icon/color match at lines 235-241 for state→color mapping).
+
+**Per-row styled-span pattern** (lines 230-255 — repo-agent rendering, the exact precedent for repo+state column):
+```rust
+for repo in &repo_assignments {
+    let is_streaming = app.is_worker_streaming(&repo.alias);
+    let (icon, icon_color) = if is_streaming {
+        ("● ", Color::Green)
+    } else if is_active {
+        ("◉ ", Color::Cyan)
+    } else {
+        ("○ ", Color::DarkGray)
+    };
+    let line = Line::from(vec![
+        Span::styled(icon, Style::default().fg(icon_color)),
+        Span::styled(format!("@{}", repo.alias), alias_style),
+        Span::styled(format!(" {}", repo_short), Style::default().fg(Color::DarkGray)),
+    ]);
+    agent_items.push(ListItem::new(line));
+}
+// Phase 4: same Line::from(vec![Span::styled(...)]) shape; the (icon, color)
+// match arm is keyed on RepoAdminState rather than is_streaming/is_active.
+```
+
+**D-07 color mapping** (Phase 4 application of the precedent):
+| State | Glyph | Color | Style |
+|-------|-------|-------|-------|
+| `ready` | `●` | `Color::DarkGray` | plain (muted baseline per D-07) |
+| `booting` | `○` | `Color::Yellow` | warning emphasis |
+| `stale` | `×` | `Color::Red` | error emphasis |
+| `disconnected` | `·` | `Color::DarkGray` | dimmed |
+
+**Drill-in pattern** (lines 175-215 — `draw_sidebar` channel list iteration; Phase 4 enriches the active-selected channel's expansion):
+- The existing `draw_sidebar` iterates `app.channels` and renders one `ListItem` per channel.
+- Phase 4 either (a) adds a state-summary suffix to the per-channel label, or (b) replaces the "agent count" parenthetical with a state roll-up (`(2/3 ready)`). Planner picks.
+
+---
+
+### `tui/src/main.rs` EXTEND — load + cache session state on tick
+
+**Analog:** existing `harness_data::load_*` consumer in `main.rs` (planner to confirm exact line; `load_channels()` is referenced at App init around lines 250-368). General pattern: call read-only `load_crosslink_sessions()` from `harness-data` on each App refresh tick; never call mutating `CrosslinkStore.discoverSessions` (Pitfall #3 — that auto-deregisters stale sessions and makes Phase 4's `stale` state unobservable).
+
+**TUI-side liveness check**: `derive_state` must work in Rust. Add `is_pid_alive(pid: u32) -> bool` to `harness-data` (via `nix::sys::signal::kill(pid, None)` or 4-line libc wrapper — per RESEARCH.md A5).
+
+---
+
+### `gui/src/components/ChannelHeader.tsx` EXTEND — state badge row
+
+**Analog:** same file lines 95-112 (`agent-stack` badge row) + `RepoChipRow.tsx` lines 12-80 (chip render with per-item primary/detach UI).
+
+**Badge-stack pattern** (`ChannelHeader.tsx` lines 95-112):
+```tsx
+<div className="agent-stack">
+  {channel.members.slice(0, 4).map((m) => {
+    const av = agentAvatar(m.agentId, m.displayName, appearance.avatarStyle);
+    return (
+      <span key={m.agentId} className="agent-avatar"
+        style={{ background: av.background, color: av.color }}
+        title={`${m.displayName} · ${m.provider}`}>
+        {av.glyph}
+      </span>
+    );
+  })}
+</div>
+// Phase 4: parallel <div className="repo-state-stack"> rendering one badge
+// per repo. Each badge color-coded per D-07 via CSS class .state-ready /
+// .state-booting / .state-stale / .state-disconnected.
+```
+
+**Tauri-cmd-call pattern** (`RepoChipRow.tsx` line 43, `api.setPrimaryRepo`):
+```tsx
+await api.setPrimaryRepo(channel.channelId, workspaceId);
+// Phase 4 mirror: const states = await api.loadRepoAdminStates(channel.channelId);
+// → calls new Tauri cmd in gui/src-tauri/src/lib.rs returning Vec<(repo, RepoAdminState)>.
+```
+
+---
+
+### `gui/src-tauri/src/lib.rs` EXTEND — new Tauri cmd returning `Vec<(repo, RepoAdminState)>`
+
+**Analog:** existing `#[tauri::command]` functions in `gui/src-tauri/src/lib.rs` that call `harness_data::load_*` (planner to confirm exact analog; pattern is the same one used by Sidebar to load channels).
+
+**Pattern shape**:
+```rust
+#[tauri::command]
+fn load_repo_admin_states(channel_id: String) -> Result<Vec<(String, RepoAdminState)>, String> {
+    // 1. harness_data::load_channel(&channel_id) → repoAssignments
+    // 2. harness_data::load_crosslink_sessions() filtered by channel_id
+    // 3. For each repoAssignment: derive_state(matching session, now)
+    //    OR RepoAdminState::Disconnected if no session
+    // 4. Return Vec of (alias, state) tuples
+}
+```
+
+**Critical:** consumes the same `harness_data::derive_state` as TUI. No re-derivation in `lib.rs` (anti-pattern from RESEARCH.md line 303).
+
+---
+
+### Hook config writes — `~/.claude/settings.json` + `~/.codex/hooks.json`
+
+**Analog:** `src/crosslink/hook.ts::getClaudeHookConfig` (lines 182-193 — emits the *shape* but doesn't write it; today `rly crosslink init` prints instructions for the user to paste).
+
+**Phase 4 change:** `rly install` writes both files directly, idempotently, with drift detection.
+
+**Existing shape** (`hook.ts` lines 182-193):
+```ts
+export function getClaudeHookConfig(shellScriptPath: string): object {
+  return {
+    hooks: {
+      UserPromptSubmit: [{ type: "command", command: shellScriptPath }],
+    },
+  };
+}
+// Phase 4: parallel getClaudeSessionStartHookConfig() returning
+// { hooks: { SessionStart: [{ matcher: "relay-channel-readiness",
+//   hooks: [{ type: "command", command: scriptPath, timeout: 30 }] }] } }
+// + getCodexSessionStartHookConfig() with identical shape.
+```
+
+**Critical idempotent-merge invariant** (Phase 4 must add — no current writer exists):
+- Read existing file → preserve user-configured hooks.
+- Filter out prior Relay entries (own tag `matcher === "relay-channel-readiness"`).
+- Append fresh entry.
+- Atomic rename write.
+- Surface SHA in `installed.json` `hooks` block for `rly install --check` drift detection.
+
+---
+
+## Shared Patterns
+
+### Schema versioning + back-compat (TS/Rust mirror)
+**Source:** Phase 1 `SessionBudget`, Phase 3 `CrosslinkSession.readyAt`. Convention: optional fields with `#[serde(default, skip_serializing_if = "Option::is_none")]` (Rust) + `.optional()` (zod). Old files deserialize cleanly; new fields surface only when present.
+
+**Apply to:** All Phase 4 schema changes — `RepoAdminState` enum, optional `lastSeenFeedIdx` watermark on `CrosslinkSession`, manifest `hooks` block, hook script entries.
+
+**Excerpt** (`crates/harness-data/src/lib.rs` lines 617-621):
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub ready_at: Option<String>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub ready_kind: Option<String>,
+```
+
+### Atomic-rename file writes
+**Source:** `src/install/manifest.ts::writeManifest` lines 64-69; same pattern in `CrosslinkStore.updateHeartbeat`.
+
+**Apply to:** All Phase 4 disk writes — hook script files (`session-start.{sh,mjs}`), `~/.claude/settings.json` merges, `~/.codex/hooks.json` merges, `~/.codex/config.toml` updates, watermark advancement on `CrosslinkSession`.
+
+```ts
+const tmp = `${target}.${process.pid}.tmp`;
+await writeFile(tmp, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+await rename(tmp, target);
+```
+
+### L3 per-file isolation
+**Source:** `src/cli/print-status-context.ts::loadActiveSessions` lines 100-107; mirrored in `src/crosslink/hook.ts::main` lines 92-95 (`/* skip malformed */`), `crates/harness-data/src/lib.rs::load_crosslink_sessions` lines 644-651 (`let Ok(...) = ... else { continue; }`).
+
+**Apply to:** All Phase 4 fs walks — hook node script's session enumeration, `loadChannelStates` channel walk, Tauri cmd's session aggregation, TUI tick refresh.
+
+```ts
+for (const file of files) {
+  try { /* parse + process one file */ }
+  catch (err) { /* log + continue — one bad file must not poison the list */ }
+}
+```
+
+### Graceful no-op hook degradation
+**Source:** `src/crosslink/hook.ts` lines 98-100 (`if (!mySession) process.exit(0)`) + line 178 (`main().catch(() => process.exit(0))`).
+
+**Apply to:** Phase 4 SessionStart hook. Exit 0 with empty stdout when:
+- No `RELAY_CHANNEL_ID` env AND no `cwd`-prefix match in any `Channel.repoAssignments[]`.
+- Resolved channel has zero `repoAssignments`.
+- Any unhandled exception in the script.
+
+Critical per Pitfall #2 — hook fires globally on every Claude/Codex session; non-Relay sessions MUST see no error output.
+
+### Forbidden API: `CrosslinkStore.discoverSessions()`
+**Source:** `src/crosslink/store.ts` lines 265-268 — auto-deregisters stale sessions.
+
+**Apply to:** All Phase 4 surfaces (hook, TUI, GUI, CLI). Read raw via:
+- Rust: `harness_data::load_crosslink_sessions()` (lines 633-652 — no cleanup).
+- TS hook node script: direct `readdir + readFile` of `crosslink-session/*.json` (matches existing pattern in `hook.ts` lines 71-96).
+- TS CLI (`loadChannelStates`): direct `readdirSync + readFileSync`.
+
+Calling `discoverSessions` makes the `stale` state unobservable — Phase 4's exact failure mode.
+
+### Pure formatter + isolated IO loader
+**Source:** `src/cli/print-status-context.ts` (formatActiveSessionsBlock + loadActiveSessions); `gui/src-tauri` Tauri cmd pattern (planner to confirm exact analog).
+
+**Apply to:** Every Phase 4 render path — `formatSessionStartContext` (hook), `formatChannelStatesBlock` (CLI), TUI state-column render (already follows this — pure function maps state → `Span::styled`), GUI badge component (props-driven, no fetching inside render).
+
+Tests assert formatter output via structured shape (not stringified blob — per Project Constraint "No snapshot tests for orchestrator output").
+
+### Closed enum, named consistently TS↔Rust
+**Source:** `src/crosslink/types.ts::ReadyKindSchema` (TS) ↔ `crates/harness-data/src/lib.rs::CrosslinkSession.ready_kind` (Rust `Option<String>` — Phase 3 left as string for forward-compat).
+
+**Apply to:** `RepoAdminState`. Wire format: kebab-case (`"disconnected" | "booting" | "ready" | "stale"`). Phase 4 ships this enum closed (no `#[serde(other)] Unknown`) — the four states cover every possible session+channel pairing per D-06.
+
+**Naming check (RESEARCH.md A7, Pitfall #1):** zero overlap with `LifecycleState = "planning" | "dispatching" | "winding_down" | "audit" | "done" | "killed"` (`src/lifecycle/types.ts` lines 7-13). Slight conceptual proximity to `RepoAdminSession._state` field (deferred Phase 3 follow-up). Planner option: bundle the `_state → _processState` rename into Phase 4 PR-1 (RESEARCH.md Pitfall #1 recommendation).
+
+---
+
+## No Analog Found
+
+| File | Role | Data Flow | Reason | Mitigation |
+|------|------|-----------|--------|-----------|
+| `~/.codex/config.toml` `[features].hooks = true` writer | install integration | TOML merge | No existing TOML writer in repo (Relay is JSON-everywhere internally) | Add a tiny TOML read-merge-write helper. Use a parsed-AST approach (e.g. `@iarna/toml` or `toml` package), NOT regex — Codex users may have hand-edited the file with comments/sections that regex would clobber. Use atomic-rename write per `manifest.ts:64-69`. |
+| Codex CLI version probe | install diagnostics | subprocess | No precedent in repo for parsing `codex --version` | One-shot `spawnSync("codex", ["--version"], { encoding: "utf8" })` then split on whitespace + parse semver. Fail-soft per RESEARCH.md Open Question #1 — log a one-line note if `< v0.130`, write config anyway. |
+| `lastSeenFeedIdx` watermark advance site | hook write | best-effort field update | No existing per-session watermark on `CrosslinkSession` | RESEARCH.md A4 recommendation: add as optional field with `#[serde(default)]` + `.optional()`. Advance via atomic-rename write at end of hook (after rendering succeeds). If write fails (permission/disk full), hook still exits 0 — watermark is best-effort. **Droppable per D-04 if cost exceeds value.** |
+
+## Metadata
+
+**Analog search scope:**
+- `src/crosslink/` (hook generator, store, types)
+- `src/cli/` (install, print-status-context, paths)
+- `src/install/` (installer, manifest)
+- `src/domain/` (channel, session-budget references)
+- `src/lifecycle/` (collision check for state naming)
+- `crates/harness-data/src/lib.rs` (Rust authoritative read path + four-value enum precedent)
+- `tui/src/` (main.rs sidebar, ui.rs render, install_drift.rs drift footer)
+- `gui/src/components/` (ChannelHeader, RepoChipRow, Sidebar)
+- `gui/src-tauri/` (Tauri cmd pattern — exact file confirmed by planner)
+
+**Files scanned:** ~14 files Read (within 2000-line cap, no re-reads); strategic `grep` for line locations in `tui/src/main.rs` (2960 lines) and `tui/src/ui.rs` (2781 lines) and `crates/harness-data/src/lib.rs` (2910 lines).
+
+**Pattern extraction date:** 2026-05-11
+
+**Key insight for planner:** Phase 4 has **zero greenfield rendering work**. Every surface (hook stdout, TUI sidebar/drill-in, GUI badge, CLI block) has a direct precedent in shipped Phase 1/3 code. The two genuinely new surfaces are (a) `derive_state` in Rust + thin TS mirror, and (b) the `rly install` writers for `~/.claude/settings.json` and `~/.codex/{hooks.json,config.toml}`. Both follow established patterns (closed enum + serde mirror; atomic-rename idempotent merge). The riskiest single line of Phase 4 is the Codex feature-flag toggle in `config.toml` — no TOML writer precedent in the repo, planner should land it in its own PR with focused tests (idempotent on re-run, preserves comments/other keys, atomic).

--- a/.planning/phases/04-project-readiness-surface/04-RESEARCH.md
+++ b/.planning/phases/04-project-readiness-surface/04-RESEARCH.md
@@ -1,0 +1,759 @@
+# Phase 4: Project readiness surface - Research
+
+**Researched:** 2026-05-11
+**Domain:** Cross-surface readiness rendering (SessionStart hook + TUI + GUI + CLI)
+**Confidence:** HIGH overall (Codex hook parity verified via official docs; Phase 3 disk shape verified in code; lifecycle collision verified in code)
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** **Channel IS the project.** Phase 4 introduces no new entity. TUI/GUI top-level lists channels (filtered by `status === "active"` or similar); drilling into a channel shows repos × admin states × recent feed events. Matches today's mental model — `Channel.repoAssignments[]` and `workspaceIds[]` already define the cross-repo unit. A new top-level `Project` entity was explicitly rejected as a future concern, not Phase 4 scope.
+- **D-02:** **Active-channel resolution for the hook:** the SessionStart hook resolves the active channel by (a) reading `RELAY_CHANNEL_ID` env if set (the spawner already threads this for repo-admin sessions per Phase 3), else (b) deriving from the session's `cwd` via `Channel.repoAssignments[]` reverse lookup. Hook degrades gracefully (no injection) if neither path resolves — this is the same degradation shape as `agent_ready` when no channel context exists (Phase 3 D-03).
+- **D-03:** **Density: terse one-liner per repo.** Target ~5-15 lines total for a typical 3-repo channel. Hook output is a fenced text block that the agent's first turn can scan in a single glance. Sample shape:
+  ```
+  [Relay] Channel: oauth-rollout (3 repos)
+    ● ui-repo       ready (admin: atlas-7f2)
+    ● backend-repo  ready (admin: atlas-3a1)
+    ○ sdk-repo      booting (since 2m ago)
+  Feed: 4 new entries since you were last here. Use rly status for detail.
+  ```
+  The `● / ○` glyphs are presentation; the canonical state string (`ready` / `booting`) is what the agent or a downstream parser reads.
+- **D-04:** **Snapshot only — no diff machinery.** Hook injects current state every time. Phase 4 ships with zero "last seen" / "diff since last turn" bookkeeping. The only "since-last-time" signal is the `Feed: N new entries` count tail, which is a single integer the hook computes from `feed.jsonl` length minus a per-session `lastSeenFeedIdx` watermark (cheap to add to the existing session.json; if too complex, drop it entirely — still acceptable).
+- **D-05:** **No structured diff section.** If the agent wants to know what changed, it can call MCP (`rly status --json` or equivalent) or read the feed via existing tools.
+- **D-06:** **Single canonical state enum, used identically across all surfaces.** `type RepoAdminState = "disconnected" | "booting" | "ready" | "stale"`. Mapping rules encoded in `harness-data` as single source of truth:
+  - `disconnected` — repo is not in the channel's `repoAssignments[]`.
+  - `booting` — `CrosslinkSession` exists, `pid` alive, `lastHeartbeat` fresh, **`readyAt` absent**.
+  - `ready` — `CrosslinkSession.readyAt` set.
+  - `stale` — `pid` dead OR `heartbeatAge > STALE_HEARTBEAT_MS`.
+  Same word in hook output (`booting`), `rly status` (`state=booting`), TUI column (`[BOOTING]`), GUI badge (`🟡 booting`).
+- **D-07:** **Muted ready, emphasized exceptions.** `ready` is the expected baseline — plain text, no color, no badge. `booting` gets a warning color/symbol (yellow ○). `stale` gets an error color/symbol (red ×). `disconnected` is dimmed/grayed.
+
+### Claude's Discretion
+
+1. **Codex hook surface** — investigate Codex's hook mechanism, propose (a) Codex-equivalent SessionStart wrapper, (b) per-launch context injection through `rly codex` shim, or (c) ship Claude-only and document the gap.
+2. **`rly project show <name>` shape** — extend `rly status`, add `rly channel show <channelId>`, or introduce `rly project show <channelId|name>` as an alias.
+3. **`lastSeenFeedIdx` persistence shape** — on `CrosslinkSession`, in a sibling file, or dropped entirely.
+4. **State enum naming** — `disconnected | starting | ready | stale` vs `unlinked | onboarding | ready | dead`. Check `src/lifecycle/session-lifecycle.ts` for collisions.
+5. **TUI/GUI navigation depth + cmux pane references** — Phase 4 or follow-up.
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- **Top-level Relay Project entity** — explicitly rejected for Phase 4.
+- **Structured diff in hook output** — explicitly rejected.
+- **cmux pane integration** — planner's call whether in scope.
+- **Multi-channel hook output** — Phase 5+ concern.
+- **Worker state (Phase 5 / AL-14)** — but Phase 4 surfaces must render workers under spawning admin without code changes (WORKER-06).
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| SURFACE-01 | `SessionStart` hook for Claude (`~/.claude/settings.json`) injects current project state into session's first turn — dropped by `rly install`. | Hook pattern verified in `src/crosslink/hook.ts` (generator) + `src/install/manifest.ts` (drift). Output shape verified via Claude Code docs: `hookSpecificOutput.additionalContext` JSON or plain stdout, 10K char limit, 600s timeout. |
+| SURFACE-02 | Codex `SessionStart` equivalent ships parity (or documents the gap explicitly). | **VERIFIED PARITY POSSIBLE.** Codex CLI v0.130 supports `SessionStart` with identical I/O shape. Feature flag: `[features].hooks = true` (legacy `codex_hooks` deprecated as of v0.129). Config in `~/.codex/hooks.json` or `[hooks]` in `~/.codex/config.toml`. Plain stdout also injected as "extra developer context." |
+| SURFACE-03 | TUI shows project-rooted view — top-level list of channels, drilling in shows repos × admin state × recent feed events. Reads via `harness-data`. | `tui/src/main.rs` already lists channels (verified line counts around channel rendering). Need to enrich rendering with state column using `load_crosslink_sessions()` + new `derive_state()` helper. |
+| SURFACE-04 | GUI matches project-rooted view, with optional cmux pane references. | `gui/src/components/Sidebar.tsx` already buckets channels. Need a repos-and-states row under each channel header. cmux pane refs are planner's call per CONTEXT.md. |
+| SURFACE-05 | `rly status` and `rly project show <name>` print terse project state for terminal consumers. | `src/index.ts::printStatus` is the extension point (line 2794). `src/cli/print-status-context.ts` is the precedent for adding a new block (Phase 1 PR-4 added the chat-session block here). |
+| SURFACE-06 | Four states (not-connected / alive-not-ready / ready / stale) unambiguous in all surfaces. | D-06 locks the enum. Mapping is mechanical given Phase 3 `CrosslinkSession.readyAt` + existing `STALE_HEARTBEAT_MS = 120_000` (verified `src/crosslink/store.ts:19`). |
+| SURFACE-07 | Closing and reopening any surface shows same state — no in-process cache. | All four surfaces must read `~/.relay/` on each render. Hook is reborn each turn; CLI is a one-shot; TUI/GUI use `load_crosslink_sessions()` on every tick (existing pattern — Phase 1 PR-3 already does this for budgets). |
+| WORKER-06 | Phase 4 surfaces render workers under their spawning admin without code changes. | **FORWARD-COMPAT CONSTRAINT.** `CrosslinkSession.readyKind` already has `"worker"` reserved (Phase 3 schema). Phase 4's state derivation operates on `CrosslinkSession` records regardless of `readyKind`. The rendering layer (TUI / GUI / hook) must group sessions by `readyKind` so when Phase 5 starts emitting worker records, they auto-appear nested under their spawning admin. Today no worker records exist — rendering must handle the empty-workers case gracefully. |
+</phase_requirements>
+
+## Project Constraints (from CLAUDE.md / AGENTS.md)
+
+- **Sub-800 LOC PRs.** One logical change per PR. Phase 4 must split into 4-5 PRs in the same shape as Phases 1-3.
+- **No drive-by reformats.** Keep diffs focused.
+- **Cross-dashboard contract — same PR.** Any TS shape change must include the Rust mirror (`crates/harness-data/src/lib.rs`) in the SAME PR. Same applies to the four-state enum.
+- **No snapshot tests for orchestrator output.** Assert on shape, not stringified blobs. Hook output should be testable as structured data, not a frozen string.
+- **Vitest scripted mode is default.** Phase 4 tests should not require `HARNESS_LIVE`.
+- **Channel-store.postEntry is append-only.** Never rewrite `feed.jsonl` in place.
+- **MCP secrets handling:** Phase 4 doesn't introduce secrets, but if the hook ever logs feed entries, redact via existing patterns. Not in scope today.
+
+## Summary
+
+Phase 4 is the consumer half of Phase 3's readiness primitive. The disk shape (`CrosslinkSession.readyAt` + `readyKind` + the `agent_ready` channel-feed entry) and the Rust read path (`crates/harness-data::load_crosslink_sessions()`) are both shipped and stable. Phase 4's job is **rendering**: four surfaces (SessionStart hook, TUI, GUI, CLI) reading the same disk state through one shared state-derivation function.
+
+The biggest unknown going in was Codex hook parity (Claude's Discretion #1). **Verified resolved**: Codex CLI v0.130+ supports a `SessionStart` lifecycle event with byte-compatible I/O to Claude Code's hook (JSON stdin including `session_id`, `cwd`, `source`; JSON or plain-stdout stdout becomes additional context). The only delta is config location (`~/.codex/hooks.json` vs `~/.claude/settings.json`) and the feature flag (`[features].hooks = true`). Phase 4 can ship true four-surface parity by generating a sibling hook entry for both adapters.
+
+**Primary recommendation:** Land the four-state enum + `derive_state(session, now) -> RepoAdminState` helper in `crates/harness-data` (single source of truth, do-it-once). Mirror the TS type in `src/domain/repo-admin-state.ts`. Wire both Claude `SessionStart` and Codex `SessionStart` through one shared TS generator following `src/crosslink/hook.ts` precedent. Extend `rly install` to write both hook entries idempotently with drift detection (using the existing `installed.json` manifest pattern). For the watermark (D-04), recommend storing `lastSeenFeedIdx` as an optional field on `CrosslinkSession` — single read path, back-compat via `#[serde(default)]`, drop the feature with no schema churn if cost > value.
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| State derivation (`session + now -> RepoAdminState`) | Rust shared crate (`harness-data`) | TS mirror (`src/domain/`) | Three consumers (TUI, GUI, hook-via-CLI) need this. Single Rust impl + thin TS mirror keeps drift impossible. |
+| `derive_state()` consumed by SessionStart hook | TS (CLI / orchestrator) | — | Hook node script runs under Node — must consume TS. The shape mirrors the Rust enum verbatim. |
+| `derive_state()` consumed by TUI | Rust crate (`tui/`) | — | TUI reads `load_crosslink_sessions()` already; adds one call to `derive_state(s, now)` per row. |
+| `derive_state()` consumed by GUI | Rust crate (`gui/src-tauri/`) | TS frontend (`gui/src/`) | Tauri backend computes state, frontend just renders strings + colors. |
+| `derive_state()` consumed by CLI | TS (`src/index.ts::printStatus`) | — | `rly status` is TS. Uses TS mirror. |
+| SessionStart hook script | TS generator (`src/crosslink/hook.ts` pattern) | Generated node script (cold path) | Existing pattern in repo: TS emits a shell + node script pair under `~/.relay/crosslink/hooks/`. Phase 4 adds a sibling `session-start.{sh,mjs}` pair. |
+| Hook installation into agent configs | TS (`src/cli/install.ts`) | Install manifest (`installed.json`) | `rly install` owns config-file writes. Drift detection via existing `--check` flow. |
+| Hook resolves active channel (env or cwd) | TS (inside generated node script) | `ChannelStore.listChannels` + reverse lookup | Hook needs `repoAssignments[]`. Existing `listChannels()` returns the full list; reverse-lookup scan is O(channels × repos), trivial. |
+| TUI rendering: state column on channel drill-in | Rust (`tui/src/ui.rs`) | — | All TUI rendering is Rust. Existing pattern: enrich existing tab. |
+| GUI rendering: state badge under each channel | TS/React (`gui/src/components/`) | Tauri command that returns `Vec<(repo, RepoAdminState)>` | Pattern matches existing `RepoChipRow.tsx` — add a state badge alongside the chip. |
+| `rly status` repo-state block | TS (`src/cli/print-status-context.ts` precedent) | — | Phase 1 added `formatActiveSessionsBlock`; Phase 4 adds `formatChannelStatesBlock`. |
+| `lastSeenFeedIdx` watermark | TS writer (`CrosslinkStore`) | Rust reader (`harness-data`) — read-only | Watermark advances after the hook fires for a session. Optional field. |
+| Workers rendered under admin | Rust (`harness-data`) — grouping helper | TUI + GUI consume | `group_by_admin(sessions)` returns `Vec<(admin, Vec<worker>)>`. Empty workers list today; Phase 5 fills it. |
+
+## Standard Stack
+
+### Core (already in repo — Phase 4 consumes, does not add)
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| `crates/harness-data` | workspace | Single Rust read path for TUI + GUI. Owns `CrosslinkSession` mirror + `load_crosslink_sessions()`. | Established Phase 3 precedent — every cross-dashboard shape lives here. `[VERIFIED: codebase grep, .planning/codebase/ARCHITECTURE.md]` |
+| `zod` | (existing) | TS schema for `CrosslinkSession` + new state enum. | Existing convention in `src/domain/`. `[VERIFIED: src/crosslink/types.ts]` |
+| `serde` / `serde_json` | (existing, harness-data) | Rust mirror serialization. | Existing convention in `harness-data`. `[VERIFIED: crates/harness-data/Cargo.toml]` |
+| Vitest + cargo test | (existing) | Test runners. | Project standard per AGENTS.md. `[VERIFIED: AGENTS.md]` |
+
+### Supporting (Phase 4-specific additions)
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| Claude Code SessionStart hook | N/A (config-only) | Inject channel state at session start. | Per Claude Code docs: output `hookSpecificOutput.additionalContext` (JSON) or plain stdout. Max 10,000 chars; default 600s timeout. `[CITED: code.claude.com/docs/en/hooks]` |
+| Codex SessionStart hook | N/A (config-only, v0.130+) | Codex equivalent. | Identical shape to Claude; gated on `[features].hooks = true`. Config in `~/.codex/hooks.json` or `[hooks]` in `~/.codex/config.toml`. `[CITED: developers.openai.com/codex/hooks]` |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| `derive_state()` in `harness-data` | Duplicate logic in each consumer (TUI, GUI, hook node script) with shared constants | Duplication risk: same state can mean different things across surfaces if one consumer's mapping drifts. The exact pitfall Phase 3 was designed to prevent. Reject. |
+| Per-launch context injection via `rly codex` shim | Wrap `codex` invocations in a Relay shim that pre-prints context | Doesn't fire on user-launched `codex` (only Relay-spawned). Hook approach catches every Codex session, including user-initiated ones. Reject — Codex hook surface is real and stable as of v0.130. |
+| Sibling file for `lastSeenFeedIdx` | `~/.relay/crosslink-session/<sid>.watermark.json` | Extra read per hook fire; back-compat is easy but doubles I/O. Field-on-record is cleaner. |
+| New top-level `RelayProject` entity | Reject per D-01 (locked). | Out of scope. |
+| `RepoAdminState` named `unlinked / onboarding / ready / dead` | — | Naming check ran (see Common Pitfalls #1): no lexical collision in `session-lifecycle.ts`. `disconnected / booting / ready / stale` is fine. |
+
+**Installation:** No new dependencies. Phase 4 is composition of existing primitives.
+
+**Version verification:** `crates/harness-data` is workspace-local; no registry. `zod` and `serde` are already in use. Codex hook stability: v0.130 (May 8, 2026) per official changelog `[CITED: developers.openai.com/codex/changelog]`. Claude Code hooks are stable in 2.1+ (silent injection via `additionalContext`) per official docs `[CITED: code.claude.com/docs/en/hooks]`.
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Disk authoritative state (~/.relay/)                                        │
+│                                                                              │
+│  channels/<id>/channel.json   →  Channel.repoAssignments[], primaryWorkspace │
+│  channels/<id>/feed.jsonl     →  ChannelEntry[] (Phase 1 + Phase 3 events)   │
+│  crosslink-session/<sid>.json →  CrosslinkSession (readyAt, lastHeartbeat,   │
+│                                  pid, readyKind?: admin|worker)              │
+└──────────────┬────────────────┬───────────────────┬─────────────────────────┘
+               │                │                   │
+               ▼                ▼                   ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Shared state-derivation: crates/harness-data                                 │
+│                                                                              │
+│  load_crosslink_sessions()  →  Vec<CrosslinkSession>                          │
+│  derive_state(session, now) →  RepoAdminState                                 │
+│  group_by_admin(sessions)   →  Vec<(Admin, Vec<Worker>)>     (WORKER-06)     │
+│  (Rust impl + thin TS mirror in src/domain/repo-admin-state.ts)              │
+└──────┬───────────────────┬──────────────────┬──────────────────┬─────────────┘
+       │                   │                  │                  │
+       ▼                   ▼                  ▼                  ▼
+┌──────────────┐  ┌──────────────────┐  ┌────────────────┐  ┌───────────────┐
+│ SessionStart │  │ TUI (tui/src/)   │  │ GUI (gui/)     │  │ CLI           │
+│ hook         │  │                  │  │ Tauri cmd ⇄    │  │ rly status    │
+│              │  │ Per-channel pane │  │ React badges   │  │ rly project   │
+│ Claude:      │  │ shows repo ×     │  │                │  │   show <name> │
+│ ~/.claude/   │  │ state column     │  │ Sidebar +      │  │   (planner's  │
+│ Codex:       │  │                  │  │ ChannelHeader  │  │    call)      │
+│ ~/.codex/    │  │                  │  │ get repo chip  │  │               │
+│ hooks.json   │  │                  │  │ + state badge  │  │               │
+└──────┬───────┘  └──────────────────┘  └────────────────┘  └───────────────┘
+       │
+       │  injects ~5-15 line context at session start
+       ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Agent's first turn (Claude or Codex)                                          │
+│ "Channel: oauth-rollout (3 repos)                                             │
+│    ● ui-repo       ready (admin: atlas-7f2)                                  │
+│    ● backend-repo  ready (admin: atlas-3a1)                                  │
+│    ○ sdk-repo      booting (since 2m ago)                                    │
+│  Feed: 4 new entries since you were last here."                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+Hook installation flow (rly install — extended by Phase 4):
+  rly install  →  generateSessionStartHookScripts()  →  ~/.relay/crosslink/hooks/session-start.{sh,mjs}
+              →  writeClaudeSettings()  →  ~/.claude/settings.json  (idempotent)
+              →  writeCodexHooks()      →  ~/.codex/hooks.json      (idempotent)
+              →  markInstalled() updates ~/.relay/installed.json
+  rly install --check  →  reports hook drift if user removed entries
+```
+
+### Recommended Project Structure (Phase 4 additions)
+```
+src/
+├── domain/
+│   └── repo-admin-state.ts          # NEW: TS mirror of Rust enum + derive_state shim
+├── crosslink/
+│   ├── hook.ts                      # EXTEND: add generateSessionStartHookScripts()
+│   └── session-start-hook-content.ts # NEW: pure formatter (testable in isolation)
+├── cli/
+│   ├── install.ts                   # EXTEND: wire SessionStart hooks for Claude + Codex
+│   ├── print-status-context.ts      # EXTEND: add formatChannelStatesBlock()
+│   └── channel-show.ts              # NEW (if planner picks rly channel/project show)
+└── install/
+    └── manifest.ts                  # EXTEND: hook entries in manifest for drift
+
+crates/harness-data/
+└── src/lib.rs                       # EXTEND: RepoAdminState enum + derive_state + group_by_admin
+
+tui/src/
+├── main.rs                          # EXTEND: render channel rows with state column
+└── ui.rs                            # EXTEND: state column formatter
+
+gui/src-tauri/src/
+└── lib.rs                           # EXTEND: Tauri cmd returning Vec<(repo, RepoAdminState)>
+
+gui/src/
+└── components/
+    ├── ChannelHeader.tsx            # EXTEND: state badge row under header
+    └── RepoChipRow.tsx              # EXTEND: state badge next to chip
+```
+
+### Pattern 1: State Derivation as a Pure Function in `harness-data`
+**What:** Single Rust function `derive_state(&CrosslinkSession, now: i64) -> RepoAdminState`. Pure (no IO). Mirrors a thin TS shim that does the same on the TS side.
+**When to use:** Every consumer (hook, TUI, GUI, CLI). Never re-derive in a consumer.
+**Example:**
+```rust
+// crates/harness-data/src/lib.rs (Phase 4 addition)
+// Source: derives from existing STALE_HEARTBEAT_MS in src/crosslink/store.ts:19
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RepoAdminState {
+    Disconnected,
+    Booting,
+    Ready,
+    Stale,
+}
+
+pub const STALE_HEARTBEAT_MS: i64 = 120_000;
+
+pub fn derive_state(session: &CrosslinkSession, now_ms: i64) -> RepoAdminState {
+    let alive = is_pid_alive(session.pid);
+    let hb = parse_iso(&session.last_heartbeat).unwrap_or(0);
+    let hb_age = now_ms - hb;
+    if !alive || hb_age > STALE_HEARTBEAT_MS {
+        return RepoAdminState::Stale;
+    }
+    if session.ready_at.is_some() {
+        return RepoAdminState::Ready;
+    }
+    RepoAdminState::Booting
+}
+// Note: "disconnected" is decided at the channel level, not the session level —
+// it means "no CrosslinkSession exists for this repo assignment." The channel-
+// rendering layer calls derive_state only for repos with a session; absence
+// maps to disconnected directly.
+```
+
+### Pattern 2: Hook Generator + Install Wiring (extension of existing `src/crosslink/hook.ts`)
+**What:** TS generator emits a shell wrapper + Node script pair under `~/.relay/crosslink/hooks/` (existing convention). `rly install` writes the entry into both `~/.claude/settings.json` and `~/.codex/hooks.json` idempotently.
+**When to use:** Phase 4 SessionStart hook.
+**Example:**
+```ts
+// Source: src/crosslink/hook.ts generateHookScripts() — Phase 4 sibling.
+// The output node script for SessionStart:
+//   - reads stdin JSON (Claude/Codex schema is compatible)
+//   - resolves active channel (D-02): env RELAY_CHANNEL_ID OR cwd reverse lookup
+//   - loads CrosslinkSession records via direct fs read of crosslink-session/
+//   - derives state per repo, formats per D-03, prints to stdout
+//   - exit 0 on success, exit 0 on no-channel (graceful no-op)
+```
+
+### Pattern 3: Hook Output Shape — Plain Stdout + JSON Wrapper
+**What:** Both Claude Code and Codex accept either (a) raw stdout (treated as additional context) or (b) JSON with `hookSpecificOutput.additionalContext`. Phase 4 should emit raw stdout for simplicity — exit 0, multi-line context block. This works for both adapters with zero adapter-specific branching.
+**When to use:** SessionStart hook output.
+**Example:**
+```bash
+# Output to stdout (works for both Claude SessionStart and Codex SessionStart):
+[Relay] Channel: oauth-rollout (3 repos)
+  ● ui-repo       ready (admin: atlas-7f2)
+  ● backend-repo  ready (admin: atlas-3a1)
+  ○ sdk-repo      booting (since 2m ago)
+Feed: 4 new entries since you were last here. Use `rly status` for detail.
+```
+**Source:** `[CITED: code.claude.com/docs/en/hooks]` (Plain stdout reaches Claude for SessionStart), `[CITED: developers.openai.com/codex/hooks]` ("Plain text on stdout also gets added as 'extra developer context.'").
+
+### Pattern 4: Channel-First Resolution (D-02 cwd reverse lookup)
+**What:** Hook walks `listChannels()`, picks the channel whose `repoAssignments[].repoPath` is a prefix of `cwd` (or matches exactly). Tie-break: most-recently-touched channel (use `updatedAt`).
+**When to use:** Hook fires from a session with no `RELAY_CHANNEL_ID` (ad-hoc `rly claude`, user `claude` invocation).
+**Example:**
+```ts
+// Source: src/domain/channel.ts::Channel.repoAssignments[] (verified)
+function resolveActiveChannel(cwd: string, channels: Channel[]): Channel | null {
+  const candidates = channels.filter(c =>
+    c.status === "active" &&
+    (c.repoAssignments ?? []).some(ra =>
+      cwd === ra.repoPath || cwd.startsWith(ra.repoPath + "/")
+    )
+  );
+  if (candidates.length === 0) return null;
+  // Most-recently-updated wins on ties.
+  return candidates.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+}
+```
+
+### Anti-Patterns to Avoid
+
+- **Re-deriving state in each consumer.** Every surface must call the SAME `derive_state()` function. Embedding the if/else mapping in three places (TUI render, GUI Tauri cmd, hook node script) is the exact failure mode Phase 3's "alive ≠ ready" lesson teaches. The state-derivation function MUST live in `harness-data` and have an exact TS mirror.
+
+- **Hard-coding the `STALE_HEARTBEAT_MS` threshold in multiple places.** Today `src/crosslink/store.ts:19` has it. Phase 4 adds a Rust mirror. Both must reference the same value. Bumping it later requires changing one place; TS imports from a shared const file or the Rust const is documented as authoritative.
+
+- **Reading `crosslink-session/` through `CrosslinkStore.discoverSessions()`.** That method **auto-deregisters** sessions older than `STALE_HEARTBEAT_MS` (verified `src/crosslink/store.ts:265-268`: `if (stale) await this.deregisterSession(...)`). Phase 4 needs to OBSERVE `stale` state, not delete it. Use `load_crosslink_sessions()` from Rust (read-only, returns raw) or a new read-only TS sibling like `listSessionsRaw()`. **DO NOT call `discoverSessions()` from hook node script.**
+
+- **Hook output that looks like system instructions.** Per Claude Code docs: phrasing like "You MUST do X" can trigger prompt-injection defenses and surface the text to the user instead of injecting as context. Use factual statements: "Channel: oauth-rollout. SDK admin is booting." not "ATTENTION: SDK is booting, do not dispatch yet." `[CITED: code.claude.com/docs/en/hooks]`
+
+- **Blocking the hook on slow IO.** SessionStart fires on every session start/resume. The node script must read at most: `channel.json` (one channel × small file), `feed.jsonl` (last N lines), `crosslink-session/*.json` (small). Target: < 100ms wall-clock. Hook has 600s default timeout but the user perceives this as "Claude takes ages to start." Same fast-path as existing `check-messages.mjs`.
+
+- **Mutating disk in the hook.** The hook is a reader. Exception: `lastSeenFeedIdx` watermark (D-04) IS a write, but ONLY for the resolved active session. If write fails (permission, disk full), the hook still succeeds — watermark is best-effort.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| State derivation logic | Custom mapping in each surface | `derive_state()` in `harness-data` (Rust) + TS mirror in `src/domain/repo-admin-state.ts` | Phase 3's exact lesson: divergent definitions of "ready" ship a lying dashboard. |
+| SessionStart hook output formatting | Adapter-specific JSON shapes (one for Claude, one for Codex) | Plain stdout — both adapters treat stdout as additional context | Same plain-text output works for both adapters. Single formatter, single test surface. |
+| Reverse lookup `cwd → channel` | Custom prefix-matching with edge cases | Pattern in Pattern 4 above — `cwd.startsWith(ra.repoPath + "/")` with most-recent-updatedAt tie-break | Two-line predicate. Existing `Channel.repoAssignments[]` already has the data. |
+| `lastSeenFeedIdx` persistence | Sibling file `<sid>.watermark.json` | Optional field on `CrosslinkSession` with `#[serde(default)]` Rust + `.optional()` zod | Halves I/O. Back-compat is automatic. Drop the field entirely if it complicates Phase 4 — Phase 4 still ships honest state without "N new entries." |
+| Hook installation drift detection | Custom file-watcher or hash-check | Extend existing `~/.relay/installed.json` manifest (`src/install/manifest.ts`) with a `hooks: { claude: { sha }, codex: { sha } }` block | The pattern is `rly install --check` already (verified `src/install/manifest.ts:diffSurface`). Same shape for hook entries. |
+| State-color presentation logic | Re-implement per surface | Surface-specific renderer consumes the canonical state string — TUI uses `Style::default().fg(Color::Yellow)` for `Booting`; GUI uses CSS class `.state-booting`; hook prints `○` glyph | Per D-07 the color/glyph mapping IS per-surface; the STATE STRING is canonical. |
+| Process-liveness check | Custom `kill -0`-style probe in three places | Existing helpers: TS `isProcessAlive(pid)` (verified pattern in `src/crosslink/hook.ts:161-167`); Rust equivalent in `harness-data` (likely needs to be added — verify in plan-phase) | Borrow the TS impl pattern; the Rust impl is a `kill(pid, 0)` syscall via `nix` or a 4-line custom Unix helper. Already needed for the stale state. |
+
+**Key insight:** Phase 4 is a *composition* phase. Every primitive (readiness flag, channel structure, hook scaffolding, install manifest, channel feed) exists. The wins come from disciplined single-source-of-truth refactoring (state derivation lives in ONE place) and avoiding the temptation to "improve" things while passing through (no drive-by reformats per AGENTS.md).
+
+## Runtime State Inventory
+
+> Phase 4 is mostly additive — net-new code, net-new hook entries. There IS one rename / install-side runtime concern (hook entries in user config files outside the repo). Inventory below.
+
+| Category | Items Found | Action Required |
+|----------|-------------|------------------|
+| Stored data | None new. Phase 4 READS `~/.relay/crosslink-session/`, `channels/<id>/feed.jsonl`, `channels/<id>/channel.json` — all existing. Optionally WRITES `lastSeenFeedIdx` field on existing `CrosslinkSession` records (back-compat default). | If watermark adopted: add field with `#[serde(default)]` Rust + `.optional()` zod. Older session.json files deserialize cleanly. |
+| Live service config | **`~/.claude/settings.json`** — Phase 4 adds a `hooks.SessionStart` entry. Lives in user's home, NOT in git. `rly install` owns the write. **`~/.codex/hooks.json`** (or `[hooks]` in `~/.codex/config.toml`) — same. **`~/.codex/config.toml`** — Phase 4 must enable `[features].hooks = true` (Codex v0.130+). | `rly install` writes both files idempotently. `rly install --check` detects drift (user manually edited / removed). |
+| OS-registered state | None. Phase 4 does not register OS services, scheduled tasks, or daemons. | None. |
+| Secrets/env vars | None new. Phase 4 reads `RELAY_CHANNEL_ID` (set by Phase 3 spawner) and `RELAY_SESSION_ID`. No new env vars introduced. | None. |
+| Build artifacts | Phase 4 doesn't change the build. Hook scripts are generated at `rly install` time, not at `pnpm build` time. | None. |
+
+**Cross-version concern:** A user on Codex < v0.130 has no `SessionStart` hook surface. `rly install` should detect Codex version (best-effort: `codex --version` parsed for major-minor) and either skip Codex hook wiring with a warning OR write the config anyway (Codex < v0.130 will ignore the `[hooks]` block silently — verify). Recommend: write unconditionally, log a one-line note that Codex hooks need v0.130+, fail-soft.
+
+## Common Pitfalls
+
+### Pitfall 1: Lexical collision between `RepoAdminState = "ready"` and `RepoAdminSession._state = "ready"`
+**What goes wrong:** Phase 3 left a deferred follow-up: `RepoAdminSession._state` (process-spawn state, `src/orchestrator/repo-admin-session.ts:90`) uses the word "ready" to mean "process is spawned." Phase 4's new `RepoAdminState.ready` means "agent finished onboarding." Reading two pieces of code that use the same string for different concepts is a maintenance booby trap.
+**Why it happens:** Renaming `_state` to `_processState` was deferred from Phase 3 (Open Follow-up #1 in `03-SUMMARY.md`).
+**How to avoid:** Phase 4 should either:
+  - (a) Bundle the rename `_state → _processState` into Phase 4's first wave (mechanical, < 50 LOC per Phase 3 SUMMARY), OR
+  - (b) Defer the rename but add a clarifying comment block at `repo-admin-session.ts:90` distinguishing `_processState` (process spawn) from `RepoAdminState.ready` (agent assertion).
+  Recommended: **(a)** — Phase 4 introduces the four-state enum, so this is the moment to flatten the naming. The rename is non-behavioral; it's just `git grep _state` and rename.
+**Warning signs:** Reviewer asks "wait, which 'ready' is this?" in PR review.
+
+### Pitfall 2: Hook fires from a session OUTSIDE any channel
+**What goes wrong:** User runs `claude` in a directory that's not in any channel's `repoAssignments[]`. The hook resolves null. If the hook fails loudly, every non-Relay Claude session shows an error.
+**Why it happens:** Hook is registered globally in `~/.claude/settings.json`. It fires on every Claude session, not just Relay-spawned ones.
+**How to avoid:** Hook MUST exit 0 with empty stdout when no active channel resolves. This is the "graceful no-op" path called out in D-02. Existing `src/crosslink/hook.ts` already follows this pattern (line 98-100: `if (!mySession) process.exit(0)`). Mirror exactly.
+**Warning signs:** Any error message in stdout/stderr when running `claude` outside a Relay channel.
+
+### Pitfall 3: `CrosslinkStore.discoverSessions()` auto-deregisters stale sessions
+**What goes wrong:** Phase 4 wants to show `stale` repos as a distinct state. If the surface calls `discoverSessions()` to read sessions, stale ones get DELETED from disk before they're rendered (verified `src/crosslink/store.ts:265-268`).
+**Why it happens:** `discoverSessions()` was designed as a write-back cleanup helper, not a read-only enumerator.
+**How to avoid:** Phase 4 surfaces read RAW sessions via:
+  - Rust: `load_crosslink_sessions()` (no auto-cleanup; verified `crates/harness-data/src/lib.rs:633`).
+  - TS hook node script: direct fs read of `crosslink-session/*.json` (the existing hook already does this — verified `src/crosslink/hook.ts:71-96`).
+  Phase 4's `derive_state()` distinguishes alive-but-stale-heartbeat from dead-PID without ever calling `discoverSessions`.
+**Warning signs:** "Stale" state never observable in dashboards because sessions vanish as soon as they go stale.
+
+### Pitfall 4: `feed.jsonl` torn last line
+**What goes wrong:** Hook reads `feed.jsonl` for the "N new entries" count. If the file has a torn last line (concurrent appender mid-write), `JSON.parse` throws.
+**Why it happens:** `feed.jsonl` is append-only with `appendFile`. No fsync. A reader can observe a partial line during write.
+**How to avoid:** Follow existing tolerance pattern — `try/catch` per line, skip malformed lines. `ChannelStore.readFeed` already does this for the bulk read (verified `src/channels/channel-store.ts:658-682`, though it loads the whole file). For the hook's count-only path, count lines, attempt to parse last line, skip on error. Per Phase 1 design doc: "A torn last line is silently skipped by the Rust reader and recovers on the next render cycle." `[CITED: docs/design/context-threshold-events.md]`
+**Warning signs:** "Feed: N new entries" count occasionally off by one during heavy write traffic. Acceptable.
+
+### Pitfall 5: Codex `[features].hooks` feature flag not enabled by default
+**What goes wrong:** User has Codex installed but never enabled hooks; `rly install` writes `~/.codex/hooks.json` but Codex silently ignores it.
+**Why it happens:** Codex hooks are opt-in via `[features].hooks = true` in `~/.codex/config.toml` (legacy: `codex_hooks`, deprecated). `[CITED: developers.openai.com/codex/hooks, developers.openai.com/codex/config-reference]`
+**How to avoid:** `rly install` should also touch `~/.codex/config.toml` and ensure `[features].hooks = true` is present (idempotent merge — read the file, set the key, write back). Same pattern as writing hooks.json. Surface a one-line note in install output: "Enabled Codex hooks feature flag in ~/.codex/config.toml."
+**Warning signs:** `rly install --check` says Codex hook is installed but agents don't see the injected context.
+
+### Pitfall 6: SessionStart hook timeout — multi-second startup
+**What goes wrong:** Hook does too much IO (reads every channel JSON, every feed.jsonl, every session record), takes > 1 second, user perceives Claude/Codex as sluggish.
+**Why it happens:** Naive implementation: load all channels, scan all sessions, render context.
+**How to avoid:**
+  - Resolve active channel FIRST (one file read if `RELAY_CHANNEL_ID` is set, or one O(channels) scan).
+  - Read ONLY that channel's `channel.json` and `feed.jsonl` (tail).
+  - Read ONLY the `CrosslinkSession` records whose channel matches (via the `channelId` field on the record — verified `crates/harness-data/src/lib.rs:610` has `pub channel_id: Option<String>`).
+  - Target wall-clock: < 100ms. Existing crosslink hook is a useful reference for the IO budget.
+**Warning signs:** User says "Claude takes longer to start now."
+
+### Pitfall 7: Channel `status === "archived"` channels still listed
+**What goes wrong:** TUI/GUI top-level show every channel including archived ones. UX clutter.
+**Why it happens:** `listChannels()` returns all channels by default; takes optional `status` filter.
+**How to avoid:** Surfaces filter to `status === "active"` (per D-01 wording: "filtered by `status === 'active'` or similar"). PR-review DMs (`kind: "dm"`) are out of scope for Phase 4 rendering — defer to follow-up.
+**Warning signs:** Old archived channels clutter the project list.
+
+## Code Examples
+
+Verified patterns from existing code and official sources.
+
+### Hook node script — read CrosslinkSession records (existing pattern)
+```ts
+// Source: src/crosslink/hook.ts:60-96 (existing UserPromptSubmit hook).
+// Phase 4 SessionStart hook reuses this exact fs-read pattern.
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const RELAY_DIR = ${JSON.stringify(relayDir)};
+const SESSIONS_DIR = join(RELAY_DIR, "crosslink-session");
+
+async function loadSessionsForChannel(channelId: string) {
+  const sessions = [];
+  for (const file of await safeReaddir(SESSIONS_DIR)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = JSON.parse(await readFile(join(SESSIONS_DIR, file), "utf8"));
+      if (raw.channelId === channelId) sessions.push(raw);
+    } catch { /* skip malformed */ }
+  }
+  return sessions;
+}
+```
+
+### State derivation (TS mirror)
+```ts
+// Source: src/domain/repo-admin-state.ts (NEW — Phase 4).
+// Mirrors Rust enum + derive_state in crates/harness-data.
+export type RepoAdminState = "disconnected" | "booting" | "ready" | "stale";
+export const STALE_HEARTBEAT_MS = 120_000; // mirror of src/crosslink/store.ts:19
+
+export function deriveRepoAdminState(
+  session: { pid: number; lastHeartbeat: string; readyAt?: string | null } | null,
+  nowMs: number,
+  isProcessAlive: (pid: number) => boolean
+): RepoAdminState {
+  if (!session) return "disconnected";
+  const hb = new Date(session.lastHeartbeat).getTime();
+  const alive = isProcessAlive(session.pid);
+  if (!alive || nowMs - hb > STALE_HEARTBEAT_MS) return "stale";
+  if (session.readyAt) return "ready";
+  return "booting";
+}
+```
+
+### SessionStart hook output formatter (testable in isolation)
+```ts
+// Source: src/crosslink/session-start-hook-content.ts (NEW — Phase 4).
+// Pure formatter — no IO — so vitest can assert shape without fixtures.
+export interface RepoState {
+  alias: string;
+  state: RepoAdminState;
+  adminAlias?: string;            // "atlas-7f2"
+  bootingSinceMs?: number;        // wall-clock since session registered
+}
+
+export function formatSessionStartContext(input: {
+  channelName: string;
+  repoStates: RepoState[];
+  newFeedEntries?: number;        // optional (D-04 — droppable)
+}): string {
+  const lines: string[] = [];
+  lines.push(`[Relay] Channel: ${input.channelName} (${input.repoStates.length} repos)`);
+  for (const r of input.repoStates) {
+    const glyph = glyphFor(r.state);
+    const detail = detailFor(r);   // "(admin: atlas-7f2)" or "(since 2m ago)"
+    lines.push(`  ${glyph} ${r.alias.padEnd(14)} ${r.state}${detail ? " " + detail : ""}`);
+  }
+  if (input.newFeedEntries !== undefined && input.newFeedEntries > 0) {
+    lines.push(`Feed: ${input.newFeedEntries} new entries since you were last here. Use \`rly status\` for detail.`);
+  }
+  return lines.join("\n");
+}
+```
+
+### Claude SessionStart hook config write (extension of `rly install`)
+```ts
+// Source: src/cli/install.ts (extension — Phase 4).
+// Idempotent merge — preserves existing user-configured hooks.
+const claudeSettingsPath = join(homedir(), ".claude", "settings.json");
+const existing = await readJsonSafe(claudeSettingsPath, { hooks: {} });
+existing.hooks = existing.hooks ?? {};
+existing.hooks.SessionStart = existing.hooks.SessionStart ?? [];
+// Find Relay's entry (matcher tag we own) — replace or append.
+const relayMatcherTag = "relay-channel-readiness";
+existing.hooks.SessionStart = existing.hooks.SessionStart.filter(
+  (h: any) => h.matcher !== relayMatcherTag
+);
+existing.hooks.SessionStart.push({
+  matcher: relayMatcherTag,
+  hooks: [{ type: "command", command: sessionStartHookScriptPath, timeout: 30 }],
+});
+await writeJsonAtomic(claudeSettingsPath, existing);
+```
+
+### Codex SessionStart hook config write
+```ts
+// Source: src/cli/install.ts (Phase 4 sibling).
+// ~/.codex/hooks.json is the cleanest path — TOML edits are messier.
+const codexHooksPath = join(homedir(), ".codex", "hooks.json");
+const existing = await readJsonSafe(codexHooksPath, { hooks: {} });
+existing.hooks = existing.hooks ?? {};
+existing.hooks.SessionStart = existing.hooks.SessionStart ?? [];
+existing.hooks.SessionStart = existing.hooks.SessionStart.filter(
+  (h: any) => h.matcher !== relayMatcherTag
+);
+existing.hooks.SessionStart.push({
+  matcher: relayMatcherTag,
+  hooks: [{ type: "command", command: sessionStartHookScriptPath, timeout: 30 }],
+});
+await writeJsonAtomic(codexHooksPath, existing);
+
+// Also ensure [features].hooks = true in ~/.codex/config.toml (idempotent).
+await ensureCodexFeatureFlag("hooks", true);
+```
+
+### `rly status` channel-states block (extension of `print-status-context.ts`)
+```ts
+// Source: src/cli/print-status-context.ts (Phase 4 extension).
+// Mirrors formatActiveSessionsBlock — pure formatter taking pre-resolved rows.
+export function formatChannelStatesBlock(rows: ChannelStateRow[]): string {
+  if (rows.length === 0) return "";
+  const lines = ["Channels:"];
+  for (const ch of rows) {
+    lines.push(`- ${ch.name} (${ch.repos.length} repos)`);
+    for (const r of ch.repos) {
+      const detail = r.adminAlias ? ` admin=${r.adminAlias}` : "";
+      lines.push(`    ${r.alias.padEnd(12)} ${r.state}${detail}`);
+    }
+  }
+  return lines.join("\n");
+}
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Codex CLI without hooks | Codex CLI with `SessionStart` lifecycle event | v0.130 (May 8, 2026); v0.129 deprecated `codex_hooks` flag for `hooks` | **Enables four-surface parity for Phase 4.** Without v0.130, Codex would be hook-less and SURFACE-02 would document a gap. With v0.130, parity is achievable today. `[CITED: developers.openai.com/codex/hooks, agenticcontrolplane.com/blog/codex-cli-hooks-reference]` |
+| Claude Code SessionStart hooks display user-visible messages | Silent context injection via `hookSpecificOutput.additionalContext` | Claude Code 2.1.0+ | Phase 4 should NOT emit user-visible "Relay is reading channel state" notifications. Inject silently as context. `[CITED: code.claude.com/docs/en/hooks]` |
+| Phase 3's "alive ≠ ready" was an open question | Shipped primitive: `CrosslinkSession.readyAt` + `agent_ready` MCP tool + Rust mirror | Phase 3 (#216, 2026-05-09; SUMMARY #221) | Phase 4 has a stable contract to consume. |
+
+**Deprecated/outdated:**
+- `[features].codex_hooks = true` is deprecated as of Codex v0.129; use `[features].hooks = true`. Phase 4 install code must write the new key. `[CITED: developers.openai.com/codex/changelog]`
+- Pre-2.1 Claude Code hook patterns that printed user-visible messages are obsolete; SessionStart now silently injects context. `[CITED: code.claude.com/docs/en/hooks]`
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | Codex `SessionStart` hook accepts plain stdout as "extra developer context" (identical to Claude Code SessionStart). | Standard Stack, Pattern 3 | LOW — both official docs confirm. If wrong, fall back to JSON-only output. Single conditional in formatter. |
+| A2 | Codex hook stdin schema is approximately compatible with Claude's (both include `session_id`, `cwd`, `source` — verified per official docs). The hook node script should not need adapter-specific parsing. | Pattern 2 | LOW — verified in both docs. If stdin shapes diverge in field naming, the script just reads what it needs (`session_id` is universal) and ignores absent fields. |
+| A3 | Users on Codex < v0.130 will silently ignore the `[hooks]` config block without crashing. | Runtime State Inventory (cross-version concern) | MEDIUM — not verified. If Codex < v0.130 errors on unknown config, `rly install` needs version detection. **Recommend planner adds a `codex --version` probe in install step to surface a warning.** |
+| A4 | Storing `lastSeenFeedIdx` as an optional field on `CrosslinkSession` is the cleanest watermark shape. | Don't Hand-Roll, D-04 | LOW — back-compat is via `#[serde(default)]` + zod `.optional()`. Worst case the field is dropped before ship; Phase 4 still satisfies SURFACE-01..07 without the "N new entries" counter. |
+| A5 | The TS-side `isProcessAlive(pid)` pattern (`process.kill(pid, 0)`) generalizes to Rust via `nix::sys::signal::kill(pid, None)` or equivalent. | Pattern 1, Don't Hand-Roll | LOW — standard syscall. Likely there's already a Rust helper somewhere in `harness-data` or it's a 4-line addition. |
+| A6 | `Channel.updatedAt` is reliably maintained and usable for tie-breaking when cwd resolves to >1 channel. | Pattern 4 | LOW — `Channel.updatedAt` is verified in `src/domain/channel.ts:191`. `ChannelStore.touchChannel` keeps it fresh on writes (referenced in `channel-store.ts:55`). |
+| A7 | The four-state enum names (`disconnected | booting | ready | stale`) do not collide lexically with `src/lifecycle/session-lifecycle.ts` states (`planning | dispatching | winding_down | audit | done | killed`). | Common Pitfalls #1 | VERIFIED in research: zero overlap with `LifecycleState` enum. Slight conceptual proximity to `RepoAdminSession._state="ready"` (deferred follow-up). |
+
+## Open Questions (RESOLVED)
+
+> All five planner-facing open questions are resolved. The plans implement the decisions noted below. The duplicate `### Open Questions (planner-facing)` block that previously appeared near the end of this file has been merged into this section to keep a single source of truth.
+
+1. **Codex install version probe**
+   - **RESOLVED:** `spawnSync("codex", ["--version"], { timeout: 2000 })` in `rly install` (Plan 03 Task 3). On `ENOENT` or detected `<v0.130`, log a friendly one-line note ("Codex hooks require v0.130+; current: <version>; config will be written but inactive until upgrade") and WRITE the hook config anyway (fail-soft). Older Codex silently ignores unknown `[hooks]` blocks per assumption A3 — verified acceptable.
+   - What we know: Codex v0.130+ supports hooks; older versions ignore the config silently (assumption A3).
+   - What's unclear: behavior on Codex pre-v0.129 (when `[features].hooks` did not exist and `codex_hooks` was the flag). Some users may have Codex but never have run `--enable hooks`.
+   - Recommendation: `rly install` runs `codex --version`, parses, surfaces a one-line note if < v0.130, but writes the config anyway. Document the version requirement in the install output and the SUMMARY.
+
+2. **`rly project show <name>` vs `rly channel show <channelId>` vs extending `rly status`**
+   - **RESOLVED:** Ship BOTH `rly channel show <id|name>` (canonical, per D-01 channel-IS-project) AND `rly project show <id|name>` as an alias dispatching to the same handler (Plan 05 Task 2). ALSO extend `rly status` with a channel-roll-up block via `formatChannelStatesBlock` (Plan 05 Task 1). Alias equivalence is locked in Plan 05 Task 2 case 8 (unit-level dispatch import OR subprocess byte-identical stdout — see Plan 05).
+   - What we know: D-01 says channel IS the project. ROADMAP says `rly project show <name>` is the suggestion.
+   - What's unclear: which CLI surface the user actually reaches for. "rly status" is already cluttered with workspace + sessions + recent-runs blocks.
+   - Recommendation (for planner): introduce `rly channel show <channelId|name>` as the canonical drill-in; alias `rly project show <name>` to the same handler (deprecation-friendly — if "project" becomes a first-class entity later, `rly project show` already exists). Extend `rly status` minimally (just a channel-roll-up — one line per active channel summarizing repo states, no per-repo detail).
+
+3. **`_state → _processState` rename (bundle into Phase 4 or defer further)**
+   - **RESOLVED:** BUNDLE into Wave 1 / Plan 01 Task 3. The rename is mechanical (~50 LOC, `git grep _state` in `src/orchestrator/repo-admin-session.ts` and call sites). Lands in the same PR that introduces `RepoAdminState`, flattening the naming collision noted in Common Pitfalls #1 in a single change. Phase 3 Open Follow-up #1 closes.
+   - What we know: Phase 3 left `RepoAdminSession._state` ambiguously named; Phase 4's `RepoAdminState.ready` collides conceptually.
+   - What's unclear: whether the rename is best bundled with Phase 4's enum introduction or deferred to a standalone hygiene PR.
+   - Recommendation: bundle into Wave 1 — the enum landing is the right moment to fix the name.
+
+4. **Watermark cost-vs-value (D-04 droppable)**
+   - **RESOLVED:** IN — `lastSeenFeedIdx` ships in Phase 4 (Plan 02 Task 3). Shape: optional field `lastSeenFeedIdx?: number` on `CrosslinkSession` with `#[serde(default, skip_serializing_if = "Option::is_none")]` (Rust) + `.optional()` (zod). Monotonic write site via `CrosslinkStore.advanceFeedWatermark`. Total cost ~30 LOC; back-compat automatic. Hook (Plan 02 Task 2) emits the `Feed: N new entries` tail ONLY when a `mySession` record is found by matching `process.env.RELAY_SESSION_ID` — for user-launched (non-Relay-spawned) Claude/Codex sessions, the Feed tail is omitted entirely.
+   - What we know: Field-on-record adds minimal complexity (one optional field + one write site at the end of hook).
+   - What's unclear: whether the "N new entries since" line is noise or signal. The user's CONTEXT.md explicitly allows dropping it.
+   - Recommendation: ship the watermark in Phase 4. Cost is ~30 LOC (schema + write site + hook count logic). If reviewer pushes back, drop it without touching the rest of the plan.
+
+5. **cmux pane references in Phase 4 vs follow-up**
+   - **RESOLVED:** DEFER to follow-up — captured in 04-SUMMARY follow-ups list (Plan 05 Task 4). Phase 4 already covers 5 surfaces × state-derivation × dual-adapter hook install; cmux is a single-line "open external app" call that can land in a follow-up PR without touching any Phase 4 contract.
+   - What we know: ROADMAP mentions cmux integration; not in D-01..D-07 locked decisions.
+   - What's unclear: whether cmux is installed for most Relay users; how the "jump to pane" UX works without it.
+   - Recommendation: **defer cmux to a follow-up.** Phase 4 already has 5 surfaces × state-derivation × hook install — enough scope. cmux is a single-line "open external app" call that can land in a follow-up PR without touching any Phase 4 contracts.
+
+6. **State-derivation placement (Rust authoritative vs TS shim)** *(originally Q3; superseded by rename Q3 above — kept here for historical traceability)*
+   - **RESOLVED:** Rust authoritative + thin TS mirror. `crates/harness-data` owns `derive_state`; `src/domain/repo-admin-state.ts` mirrors via `deriveRepoAdminState` for the hook + CLI. Same-PR cross-dashboard rule applies (any change to either side requires the other in the same PR). Implemented in Plan 01.
+   - What we know: TUI and GUI both consume Rust. Hook node script and `rly status` consume TS. Both need the same logic.
+   - What's unclear: whether TS should call out to a Rust helper (via subprocess or wasm) or maintain its own mirror.
+   - Recommendation: maintain a thin TS mirror in `src/domain/repo-admin-state.ts` — keeps both surfaces fast (no IPC for hook), but the function is small enough that drift is rare. Same shape as Phase 3's pattern (CrosslinkSession exists in TS and Rust; updates land in same PR per AGENTS.md).
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| Node (runs generated hook script) | Hook node script | Assumed (existing convention; `src/crosslink/hook.ts:42` already checks `which node`) | — | Hook exits 0 with no output if node missing (existing pattern). |
+| `~/.claude/settings.json` | Claude SessionStart hook | Created by user when they install Claude Code | — | If file absent, `rly install` creates it with a `{ "hooks": { "SessionStart": [...] } }` skeleton. |
+| `~/.codex/hooks.json` (or config.toml) | Codex SessionStart hook | Created by Codex v0.130+ | v0.130+ | Skip Codex hook install with a clear warning if Codex < v0.130. |
+| Codex CLI v0.130+ | SURFACE-02 parity | User-dependent | — | Document the gap in `rly install --check` output. |
+| `process.kill(pid, 0)` for liveness check | State derivation (TS) | POSIX-standard | — | Existing pattern; already used in `src/crosslink/hook.ts:161-167`. |
+| Rust `kill(pid)` syscall for liveness check | State derivation (Rust) | Via `nix` or libc | — | Verify a Rust helper exists or add a 4-line wrapper. |
+| Existing `~/.relay/installed.json` manifest | Hook drift detection | Yes, created by `rly install` (#208) | schemaVersion: 1 | Bump schemaVersion to 2 OR add hooks block as additive (recommend additive). |
+
+**Missing dependencies with no fallback:** None. Every dependency has a graceful path.
+
+**Missing dependencies with fallback:**
+- Codex < v0.130 — install writes config anyway with a warning (assumption A3) or skips with a warning. Either is acceptable.
+
+## Validation Architecture
+
+> `workflow.nyquist_validation` is `false` in `.planning/config.json` — this section is intentionally minimal, but Phase 4 inherits the test conventions from AGENTS.md and Phases 1-3.
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | Vitest (TS) + cargo test (Rust) — existing per AGENTS.md |
+| Config file | `vitest.config.ts` (TS); per-crate `Cargo.toml` (Rust) |
+| Quick run command | `pnpm test <path-glob>` (TS) / `cargo test -p harness-data <name>` (Rust) |
+| Full suite command | `pnpm test && pnpm typecheck && pnpm build && cargo check --workspace --locked && cargo test --workspace` |
+
+### Phase 4 Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| SURFACE-01 | Hook output for a channel with mixed states | unit (pure formatter) | `pnpm test test/crosslink/session-start-hook-content.test.ts` | ❌ — to be added |
+| SURFACE-02 | Codex hook config written + feature flag set | unit (install path) | `pnpm test test/cli/install-session-start.test.ts` | ❌ — to be added |
+| SURFACE-03 | TUI renders state column | manual smoke + rust unit on derive_state | `cargo test -p harness-data derive_state` | ❌ — to be added |
+| SURFACE-04 | GUI renders state badge | manual smoke + frontend unit | `cd gui && pnpm test` | partial |
+| SURFACE-05 | `rly status` channel block | unit (pure formatter) | `pnpm test test/cli/print-status-context.test.ts` | partial — extend existing |
+| SURFACE-06 | Four states mutually exclusive | unit (derive_state truth table) | `cargo test -p harness-data derive_state` | ❌ — to be added |
+| SURFACE-07 | All surfaces read from disk on each render (no in-process cache) | review-time invariant + unit (no globals) | code review | N/A |
+| WORKER-06 | Worker rendering nested under admin (forward-compat) | unit on group_by_admin grouping shape | `cargo test -p harness-data group_by_admin` | ❌ — to be added |
+
+### Wave 0 Gaps
+- [ ] `test/crosslink/session-start-hook-content.test.ts` — covers SURFACE-01 (output formatter); pure functions, scripted mode.
+- [ ] `test/cli/install-session-start.test.ts` — covers SURFACE-02 (Claude + Codex install writes; idempotency on re-run; drift detection).
+- [ ] `test/cli/print-status-context.test.ts` — extend with `formatChannelStatesBlock` cases.
+- [ ] Rust tests in `crates/harness-data/src/lib.rs` for `derive_state`, `group_by_admin`, `RepoAdminState` serde round-trip.
+- [ ] Manual smoke (live `rly claude` + live `codex` invocation in a Relay channel) — recommend a 04-SUMMARY checkpoint per Phase 3 precedent.
+
+## Security Domain
+
+> `security_enforcement` is not explicitly set in `.planning/config.json` — treating as enabled per default. Phase 4 has limited security surface (no secrets, no network, local-only).
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | no | n/a (no auth surface) |
+| V3 Session Management | no | n/a |
+| V4 Access Control | partial | Hook reads `~/.relay/` — same file-system trust boundary as the rest of Relay. No new privilege escalation. |
+| V5 Input Validation | yes | Hook reads JSON on stdin (from Claude/Codex) — must parse defensively. Existing `try/catch` pattern in hook script is sufficient. |
+| V6 Cryptography | no | n/a (no crypto in Phase 4) |
+
+### Known Threat Patterns for Phase 4 stack
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Hook output interpreted as system instructions by the agent (prompt injection) | Tampering | Use factual phrasing per Claude Code docs guidance; never use imperative "you MUST" language. `[CITED: code.claude.com/docs/en/hooks]` |
+| Malicious `channel.json` triggers parse error in hook, crashes user's Claude session | Denial of Service | Existing pattern: `try/catch` per file; skip malformed; exit 0 always. Matches `src/crosslink/hook.ts:93-95`. |
+| Hook script path injection (user-supplied path in settings.json) | Tampering | `rly install` writes the canonical path; `--check` detects drift. User can manually edit but that's their own machine. |
+| Watermark write race (two hook invocations advance the same `lastSeenFeedIdx`) | Tampering | Atomic write via tmp+rename (existing pattern in `CrosslinkStore.updateHeartbeat`). Last-writer-wins is acceptable for a best-effort counter. |
+
+## Sources
+
+### Primary (HIGH confidence)
+- **Codex SessionStart hook docs** — `https://developers.openai.com/codex/hooks` — verified event list (`SessionStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `UserPromptSubmit`, `Stop`), I/O schema, plain-stdout-as-context, feature flag.
+- **Codex changelog / config reference** — `https://developers.openai.com/codex/changelog`, `https://developers.openai.com/codex/config-reference` — feature flag deprecation (`codex_hooks` → `hooks` at v0.129).
+- **Claude Code hooks docs** — `https://code.claude.com/docs/en/hooks` — verified SessionStart input/output, `additionalContext` 10K limit, 600s default timeout, four `source` values (`startup`, `resume`, `clear`, `compact`), silent injection since 2.1.0.
+- **Phase 3 SUMMARY** — `.planning/phases/03-repo-admin-readiness-handshake/03-SUMMARY.md` — confirmed disk shape, Rust read path, channel-feed event shape that Phase 4 consumes.
+- **Phase 3 PLAN** — `.planning/phases/03-repo-admin-readiness-handshake/03-PLAN.md` — explicit `<phase_handoff_contract>` declaring stability of `readyAt`, `load_crosslink_sessions()`, the `agent_ready` feed entry.
+- **Phase 1 design doc** — `docs/design/context-threshold-events.md` — schemaVersion conventions, torn-line tolerance pattern, Rust mirror pattern.
+- **Codebase** — `src/crosslink/hook.ts`, `src/cli/install.ts`, `src/domain/channel.ts`, `src/channels/channel-store.ts`, `src/lifecycle/session-lifecycle.ts`, `src/crosslink/store.ts`, `src/cli/print-status-context.ts`, `src/install/manifest.ts`, `crates/harness-data/src/lib.rs`, `.planning/codebase/ARCHITECTURE.md`, `.planning/codebase/STRUCTURE.md`, `.planning/codebase/INTEGRATIONS.md`, `AGENTS.md`.
+
+### Secondary (MEDIUM confidence)
+- **Agentic Control Plane "Codex CLI hook governance"** — `https://agenticcontrolplane.com/blog/codex-cli-hooks-reference` — corroborates feature-flag deprecation and stable-as-of-v0.130 timing.
+
+### Tertiary (LOW confidence)
+- None — primary sources covered all critical claims.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — Phase 4 stack is the existing repo + two hook config files (official-docs-verified).
+- Architecture: HIGH — pattern mirrors Phases 1 + 3; single Rust source of truth + thin TS mirror is the established convention.
+- Pitfalls: HIGH — pitfalls #1-#3 verified directly in code; pitfalls #4-#7 verified via existing patterns or official docs.
+- Codex hook parity: HIGH — verified in two official docs and one third-party reference.
+- `lastSeenFeedIdx` shape: MEDIUM — recommendation is reasonable but droppable per D-04; planner can revisit.
+- TUI / GUI navigation depth: LOW — left to planner per D-01 and Claude's Discretion #5. Research scoped this as out-of-scope to research deeply; the rendering work is mechanical given `derive_state()`.
+
+**Research date:** 2026-05-11
+**Valid until:** 2026-06-10 (30 days — Phase 4 is stable composition of shipped primitives; only risk is Codex CLI hook surface changes, which has been stable since v0.130 May 8, 2026).
+
+---
+
+## RESEARCH COMPLETE
+
+**Phase:** 4 - Project readiness surface
+**Confidence:** HIGH overall (one MEDIUM area: Codex < v0.130 behavior — recommend version probe in install step)
+
+### Key Findings (one-screen summary for planner)
+
+1. **Codex hook parity IS achievable today.** Codex CLI v0.130+ supports `SessionStart` with byte-compatible I/O to Claude Code: JSON stdin includes `session_id`, `cwd`, `source`; stdout (plain or JSON-wrapped) becomes additional context. Feature flag: `[features].hooks = true` (legacy `codex_hooks` deprecated v0.129). Config at `~/.codex/hooks.json` or `[hooks]` in `~/.codex/config.toml`. **No four-surface gap.** `rly install` writes both hook configs idempotently.
+
+2. **`derive_state(session, now) -> RepoAdminState` belongs in `crates/harness-data`.** Single source of truth for the four-state mapping; thin TS mirror in `src/domain/repo-admin-state.ts`. All four surfaces (hook, TUI, GUI, CLI) consume the same function. Constant `STALE_HEARTBEAT_MS = 120_000` already exists in `src/crosslink/store.ts:19` — Phase 4 mirrors it into Rust and removes the duplication.
+
+3. **CRITICAL pitfall #3: `CrosslinkStore.discoverSessions()` auto-deregisters stale sessions** (verified `src/crosslink/store.ts:265-268`). Phase 4 surfaces MUST read raw via `load_crosslink_sessions()` (Rust, no cleanup) or direct fs in the hook (TS) — otherwise the `stale` state is unobservable.
+
+4. **State enum naming has no lexical collisions.** `disconnected | booting | ready | stale` does NOT clash with `LifecycleState` enum (`planning | dispatching | winding_down | audit | done | killed` in `src/lifecycle/types.ts`). The minor `RepoAdminSession._state="ready"` proximity is a Phase 3 deferred follow-up — recommend bundling the rename `_state → _processState` into Phase 4 Wave 1 (~50 LOC, mechanical).
+
+5. **`lastSeenFeedIdx` (D-04 watermark): recommend field-on-`CrosslinkSession` with `#[serde(default)]` + `.optional()`.** Lowest I/O cost, back-compat automatic, droppable without schema churn. Phase 4 still ships honest state if the watermark is cut for scope.
+
+6. **Hook installation extends existing `rly install` manifest.** `src/install/manifest.ts` already handles drift for `cli`/`tui`/`gui` surfaces. Phase 4 adds a `hooks` block (additive — no schemaVersion bump needed). `rly install --check` reports drift when the user manually edits the hook entries.
+
+7. **Wave shape suggestion** (planner's call, four 4-PR phases per Phase 1-3 precedent):
+   - **PR-1 (scaffolds + tests RED, ≤150 LOC):** `RepoAdminState` enum in TS + Rust mirror + `derive_state` stub + test scaffolds. Optionally bundle the `_state → _processState` rename here.
+   - **PR-2 (state derivation GREEN, ≤200 LOC):** `derive_state` body + `group_by_admin` + tests GREEN in both TS and Rust.
+   - **PR-3 (hook generator + install wiring, ≤350 LOC):** new SessionStart hook generator following `src/crosslink/hook.ts` pattern; install writes Claude + Codex configs; drift detection in manifest.
+   - **PR-4 (TUI + GUI + CLI rendering, ≤400 LOC):** TUI state column; GUI state badge; `rly status` channel block; optional `rly channel show <id>` command.
+   - **PR-5 (manual smoke + 04-SUMMARY):** end-to-end live test with Claude AND Codex; document parity. Defer cmux integration explicitly.
+
+### File Created
+`/Users/jonathanlancaster/projects/agent-harness/.planning/phases/04-project-readiness-surface/04-RESEARCH.md`
+
+### Confidence Assessment
+| Area | Level | Reason |
+|------|-------|--------|
+| Standard Stack | HIGH | Composition of shipped primitives; hook surfaces verified in official docs |
+| Architecture | HIGH | Mirrors Phase 1 + Phase 3 patterns (Rust source of truth + TS mirror, same-PR cross-dashboard rule) |
+| Pitfalls | HIGH | All verified in code or official docs |
+| Codex hook parity (claude discretion #1) | HIGH | Two official sources + one third-party corroboration |
+| `rly project show` shape (claude discretion #2) | MEDIUM | Recommended `rly channel show` + alias, but planner picks |
+| Watermark shape (claude discretion #3) | MEDIUM | Recommended field-on-record, but droppable per D-04 |
+| State enum naming (claude discretion #4) | HIGH | Verified no `session-lifecycle.ts` collision |
+| State-derivation placement (claude discretion #5) | HIGH | Standard pattern in this codebase |
+| cmux integration (claude discretion #6) | MEDIUM | Recommend defer to follow-up — scope-control |
+
+### Open Questions (planner-facing)
+*(All five resolved; see `## Open Questions (RESOLVED)` above for the full decisions. Summary:)*
+1. Codex install version probe — RESOLVED: probe + write anyway (Plan 03).
+2. `rly channel show` vs `rly project show` — RESOLVED: both, alias to same handler (Plan 05).
+3. `_state → _processState` rename — RESOLVED: bundled into Wave 1 / Plan 01 Task 3.
+4. Watermark in or out — RESOLVED: IN, optional field on CrosslinkSession (Plan 02).
+5. cmux pane refs — RESOLVED: deferred to follow-up (Plan 05 SUMMARY).
+
+### Ready for Planning
+Research complete. Planner can now create PLAN.md. The four-surface contract is achievable with current primitives; no architectural shifts required. Recommended sequencing biases toward landing the shared `derive_state()` first so all four surfaces consume one canonical state-mapping function.
+
+Sources:
+- [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks)
+- [Codex Hooks Documentation](https://developers.openai.com/codex/hooks)
+- [Codex Config Reference](https://developers.openai.com/codex/config-reference)
+- [Codex CLI Changelog](https://developers.openai.com/codex/changelog)
+- [Codex CLI hook governance — Agentic Control Plane](https://agenticcontrolplane.com/blog/codex-cli-hooks-reference)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,12 +150,20 @@ This is also the surface that downstream work (slash commands, hook-based intent
 
 **Dependencies.** Phase 3 (readiness handshake — without it, the surface conflates alive with ready and lies to users).
 
-**Open questions for plan-phase.**
+**Plans:** 5 plans
 
-- Exact format of the hook-injected context (token budget vs information density).
-- Whether the hook also injects a diff since last turn (unread events) or only current state.
-- Whether "project" is an explicit first-class concept in `~/.relay/` already, or whether this phase needs to formalise it.
-- Codex hook surface parity with Claude Code's `SessionStart` — may differ; document the gap.
+- [ ] 04-01-PLAN.md — RepoAdminState enum (TS zod + Rust serde kebab-case), `derive_state` + `group_by_admin` in `harness-data`, `_state → _processState` rename closes Phase 3 follow-up #1.
+- [ ] 04-02-PLAN.md — SessionStart hook generator + pure formatter `formatSessionStartContext` + `lastSeenFeedIdx` watermark on CrosslinkSession.
+- [ ] 04-03-PLAN.md — `rly install` wires SessionStart hooks for Claude + Codex (idempotent merge, atomic rename); Codex `[features].hooks = true` via comment-preserving TOML helper; manifest `hooks` block + drift detection.
+- [ ] 04-04-PLAN.md — TUI state column on channel drill-in; GUI Tauri command `load_repo_admin_states` + `load_channel_admins_grouped` (WORKER-06 forward-compat); React state-badge row with D-07 CSS classes.
+- [ ] 04-05-PLAN.md — `rly status` channel-states block + `rly channel show <id|name>` subcommand + `rly project show` alias + manual smoke checkpoint + 04-SUMMARY.
+
+**Open questions answered in plan-phase.**
+
+- Hook context shape — terse 5-15 line snapshot per D-03; pure formatter testable in isolation.
+- Snapshot only — no diff machinery; optional `Feed: N new entries` count via per-session `lastSeenFeedIdx` watermark.
+- "Project" is NOT a new entity — channel IS the project per D-01.
+- Codex hook parity — VERIFIED achievable via Codex CLI v0.130+; `rly install` writes config unconditionally and logs a friendly note on older versions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds RESEARCH.md, PATTERNS.md, and 5 PLAN.md files for Phase 4 (project-readiness-surface).
- All 8 phase REQ-IDs covered: SURFACE-01..07 + WORKER-06.
- Verification passed after one revision pass (resolved 2 blockers + 4 warnings from the plan-checker).

## Wave structure

| Wave | Plan | depends_on | Notes |
|------|------|------------|-------|
| 1 | 04-01 state contract | — | `RepoAdminState` (TS + Rust), `derive_state`, `group_by_admin`, `_state → _processState` rename |
| 2 | 04-02 hook + watermark | [01] | SessionStart hook generator, `formatSessionStartContext`, optional `lastSeenFeedIdx` |
| 2 | 04-04 TUI + GUI render | [01] | Parallel with 02 — different file sets. State column / state badge with `group_by_admin` forward-compat for workers |
| 3 | 04-03 install wiring | [02] | `rly install` writes Claude + Codex hook configs; manifest `hooks` block with drift detection |
| 5 | 04-05 CLI + smoke + SUMMARY | [01,02,03,04] | `rly status` channel block, `rly channel show` + `rly project show` alias, manual smoke checkpoint, 04-SUMMARY |

## Open-question resolutions (recorded in 04-RESEARCH.md `## Open Questions (RESOLVED)`)

1. **Codex install version probe** — fail-soft: write config anyway; log friendly note on `<v0.130` or `codex` not on PATH.
2. **`rly project show` vs `rly channel show`** — ship both; `channel show` is canonical (per D-01: channel IS the project), `project show` is an alias to the same handler. Also extends `rly status` with a channel-roll-up block.
3. **`_state → _processState` rename** — bundled into Wave 1 / Plan 01 Task 3 (resolves Phase 3 follow-up #1 and avoids lexical collision with `RepoAdminState.ready`).
4. **`lastSeenFeedIdx` watermark** — in, as optional `#[serde(default)]` field on `CrosslinkSession`. `Feed:` tail rendering is gated on a real session record (omitted for user-launched non-Relay sessions, so the count is signal not noise).
5. **cmux pane refs** — deferred to follow-up; captured in 04-SUMMARY follow-ups.

## Key guardrails enforced across plans

- **No `discoverSessions()` read paths** — every surface uses raw `load_crosslink_sessions()` (Rust) or direct fs read (TS). Stale state must be observable; `discoverSessions()` auto-deregisters stale records.
- **D-06 enum vocabulary parity** — `disconnected | booting | ready | stale` strings are byte-identical across hook output, TUI column, GUI badge, CLI text.
- **WORKER-06 forward-compat** — both TUI and GUI cache `Vec<AdminWithWorkers>` and iterate `admin → admin.workers`; Phase 5 worker rendering needs no code change in Phase 4 surfaces.
- **Three-dashboard rule** — no in-process IPC between TUI/GUI/CLI; all read `~/.relay/`.
- **Hook graceful no-op** — `process.exit(0)` with empty stdout when no channel resolves (D-02).
- **D-07 visual contract** — muted ready, emphasized exceptions (booting=yellow, stale=red, disconnected=dim).

## Test plan

- [ ] Review 04-RESEARCH.md and confirm the 5 RESOLVED decisions still match your intent.
- [ ] Review 04-PATTERNS.md analog file:line refs for accuracy.
- [ ] Skim each 04-0N-PLAN.md frontmatter for correctness (wave / depends_on / requirements / files_modified).
- [ ] Confirm ROADMAP.md Phase 4 section matches the wave structure above.
- [ ] After merge, `/clear` and run `/gsd-execute-phase 04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)