### PR TITLE
feat(cost): per-model USD pricing table + costUsd() [PR 1/4]

### DIFF
--- a/src/domain/model-pricing.ts
+++ b/src/domain/model-pricing.ts
@@ -1,0 +1,127 @@
+import type { TokenUsage } from "./agent.js";
+
+/**
+ * Hard-coded per-model USD pricing as of 2026-07-08. Prices are USD per
+ * *million* tokens, split by token class so cache reads/writes bill at their
+ * own rate (they occupy the window but cost far less than fresh input).
+ *
+ * Sources:
+ *   - Claude: anthropic.com/pricing (Opus 4.7 / Sonnet 4.5 / Haiku 3.5 tiers)
+ *   - OpenAI: openai.com/api/pricing (gpt-5 / o3-mini)
+ *
+ * Keys MUST match {@link ./model-context-windows.ts MODEL_CONTEXT_WINDOWS} so
+ * a model that has a context window also has a price. When a model ships, add
+ * it in BOTH tables in the same PR. Missing keys fall back to zero-cost with a
+ * one-line stderr warning (deduped per process) — we never crash a run over a
+ * pricing gap, but we make the gap loud so the cost report isn't silently
+ * under-counting.
+ *
+ * Unlike the context-window table, this is NOT mirrored into the GUI / Rust
+ * crate: no dashboard consumes USD yet. The cost surface is TS-only (`rly
+ * cost`). If a dashboard later renders USD, mirror this the same way
+ * `MODEL_CONTEXT_WINDOWS` is mirrored (with a drift-guard test).
+ */
+export interface ModelPrice {
+  /** USD per 1M fresh input tokens. */
+  inputPerMTok: number;
+  /** USD per 1M output tokens. */
+  outputPerMTok: number;
+  /** USD per 1M cache-read tokens (cheaper than fresh input). */
+  cacheReadPerMTok: number;
+  /** USD per 1M cache-write tokens (a premium over fresh input). */
+  cacheWritePerMTok: number;
+}
+
+export const MODEL_PRICING: Record<string, ModelPrice> = {
+  "claude-opus-4-7": {
+    inputPerMTok: 15,
+    outputPerMTok: 75,
+    cacheReadPerMTok: 1.5,
+    cacheWritePerMTok: 18.75,
+  },
+  "claude-sonnet-4-5": {
+    inputPerMTok: 3,
+    outputPerMTok: 15,
+    cacheReadPerMTok: 0.3,
+    cacheWritePerMTok: 3.75,
+  },
+  "claude-haiku-3-5": {
+    inputPerMTok: 0.8,
+    outputPerMTok: 4,
+    cacheReadPerMTok: 0.08,
+    cacheWritePerMTok: 1,
+  },
+  "gpt-5": {
+    inputPerMTok: 1.25,
+    outputPerMTok: 10,
+    cacheReadPerMTok: 0.125,
+    cacheWritePerMTok: 1.25,
+  },
+  "o3-mini": {
+    inputPerMTok: 1.1,
+    outputPerMTok: 4.4,
+    cacheReadPerMTok: 0.55,
+    cacheWritePerMTok: 1.1,
+  },
+};
+
+const PER_MTOK = 1_000_000;
+
+const warnedModels = new Set<string>();
+
+/**
+ * USD cost of a single call's {@link TokenUsage} for `modelName`.
+ *
+ * Cache accounting mirrors the adapter normalizers (research Q3): the
+ * adapters fold cache-read + cache-write into `inputTokens`, but ALSO surface
+ * the breakdown on `cacheReadTokens` / `cacheWriteTokens`. To avoid
+ * double-charging, the cache tokens are subtracted out of `inputTokens` and
+ * billed at their own (cheaper) rate; whatever remains is fresh input. When
+ * the adapter didn't surface a breakdown, the whole `inputTokens` bills as
+ * fresh input — a conservative over-estimate, never an under-count.
+ *
+ * Unknown / missing models return 0 and emit a one-line `[cost]` stderr
+ * warning (deduped per process), matching `resolveContextWindow`'s
+ * fail-loud-but-don't-crash discipline.
+ */
+export function costUsd(modelName: string | undefined | null, usage: TokenUsage): number {
+  if (!modelName) {
+    warnUnknown("<missing>");
+    return 0;
+  }
+  const price = MODEL_PRICING[modelName];
+  if (!price) {
+    warnUnknown(modelName);
+    return 0;
+  }
+
+  const cacheRead = usage.cacheReadTokens ?? 0;
+  const cacheWrite = usage.cacheWriteTokens ?? 0;
+  // `inputTokens` already includes cache tokens; peel them off so each class
+  // bills once. Clamp at 0 in case an adapter reports cache tokens that
+  // exceed the folded input total.
+  const freshInput = Math.max(0, usage.inputTokens - cacheRead - cacheWrite);
+
+  const cost =
+    (freshInput * price.inputPerMTok +
+      usage.outputTokens * price.outputPerMTok +
+      cacheRead * price.cacheReadPerMTok +
+      cacheWrite * price.cacheWritePerMTok) /
+    PER_MTOK;
+
+  return cost;
+}
+
+function warnUnknown(modelName: string): void {
+  if (warnedModels.has(modelName)) return;
+  warnedModels.add(modelName);
+  console.warn(
+    `[cost] No pricing for model "${modelName}"; billing this model's calls as $0. ` +
+      `Add it to MODEL_PRICING (src/domain/model-pricing.ts) to fix cost totals.`
+  );
+}
+
+/** Test helper — reset the per-process dedup cache so warnings re-fire. */
+export function __resetPricingWarnedForTests(): void {
+  warnedModels.clear();
+}

