### PR TITLE
fix(ci): pin format-check to the lockfile Prettier instead of `pnpm dlx`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Runs the lockfile-pinned Prettier, NOT `pnpm dlx prettier` — dlx
+      # resolves the latest registry version at run time, so a Prettier minor
+      # release silently reformats files nobody touched and every open PR goes
+      # red on someone else's code. Keep the version coming from the lockfile.
       - name: Prettier check
-        run: pnpm dlx prettier --check 'src/**/*.{ts,tsx}' 'test/**/*.{ts,tsx}' 'gui/src/**/*.{ts,tsx}' 'scripts/**/*.{ts,mts}' '*.md' 'docs/**/*.md'
+        run: pnpm format:check
 
       - name: No window.prompt/confirm/alert in gui/src
         # Tauri v2 WKWebView no-ops these (see gui/src/lib/dialogs.ts).


### PR DESCRIPTION
The `format-check` job ran `pnpm dlx prettier --check`. `dlx` resolves the **latest** Prettier from the registry at run time, and the job never installed dependencies — so it ignored the `prettier@3.8.3` pinned in `pnpm-lock.yaml` entirely.

Prettier 3.9 changed formatting defaults. The result:

- main’s last CI run (May 17 — `dlx` fetched 3.8.x) went **green**.
- Every PR opened since goes **red** on ten files nobody touched.

#238 is the clearest symptom: it adds two brand-new files and `format-check` fails on `run.ts`, `artifact-store.ts`, `fields.ts`, `lifecycle/types.ts`, `serve-validation.ts`, `ticket-router.ts`, `welcome.ts`, `coordinator.ts`, and two test files. None are in its diff.

## Verified

Against `origin/main`, unmodified:

| Prettier | Source | Result |
| --- | --- | --- |
| 3.8.3 | `pnpm-lock.yaml` (pinned) | `All matched files use Prettier code style!` |
| 3.9.4 | what `pnpm dlx` fetches today | `Code style issues found in 10 files` |

Those ten are exactly the ten in #238’s CI log.

## The fix

Install with `--frozen-lockfile` and run the local pinned binary via `pnpm format:check` — the same pattern `ts-verify` already uses. Globs are unchanged; `format:check` already carried the identical glob list.

This **only restores determinism**. It does not adopt 3.9’s style. Bumping Prettier and reformatting those ten files is a separate, deliberate change — worth doing, but not as a drive-by that lands reformats in an unrelated PR ([AGENTS.md](../blob/main/AGENTS.md): *no drive-by reformats*).

## Why this matters beyond one PR

Left alone, `format-check` re-breaks on every future Prettier release, always on code the PR author did not write. It also silently blocked the entire `feat/cost-*` stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)