### PR TITLE
feat(cost): cost-aware model routing by measured cost-per-task [PR 4/4]

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -113,6 +113,18 @@ rly channel set-provider <channelId> clear         # inherit default / HARNESS_P
 
 The GUI exposes the same surface: Settings drawer → About → Provider dropdown on each channel, and a Providers tab in the global Settings page for full CRUD.
 
+## Cost-aware model routing (opt-in)
+
+By default each run uses one model (the profile's `defaultModel` or `--model`). Set `RELAY_COST_ROUTING=1` to let the orchestrator pick the model per task instead:
+
+```bash
+export RELAY_COST_ROUTING=1
+```
+
+When on, each task routes to the model with the lowest **measured cost-per-task** for its complexity tier — read from the per-task cost ledger (`~/.relay/task-costs.jsonl`, see `rly cost`). Until a tier has ≥ 5 measured tasks, it falls back to the cheapest **headline per-token price**. Candidates are the active provider's tier family (Claude: haiku → sonnet → opus; Codex: o3-mini → gpt-5).
+
+It's opt-in because routing across a tier family assumes your auth covers **all** of those models. If you only have access to one, leave it off (or the routed model will fail to spawn). The chosen model is recorded on each `AgentDispatched` event (`model` field) so `rly` surfaces show what actually ran.
+
 ## GitHub Projects v2 auth
 
 The v0.2 GitHub Projects v2 integration ([`docs/trackers.md`](./trackers.md)) reuses the **existing GitHub auth surface** — no new token, no new env var. The classifier and the sync worker both pick `GITHUB_TOKEN` up at the entry boundary (URL paste, scheduled tick) and pass it down to the GraphQL client through the classifier deps bag (`ProjectsClientDeps` in `src/integrations/github-projects/client.ts`). Internal callers never read the env var directly — they receive it as an explicit dependency, which keeps the integration testable without touching `process.env`.

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -280,15 +280,18 @@ abstract class CliAgentBase implements Agent {
   }
 
   async run(request: WorkRequest) {
-    const response = await this.invokeProvider(buildPrompt(this.name, request));
+    // Per-call routed model (cost-aware router) wins over the statically
+    // configured model; fall back to `this.model` when routing is off.
+    const effectiveModel = request.model ?? this.model;
+    const response = await this.invokeProvider(buildPrompt(this.name, request), effectiveModel);
 
     return {
       ...response.parsed,
       rawResponse: response.rawResponse,
-      // Tag the result with the configured model so per-task cost accounting
-      // can price the call. Omitted when the agent has no model pinned (the
-      // call then bills at $0 with a `[cost]` warning).
-      ...(this.model ? { model: this.model } : {}),
+      // Tag the result with the model that actually ran so per-task cost
+      // accounting prices the call. Omitted when neither routing nor config
+      // pinned a model (the call then bills at $0 with a `[cost]` warning).
+      ...(effectiveModel ? { model: effectiveModel } : {}),
     };
   }
 
@@ -305,11 +308,17 @@ abstract class CliAgentBase implements Agent {
     };
   }
 