--- a/src/domain/model-pricing.ts
+++ b/src/domain/model-pricing.ts
@@ -70,6 +70,24 @@ const PER_MTOK = 1_000_000;
 const warnedModels = new Set<string>();
 
 /**
+ * Strip the release-date suffix off a model ID.
+ *
+ * The tables above are keyed on undated names (`claude-sonnet-4-5`), but the
+ * Claude CLI reports the *dated* ID it actually ran
+ * (`claude-sonnet-4-5-20250929`) in its `system`/`result` events. Without this,
+ * the exact-match lookup in {@link costUsd} misses on every real run and bills
+ * $0 — which is the whole thing the cost surface exists to prevent. Dates are
+ * an addressing detail, not a pricing dimension: Anthropic prices a model, not
+ * a snapshot of it.
+ *
+ * Anything without a trailing `-YYYYMMDD` passes through untouched, so undated
+ * IDs (what `CliAgentBase` tags calls with) still resolve.
+ */
+export function normalizeModelId(modelName: string): string {
+  return modelName.replace(/-\d{8}$/, "");
+}
+
+/**
  * USD cost of a single call's {@link TokenUsage} for `modelName`.
  *
  * Cache accounting mirrors the adapter normalizers (research Q3): the
@@ -89,8 +107,10 @@ export function costUsd(modelName: string | undefined | null, usage: TokenUsage)
     warnUnknown("<missing>");
     return 0;
   }
-  const price = MODEL_PRICING[modelName];
+  const price = MODEL_PRICING[normalizeModelId(modelName)];
   if (!price) {
+    // Warn on the ID as given, not the normalized one — the raw string is what
+    // the operator has to go look for.
     warnUnknown(modelName);
     return 0;
   }

--- a/test/domain/model-pricing.test.ts
+++ b/test/domain/model-pricing.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MODEL_PRICING,
+  __resetPricingWarnedForTests,
+  costUsd,
+} from "../../src/domain/model-pricing.js";
+import { MODEL_CONTEXT_WINDOWS } from "../../src/domain/model-context-windows.js";
+
+describe("model-pricing", () => {
+  afterEach(() => {
+    __resetPricingWarnedForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("has a price for every model with a context window (tables stay in lockstep)", () => {
+    for (const model of Object.keys(MODEL_CONTEXT_WINDOWS)) {
+      expect(MODEL_PRICING[model], `missing pricing for ${model}`).toBeDefined();
+    }
+  });
+
+  it("bills fresh input + output at the model's per-MTok rate", () => {
+    // Opus 4.7: $15/MTok input, $75/MTok output.
+    const cost = costUsd("claude-opus-4-7", {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(15 + 75, 6);
+  });
+
+  it("peels cache tokens out of inputTokens and bills them at the cache rate", () => {
+    // inputTokens folds in cache tokens (research Q3). 1M input of which
+    // 800k is cache-read → 200k fresh input @ $3 + 800k cache-read @ $0.3.
+    const cost = costUsd("claude-sonnet-4-5", {
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheReadTokens: 800_000,
+    });
+    const expected = (200_000 * 3 + 800_000 * 0.3) / 1_000_000;
+    expect(cost).toBeCloseTo(expected, 6);
+  });
+
+  it("bills cache-write at its premium rate", () => {
+    const cost = costUsd("claude-sonnet-4-5", {
+      inputTokens: 100_000,
+      outputTokens: 0,
+      cacheWriteTokens: 100_000,
+    });
+    // All 100k is cache-write → 0 fresh input, 100k @ $3.75/MTok.
+    expect(cost).toBeCloseTo((100_000 * 3.75) / 1_000_000, 6);
+  });
+
+  it("clamps fresh input at 0 when cache tokens exceed the folded total", () => {
+    const cost = costUsd("claude-haiku-3-5", {
+      inputTokens: 500,
+      outputTokens: 0,
+      cacheReadTokens: 1_000,
+    });
+    // freshInput clamps to 0; only the 1000 cache-read tokens bill.
+    expect(cost).toBeCloseTo((1_000 * 0.08) / 1_000_000, 6);
+  });
+
+  it("returns 0 and warns once for an unknown model", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+
+    expect(costUsd("some-future-model", usage)).toBe(0);
+    expect(costUsd("some-future-model", usage)).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("some-future-model");
+  });
+
+  it("returns 0 and warns for a missing model name", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(costUsd(undefined, { inputTokens: 100, outputTokens: 100 })).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/domain/model-pricing.test.ts
+++ b/test/domain/model-pricing.test.ts
@@ -4,6 +4,7 @@ import {
   MODEL_PRICING,
   __resetPricingWarnedForTests,
   costUsd,
+  normalizeModelId,
 } from "../../src/domain/model-pricing.js";
 import { MODEL_CONTEXT_WINDOWS } from "../../src/domain/model-context-windows.js";
 
@@ -58,6 +59,37 @@ describe("model-pricing", () => {
     });
     // freshInput clamps to 0; only the 1000 cache-read tokens bill.
     expect(cost).toBeCloseTo((1_000 * 0.08) / 1_000_000, 6);
+  });
+
+  it("prices a DATED model ID the same as its undated name", () => {
+    // The Claude CLI reports the dated ID it actually ran. MODEL_PRICING is
+    // keyed on undated names. Before normalization this lookup missed and
+    // every executor-path call billed $0 — the exact under-count the cost
+    // surface exists to prevent.
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    expect(costUsd("claude-sonnet-4-5-20250929", usage)).toBeCloseTo(3 + 15, 6);
+    expect(costUsd("claude-sonnet-4-5-20250929", usage)).toBeCloseTo(
+      costUsd("claude-sonnet-4-5", usage),
+      6
+    );
+  });
+
+  it("does not warn for a dated ID of a known model", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    costUsd("claude-opus-4-7-20250514", { inputTokens: 100, outputTokens: 100 });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("normalizeModelId only strips a trailing 8-digit date", () => {
+    expect(normalizeModelId("claude-sonnet-4-5-20250929")).toBe("claude-sonnet-4-5");
+    expect(normalizeModelId("claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
+    // Version segments are not dates — must survive untouched, or `gpt-5`-style
+    // names with numeric tails would be mangled into a miss.
+    expect(normalizeModelId("gpt-5")).toBe("gpt-5");
+    expect(normalizeModelId("o3-mini")).toBe("o3-mini");
+    // Too short / too long to be YYYYMMDD.
+    expect(normalizeModelId("model-1234567")).toBe("model-1234567");
+    expect(normalizeModelId("model-123456789")).toBe("model-123456789");
   });
 
   it("returns 0 and warns once for an unknown model", () => {


### PR DESCRIPTION
## What

First of 4 stacked PRs adding **end-to-end per-task cost tracking** and cost-aware model routing to Relay. This PR lands the pricing primitive everything else reads.

- `src/domain/model-pricing.ts` — `MODEL_PRICING` (USD per MTok, split into input / output / cache-read / cache-write) keyed to match `MODEL_CONTEXT_WINDOWS`, plus `costUsd(model, tokenUsage)`.
- `costUsd` peels cache tokens out of the folded `inputTokens` (adapters fold cache-read/write into `inputTokens` per research Q3) so each token class bills exactly once; clamps fresh input at 0 defensively.
- Unknown/missing models bill **$0 with a deduped `[cost]` stderr warning** — same fail-loud-don't-crash discipline as `resolveContextWindow`.

## Why TS-only (no GUI/Rust mirror)

Unlike `MODEL_CONTEXT_WINDOWS`, no dashboard consumes USD yet — the cost surface is `rly cost` (PR 3). Documented in the file header so the missing mirror reads as intentional, not forgotten.

## Test

`test/domain/model-pricing.test.ts` — 7 tests: table lockstep with context-window keys, input/output billing, cache peel-off, cache-write premium, clamp, unknown-model $0 + single warn. `tsc` clean, prettier clean.

## Stack

This is **PR 1/4**. Follow-ups (each its own PR, stacked):
2. Thread `tokenUsage` through the executor path (`ExecutionResult`).
3. Per-task cost ledger (`~/.relay/task-costs.jsonl`) + `rly cost` report by `ComplexityTier`.
4. Cost-aware model routing (measured cost-per-task, price-table fallback at cold-start, N=5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)