### PR TITLE
fix(gui): close the hover-state AA gap left by the contrast audit (#235)

### DIFF
--- a/agent_docs/tidewater_handoff/tokens.json
+++ b/agent_docs/tidewater_handoff/tokens.json
@@ -4,7 +4,7 @@
     "palette": "Tidewater (fork of Tide)",
     "source": "design/direction-a-base.jsx — window.RELAY_A.A",
     "notes": "Two-surface system: deep 'ink' rail (sidebar/workspace rail) + warm 'paper' content. Coral is the only strong accent; reserve it for primary CTAs, active tabs, the primary repo, and selection.",
-    "overrides": "Some values below are accessibility-darkened from the original Tidewater palette to clear WCAG 2.1 AA (≥4.5:1 for normal text). When the live CSS in gui/src/styles/tokens.css differs from this file, the CSS value supersedes — re-deriving from this file without re-checking ratios will revert the a11y fix. Current overrides: color.mention.repoPrimaryFg #a43c32 (was #e65a4f, 5.17:1 on -primaryBg); color.mention.humanFg #1f6e54 (was #2a7a5a, 5.22:1 on -humanBg)."
+    "overrides": "Some values below are accessibility-darkened from the original Tidewater palette to clear WCAG 2.1 AA (≥4.5:1 for normal text). When the live CSS in gui/src/styles/tokens.css differs from this file, the CSS value supersedes — re-deriving from this file without re-checking ratios will revert the a11y fix. Current overrides, spelled `token: NEW (ratio) replaces OLD (ratio)`: color.mention.repoPrimaryFg: #a43c32 (5.17:1 on -primaryBg, PASS) replaces #e65a4f (2.85:1, FAIL); color.mention.humanFg: #1f6e54 (5.17:1 on -humanBg, PASS) replaces #2a7a5a (4.39:1, FAIL)."
   },
 
   "color": {

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1042,6 +1042,15 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   font-size: var(--font-size-xs);
   font-family: var(--font-mono);
 }
+/* The contrast audit walked resting backgrounds only. `text-muted` clears AA
+   on paper-base (5.57:1), but `.popover-item:hover` swaps the ground to
+   paper-hover (#d8cfb0), where it drops to 3.76:1 — failing AA exactly while
+   the user is hovering to read it. Darken on interaction: 6.45:1 on hover,
+   4.66:1 on pressed. */
+.popover-item:hover .item-sub,
+.popover-item:active .item-sub {
+  color: var(--color-text-muted-strong);
+}
 .popover-item.disabled { opacity: 0.45; cursor: not-allowed; }
 
 /* ── DM header + banner ───────────────────────────────────── */

--- a/gui/src/styles/tokens.css
+++ b/gui/src/styles/tokens.css
@@ -37,6 +37,12 @@
   --color-text-primary:      #1b1f2a;
   --color-text-muted:        #5b6579;
   --color-text-dim:          #8a93a5;
+  /* `text-muted` clears AA only on the RESTING paper surfaces (5.57:1 on
+     paper-base). The interaction fills are far darker — on paper-hover
+     (#d8cfb0) it drops to 3.76:1 and on paper-pressed (#bdb088) to 2.72:1, so
+     it fails exactly while the user is hovering to read it. Use this for muted
+     text sitting on a hover/pressed fill: 6.45:1 and 4.66:1 respectively. */
+  --color-text-muted-strong: #3a4254;
   --color-text-on-dark:      #e8ecf4;
   --color-text-on-dark-muted:#8a93a5;
 
@@ -67,10 +73,10 @@
   --color-mention-primary-fg:    #a43c32; /* 5.17:1 on -primary-bg */
   --color-mention-primary-line:  rgba(230, 90, 79, 0.33);
   --color-mention-attached-bg:   #dce6f5;
-  --color-mention-attached-fg:   #3a5fa0; /* 4.94:1 on -attached-bg */
+  --color-mention-attached-fg:   #3a5fa0; /* 5.02:1 on -attached-bg */
   --color-mention-attached-line: #b3c5e0;
   --color-mention-human-bg:      #d9f1e6;
-  --color-mention-human-fg:      #1f6e54; /* 5.22:1 on -human-bg */
+  --color-mention-human-fg:      #1f6e54; /* 5.17:1 on -human-bg */
 
   /* Typography */
   --font-ui:   "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;


### PR DESCRIPTION
Follow-up to #235. That PR is a real improvement and its resting-surface numbers all check out — I recomputed every pair with the WCAG 2.1 relative-luminance formula and they hold (in two cases it *understated* its own gain). But its audit only walked **resting** backgrounds.

## The gap

`text-muted` (`#5b6579`) clears AA on `paper-base` at **5.57:1**. Then `.popover-item:hover` swaps the ground out from under it:

| `.item-sub` sits on | Ratio | AA (4.5:1) |
| --- | --- | --- |
| `paper-base` `#fbf9f4` (resting) | **5.57:1** | ✅ |
| `paper-hover` `#d8cfb0` (**hovering**) | **3.76:1** | ❌ |
| `paper-pressed` `#bdb088` (pressed) | **2.72:1** | ❌ |

So it fails AA *precisely while the user is hovering to read it* — the one moment it has to be legible.

To be fair to #235: it improved that spot enormously. The pre-audit value scored **1.98:1** there. This just finishes the job.

## The fix

Adds `--color-text-muted-strong` (`#3a4254`), applied to `.item-sub` on `:hover` and `:active`:

| | Ratio | AA |
| --- | --- | --- |
| on `paper-hover` | **6.45:1** | ✅ |
| on `paper-pressed` | **4.66:1** | ✅ |

It is the same hex the `prefers-contrast: more` tier already uses for muted, so **no new color enters the palette** — and scoping it to the interaction state keeps the three-tier text hierarchy intact at rest, rather than flattening `.item-sub` to `text-primary`.

## Annotation corrections

Three comments were off. They pass either way, but an audit trail nobody can trust is worse than none:

- `tokens.css`: `attached-fg` is **5.02:1**, not 4.94:1. `human-fg` is **5.17:1**, not 5.22:1.
- `tokens.json` `_meta.overrides` read:
  > `repoPrimaryFg #a43c32 (was #e65a4f, 5.17:1 on -primaryBg)`

  which parses as *the old value scored 5.17:1*. It scored **2.85:1** — 5.17:1 is the new one. This note exists specifically to stop someone re-deriving tokens from the handoff and silently reverting the a11y fix; as written it invited exactly that. Now spelled `NEW (ratio) replaces OLD (ratio)` with a PASS/FAIL on each.

## Verified

- GUI vitest: **53 passed**
- `vite build`: clean
- `prettier --check`: clean
- Every ratio recomputed from the hex values, not copied from the source PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)