### PR TITLE
docs(readme): add "Compared to alternatives" table

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Relay turns a sentence, a GitHub issue URL, or a Linear ticket into a **running 
 
 Suitable for individual developers and teams. CLI: **`rly`**.
 
+## Compared to alternatives
+
+|                      | Relay | aider | Devin | Cursor  | claude-flow |
+| -------------------- | ----- | ----- | ----- | ------- | ----------- |
+| Local-first          | ✅    | ✅    | ❌    | partial | ✅          |
+| Multi-repo           | ✅    | ❌    | ❌    | partial | ✅          |
+| Supervises long runs | ✅    | ❌    | ✅    | partial | partial     |
+| Uses your Claude CLI | ✅    | ❌    | ❌    | ❌      | ✅          |
+| No hosted service    | ✅    | ✅    | ❌    | ❌      | ✅          |
+
+A few rows need an asterisk. Cursor 3 (April 2026) introduced local agents that can span multiple repos, but the promoted default — cloud agents — still runs in Cursor-owned VMs and is single-repo today. claude-flow has the `github-multi-repo` skill and a token cost tracker, but its long-run budget caps are advisory rather than hard wall-clock stops. Devin's cloud agent supports cross-repo work in principle, but the session model is one task per VM, not parallel orchestration across repos.
+
+Relay sits next to these tools, not against them. Use Cursor or aider for the inner editing loop and Relay for the outer coordination loop across repos — because Relay shells your existing Claude or Codex CLI, your editor agent and your orchestrator can share the same provider session. The table above is where Relay is differentiated, not where it competes; most users on this list run two of these tools side by side.
+
 ## Use cases
 
 Where Relay earns its keep today:
@@ -62,6 +76,7 @@ Where Relay earns its keep today:
 
 ## Table of contents
 
+- [Compared to alternatives](#compared-to-alternatives)
 - [Install](#install)
   - [Install prerequisites (platform notes)](#install-prerequisites-platform-notes)
 - [Quickstart](#quickstart)

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Suitable for individual developers and teams. CLI: **`rly`**.
 
 ## Compared to alternatives
 
-|                      | Relay | aider | Devin | Cursor  | claude-flow |
-| -------------------- | ----- | ----- | ----- | ------- | ----------- |
-| Local-first          | ✅    | ✅    | ❌    | partial | ✅          |
-| Multi-repo           | ✅    | ❌    | ❌    | partial | ✅          |
-| Supervises long runs | ✅    | ❌    | ✅    | partial | partial     |
-| Uses your Claude CLI | ✅    | ❌    | ❌    | ❌      | ✅          |
-| No hosted service    | ✅    | ✅    | ❌    | ❌      | ✅          |
+|                            | Relay | aider | Devin | Cursor  | claude-flow |
+| -------------------------- | ----- | ----- | ----- | ------- | ----------- |
+| Local-first                | ✅    | ✅    | ❌    | partial | ✅          |
+| Multi-repo                 | ✅    | ❌    | ❌    | partial | ✅          |
+| Supervises long runs       | ✅    | ❌    | ✅    | partial | partial     |
+| Uses your Claude/Codex CLI | ✅    | ❌    | ❌    | ❌      | ✅ (Claude) |
+| No hosted service          | ✅    | ✅    | ❌    | ❌      | ✅          |
 
-A few rows need an asterisk. Cursor 3 (April 2026) introduced local agents that can span multiple repos, but the promoted default — cloud agents — still runs in Cursor-owned VMs and is single-repo today. claude-flow has the `github-multi-repo` skill and a token cost tracker, but its long-run budget caps are advisory rather than hard wall-clock stops. Devin's cloud agent supports cross-repo work in principle, but the session model is one task per VM, not parallel orchestration across repos.
+A few rows need an asterisk. Cursor 3 (April 2026) introduced local agents that can span multiple repos and earned the multi-repo partial; the promoted default — cloud agents — still runs in Cursor-owned VMs and is single-repo today. Cursor's long-run partial sits in the same gap: cloud agents support unattended runs with handoff, but local agents have no documented budget caps. claude-flow has the `github-multi-repo` skill and a token cost tracker, but its long-run budget caps are advisory rather than hard wall-clock stops. Devin's cloud agent supports cross-repo work in principle, but the session model is one task per VM, not parallel orchestration across repos. Relay's ✅ for long-run supervision rests on `--max-hours` wall-clock + `--budget-tokens` token caps + a STOP-file kill switch — the hard stops claude-flow's advisory caps miss; per-dollar cost tracking is still in design (see [Known limits](#known-limits)).
 
 Relay sits next to these tools, not against them. Use Cursor or aider for the inner editing loop and Relay for the outer coordination loop across repos — because Relay shells your existing Claude or Codex CLI, your editor agent and your orchestrator can share the same provider session. The table above is where Relay is differentiated, not where it competes; most users on this list run two of these tools side by side.
 


### PR DESCRIPTION
## Summary

Closes #140.

Adds a 5-row comparison table right after the "What Relay is" pitch, covering Relay vs aider, Devin, Cursor, and claude-flow on the five dimensions HN / Reddit readers consistently ask about: local-first, multi-repo, long-run supervision, Claude/Codex CLI reuse, and hosted-service status.

|                            | Relay | aider | Devin | Cursor  | claude-flow |
| -------------------------- | ----- | ----- | ----- | ------- | ----------- |
| Local-first                | ✅    | ✅    | ❌    | partial | ✅          |
| Multi-repo                 | ✅    | ❌    | ❌    | partial | ✅          |
| Supervises long runs       | ✅    | ❌    | ✅    | partial | partial     |
| Uses your Claude/Codex CLI | ✅    | ❌    | ❌    | ❌      | ✅ (Claude) |
| No hosted service          | ✅    | ✅    | ❌    | ❌      | ✅          |

## Notes

- Cells were verified against current docs / source rather than guessed.
- Cursor 3 (April 2026) shipped local agents with multi-repo support, so several Cursor cells are "partial" rather than ❌; the asterisk paragraph explains each one (multi-repo, long-run).
- claude-flow earns a ✅ on multi-repo because of its `github-multi-repo` skill, but stays "partial" on long-run supervision because its budget caps are advisory rather than hard wall-clock stops.
- Devin's cell wording acknowledges its cloud-agent model supports cross-repo work in principle but runs one task per VM.
- Relay's ✅ for long-run supervision is defended explicitly: `--max-hours`, `--budget-tokens`, and the STOP-file kill switch as hard stops. Per-dollar cost tracking is still in design and links to the Known limits section.
- Includes a complementary-not-adversarial framing paragraph: most users on this list run two of these tools side by side (Cursor or aider as the inner editing loop, Relay as the outer coordination loop), and because Relay shells the user's Claude / Codex CLI, the editor agent and the orchestrator can share the same provider session.
- TOC entry added for the new section.

## Test plan

- [ ] README renders cleanly on GitHub (table layout, anchors, no broken links)
- [ ] TOC link `#compared-to-alternatives` jumps to the new section
- [ ] In-paragraph link `[Known limits](#known-limits)` resolves
- [ ] `pnpm format:check` passes locally (verified)
- [ ] CI green