-  protected abstract invokeProvider(prompt: string): Promise<ParsedProviderResult>;
+  protected abstract invokeProvider(
+    prompt: string,
+    model: string | undefined
+  ): Promise<ParsedProviderResult>;
 }
 
 export class CodexCliAgent extends CliAgentBase {
-  protected async invokeProvider(prompt: string): Promise<ParsedProviderResult> {
+  protected async invokeProvider(
+    prompt: string,
+    model: string | undefined
+  ): Promise<ParsedProviderResult> {
     const tempDir = await mkdtemp(join(tmpdir(), "relay-codex-"));
     const schemaPath = join(tempDir, "schema.json");
     const outputPath = join(tempDir, "response.json");
@@ -344,8 +353,8 @@ export class CodexCliAgent extends CliAgentBase {
         args.push("--ask-for-approval", "never");
       }
 
-      if (this.model) {
-        args.push("--model", this.model);
+      if (model) {
+        args.push("--model", model);
       }
 
       args.push(prompt);
@@ -413,7 +422,10 @@ export class CodexCliAgent extends CliAgentBase {
 }
 
 export class ClaudeCliAgent extends CliAgentBase {
-  protected async invokeProvider(prompt: string): Promise<ParsedProviderResult> {
+  protected async invokeProvider(
+    prompt: string,
+    model: string | undefined
+  ): Promise<ParsedProviderResult> {
     // When the user sets RELAY_AUTO_APPROVE=1 (or launched with --auto-approve
     // / --yolo), or the channel has opted in to full-access mode (AL-0),
     // internal dispatched agents run fully unattended. Otherwise we stay on
@@ -430,7 +442,7 @@ export class ClaudeCliAgent extends CliAgentBase {
     // NodeCommandInvoker. We fall back to the buffered path otherwise so
     // no call site breaks just because streaming wasn't configured.
     if (this.onStreamLine && typeof this.invoker.spawn === "function") {
-      return this.invokeStreaming(prompt, autoApprove);
+      return this.invokeStreaming(prompt, autoApprove, model);
     }
 
     const args = [
@@ -447,8 +459,8 @@ export class ClaudeCliAgent extends CliAgentBase {
       args.push("--permission-mode", "default");
     }
 
-    if (this.model) {
-      args.push("--model", this.model);
+    if (model) {
+      args.push("--model", model);
     }
 
     // AL-11: when a restricted role is assigned to this agent, tell the
@@ -499,7 +511,8 @@ export class ClaudeCliAgent extends CliAgentBase {
    */
   private async invokeStreaming(
     prompt: string,
-    autoApprove: boolean
+    autoApprove: boolean,
+    model: string | undefined
   ): Promise<ParsedProviderResult> {
     const args: string[] = [
       "-p",
@@ -511,7 +524,7 @@ export class ClaudeCliAgent extends CliAgentBase {
     ];
     if (autoApprove) args.push("--dangerously-skip-permissions");
     else args.push("--permission-mode", "default");
-    if (this.model) args.push("--model", this.model);
+    if (model) args.push("--model", model);
     // AL-11: same `--disallowed-tools` lockdown as the buffered path.
     appendDisallowedBuiltinArgs(args, this.role);
     args.push(prompt);

--- a/src/agents/model-router.ts
+++ b/src/agents/model-router.ts
@@ -1,0 +1,160 @@
+import type { AgentProvider } from "../domain/agent.js";
+import type { ComplexityTier } from "../domain/classification.js";
+import { MODEL_PRICING } from "../domain/model-pricing.js";
+import type { TaskCostCall } from "../domain/task-cost.js";
+import { rollupTasks } from "../orchestrator/cost-report.js";
+
+/**
+ * Default candidate model families the router chooses among, per provider.
+ * Cheapest → most capable. Callers can override; these are the safe defaults
+ * for a provider whose auth covers its whole tier family. Keys must exist in
+ * {@link MODEL_PRICING} so cold-start price ranking works.
+ */
+export const DEFAULT_CANDIDATES: Record<AgentProvider, string[]> = {
+  claude: ["claude-haiku-3-5", "claude-sonnet-4-5", "claude-opus-4-7"],
+  codex: ["o3-mini", "gpt-5"],
+  harness: [],
+};
+
+export function defaultCandidatesForProvider(provider: AgentProvider): string[] {
+  return DEFAULT_CANDIDATES[provider] ?? [];
+}
+
+/**
+ * Measured cost-per-task, per (task type, model). Built from the per-task
+ * cost ledger: tasks are rolled up (cost summed across retries), then grouped
+ * by tier and by the model that produced the task's costliest call. This is
+ * the evidence the router prefers over headline per-token price.
+ */
+export interface ModelTypeStat {
+  taskCount: number;
+  meanUsd: number;
+}
+export type RoutingStats = Map<ComplexityTier, Map<string, ModelTypeStat>>;
+
+/** Why the router picked what it picked — surfaced for logging / tests. */
+export type RoutingBasis =
+  | "measured" // enough samples → cheapest measured cost-per-task
+  | "cold-start-price" // too few samples → cheapest headline per-token price
+  | "single-candidate" // only one candidate, nothing to decide
+  | "no-candidates"; // nothing to route among → caller keeps its default
+
+export interface RoutingDecision {
+  /** Chosen model, or undefined when there are no candidates. */
+  model: string | undefined;
+  basis: RoutingBasis;
+  taskType: ComplexityTier;
+  candidateCount: number;
+}
+
+/**
+ * Blended headline price used for cold-start ranking, in USD per MTok.
+ * Coding traffic is input-heavy, so input is weighted 3:1 over output. This
+ * is only a tie-breaker until measured cost-per-task exists — once a tier has
+ * ≥ `minSamples` real tasks, measured cost supersedes it entirely.
+ */
+const HEADLINE_INPUT_WEIGHT = 0.75;
+const HEADLINE_OUTPUT_WEIGHT = 0.25;
+
+export function headlinePricePerMTok(model: string): number {
+  const price = MODEL_PRICING[model];
+  if (!price) return Number.POSITIVE_INFINITY; // unknown price → rank last
+  return price.inputPerMTok * HEADLINE_INPUT_WEIGHT + price.outputPerMTok * HEADLINE_OUTPUT_WEIGHT;
+}
+
+/** Roll the ledger up into per-(tier, model) mean cost-per-task. */
+export function buildRoutingStats(lines: TaskCostCall[]): RoutingStats {
+  const stats: RoutingStats = new Map();
+  // group rollups by tier → model → costs
+  const acc = new Map<ComplexityTier, Map<string, number[]>>();
+  for (const task of rollupTasks(lines)) {
+    if (!task.model) continue; // unpriced/unknown-model task can't inform routing
+    let byModel = acc.get(task.taskType);
+    if (!byModel) {
+      byModel = new Map();
+      acc.set(task.taskType, byModel);
+    }
+    const costs = byModel.get(task.model);
+    if (costs) costs.push(task.costUsd);
+    else byModel.set(task.model, [task.costUsd]);
+  }
+  for (const [tier, byModel] of acc) {
+    const out = new Map<string, ModelTypeStat>();
+    for (const [model, costs] of byModel) {
+      const total = costs.reduce((a, b) => a + b, 0);
+      out.set(model, { taskCount: costs.length, meanUsd: total / costs.length });
+    }
+    stats.set(tier, out);
+  }
+  return stats;
+}
+
+export interface ModelRouterOptions {
+  /** Models the router may choose among (e.g. a provider's tier family). */
+  candidates: string[];
+  /**
+   * Minimum measured tasks for a (tier, model) before its measured cost is
+   * trusted over headline price. Default 5.
+   */
+  minSamples?: number;
+}
+
+/**
+ * Cost-aware model router. Given a task type, picks the model with the lowest
+ * **measured cost-per-task** for that tier once enough samples exist; before
+ * that (cold-start) it falls back to the cheapest **headline per-token
+ * price**. This is the behavior change the feature asks for: routing on what a
+ * task actually costs, not on sticker per-token rates.
+ *
+ * Pure and synchronous — the caller loads the ledger once and hands the
+ * {@link RoutingStats} in, so a hot dispatch loop never touches disk.
+ */
+export class ModelRouter {
+  private readonly candidates: string[];
+  private readonly minSamples: number;
+
+  constructor(
+    private readonly stats: RoutingStats,
+    options: ModelRouterOptions
+  ) {
+    // De-dupe while preserving order so a stable tie-break is possible.
+    this.candidates = [...new Set(options.candidates)];
+    this.minSamples = options.minSamples ?? 5;
+  }
+
+  chooseModel(taskType: ComplexityTier): RoutingDecision {
+    const candidateCount = this.candidates.length;
+    if (candidateCount === 0) {
+      return { model: undefined, basis: "no-candidates", taskType, candidateCount };
+    }
+    if (candidateCount === 1) {
+      return { model: this.candidates[0], basis: "single-candidate", taskType, candidateCount };
+    }
+
+    const byModel = this.stats.get(taskType);
+    const measured = this.candidates
+      .map((model) => ({ model, stat: byModel?.get(model) }))
+      .filter(
+        (c): c is { model: string; stat: ModelTypeStat } =>
+          c.stat !== undefined && c.stat.taskCount >= this.minSamples
+      );
+
+    if (measured.length > 0) {
+      // Cheapest measured mean cost-per-task. Tie-break: cheaper headline
+      // price, then candidate order (stable).
+      const best = measured.reduce((a, b) => {
+        if (b.stat.meanUsd !== a.stat.meanUsd) return b.stat.meanUsd < a.stat.meanUsd ? b : a;
+        const ha = headlinePricePerMTok(a.model);
+        const hb = headlinePricePerMTok(b.model);
+        return hb < ha ? b : a;
+      });
+      return { model: best.model, basis: "measured", taskType, candidateCount };
+    }
+
+    // Cold-start: cheapest blended headline price. Stable on ties.
+    const best = this.candidates.reduce((a, b) =>
+      headlinePricePerMTok(b) < headlinePricePerMTok(a) ? b : a
+    );
+    return { model: best, basis: "cold-start-price", taskType, candidateCount };
+  }
+}

--- a/src/domain/agent.ts
+++ b/src/domain/agent.ts
@@ -63,6 +63,14 @@ export interface WorkRequest {
   attempt: number;
   maxAttempts: number;
   priorEvidence: string[];
+  /**
+   * Optional per-call model override chosen by the cost-aware router
+   * (`ModelRouter`) for this task's tier. When set, the CLI adapter passes it
+   * as `--model` instead of its statically-configured model. Absent → the
+   * adapter uses its own `this.model` (today's behavior). Lets routing vary
+   * the model per task without rebuilding the agent registry mid-run.
+   */
+  model?: string;
 }
 
 /**

--- a/src/orchestrator/dispatch.ts
+++ b/src/orchestrator/dispatch.ts
@@ -1,5 +1,6 @@
 import { AgentRegistry } from "../agents/registry.js";
 import { createLiveAgents, registerAgentNames } from "../agents/factory.js";
+import { defaultCandidatesForProvider } from "../agents/model-router.js";
 import { NodeCommandInvoker } from "../agents/command-invoker.js";
 import type { ProviderProfile, ProviderProfileLookup } from "../agents/provider-profile-lookup.js";
 import { ProviderProfileStore } from "../storage/provider-profile-store.js";
@@ -122,6 +123,18 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
 
   const verificationRunner = new VerificationRunner(new NodeCommandInvoker(), artifactStore);
 
+  // Cost-aware model routing is opt-in (RELAY_COST_ROUTING) because routing
+  // among a provider's tier family assumes the caller's auth covers all of
+  // them. When on, the orchestrator routes each task's model by measured
+  // cost-per-task for its tier, falling back to headline price at cold-start.
+  const costRoutingEnabled =
+    process.env.RELAY_COST_ROUTING === "1" ||
+    process.env.RELAY_COST_ROUTING === "true" ||
+    process.env.RELAY_COST_ROUTING === "yes";
+  const modelRouting = costRoutingEnabled
+    ? { candidates: defaultCandidatesForProvider(defaultProvider) }
+    : undefined;
+
   const orchestrator = new OrchestratorV2(
     registry,
     repoPath,
@@ -129,7 +142,8 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     artifactStore,
     artifactsDir,
     channelStore,
-    workspaceId
+    workspaceId,
+    modelRouting ? { modelRouting } : undefined
   );
   // Auto-attach PR watcher. No-op without GITHUB_TOKEN; safe to always call.
   orchestrator.attachPoller(

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -29,6 +29,7 @@ import { SessionTrackerPool } from "../budget/session-tracker-pool.js";
 import { TaskCostLedger } from "../budget/task-cost-ledger.js";
 import { dispatchTokenUsageOrThrow } from "./dispatch-token-usage.js";
 import { attachThresholdFeed } from "../budget/threshold-feed-bridge.js";
+import { ModelRouter, buildRoutingStats, type ModelRouterOptions } from "../agents/model-router.js";
 
 /**
  * Anything the orchestrator can hook into for follow-up enqueueing (PR poller,
@@ -78,6 +79,15 @@ export interface OrchestratorV2Options {
    * orchestrator constructs one writing to `~/.relay/task-costs.jsonl`.
    */
   costLedger?: TaskCostLedger;
+  /**
+   * Cost-aware model routing. When set, ticket dispatches route to the model
+   * with the lowest measured cost-per-task for the run's tier (falling back to
+   * headline per-token price during cold-start). Omitted → no routing; agents
+   * keep their statically-configured model (today's behavior). Opt-in because
+   * routing among a candidate set assumes the caller's auth covers all of
+   * them — the production entrypoint gates it behind `RELAY_COST_ROUTING`.
+   */
+  modelRouting?: ModelRouterOptions;
 }
 
 export class OrchestratorV2 {
@@ -103,6 +113,15 @@ export class OrchestratorV2 {
    * completion so `rly cost` sees the run's costs immediately after it ends.
    */
   private readonly costLedger: TaskCostLedger;
+
+  /**
+   * Cost-aware router config (candidates + minSamples), if routing is on.
+   * The {@link ModelRouter} itself is built lazily on first ticket dispatch
+   * from a one-time ledger snapshot — see {@link ensureModelRouter}.
+   */
+  private readonly modelRoutingOptions: ModelRouterOptions | null;
+  private modelRouter: ModelRouter | null = null;
+  private modelRouterLoaded = false;
 
   /**
    * Per-tracker unsubscribe handles for the threshold-feed bridge. Keyed
@@ -137,6 +156,7 @@ export class OrchestratorV2 {
     this.executor = options?.executor ?? null;
     this.trackerPool = options?.trackerPool ?? new SessionTrackerPool();
     this.costLedger = options?.costLedger ?? new TaskCostLedger();
+    this.modelRoutingOptions = options?.modelRouting ?? null;
   }
 
   /**
@@ -518,11 +538,44 @@ export class OrchestratorV2 {
     }
   }
 
+  /**
+   * Resolve the routed model for a run's tier, or undefined when routing is
+   * off or the run isn't classified yet. Builds the {@link ModelRouter} once
+   * per orchestrator from a single ledger snapshot (loaded lazily so a
+   * routing-off run never reads the file).
+   */
+  private async resolveRoutedModel(run: HarnessRun): Promise<string | undefined> {
+    if (!this.modelRoutingOptions || !run.classification) return undefined;
+    if (!this.modelRouterLoaded) {
+      this.modelRouterLoaded = true;
+      try {
+        const lines = await this.costLedger.readAll();
+        this.modelRouter = new ModelRouter(buildRoutingStats(lines), this.modelRoutingOptions);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[cost] routing disabled — ledger read failed: ${message}`);
+        this.modelRouter = null;
+      }
+    }
+    return this.modelRouter?.chooseModel(run.classification.tier).model;
+  }
+
   private async dispatch(run: HarnessRun, input: Omit<WorkRequest, "runId">): Promise<AgentResult> {
     let lastError: Error | null = null;
 
+    // Cost-aware routing: once the run is classified, pick the model with the
+    // lowest measured cost-per-task for this tier (headline price at cold-
+    // start). Only applies when routing is configured; planning calls that
+    // precede classification keep the agent's default model.
+    const routedModel = await this.resolveRoutedModel(run);
+
     for (let attempt = 1; attempt <= input.maxAttempts; attempt += 1) {
-      const request: WorkRequest = { runId: run.id, ...input, attempt };
+      const request: WorkRequest = {
+        runId: run.id,
+        ...input,
+        attempt,
+        ...(routedModel ? { model: routedModel } : {}),
+      };
       const agent = this.registry.resolve(request);
 
       this.recordEvent(run, "AgentDispatched", input.phaseId, {
@@ -530,6 +583,7 @@ export class OrchestratorV2 {
         provider: agent.provider,
         workKind: input.kind,
         attempt: String(attempt),
+        ...(routedModel ? { model: routedModel } : {}),
       });
 
       if (run.channelId && this.channelStore) {

--- a/test/agents/cli-agents-routed-model.test.ts
+++ b/test/agents/cli-agents-routed-model.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { ClaudeCliAgent } from "../../src/agents/cli-agents.js";
+import type { CommandInvoker, CommandInvocation } from "../../src/agents/command-invoker.js";
+
+class CapturingInvoker implements CommandInvoker {
+  readonly invocations: CommandInvocation[] = [];
+  constructor(private readonly stdout: string) {}
+  async exec(invocation: CommandInvocation) {
+    this.invocations.push(invocation);
+    return { stdout: this.stdout, stderr: "", exitCode: 0 };
+  }
+}
+
+const CANNED = JSON.stringify({ summary: "ok", evidence: [], proposedCommands: [], blockers: [] });
+
+function baseRequest(model?: string) {
+  return {
+    runId: "run-1",
+    phaseId: "t-1",
+    kind: "implement_phase" as const,
+    specialty: "general" as const,
+    attempt: 1,
+    maxAttempts: 3,
+    title: "noop",
+    objective: "test",
+    acceptanceCriteria: [],
+    allowedCommands: [],
+    verificationCommands: [],
+    docsToUpdate: [],
+    context: [],
+    artifactContext: [],
+    priorEvidence: [],
+    ...(model ? { model } : {}),
+  };
+}
+
+function agent(invoker: CommandInvoker, configuredModel?: string) {
+  return new ClaudeCliAgent({
+    id: "atlas",
+    name: "Atlas",
+    provider: "claude",
+    capability: { role: "planner", specialties: ["general"] },
+    cwd: "/tmp/fake-repo",
+    invoker,
+    model: configuredModel,
+  });
+}
+
+function modelArg(args: string[]): string | undefined {
+  const i = args.indexOf("--model");
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+describe("ClaudeCliAgent honors the routed per-call model", () => {
+  it("passes request.model as --model, overriding the configured model", async () => {
+    const invoker = new CapturingInvoker(CANNED);
+    const result = await agent(invoker, "claude-sonnet-4-5").run(baseRequest("claude-haiku-3-5"));
+
+    expect(modelArg(invoker.invocations[0]!.args)).toBe("claude-haiku-3-5");
+    // The result is tagged with the model that actually ran (the routed one).
+    expect(result.model).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back to the configured model when no override is set", async () => {
+    const invoker = new CapturingInvoker(CANNED);
+    const result = await agent(invoker, "claude-sonnet-4-5").run(baseRequest());
+
+    expect(modelArg(invoker.invocations[0]!.args)).toBe("claude-sonnet-4-5");
+    expect(result.model).toBe("claude-sonnet-4-5");
+  });
+});

--- a/test/agents/model-router.test.ts
+++ b/test/agents/model-router.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ModelRouter,
+  buildRoutingStats,
+  defaultCandidatesForProvider,
+  headlinePricePerMTok,
+} from "../../src/agents/model-router.js";
+import type { TaskCostCall } from "../../src/domain/task-cost.js";
+
+const CLAUDE = ["claude-haiku-3-5", "claude-sonnet-4-5", "claude-opus-4-7"];
+
+function line(partial: Partial<TaskCostCall>): TaskCostCall {
+  return {
+    schemaVersion: 1,
+    ts: "2026-07-08T00:00:00.000Z",
+    runId: "r",
+    ticketId: "t",
+    taskType: "feature_small",
+    workKind: "implement_phase",
+    attempt: 1,
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    ...partial,
+  };
+}
+
+/** N tasks of one (tier, model) at a fixed per-task cost. */
+function tasks(
+  tier: TaskCostCall["taskType"],
+  model: string,
+  n: number,
+  costEach: number
+): TaskCostCall[] {
+  return Array.from({ length: n }, (_, i) =>
+    line({ ticketId: `${tier}-${model}-${i}`, taskType: tier, model, costUsd: costEach })
+  );
+}
+
+describe("ModelRouter", () => {
+  it("returns undefined with no candidates and the sole candidate with one", () => {
+    const empty = new ModelRouter(new Map(), { candidates: [] });
+    expect(empty.chooseModel("feature_small")).toMatchObject({
+      model: undefined,
+      basis: "no-candidates",
+    });
+
+    const one = new ModelRouter(new Map(), { candidates: ["claude-opus-4-7"] });
+    expect(one.chooseModel("feature_small")).toMatchObject({
+      model: "claude-opus-4-7",
+      basis: "single-candidate",
+    });
+  });
+
+  it("cold-starts on cheapest headline price when samples are thin", () => {
+    const router = new ModelRouter(new Map(), { candidates: CLAUDE, minSamples: 5 });
+    const decision = router.chooseModel("feature_small");
+    // Haiku is the cheapest headline price of the three.
+    expect(decision).toMatchObject({ model: "claude-haiku-3-5", basis: "cold-start-price" });
+  });
+
+  it("prefers the cheapest MEASURED cost-per-task once minSamples is met", () => {
+    // Opus is measured cheap-per-task here (5 tasks @ $0.10) while sonnet is
+    // pricier per task ($2.00) — measured cost inverts the headline order.
+    const stats = buildRoutingStats([
+      ...tasks("feature_small", "claude-opus-4-7", 5, 0.1),
+      ...tasks("feature_small", "claude-sonnet-4-5", 5, 2.0),
+    ]);
+    const router = new ModelRouter(stats, { candidates: CLAUDE, minSamples: 5 });
+    expect(router.chooseModel("feature_small")).toMatchObject({
+      model: "claude-opus-4-7",
+      basis: "measured",
+    });
+  });
+
+  it("ignores measured data below minSamples and falls back to price", () => {
+    // Only 4 opus tasks — under the threshold — so measured is not trusted.
+    const stats = buildRoutingStats(tasks("feature_small", "claude-opus-4-7", 4, 0.01));
+    const router = new ModelRouter(stats, { candidates: CLAUDE, minSamples: 5 });
+    expect(router.chooseModel("feature_small").basis).toBe("cold-start-price");
+  });
+
+  it("scopes measured data to the matching tier", () => {
+    // Opus is measured-cheap for bugfix, but we're routing feature_small →
+    // no qualifying measured data → cold-start.
+    const stats = buildRoutingStats(tasks("bugfix", "claude-opus-4-7", 10, 0.01));
+    const router = new ModelRouter(stats, { candidates: CLAUDE, minSamples: 5 });
+    expect(router.chooseModel("feature_small").basis).toBe("cold-start-price");
+    expect(router.chooseModel("bugfix")).toMatchObject({
+      model: "claude-opus-4-7",
+      basis: "measured",
+    });
+  });
+
+  it("headlinePricePerMTok ranks known models and sinks unknown ones", () => {
+    expect(headlinePricePerMTok("claude-haiku-3-5")).toBeLessThan(
+      headlinePricePerMTok("claude-opus-4-7")
+    );
+    expect(headlinePricePerMTok("totally-unknown")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("buildRoutingStats rolls tasks up per tier+model and skips unpriced tasks", () => {
+    const stats = buildRoutingStats([
+      ...tasks("feature_small", "claude-sonnet-4-5", 3, 1),
+      line({ ticketId: "no-model", taskType: "feature_small", model: undefined, costUsd: 9 }),
+    ]);
+    const bucket = stats.get("feature_small")!;
+    expect(bucket.get("claude-sonnet-4-5")).toEqual({ taskCount: 3, meanUsd: 1 });
+    expect(bucket.has("undefined")).toBe(false);
+  });
+
+  it("exposes provider default candidate families", () => {
+    expect(defaultCandidatesForProvider("claude")).toEqual(CLAUDE);
+    expect(defaultCandidatesForProvider("codex")).toContain("gpt-5");
+    expect(defaultCandidatesForProvider("harness")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

**PR 4/4** — the behavior change. Model routing now decides on **measured cost-per-task** instead of a static/headline per-token rate. Opt-in via `RELAY_COST_ROUTING=1`.

- `agents/model-router.ts` — pure `ModelRouter`. For a task's tier, pick the candidate model with the lowest **measured cost-per-task** once it has ≥ `minSamples` (**default 5**) tasks; before that, fall back to the cheapest **blended headline per-token price**. `buildRoutingStats()` rolls the PR-3 ledger up per (tier, model). Provider default candidate families included.
- `WorkRequest.model` — optional per-call override; CLI adapters pass it as `--model` over their configured model and tag the result with the model that actually ran (feeds PR-3 cost accounting, so the loop closes).
- `OrchestratorV2` — builds the router once per run from a one-time ledger snapshot and routes each classified dispatch by the run's tier; records the chosen model on the `AgentDispatched` event. `dispatch.ts` gates it behind `RELAY_COST_ROUTING`.

## Why opt-in

Routing across a provider's tier family (Claude: haiku→sonnet→opus) assumes your auth covers all of them. Off by default → **zero behavior change** (agents keep their configured model). Documented in `docs/providers.md`.

## The feedback loop

PR 3 records what each task *actually cost* per model+tier → this PR reads that back and routes the next task of that tier to the cheapest **measured** option. Headline price only governs cold-start (< 5 samples). That's the "measured cost-per-task, not headline per-token price" ask.

## Test coverage

- `model-router.test.ts` (8) — no/single candidate, cold-start price ranking, measured-wins-once-minSamples, sub-threshold→cold-start, tier-scoping, headline ranking, stats rollup, provider families.
- `cli-agents-routed-model.test.ts` (2) — adapter passes `request.model` as `--model` and tags the result; falls back to configured model when unset.
- Wiring (`OrchestratorV2.resolveRoutedModel` → `request.model` → adapter) is typechecked; end-to-end routing is covered by composition of the two suites above. **Full suite: 1226 pass, 0 fail.**

## Stack

Based on **PR 3** (`feat/cost-03-task-ledger`). Final PR in the series — merge PR 1→2→3→4 in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)