### PR TITLE
Wire live worker usage into cost reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ A **`CLAUDE.md`** at the repo root (when present) tells any Claude agent working
 ## Known limits
 
 - **Spawn is cross-platform but lightly tested off macOS.** macOS is daily-driven; Linux and Windows branches are compile-checked and unit-tested but real-device integration testing is still the gate before tagging a release.
-- **Cost guardrails not yet implemented.** Per-session context-window telemetry ships in v0.7.x (see [Token-usage telemetry](#token-usage-telemetry)); cost tracking and per-run dollar / token budget caps are still a follow-up. Use `RELAY_AUTO_APPROVE=1` with care.
+- **Cost reporting is observational, not a guardrail.** `rly cost` aggregates the per-task ledger, using Claude's provider-reported estimate when available and token-table estimates otherwise. These are not billing statements, and enforced per-run dollar / token caps are still a follow-up. Use `RELAY_AUTO_APPROVE=1` with care.
 
 ## Roadmap
 

--- a/crates/harness-data/src/lib.rs
+++ b/crates/harness-data/src/lib.rs
@@ -80,6 +80,8 @@ pub struct TicketLedgerEntry {
     /// before per-repo routing existed still deserialize.
     #[serde(default)]
     pub assigned_alias: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_type: Option<String>,
     /// Provenance of the ticket. Omitted / "relay" = Relay-produced;
     /// "linear" = read-only mirror of a Linear issue. All
     /// `#[serde(default)]` for back-compat with ticket files written before
@@ -1966,12 +1968,14 @@ mod tests {
             "dependsOn":["T-0"],
             "verification":"tests",
             "attempt":0,
-            "assignedAlias":"ui"
+            "assignedAlias":"ui",
+            "taskType":"bugfix"
         }"#;
         let t: TicketLedgerEntry = serde_json::from_str(json).unwrap();
         assert_eq!(t.ticket_id, "T-1");
         assert_eq!(t.depends_on, vec!["T-0"]);
         assert_eq!(t.assigned_alias.as_deref(), Some("ui"));
+        assert_eq!(t.task_type.as_deref(), Some("bugfix"));
         assert!(t.assigned_agent_id.is_none());
     }
 
@@ -2097,6 +2101,7 @@ mod tests {
         let t: TicketLedgerEntry = serde_json::from_str(json).unwrap();
         assert_eq!(t.attempt, 3);
         assert!(t.assigned_alias.is_none());
+        assert!(t.task_type.is_none());
     }
 
     #[test]

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -26,6 +26,13 @@ export type ChannelRef = {
 };
 
 export type ChannelTier = "feature_large" | "feature" | "bugfix" | "chore" | "question";
+export type ComplexityTier =
+  | "trivial"
+  | "bugfix"
+  | "feature_small"
+  | "feature_large"
+  | "architectural"
+  | "multi_repo";
 
 // Must stay in sync with the Rust `TicketProvider` enum in
 // `crates/harness-data/src/lib.rs`. `unknown` is the forward-compat catch-all
@@ -193,6 +200,7 @@ export type TicketLedgerEntry = {
   // Alias of the channel repo assignment this ticket is routed to.
   // Optional; absent on tickets written before per-repo routing existed.
   assignedAlias?: string;
+  taskType?: ComplexityTier;
   // Provenance. Absent = Relay-authored. "linear" = read-only mirror of
   // a Linear issue surfaced by the Linear → channel-board poller.
   source?: "relay" | "linear";

--- a/scripts/seed-autonomous-loop-tickets.ts
+++ b/scripts/seed-autonomous-loop-tickets.ts
@@ -342,10 +342,11 @@ async function main(): Promise<void> {
     retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
   }));
 
-  const ticketLedger = initializeTicketLedger(tickets, runId);
+  const taskType = "architectural" as const;
+  const ticketLedger = initializeTicketLedger(tickets, runId, taskType);
 
   const classification = {
-    tier: "architectural" as const,
+    tier: taskType,
     rationale:
       "Builds a long-running autonomous execution loop with budget tracking, trust modes, PR review integration, and post-completion audit. Touches storage, orchestrator, execution, and all three UIs.",
     suggestedSpecialties: ["general"] as string[],

--- a/scripts/seed-plan-tickets.ts
+++ b/scripts/seed-plan-tickets.ts
@@ -441,10 +441,11 @@ async function main(): Promise<void> {
     retryPolicy: { maxAgentAttempts: 1, maxTestFixLoops: 1 },
   }));
 
-  const ticketLedger = initializeTicketLedger(tickets, runId);
+  const taskType = "architectural" as const;
+  const ticketLedger = initializeTicketLedger(tickets, runId, taskType);
 
   const classification = {
-    tier: "architectural" as const,
+    tier: taskType,
     rationale:
       "Cross-cutting refactor across storage, execution, and transport layers; enables cloud deployment without breaking local usage.",
     suggestedSpecialties: ["general", "devops"] as string[],

--- a/src/agents/cli-agents.ts
+++ b/src/agents/cli-agents.ts
@@ -517,6 +517,7 @@ export class ClaudeCliAgent extends CliAgentBase {
       resultText: null,
       capturedUsage: null,
       capturedModel: null,
+      reportedCostUsd: null,
     };
 
     const consume = (line: string) => processStreamLine(line, state, onLine);

--- a/src/agents/process-stream-line.ts
+++ b/src/agents/process-stream-line.ts
@@ -20,6 +20,8 @@ export interface StreamParseState {
    */
   capturedModel: string | null;
   reportedCostUsd: number | null;
+  maxAccumTextChars?: number;
+  lastAssistantText?: string;
 }
 
 export type ProcessedStreamLine =
@@ -126,6 +128,18 @@ export function processStreamLine(
         }
       }
     }
+    const maxRetainedChars = state.maxAccumTextChars;
+    if (maxRetainedChars !== undefined && state.accumText.length > maxRetainedChars) {
+      state.accumText = maxRetainedChars === 0 ? "" : state.accumText.slice(-maxRetainedChars);
+    }
+    if (assistantText) {
+      state.lastAssistantText =
+        maxRetainedChars !== undefined && assistantText.length > maxRetainedChars
+          ? maxRetainedChars === 0
+            ? ""
+            : assistantText.slice(-maxRetainedChars)
+          : assistantText;
+    }
     return assistantText ? { kind: "structured", assistantText } : { kind: "structured" };
   } else if (obj.type === "result") {
     // Deliberately NOT gated on `typeof obj.result === "string"`. Claude's
@@ -148,7 +162,7 @@ export function processStreamLine(
         state.capturedUsage = usage;
       }
     }
-    if (typeof obj.result === "string" && !state.accumText.includes(obj.result)) {
+    if (typeof obj.result === "string" && state.lastAssistantText !== obj.result) {
       return { kind: "structured", assistantText: obj.result };
     }
   }

--- a/src/agents/process-stream-line.ts
+++ b/src/agents/process-stream-line.ts
@@ -19,7 +19,12 @@ export interface StreamParseState {
    * `assistant` / `result` events as fallbacks.
    */
   capturedModel: string | null;
+  reportedCostUsd: number | null;
 }
+
+export type ProcessedStreamLine =
+  | { kind: "diagnostic"; text: string }
+  | { kind: "structured"; assistantText?: string };
 
 /**
  * Coerce an unknown value to a non-negative integer. Non-finite / non-numeric
@@ -91,16 +96,16 @@ export function processStreamLine(
   line: string,
   state: StreamParseState,
   onLine: (line: string) => void
-): void {
-  if (!line) return;
+): ProcessedStreamLine {
+  if (!line) return { kind: "diagnostic", text: line };
   onLine(line);
   let parsed: unknown;
   try {
     parsed = JSON.parse(line);
   } catch {
-    return;
+    return { kind: "diagnostic", text: line };
   }
-  if (!parsed || typeof parsed !== "object") return;
+  if (!parsed || typeof parsed !== "object") return { kind: "structured" };
   const obj = parsed as Record<string, unknown>;
   if (obj.type === "system") {
     // The init event names the model the CLI resolved — the first and most
@@ -110,15 +115,18 @@ export function processStreamLine(
     const msg = obj.message as { content?: unknown; model?: unknown } | undefined;
     if (typeof msg?.model === "string") state.capturedModel ??= msg.model;
     const blocks = Array.isArray(msg?.content) ? msg?.content : null;
-    if (!blocks) return;
+    if (!blocks) return { kind: "structured" };
+    let assistantText = "";
     for (const block of blocks) {
       if (block && typeof block === "object") {
         const b = block as Record<string, unknown>;
         if (b.type === "text" && typeof b.text === "string") {
           state.accumText += b.text;
+          assistantText += b.text;
         }
       }
     }
+    return assistantText ? { kind: "structured", assistantText } : { kind: "structured" };
   } else if (obj.type === "result") {
     // Deliberately NOT gated on `typeof obj.result === "string"`. Claude's
     // error subtypes (`error_max_turns`, `error_during_execution`) omit the
@@ -127,8 +135,22 @@ export function processStreamLine(
     // recorded exactly $0.
     if (typeof obj.result === "string") state.resultText = obj.result;
     if (typeof obj.model === "string") state.capturedModel ??= obj.model;
+    if (
+      typeof obj.total_cost_usd === "number" &&
+      Number.isFinite(obj.total_cost_usd) &&
+      obj.total_cost_usd >= 0
+    ) {
+      state.reportedCostUsd = obj.total_cost_usd;
+    }
     if (obj.usage && typeof obj.usage === "object") {
-      state.capturedUsage = normalizeClaudeUsage(obj.usage as Record<string, unknown>);
+      const usage = normalizeClaudeUsage(obj.usage as Record<string, unknown>);
+      if (usage.inputTokens > 0 || usage.outputTokens > 0) {
+        state.capturedUsage = usage;
+      }
+    }
+    if (typeof obj.result === "string" && !state.accumText.includes(obj.result)) {
+      return { kind: "structured", assistantText: obj.result };
     }
   }
+  return { kind: "structured" };
 }

--- a/src/agents/process-stream-line.ts
+++ b/src/agents/process-stream-line.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { TokenUsage } from "../domain/agent.js";
 
 /**
@@ -21,7 +23,7 @@ export interface StreamParseState {
   capturedModel: string | null;
   reportedCostUsd: number | null;
   maxAccumTextChars?: number;
-  lastAssistantText?: string;
+  lastAssistantTextHash?: string;
 }
 
 export type ProcessedStreamLine =
@@ -35,7 +37,22 @@ export type ProcessedStreamLine =
  */
 function num(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return 0;
-  return Math.trunc(value);
+  const truncated = Math.trunc(value);
+  return Number.isSafeInteger(truncated) ? truncated : 0;
+}
+
+function sumTokens(...values: number[]): number {
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return Number.isSafeInteger(total) ? total : 0;
+}
+
+function retainTextTail(text: string, maxChars: number | undefined): string {
+  if (maxChars === undefined || text.length <= maxChars) return text;
+  return maxChars === 0 ? "" : text.slice(-maxChars);
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("base64");
 }
 
 /**
@@ -51,7 +68,7 @@ export function normalizeClaudeUsage(usage: Record<string, unknown>): TokenUsage
   const cacheRead = num(usage.cache_read_input_tokens);
   const cacheWrite = num(usage.cache_creation_input_tokens);
   const result: TokenUsage = {
-    inputTokens: input + cacheRead + cacheWrite,
+    inputTokens: sumTokens(input, cacheRead, cacheWrite),
     outputTokens: num(usage.output_tokens),
   };
   if (cacheRead > 0) result.cacheReadTokens = cacheRead;
@@ -74,7 +91,7 @@ export function normalizeCodexUsage(usage: Record<string, unknown>): TokenUsage 
   const input = num(usage.input_tokens);
   const cached = num(usage.cached_input_tokens);
   const result: TokenUsage = {
-    inputTokens: input + cached,
+    inputTokens: sumTokens(input, cached),
     outputTokens: num(usage.output_tokens),
   };
   if (cached > 0) result.cacheReadTokens = cached;
@@ -130,15 +147,10 @@ export function processStreamLine(
     }
     const maxRetainedChars = state.maxAccumTextChars;
     if (maxRetainedChars !== undefined && state.accumText.length > maxRetainedChars) {
-      state.accumText = maxRetainedChars === 0 ? "" : state.accumText.slice(-maxRetainedChars);
+      state.accumText = retainTextTail(state.accumText, maxRetainedChars);
     }
-    if (assistantText) {
-      state.lastAssistantText =
-        maxRetainedChars !== undefined && assistantText.length > maxRetainedChars
-          ? maxRetainedChars === 0
-            ? ""
-            : assistantText.slice(-maxRetainedChars)
-          : assistantText;
+    if (assistantText && maxRetainedChars !== undefined) {
+      state.lastAssistantTextHash = hashText(assistantText);
     }
     return assistantText ? { kind: "structured", assistantText } : { kind: "structured" };
   } else if (obj.type === "result") {
@@ -147,12 +159,15 @@ export function processStreamLine(
     // `result` string but DO carry `usage` — and those are the expensive runs.
     // Gating usage capture on the text meant a runaway agent that burned $12
     // recorded exactly $0.
-    if (typeof obj.result === "string") state.resultText = obj.result;
+    if (typeof obj.result === "string") {
+      state.resultText = retainTextTail(obj.result, state.maxAccumTextChars);
+    }
     if (typeof obj.model === "string") state.capturedModel ??= obj.model;
     if (
       typeof obj.total_cost_usd === "number" &&
       Number.isFinite(obj.total_cost_usd) &&
-      obj.total_cost_usd >= 0
+      obj.total_cost_usd >= 0 &&
+      obj.total_cost_usd <= Number.MAX_SAFE_INTEGER
     ) {
       state.reportedCostUsd = obj.total_cost_usd;
     }
@@ -162,8 +177,12 @@ export function processStreamLine(
         state.capturedUsage = usage;
       }
     }
-    if (typeof obj.result === "string" && state.lastAssistantText !== obj.result) {
-      return { kind: "structured", assistantText: obj.result };
+    if (typeof obj.result === "string") {
+      const alreadyEmitted =
+        state.maxAccumTextChars === undefined
+          ? state.accumText.includes(obj.result)
+          : state.lastAssistantTextHash === hashText(obj.result);
+      if (!alreadyEmitted) return { kind: "structured", assistantText: obj.result };
     }
   }
   return { kind: "structured" };

--- a/src/budget/task-cost-ledger.ts
+++ b/src/budget/task-cost-ledger.ts
@@ -20,6 +20,7 @@ export interface TaskCostRecordInput {
   attempt: number;
   model: string | undefined;
   tokenUsage: TokenUsage;
+  reportedCostUsd?: number;
   /** ISO timestamp; defaults to now. Injectable so tests get stable lines. */
   ts?: string;
 }
@@ -35,8 +36,9 @@ export interface TaskCostRecordInput {
  * partial line (mirrors `token-tracker.ts`).
  *
  * `record()` is fire-and-forget from the caller's view but returns the write
- * promise so a run-completion drain can `await` outstanding writes. Cost is
- * computed here (via {@link costUsd}) so callers only supply raw token usage.
+ * promise so a run-completion drain can `await` outstanding writes. A positive
+ * provider-reported estimate takes precedence; otherwise cost falls back to
+ * {@link costUsd} from the raw token usage.
  */
 export class TaskCostLedger {
   private readonly filePath: string;
@@ -56,10 +58,10 @@ export class TaskCostLedger {
   }
 
   /**
-   * Append one call's cost. Computes `costUsd` from the token usage + model
-   * (unknown/missing model → $0 with the `[cost]` warning from
-   * model-pricing). Returns the write promise; callers that need durability
-   * before proceeding should await it (or {@link flush}).
+   * Append one call's cost. Uses a positive provider-reported estimate when
+   * available, otherwise computes `costUsd` from token usage + model. Returns
+   * the write promise; callers that need durability should await it or
+   * {@link flush}.
    */
   record(input: TaskCostRecordInput): Promise<void> {
     const usage = input.tokenUsage;
@@ -76,7 +78,12 @@ export class TaskCostLedger {
       outputTokens: usage.outputTokens,
       ...(usage.cacheReadTokens ? { cacheReadTokens: usage.cacheReadTokens } : {}),
       ...(usage.cacheWriteTokens ? { cacheWriteTokens: usage.cacheWriteTokens } : {}),
-      costUsd: costUsd(input.model, usage),
+      costUsd:
+        input.reportedCostUsd !== undefined &&
+        Number.isFinite(input.reportedCostUsd) &&
+        input.reportedCostUsd > 0
+          ? input.reportedCostUsd
+          : costUsd(input.model, usage),
     };
 
     const serialized = JSON.stringify(line) + "\n";

--- a/src/budget/task-cost-ledger.ts
+++ b/src/budget/task-cost-ledger.ts
@@ -65,7 +65,7 @@ export class TaskCostLedger {
    */
   record(input: TaskCostRecordInput): Promise<void> {
     const usage = input.tokenUsage;
-    const line: TaskCostCall = {
+    const candidate = {
       schemaVersion: TASK_COST_SCHEMA_VERSION,
       ts: input.ts ?? new Date().toISOString(),
       runId: input.runId,
@@ -81,10 +81,15 @@ export class TaskCostLedger {
       costUsd:
         input.reportedCostUsd !== undefined &&
         Number.isFinite(input.reportedCostUsd) &&
-        input.reportedCostUsd > 0
+        input.reportedCostUsd > 0 &&
+        input.reportedCostUsd <= Number.MAX_SAFE_INTEGER
           ? input.reportedCostUsd
           : costUsd(input.model, usage),
     };
+
+    const parsed = TaskCostCallSchema.safeParse(candidate);
+    if (!parsed.success) return Promise.reject(parsed.error);
+    const line: TaskCostCall = parsed.data;
 
     const serialized = JSON.stringify(line) + "\n";
     this.writeChain = this.writeChain.then(async () => {

--- a/src/domain/task-cost.ts
+++ b/src/domain/task-cost.ts
@@ -10,6 +10,8 @@ import { ComplexityTierSchema } from "./classification.js";
  */
 export const TASK_COST_SCHEMA_VERSION = 1 as const;
 
+const SafeTokenCountSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+
 /**
  * One appended line in `~/.relay/task-costs.jsonl` — the USD cost of a SINGLE
  * agent call (one `agent.run()` / executor run), tagged with the task it
@@ -42,12 +44,12 @@ export const TaskCostCallSchema = z.object({
   attempt: z.number().int().positive().default(1),
   /** Model that produced this call. Absent → costUsd was billed at $0. */
   model: z.string().optional(),
-  inputTokens: z.number().int().nonnegative(),
-  outputTokens: z.number().int().nonnegative(),
-  cacheReadTokens: z.number().int().nonnegative().optional(),
-  cacheWriteTokens: z.number().int().nonnegative().optional(),
+  inputTokens: SafeTokenCountSchema,
+  outputTokens: SafeTokenCountSchema,
+  cacheReadTokens: SafeTokenCountSchema.optional(),
+  cacheWriteTokens: SafeTokenCountSchema.optional(),
   /** USD cost of this call, computed via `costUsd()` at record time. */
-  costUsd: z.number().nonnegative(),
+  costUsd: z.number().nonnegative().max(Number.MAX_SAFE_INTEGER),
 });
 
 export type TaskCostCall = z.infer<typeof TaskCostCallSchema>;

--- a/src/domain/ticket.ts
+++ b/src/domain/ticket.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-import { ClassificationResultSchema, type ClassificationResult } from "./classification.js";
+import {
+  ClassificationResultSchema,
+  type ClassificationResult,
+  type ComplexityTier,
+} from "./classification.js";
 import { RetryPolicySchema } from "./phase-plan.js";
 import type { FailureCategory } from "./agent.js";
 import { AgentSpecialtySchema, type AgentSpecialty } from "./specialty.js";
@@ -83,6 +87,7 @@ export interface TicketLedgerEntry {
    * must do so by re-initializing, not by patching this field in place.
    */
   runId: string | null;
+  taskType?: ComplexityTier;
   /**
    * Optional alias of the repo (from `Channel.repoAssignments[].alias`) this
    * ticket should be routed to. When set, the orchestrator / spawner uses
@@ -126,7 +131,8 @@ export interface TicketExternalIds {
 
 export function initializeTicketLedger(
   tickets: TicketDefinition[],
-  runId: string | null = null
+  runId: string | null = null,
+  taskType?: ComplexityTier
 ): TicketLedgerEntry[] {
   const now = new Date().toISOString();
 
@@ -147,6 +153,7 @@ export function initializeTicketLedger(
     completedAt: null,
     updatedAt: now,
     runId,
+    ...(taskType ? { taskType } : {}),
   }));
 }
 

--- a/src/execution/extract-usage.ts
+++ b/src/execution/extract-usage.ts
@@ -51,6 +51,7 @@ export function extractUsageFromStdout(stdout: string): ExtractedUsage | undefin
     resultText: null,
     capturedUsage: null,
     capturedModel: null,
+    reportedCostUsd: null,
   };
   for (const line of stdout.split("\n")) {
     const trimmed = line.trim();

--- a/src/orchestrator/autonomous-loop.ts
+++ b/src/orchestrator/autonomous-loop.ts
@@ -1,5 +1,6 @@
 import type { SessionLifecycle, TransitionEvent } from "../lifecycle/session-lifecycle.js";
 import type { TokenTracker } from "../budget/token-tracker.js";
+import { TaskCostLedger } from "../budget/task-cost-ledger.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
 import { ChannelStore } from "../channels/channel-store.js";
@@ -414,6 +415,9 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
   // instance avoids redundant on-disk state checks and keeps all
   // writes going through the same in-memory mirror.
   const channelStore = testOverrides?.channelStore ?? new ChannelStore();
+  const costLedger = new TaskCostLedger(
+    testOverrides?.rootDir ? { rootDir: testOverrides.rootDir } : {}
+  );
 
   // AL-16: inter-admin coordination bus. Construct BEFORE the pool so
   // the pool can thread the reference into each session it spawns —
@@ -644,6 +648,7 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
       allowedRepos,
       lifecycle,
       workerSpawner: testOverrides?.workerSpawner ?? new WorkerSpawner(),
+      costLedger,
       pollIntervalMs: testOverrides?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
       prPoller: testOverrides?.prPoller,
     });
@@ -696,6 +701,13 @@ export async function startAutonomousSession(opts: StartAutonomousSessionOptions
       })
     )
   );
+  await costLedger.flush().catch((err) => {
+    console.warn(
+      `[cost] ledger flush failed for session ${sessionId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  });
 
   // AL-14 follow-up: terminal worktree sweep. Before we transition the
   // lifecycle, walk any ticket in `verifying` state whose PR has already
@@ -1074,6 +1086,7 @@ interface SteadyStateDriverArgs {
   allowedRepos: RepoAssignment[];
   lifecycle: SessionLifecycle;
   workerSpawner: WorkerSpawner;
+  costLedger: TaskCostLedger;
   pollIntervalMs: number;
   /**
    * AL-14 follow-up: optional merge-event subscription bus. When set,
@@ -1129,6 +1142,7 @@ async function runSteadyStateDriver(args: SteadyStateDriverArgs): Promise<Steady
     allowedRepos,
     lifecycle,
     workerSpawner,
+    costLedger,
     pollIntervalMs,
     prPoller,
   } = args;
@@ -1404,6 +1418,7 @@ async function runSteadyStateDriver(args: SteadyStateDriverArgs): Promise<Steady
           channel,
           channelStore,
           spawner: workerSpawner,
+          costLedger,
         });
         // A runner created AFTER a wind-down / kill fired inherits the
         // stop-accepting-new flag immediately so its drain loop exits

--- a/src/orchestrator/orchestrator-v2.ts
+++ b/src/orchestrator/orchestrator-v2.ts
@@ -314,7 +314,7 @@ export class OrchestratorV2 {
     });
 
     run.ticketPlan = ticketPlan;
-    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id);
+    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id, classification.tier);
 
     await this.artifactStore.saveTicketLedger({
       runId: run.id,
@@ -434,7 +434,7 @@ export class OrchestratorV2 {
 
     const ticketPlan = buildTicketPlanFromPhases(trivialPlan, classification);
     run.ticketPlan = ticketPlan;
-    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id);
+    run.ticketLedger = initializeTicketLedger(ticketPlan.tickets, run.id, classification.tier);
 
     // Same log-and-continue policy as the regular decomposition path.
     await this.mirrorToChannelBoard(run);

--- a/src/orchestrator/ticket-runner.ts
+++ b/src/orchestrator/ticket-runner.ts
@@ -553,10 +553,15 @@ export class TicketRunner {
   }
 
   private async recordCost(ticket: TicketLedgerEntry, evt: WorkerExitEvent): Promise<void> {
-    if (!this.costLedger || !evt.tokenUsage) return;
+    if (!this.costLedger) return;
+    const hasReportedCost =
+      evt.reportedCostUsd !== undefined &&
+      Number.isFinite(evt.reportedCostUsd) &&
+      evt.reportedCostUsd > 0;
+    if (!evt.tokenUsage && !hasReportedCost) return;
     if (!ticket.runId || !ticket.taskType) {
       console.warn(
-        `[cost] live worker ${ticket.ticketId} has usage but no run classification; ` +
+        `[cost] live worker ${ticket.ticketId} has cost data but no run classification; ` +
           `omitting it from the task cost ledger.`
       );
       return;
@@ -569,7 +574,7 @@ export class TicketRunner {
         workKind: "implement_phase",
         attempt: (ticket.attempt ?? 0) + 1,
         model: evt.model,
-        tokenUsage: evt.tokenUsage,
+        tokenUsage: evt.tokenUsage ?? { inputTokens: 0, outputTokens: 0 },
         ...(evt.reportedCostUsd !== undefined ? { reportedCostUsd: evt.reportedCostUsd } : {}),
       });
     } catch (err) {

--- a/src/orchestrator/ticket-runner.ts
+++ b/src/orchestrator/ticket-runner.ts
@@ -52,6 +52,7 @@
 
 import { EventEmitter } from "node:events";
 
+import type { TaskCostLedger } from "../budget/task-cost-ledger.js";
 import type { ChannelStore } from "../channels/channel-store.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import type { TicketLedgerEntry, TicketStatus } from "../domain/ticket.js";
@@ -83,6 +84,7 @@ export interface TicketRunnerOptions {
   channel: Channel;
   channelStore: ChannelStore;
   spawner: WorkerSpawner;
+  costLedger?: TaskCostLedger;
   /**
    * Clock for `updatedAt` stamps. Tests inject deterministic values so the
    * ticket mirror is snapshot-friendly. Defaults to `() => new Date().toISOString()`.
@@ -120,6 +122,7 @@ export class TicketRunner {
   private readonly channel: Channel;
   private readonly channelStore: ChannelStore;
   private readonly spawner: WorkerSpawner;
+  private readonly costLedger?: TaskCostLedger;
   private readonly now: () => string;
   private readonly prUrlFallback?: (args: {
     branch: string;
@@ -159,6 +162,7 @@ export class TicketRunner {
     this.channel = options.channel;
     this.channelStore = options.channelStore;
     this.spawner = options.spawner;
+    this.costLedger = options.costLedger;
     this.now = options.now ?? (() => new Date().toISOString());
     this.prUrlFallback = options.prUrlFallback;
   }
@@ -432,6 +436,7 @@ export class TicketRunner {
     });
 
     this.activeHandles.delete(ticket.ticketId);
+    await this.recordCost(ticket, evt);
 
     // Resolve the PR URL: prefer stdout-tail; fall back to an injected
     // probe (typically `gh pr list --head <branch>`).
@@ -545,6 +550,35 @@ export class TicketRunner {
           }`
         );
       });
+  }
+
+  private async recordCost(ticket: TicketLedgerEntry, evt: WorkerExitEvent): Promise<void> {
+    if (!this.costLedger || !evt.tokenUsage) return;
+    if (!ticket.runId || !ticket.taskType) {
+      console.warn(
+        `[cost] live worker ${ticket.ticketId} has usage but no run classification; ` +
+          `omitting it from the task cost ledger.`
+      );
+      return;
+    }
+    try {
+      await this.costLedger.record({
+        runId: ticket.runId,
+        ticketId: ticket.ticketId,
+        taskType: ticket.taskType,
+        workKind: "implement_phase",
+        attempt: (ticket.attempt ?? 0) + 1,
+        model: evt.model,
+        tokenUsage: evt.tokenUsage,
+        ...(evt.reportedCostUsd !== undefined ? { reportedCostUsd: evt.reportedCostUsd } : {}),
+      });
+    } catch (err) {
+      console.warn(
+        `[cost] ledger write failed (runId=${ticket.runId} ticketId=${ticket.ticketId}): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   private async updateTicket(

--- a/src/orchestrator/ticket-scheduler.ts
+++ b/src/orchestrator/ticket-scheduler.ts
@@ -566,7 +566,7 @@ export class TicketScheduler {
       return;
     }
 
-    const [entry] = initializeTicketLedger([ticket]);
+    const [entry] = initializeTicketLedger([ticket], run.id, run.classification?.tier);
     run.ticketLedger.push(entry);
 
     if (run.ticketPlan) {

--- a/src/orchestrator/worker-spawner.ts
+++ b/src/orchestrator/worker-spawner.ts
@@ -54,6 +54,7 @@ import type { SandboxProvider, SandboxRef } from "../execution/sandbox.js";
  */
 export const WORKER_STDOUT_TAIL_LINES = 200;
 export const WORKER_STDERR_TAIL_LINES = 200;
+export const WORKER_STREAM_TEXT_CHARS = 64 * 1024;
 
 /**
  * Env vars a worker's Claude/Codex subprocess is allowed to read from the
@@ -422,6 +423,7 @@ class LiveWorkerHandle implements WorkerHandle {
     capturedUsage: null,
     capturedModel: null,
     reportedCostUsd: null,
+    maxAccumTextChars: WORKER_STREAM_TEXT_CHARS,
   };
   private _detectedPrUrl: string | null = null;
   private finalEvent: WorkerExitEvent | null = null;
@@ -557,11 +559,8 @@ class LiveWorkerHandle implements WorkerHandle {
     const processed = processStreamLine(line, this.streamState, () => {});
     const text = processed.kind === "diagnostic" ? processed.text : processed.assistantText;
     if (text) this.pushHumanText(text);
-    const prText =
-      processed.kind === "diagnostic"
-        ? processed.text
-        : (processed.assistantText ?? this.streamState.accumText);
-    if (!this._detectedPrUrl) {
+    const prText = processed.kind === "diagnostic" ? processed.text : processed.assistantText;
+    if (!this._detectedPrUrl && prText) {
       const match = prText.match(PR_URL_PATTERN);
       if (match) this._detectedPrUrl = match[0];
     }

--- a/src/orchestrator/worker-spawner.ts
+++ b/src/orchestrator/worker-spawner.ts
@@ -33,6 +33,7 @@
 
 import { EventEmitter } from "node:events";
 
+import type { TokenUsage } from "../domain/agent.js";
 import type { Channel, RepoAssignment } from "../domain/channel.js";
 import type { AgentSpecialty } from "../domain/specialty.js";
 import type { TicketLedgerEntry } from "../domain/ticket.js";
@@ -42,6 +43,7 @@ import {
   type CommandInvoker,
   type SpawnedProcess,
 } from "../agents/command-invoker.js";
+import { processStreamLine, type StreamParseState } from "../agents/process-stream-line.js";
 import { GitWorktreeSandboxProvider } from "../execution/sandboxes/git-worktree.js";
 import type { SandboxProvider, SandboxRef } from "../execution/sandbox.js";
 
@@ -99,6 +101,9 @@ export interface WorkerExitEvent {
   stderrTail: string;
   /** PR URL detected in stdout, if any. Used by the ticket runner for AC3. */
   detectedPrUrl: string | null;
+  tokenUsage?: TokenUsage;
+  model?: string;
+  reportedCostUsd?: number;
 }
 
 export interface WorkerHandle {
@@ -179,6 +184,7 @@ export interface WorkerSpawnerOptions {
   invoker?: CommandInvoker;
   /** Session-id factory. Tests inject a deterministic one. */
   buildSessionId?: () => string;
+  buildPrompt?: typeof buildWorkerPrompt;
   /** Clock for short-timestamp branch suffixes. Tests inject a fixed value. */
   clock?: () => number;
   /**
@@ -261,6 +267,7 @@ export class WorkerSpawner {
   private readonly sandboxProvider: SandboxProvider;
   private readonly invoker: CommandInvoker;
   private readonly buildSessionId: () => string;
+  private readonly buildPrompt: typeof buildWorkerPrompt;
   private readonly clock: () => number;
   private readonly stopGraceMs: number;
 
@@ -268,6 +275,7 @@ export class WorkerSpawner {
     this.sandboxProvider = options.sandboxProvider ?? new GitWorktreeSandboxProvider();
     this.invoker = options.invoker ?? new NodeCommandInvoker();
     this.buildSessionId = options.buildSessionId ?? defaultBuildWorkerSessionId;
+    this.buildPrompt = options.buildPrompt ?? buildWorkerPrompt;
     this.clock = options.clock ?? Date.now;
     this.stopGraceMs = options.stopGraceMs ?? WORKER_STOP_GRACE_MS;
   }
@@ -322,10 +330,10 @@ export class WorkerSpawner {
     // stdin like a repo-admin session. The worker's own agent role governs
     // *what* it does; AL-14's scope is the spawn + monitoring, not the
     // prompt content.
-    const prompt = buildWorkerPrompt(ticket, repoAssignment, specialty);
+    const prompt = this.buildPrompt(ticket, repoAssignment, specialty);
     const fullAccess = channel.fullAccess === true;
 
-    const args: string[] = ["-p"];
+    const args: string[] = ["-p", "--output-format", "stream-json", "--verbose"];
     if (fullAccess) {
       // AC2 — inherit the channel's full-access flag.
       args.push("--dangerously-skip-permissions");
@@ -408,6 +416,13 @@ class LiveWorkerHandle implements WorkerHandle {
   private stderrBuf = "";
   private stdoutLines: string[] = [];
   private stderrLines: string[] = [];
+  private readonly streamState: StreamParseState = {
+    accumText: "",
+    resultText: null,
+    capturedUsage: null,
+    capturedModel: null,
+    reportedCostUsd: null,
+  };
   private _detectedPrUrl: string | null = null;
   private finalEvent: WorkerExitEvent | null = null;
 
@@ -539,13 +554,25 @@ class LiveWorkerHandle implements WorkerHandle {
 
   private pushStdoutLine(line: string): void {
     if (!line) return;
-    this.stdoutLines.push(line);
+    const processed = processStreamLine(line, this.streamState, () => {});
+    const text = processed.kind === "diagnostic" ? processed.text : processed.assistantText;
+    if (text) this.pushHumanText(text);
+    const prText =
+      processed.kind === "diagnostic"
+        ? processed.text
+        : (processed.assistantText ?? this.streamState.accumText);
+    if (!this._detectedPrUrl) {
+      const match = prText.match(PR_URL_PATTERN);
+      if (match) this._detectedPrUrl = match[0];
+    }
+  }
+
+  private pushHumanText(text: string): void {
+    for (const line of text.split("\n")) {
+      if (line) this.stdoutLines.push(line);
+    }
     if (this.stdoutLines.length > WORKER_STDOUT_TAIL_LINES) {
       this.stdoutLines.splice(0, this.stdoutLines.length - WORKER_STDOUT_TAIL_LINES);
-    }
-    if (!this._detectedPrUrl) {
-      const match = line.match(PR_URL_PATTERN);
-      if (match) this._detectedPrUrl = match[0];
     }
   }
 
@@ -585,6 +612,11 @@ class LiveWorkerHandle implements WorkerHandle {
       stdoutTail: this.stdoutLines.join("\n"),
       stderrTail: this.stderrLines.join("\n"),
       detectedPrUrl: this._detectedPrUrl,
+      ...(this.streamState.capturedUsage ? { tokenUsage: this.streamState.capturedUsage } : {}),
+      ...(this.streamState.capturedModel ? { model: this.streamState.capturedModel } : {}),
+      ...(this.streamState.reportedCostUsd !== null
+        ? { reportedCostUsd: this.streamState.reportedCostUsd }
+        : {}),
     };
     this.finalEvent = evt;
 

--- a/src/orchestrator/worker-spawner.ts
+++ b/src/orchestrator/worker-spawner.ts
@@ -55,6 +55,17 @@ import type { SandboxProvider, SandboxRef } from "../execution/sandbox.js";
 export const WORKER_STDOUT_TAIL_LINES = 200;
 export const WORKER_STDERR_TAIL_LINES = 200;
 export const WORKER_STREAM_TEXT_CHARS = 64 * 1024;
+export const WORKER_STREAM_LINE_CHARS = 1024 * 1024;
+
+function appendBoundedTail(lines: string[], text: string, maxLines: number): string[] {
+  const retainedText =
+    text.length > WORKER_STREAM_TEXT_CHARS ? text.slice(-WORKER_STREAM_TEXT_CHARS) : text;
+  const nextLines = [...lines, ...retainedText.split(/\r?\n/).filter(Boolean)].slice(-maxLines);
+  const joined = nextLines.join("\n");
+  const bounded =
+    joined.length > WORKER_STREAM_TEXT_CHARS ? joined.slice(-WORKER_STREAM_TEXT_CHARS) : joined;
+  return bounded ? bounded.split("\n").slice(-maxLines) : [];
+}
 
 /**
  * Env vars a worker's Claude/Codex subprocess is allowed to read from the
@@ -100,7 +111,7 @@ export interface WorkerExitEvent {
   stdoutTail: string;
   /** Last {@link WORKER_STDERR_TAIL_LINES} lines of stderr for diagnostics. */
   stderrTail: string;
-  /** PR URL detected in stdout, if any. Used by the ticket runner for AC3. */
+  /** PR URL detected in parsed assistant text, if any. Used by the ticket runner for AC3. */
   detectedPrUrl: string | null;
   tokenUsage?: TokenUsage;
   model?: string;
@@ -415,6 +426,8 @@ class LiveWorkerHandle implements WorkerHandle {
 
   private stdoutBuf = "";
   private stderrBuf = "";
+  private stdoutLineOverflowed = false;
+  private stderrLineOverflowed = false;
   private stdoutLines: string[] = [];
   private stderrLines: string[] = [];
   private readonly streamState: StreamParseState = {
@@ -518,40 +531,72 @@ class LiveWorkerHandle implements WorkerHandle {
 
   private wireChild(): void {
     this.child.onStdout((chunk) => {
-      this.stdoutBuf += chunk;
-      let idx: number;
-      while ((idx = this.stdoutBuf.indexOf("\n")) >= 0) {
-        const line = this.stdoutBuf.slice(0, idx);
-        this.stdoutBuf = this.stdoutBuf.slice(idx + 1);
-        this.pushStdoutLine(line);
-      }
+      const drained = this.drainLines(this.stdoutBuf + chunk, this.stdoutLineOverflowed, "stdout");
+      this.stdoutBuf = drained.buffer;
+      this.stdoutLineOverflowed = drained.overflowed;
     });
     this.child.onStderr((chunk) => {
-      this.stderrBuf += chunk;
-      let idx: number;
-      while ((idx = this.stderrBuf.indexOf("\n")) >= 0) {
-        const line = this.stderrBuf.slice(0, idx);
-        this.stderrBuf = this.stderrBuf.slice(idx + 1);
-        this.pushStderrLine(line);
-      }
+      const drained = this.drainLines(this.stderrBuf + chunk, this.stderrLineOverflowed, "stderr");
+      this.stderrBuf = drained.buffer;
+      this.stderrLineOverflowed = drained.overflowed;
     });
     this.child.onError((err) => {
       // Spawn-level error (e.g. ENOENT) — treat as failure.
-      this.stderrLines.push(`[spawn-error] ${err.message}`);
+      this.pushStderrLine(`[spawn-error] ${err.message}`);
       this.finish(null, null);
     });
     this.child.onExit((code, signal) => {
       // Flush any leftover partial lines before we stamp the tail.
-      if (this.stdoutBuf) {
+      if (this.stdoutLineOverflowed) {
+        this.pushOversizedLine("stdout");
+      } else if (this.stdoutBuf) {
         this.pushStdoutLine(this.stdoutBuf);
-        this.stdoutBuf = "";
       }
-      if (this.stderrBuf) {
+      this.stdoutBuf = "";
+      this.stdoutLineOverflowed = false;
+      if (this.stderrLineOverflowed) {
+        this.pushOversizedLine("stderr");
+      } else if (this.stderrBuf) {
         this.pushStderrLine(this.stderrBuf);
-        this.stderrBuf = "";
       }
+      this.stderrBuf = "";
+      this.stderrLineOverflowed = false;
       this.finish(code ?? null, signal ?? null);
     });
+  }
+
+  private drainLines(
+    initialBuffer: string,
+    initialOverflowed: boolean,
+    stream: "stdout" | "stderr"
+  ): { buffer: string; overflowed: boolean } {
+    let buffer = initialBuffer;
+    let overflowed = initialOverflowed;
+    let idx: number;
+    while ((idx = buffer.indexOf("\n")) >= 0) {
+      if (overflowed || idx > WORKER_STREAM_LINE_CHARS) {
+        this.pushOversizedLine(stream);
+      } else {
+        const line = buffer.slice(0, idx);
+        if (stream === "stdout") this.pushStdoutLine(line);
+        else this.pushStderrLine(line);
+      }
+      buffer = buffer.slice(idx + 1);
+      overflowed = false;
+    }
+    if (buffer.length > WORKER_STREAM_LINE_CHARS) {
+      buffer = "";
+      overflowed = true;
+    }
+    return { buffer, overflowed };
+  }
+
+  private pushOversizedLine(stream: "stdout" | "stderr"): void {
+    const message =
+      `[relay] worker ${stream} line exceeded ${WORKER_STREAM_LINE_CHARS} characters ` +
+      "and was omitted";
+    if (stream === "stdout") this.pushHumanText(message);
+    else this.pushStderrLine(message);
   }
 
   private pushStdoutLine(line: string): void {
@@ -559,28 +604,19 @@ class LiveWorkerHandle implements WorkerHandle {
     const processed = processStreamLine(line, this.streamState, () => {});
     const text = processed.kind === "diagnostic" ? processed.text : processed.assistantText;
     if (text) this.pushHumanText(text);
-    const prText = processed.kind === "diagnostic" ? processed.text : processed.assistantText;
-    if (!this._detectedPrUrl && prText) {
-      const match = prText.match(PR_URL_PATTERN);
+    if (!this._detectedPrUrl && processed.kind === "structured" && processed.assistantText) {
+      const match = processed.assistantText.match(PR_URL_PATTERN);
       if (match) this._detectedPrUrl = match[0];
     }
   }
 
   private pushHumanText(text: string): void {
-    for (const line of text.split("\n")) {
-      if (line) this.stdoutLines.push(line);
-    }
-    if (this.stdoutLines.length > WORKER_STDOUT_TAIL_LINES) {
-      this.stdoutLines.splice(0, this.stdoutLines.length - WORKER_STDOUT_TAIL_LINES);
-    }
+    this.stdoutLines = appendBoundedTail(this.stdoutLines, text, WORKER_STDOUT_TAIL_LINES);
   }
 
   private pushStderrLine(line: string): void {
     if (!line) return;
-    this.stderrLines.push(line);
-    if (this.stderrLines.length > WORKER_STDERR_TAIL_LINES) {
-      this.stderrLines.splice(0, this.stderrLines.length - WORKER_STDERR_TAIL_LINES);
-    }
+    this.stderrLines = appendBoundedTail(this.stderrLines, line, WORKER_STDERR_TAIL_LINES);
   }
 
   private finish(exitCode: number | null, signal: NodeJS.Signals | null): void {

--- a/test/agents/cli-agents-claude-usage.test.ts
+++ b/test/agents/cli-agents-claude-usage.test.ts
@@ -87,4 +87,60 @@ describe("processStreamLine — Claude streaming usage capture", () => {
 
     expect(state.reportedCostUsd).toBe(0.2);
   });
+
+  it("bounds retained assistant text when the caller configures a limit", () => {
+    const state = { ...freshState(), maxAccumTextChars: 8 };
+
+    processStreamLine(
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "0123456789" }] },
+      }),
+      state,
+      () => {}
+    );
+
+    expect(state.accumText).toBe("23456789");
+    expect(state.lastAssistantText).toBe("23456789");
+  });
+
+  it("retains a terminal result that is only a substring of earlier assistant text", () => {
+    const state = freshState();
+
+    processStreamLine(
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Work already done earlier." }] },
+      }),
+      state,
+      () => {}
+    );
+    const result = processStreamLine(
+      JSON.stringify({ type: "result", result: "done" }),
+      state,
+      () => {}
+    );
+
+    expect(result).toEqual({ kind: "structured", assistantText: "done" });
+  });
+
+  it("does not repeat a terminal result that exactly matches the last assistant text", () => {
+    const state = freshState();
+
+    processStreamLine(
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "done" }] },
+      }),
+      state,
+      () => {}
+    );
+    const result = processStreamLine(
+      JSON.stringify({ type: "result", result: "done" }),
+      state,
+      () => {}
+    );
+
+    expect(result).toEqual({ kind: "structured" });
+  });
 });

--- a/test/agents/cli-agents-claude-usage.test.ts
+++ b/test/agents/cli-agents-claude-usage.test.ts
@@ -2,12 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import { processStreamLine, type StreamParseState } from "../../src/agents/process-stream-line.js";
 
-/**
- * RED tests for the Claude streaming-usage extraction. PR-1 ships the
- * stub-throwing `processStreamLine`; PR-2 (Task 3) lifts the existing
- * closure body in `cli-agents.ts::invokeStreaming` into this function
- * and adds the `obj.usage` capture on the `result` arm.
- */
 describe("processStreamLine — Claude streaming usage capture", () => {
   function freshState(): StreamParseState {
     return {
@@ -101,11 +95,11 @@ describe("processStreamLine — Claude streaming usage capture", () => {
     );
 
     expect(state.accumText).toBe("23456789");
-    expect(state.lastAssistantText).toBe("23456789");
+    expect(state.lastAssistantTextHash).toBeDefined();
   });
 
   it("retains a terminal result that is only a substring of earlier assistant text", () => {
-    const state = freshState();
+    const state = { ...freshState(), maxAccumTextChars: 64 };
 
     processStreamLine(
       JSON.stringify({
@@ -125,22 +119,58 @@ describe("processStreamLine — Claude streaming usage capture", () => {
   });
 
   it("does not repeat a terminal result that exactly matches the last assistant text", () => {
-    const state = freshState();
+    const state = { ...freshState(), maxAccumTextChars: 8 };
+    const text = "0123456789";
 
     processStreamLine(
       JSON.stringify({
         type: "assistant",
-        message: { content: [{ type: "text", text: "done" }] },
+        message: { content: [{ type: "text", text }] },
       }),
       state,
       () => {}
     );
     const result = processStreamLine(
-      JSON.stringify({ type: "result", result: "done" }),
+      JSON.stringify({ type: "result", result: text }),
       state,
       () => {}
     );
 
     expect(result).toEqual({ kind: "structured" });
+  });
+
+  it("bounds retained terminal result text when the caller configures a limit", () => {
+    const state = { ...freshState(), maxAccumTextChars: 8 };
+
+    const result = processStreamLine(
+      JSON.stringify({ type: "result", result: "0123456789" }),
+      state,
+      () => {}
+    );
+
+    expect(state.resultText).toBe("23456789");
+    expect(result).toEqual({ kind: "structured", assistantText: "0123456789" });
+  });
+
+  it("ignores unsafe token sums and provider totals", () => {
+    const state = freshState();
+
+    processStreamLine(JSON.stringify({ type: "result", total_cost_usd: 0.2 }), state, () => {});
+    processStreamLine(
+      JSON.stringify({
+        type: "result",
+        total_cost_usd: 1e308,
+        usage: {
+          input_tokens: Number.MAX_SAFE_INTEGER,
+          cache_read_input_tokens: Number.MAX_SAFE_INTEGER,
+          output_tokens: 0,
+        },
+      }),
+      state,
+      () => {}
+    );
+
+    expect(state.reportedCostUsd).toBe(0.2);
+    expect(state.capturedUsage).toBeNull();
   });
 });

--- a/test/agents/cli-agents-claude-usage.test.ts
+++ b/test/agents/cli-agents-claude-usage.test.ts
@@ -10,7 +10,13 @@ import { processStreamLine, type StreamParseState } from "../../src/agents/proce
  */
 describe("processStreamLine — Claude streaming usage capture", () => {
   function freshState(): StreamParseState {
-    return { accumText: "", resultText: null, capturedUsage: null, capturedModel: null };
+    return {
+      accumText: "",
+      resultText: null,
+      capturedUsage: null,
+      capturedModel: null,
+      reportedCostUsd: null,
+    };
   }
 
   it("captures `usage` from the `result` event with cache tokens summed into inputTokens", () => {
@@ -55,5 +61,30 @@ describe("processStreamLine — Claude streaming usage capture", () => {
     processStreamLine(line, state, () => {});
     expect(state.capturedUsage?.inputTokens).toBe(100 + 200);
     expect(state.capturedUsage?.cacheWriteTokens).toBe(200);
+  });
+
+  it("keeps the latest valid reported total cost without summing cumulative result events", () => {
+    const state = freshState();
+
+    processStreamLine(
+      JSON.stringify({
+        type: "result",
+        total_cost_usd: 0.12,
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+      state,
+      () => {}
+    );
+    processStreamLine(
+      JSON.stringify({
+        type: "result",
+        total_cost_usd: 0.2,
+        usage: { input_tokens: 20, output_tokens: 4 },
+      }),
+      state,
+      () => {}
+    );
+
+    expect(state.reportedCostUsd).toBe(0.2);
   });
 });

--- a/test/budget/task-cost-ledger.test.ts
+++ b/test/budget/task-cost-ledger.test.ts
@@ -87,6 +87,50 @@ describe("TaskCostLedger", () => {
     }
   });
 
+  it("falls back to token pricing when a provider total is outside the safe range", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-cost-"));
+    try {
+      const ledger = new TaskCostLedger({ rootDir: dir });
+      await ledger.record({
+        runId: "run-1",
+        ticketId: "t-1",
+        taskType: "bugfix",
+        workKind: "implement_phase",
+        attempt: 1,
+        model: "claude-sonnet-4-5",
+        tokenUsage: { inputTokens: 1_000_000, outputTokens: 0 },
+        reportedCostUsd: 1e308,
+      });
+
+      const [line] = await ledger.readAll();
+      expect(line?.costUsd).toBe(3);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unsafe token values instead of appending a corrupt line", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-cost-"));
+    try {
+      const ledger = new TaskCostLedger({ rootDir: dir });
+
+      await expect(
+        ledger.record({
+          runId: "run-1",
+          ticketId: "t-unsafe",
+          taskType: "bugfix",
+          workKind: "implement_phase",
+          attempt: 1,
+          model: "claude-sonnet-4-5",
+          tokenUsage: { inputTokens: Number.MAX_VALUE, outputTokens: 0 },
+        })
+      ).rejects.toThrow();
+      expect(await ledger.readAll()).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("bills $0 (with a warning) when the model is missing", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const dir = await mkdtemp(join(tmpdir(), "task-cost-"));

--- a/test/budget/task-cost-ledger.test.ts
+++ b/test/budget/task-cost-ledger.test.ts
@@ -43,6 +43,50 @@ describe("TaskCostLedger", () => {
     }
   });
 
+  it("uses a provider-reported total instead of adding token-derived cost", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-cost-"));
+    try {
+      const ledger = new TaskCostLedger({ rootDir: dir });
+      await ledger.record({
+        runId: "run-1",
+        ticketId: "t-1",
+        taskType: "feature_small",
+        workKind: "implement_phase",
+        attempt: 1,
+        model: "claude-sonnet-4-5",
+        tokenUsage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+        reportedCostUsd: 0.123,
+      });
+
+      const [line] = await ledger.readAll();
+      expect(line?.costUsd).toBe(0.123);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to token pricing when a failed provider reports zero cost", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-cost-"));
+    try {
+      const ledger = new TaskCostLedger({ rootDir: dir });
+      await ledger.record({
+        runId: "run-1",
+        ticketId: "t-1",
+        taskType: "bugfix",
+        workKind: "implement_phase",
+        attempt: 1,
+        model: "claude-sonnet-4-5",
+        tokenUsage: { inputTokens: 1_000_000, outputTokens: 0 },
+        reportedCostUsd: 0,
+      });
+
+      const [line] = await ledger.readAll();
+      expect(line?.costUsd).toBe(3);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("bills $0 (with a warning) when the model is missing", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const dir = await mkdtemp(join(tmpdir(), "task-cost-"));

--- a/test/integration/live-worker-cost.test.ts
+++ b/test/integration/live-worker-cost.test.ts
@@ -1,0 +1,191 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { NodeCommandInvoker, type SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { TaskCostLedger } from "../../src/budget/task-cost-ledger.js";
+import { ChannelStore } from "../../src/channels/channel-store.js";
+import { handleCostCommand } from "../../src/cli/cost.js";
+import { handleRunAutonomous } from "../../src/cli/run-autonomous.js";
+import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
+import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
+import type { SandboxProvider, SandboxRef } from "../../src/execution/sandbox.js";
+import {
+  RELAY_AL14_WORKER_DRAIN,
+  startAutonomousSession,
+} from "../../src/orchestrator/autonomous-loop.js";
+import { RELAY_REPO_ADMIN_POOL_ENABLED } from "../../src/orchestrator/repo-admin-pool.js";
+import type { RepoAdminProcessSpawner } from "../../src/orchestrator/repo-admin-session.js";
+import { WorkerSpawner } from "../../src/orchestrator/worker-spawner.js";
+import { FileHarnessStore } from "../../src/storage/file-store.js";
+
+class Sink {
+  data = "";
+  write(chunk: string): boolean {
+    this.data += chunk;
+    return true;
+  }
+}
+
+class FakeAdminSpawner implements RepoAdminProcessSpawner {
+  spawn(): SpawnedProcess {
+    const exitListeners: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = [];
+    let exited = false;
+    return {
+      pid: 41_001,
+      onStdout() {},
+      onStderr() {},
+      onExit(listener) {
+        exitListeners.push(listener);
+      },
+      onError() {},
+      kill() {
+        if (!exited) {
+          exited = true;
+          for (const listener of exitListeners) listener(0, "SIGTERM");
+        }
+        return true;
+      },
+    };
+  }
+}
+
+class LocalSandboxProvider implements SandboxProvider {
+  async create(repo: { root: string }, base: string): Promise<SandboxRef> {
+    return {
+      id: "live-worker-cost",
+      workdir: { kind: "local", path: repo.root },
+      meta: { branch: "live-worker-cost", base },
+    };
+  }
+
+  async destroy() {
+    return { kind: "missing" } as const;
+  }
+}
+
+const liveDescribe = process.env.HARNESS_LIVE === "1" ? describe : describe.skip;
+
+liveDescribe("live Claude worker cost capture", () => {
+  it("records a real worker result and renders it through rly cost", async () => {
+    expect(process.env.HARNESS_LIVE).toBe("1");
+    const base = await mkdtemp(join(tmpdir(), "relay-live-worker-cost-"));
+    const root = join(base, "home", ".relay");
+    const originalHome = process.env.HOME;
+    const originalPoolFlag = process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+    const originalDrainFlag = process.env[RELAY_AL14_WORKER_DRAIN];
+    try {
+      process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = "1";
+      process.env[RELAY_AL14_WORKER_DRAIN] = "1";
+      const repoAssignment: RepoAssignment = {
+        alias: "relay",
+        workspaceId: "live-worker-cost",
+        repoPath: base,
+      };
+      const channelStore = new ChannelStore(
+        join(root, "channels"),
+        new FileHarnessStore(join(root, "store"))
+      );
+      const persisted = await channelStore.createChannel({
+        name: "live-worker-cost",
+        description: "opt-in worker accounting check",
+        workspaceIds: [repoAssignment.workspaceId],
+        repoAssignments: [repoAssignment],
+      });
+      const channel: Channel = {
+        ...persisted,
+        repoAssignments: [repoAssignment],
+        fullAccess: false,
+      };
+      const ticket: TicketLedgerEntry = {
+        ticketId: "live-worker-cost",
+        title: "verify live worker cost capture",
+        specialty: "general",
+        status: "ready",
+        dependsOn: [],
+        assignedAgentId: null,
+        assignedAgentName: null,
+        crosslinkSessionId: null,
+        verification: "pending",
+        lastClassification: null,
+        chosenNextAction: null,
+        attempt: 0,
+        startedAt: null,
+        completedAt: null,
+        updatedAt: new Date().toISOString(),
+        runId: "live-worker-cost",
+        taskType: "trivial",
+        assignedAlias: "relay",
+      };
+      await channelStore.writeChannelTickets(channel.channelId, [ticket]);
+
+      const spawner = new WorkerSpawner({
+        invoker: new NodeCommandInvoker(),
+        sandboxProvider: new LocalSandboxProvider(),
+        buildPrompt: () =>
+          "Do not call tools or modify files. Reply with exactly: Opened https://github.com/jcast90/relay/pull/999999",
+      });
+      const run = await handleRunAutonomous(
+        [
+          "--autonomous",
+          channel.channelId,
+          "--budget-tokens",
+          "10000",
+          "--max-hours",
+          "1",
+          "--json",
+        ],
+        {
+          rootDir: root,
+          channelsDir: join(root, "channels"),
+          channelStore,
+          sessionIdFactory: () => "live-worker-cost",
+          stdout: () => {},
+          stderr: () => {},
+          startSession: (options) =>
+            startAutonomousSession({
+              ...options,
+              testOverrides: {
+                channelStore,
+                repoAdminSpawner: new FakeAdminSpawner(),
+                workerSpawner: spawner,
+                rootDir: root,
+                pollIntervalMs: 2,
+              },
+            }),
+        }
+      );
+      expect(run.exitCode).toBe(0);
+
+      const costLedger = new TaskCostLedger({ rootDir: root });
+      await costLedger.flush();
+
+      const lines = await costLedger.readAll();
+      expect(lines).toHaveLength(1);
+      expect(lines[0].inputTokens + lines[0].outputTokens).toBeGreaterThan(0);
+      expect(lines[0].costUsd).toBeGreaterThan(0);
+      const board = await channelStore.readChannelTickets(channel.channelId);
+      expect(board[0].status).toBe("verifying");
+
+      process.env.HOME = join(base, "home");
+      const stdout = new Sink();
+      const stderr = new Sink();
+      const result = await handleCostCommand({ argv: ["--json"], stdout, stderr });
+      expect(result.exitCode).toBe(0);
+      expect(stderr.data).toBe("");
+      const report = JSON.parse(stdout.data);
+      expect(report.callCount).toBe(1);
+      expect(report.taskCount).toBe(1);
+      expect(report.totalUsd).toBe(lines[0].costUsd);
+    } finally {
+      process.env.HOME = originalHome;
+      if (originalPoolFlag === undefined) delete process.env[RELAY_REPO_ADMIN_POOL_ENABLED];
+      else process.env[RELAY_REPO_ADMIN_POOL_ENABLED] = originalPoolFlag;
+      if (originalDrainFlag === undefined) delete process.env[RELAY_AL14_WORKER_DRAIN];
+      else process.env[RELAY_AL14_WORKER_DRAIN] = originalDrainFlag;
+      await rm(base, { recursive: true, force: true });
+    }
+  }, 180_000);
+});

--- a/test/orchestrator/autonomous-loop-drain.test.ts
+++ b/test/orchestrator/autonomous-loop-drain.test.ts
@@ -35,7 +35,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SpawnedProcess } from "../../src/agents/command-invoker.js";
+import { TaskCostLedger } from "../../src/budget/task-cost-ledger.js";
 import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { TokenUsage } from "../../src/domain/agent.js";
 import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
 import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
 import type { SandboxRef } from "../../src/execution/sandbox.js";
@@ -161,6 +163,9 @@ class FakeWorkerHandle implements WorkerHandle {
     prUrl?: string | null;
     stdoutTail?: string;
     stderrTail?: string;
+    tokenUsage?: TokenUsage;
+    model?: string;
+    reportedCostUsd?: number;
   }): void {
     if (this.finalEvent) return;
     this._prUrl = args.prUrl ?? null;
@@ -176,6 +181,9 @@ class FakeWorkerHandle implements WorkerHandle {
       stdoutTail: args.stdoutTail ?? "",
       stderrTail: args.stderrTail ?? "",
       detectedPrUrl: args.prUrl ?? null,
+      ...(args.tokenUsage ? { tokenUsage: args.tokenUsage } : {}),
+      ...(args.model ? { model: args.model } : {}),
+      ...(args.reportedCostUsd !== undefined ? { reportedCostUsd: args.reportedCostUsd } : {}),
     };
     if (args.exitCode === 0) this._state = "completed";
     else if (args.exitCode === null) this._state = "stopped";
@@ -283,7 +291,8 @@ function makeTicket(id: string, alias: string): TicketLedgerEntry {
     startedAt: null,
     completedAt: null,
     updatedAt: "2026-04-21T00:00:00.000Z",
-    runId: null,
+    runId: "run-drain-cost",
+    taskType: "feature_small",
     assignedAlias: alias,
   };
 }
@@ -428,12 +437,20 @@ describe("startAutonomousSession — AL-14 drain wiring", () => {
     // Complete fe-1 and be-1 so each admin progresses to its second
     // ticket (fe-2 / be-2 respectively). PR URLs are distinct so the
     // verifying-state mirror on the board doesn't collide.
-    fx.workerSpawner
-      .handles("frontend")[0]
-      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/1" });
-    fx.workerSpawner
-      .handles("backend")[0]
-      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/2" });
+    fx.workerSpawner.handles("frontend")[0].fire({
+      exitCode: 0,
+      prUrl: "https://github.com/o/r/pull/1",
+      tokenUsage: { inputTokens: 10, outputTokens: 2 },
+      model: "claude-sonnet-4-6",
+      reportedCostUsd: 0.01,
+    });
+    fx.workerSpawner.handles("backend")[0].fire({
+      exitCode: 0,
+      prUrl: "https://github.com/o/r/pull/2",
+      tokenUsage: { inputTokens: 20, outputTokens: 4 },
+      model: "claude-sonnet-4-6",
+      reportedCostUsd: 0.02,
+    });
 
     await waitUntil(
       () =>
@@ -444,12 +461,20 @@ describe("startAutonomousSession — AL-14 drain wiring", () => {
     expect(fx.workerSpawner.handles("backend")[1].ticketId).toBe("be-2");
 
     // Complete the second ticket on each admin.
-    fx.workerSpawner
-      .handles("frontend")[1]
-      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/3" });
-    fx.workerSpawner
-      .handles("backend")[1]
-      .fire({ exitCode: 0, prUrl: "https://github.com/o/r/pull/4" });
+    fx.workerSpawner.handles("frontend")[1].fire({
+      exitCode: 0,
+      prUrl: "https://github.com/o/r/pull/3",
+      tokenUsage: { inputTokens: 30, outputTokens: 6 },
+      model: "claude-sonnet-4-6",
+      reportedCostUsd: 0.03,
+    });
+    fx.workerSpawner.handles("backend")[1].fire({
+      exitCode: 0,
+      prUrl: "https://github.com/o/r/pull/4",
+      tokenUsage: { inputTokens: 40, outputTokens: 8 },
+      model: "claude-sonnet-4-6",
+      reportedCostUsd: 0.04,
+    });
 
     await driverP;
 
@@ -478,6 +503,13 @@ describe("startAutonomousSession — AL-14 drain wiring", () => {
     // SPAWN-COUNT INVARIANT: exactly one spawn per ticket (no retries,
     // no duplicates).
     expect(fx.workerSpawner.spawn).toHaveBeenCalledTimes(4);
+
+    const costLines = await new TaskCostLedger({ rootDir: fx.root }).readAll();
+    expect(costLines).toHaveLength(4);
+    expect(costLines.map((line) => line.ticketId).sort()).toEqual(["be-1", "be-2", "fe-1", "fe-2"]);
+    expect(costLines.every((line) => line.runId === "run-drain-cost")).toBe(true);
+    expect(costLines.every((line) => line.taskType === "feature_small")).toBe(true);
+    expect(costLines.reduce((sum, line) => sum + line.costUsd, 0)).toBeCloseTo(0.1);
   }, 10_000);
 
   it("one admin's drain failure does NOT wedge the other admin's drain", async () => {

--- a/test/orchestrator/ticket-runner.test.ts
+++ b/test/orchestrator/ticket-runner.test.ts
@@ -410,7 +410,7 @@ describe("TicketRunner", () => {
     });
   });
 
-  it("does not fabricate a ledger entry when the worker reports no usage", async () => {
+  it("records a positive provider estimate when token usage is missing", async () => {
     const h = await buildHarness();
     cleanup = h.cleanup;
 
@@ -418,6 +418,28 @@ describe("TicketRunner", () => {
     const drainP = h.runner.drain();
     await waitUntil(() => h.spawner.spawned.length >= 1);
     h.spawner.last().fire({ exitCode: 2, reportedCostUsd: 0.5 });
+    await drainP;
+
+    expect(await h.costLedger.readAll()).toEqual([
+      expect.objectContaining({
+        runId: "run-cost",
+        ticketId: "t-no-usage",
+        taskType: "feature_small",
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0.5,
+      }),
+    ]);
+  });
+
+  it("does not fabricate a ledger entry when the worker reports no cost data", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(buildTicket("t-no-cost", { runId: "run-cost", taskType: "feature_small" }));
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    h.spawner.last().fire({ exitCode: 2 });
     await drainP;
 
     expect(await h.costLedger.readAll()).toEqual([]);

--- a/test/orchestrator/ticket-runner.test.ts
+++ b/test/orchestrator/ticket-runner.test.ts
@@ -19,7 +19,9 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { TaskCostLedger } from "../../src/budget/task-cost-ledger.js";
 import { ChannelStore } from "../../src/channels/channel-store.js";
+import type { TokenUsage } from "../../src/domain/agent.js";
 import type { Channel, RepoAssignment } from "../../src/domain/channel.js";
 import type { TicketLedgerEntry } from "../../src/domain/ticket.js";
 import type { SandboxRef } from "../../src/execution/sandbox.js";
@@ -109,6 +111,9 @@ class FakeWorkerHandle implements WorkerHandle {
     stdoutTail?: string;
     stderrTail?: string;
     prUrl?: string | null;
+    tokenUsage?: TokenUsage;
+    model?: string;
+    reportedCostUsd?: number;
   }): void {
     if (this.finalEvent) return; // idempotent
     this._prUrl = args.prUrl ?? null;
@@ -124,6 +129,9 @@ class FakeWorkerHandle implements WorkerHandle {
       stdoutTail: args.stdoutTail ?? "",
       stderrTail: args.stderrTail ?? "",
       detectedPrUrl: args.prUrl ?? null,
+      ...(args.tokenUsage ? { tokenUsage: args.tokenUsage } : {}),
+      ...(args.model ? { model: args.model } : {}),
+      ...(args.reportedCostUsd !== undefined ? { reportedCostUsd: args.reportedCostUsd } : {}),
     };
     if (args.exitCode === 0) this._state = "completed";
     else if (args.exitCode === null) this._state = "stopped";
@@ -245,12 +253,14 @@ async function buildHarness() {
 
   const admin = new FakeAdmin("backend");
   const spawner = new FakeSpawner();
+  const costLedger = new TaskCostLedger({ rootDir: root });
   const runner = new TicketRunner({
     admin: admin as unknown as RepoAdminSession,
     repoAssignment: repoAssignments[0],
     channel,
     channelStore,
     spawner: spawner as unknown as WorkerSpawner,
+    costLedger,
     now: () => "2026-04-21T00:00:00.000Z",
   });
 
@@ -258,7 +268,7 @@ async function buildHarness() {
     await rm(root, { recursive: true, force: true });
   };
 
-  return { root, channelStore, channel, admin, spawner, runner, cleanup };
+  return { root, channelStore, channel, admin, spawner, costLedger, runner, cleanup };
 }
 
 describe("TicketRunner", () => {
@@ -368,6 +378,49 @@ describe("TicketRunner", () => {
 
     // Event emitted on the runner (AC4).
     expect(failures).toEqual([{ ticketId: "t-fail", exitCode: 2 }]);
+  });
+
+  it("records usage from a failed live worker and prefers its reported total cost", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(
+      buildTicket("t-cost", { runId: "run-cost", taskType: "feature_small", attempt: 2 })
+    );
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    h.spawner.last().fire({
+      exitCode: 2,
+      tokenUsage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      model: "claude-sonnet-4-5",
+      reportedCostUsd: 0.5,
+    });
+    await drainP;
+
+    const lines = await h.costLedger.readAll();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      runId: "run-cost",
+      ticketId: "t-cost",
+      taskType: "feature_small",
+      attempt: 3,
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      costUsd: 0.5,
+    });
+  });
+
+  it("does not fabricate a ledger entry when the worker reports no usage", async () => {
+    const h = await buildHarness();
+    cleanup = h.cleanup;
+
+    h.admin.enqueue(buildTicket("t-no-usage", { runId: "run-cost", taskType: "feature_small" }));
+    const drainP = h.runner.drain();
+    await waitUntil(() => h.spawner.spawned.length >= 1);
+    h.spawner.last().fire({ exitCode: 2, reportedCostUsd: 0.5 });
+    await drainP;
+
+    expect(await h.costLedger.readAll()).toEqual([]);
   });
 
   it("clean exit with no PR URL fails the ticket and preserves the worktree", async () => {

--- a/test/orchestrator/worker-spawner.test.ts
+++ b/test/orchestrator/worker-spawner.test.ts
@@ -32,7 +32,12 @@ import type {
   SandboxProvider,
   SandboxRef,
 } from "../../src/execution/sandbox.js";
-import { WorkerSpawner, type WorkerExitEvent } from "../../src/orchestrator/worker-spawner.js";
+import {
+  WORKER_STREAM_LINE_CHARS,
+  WORKER_STREAM_TEXT_CHARS,
+  WorkerSpawner,
+  type WorkerExitEvent,
+} from "../../src/orchestrator/worker-spawner.js";
 
 type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
 type StdListener = (chunk: string) => void;
@@ -337,6 +342,70 @@ describe("WorkerSpawner", () => {
     expect(evt.stdoutTail).toBe('starting worker\n{"type":"assistant"');
     expect(evt.tokenUsage).toBeUndefined();
     expect(evt.reportedCostUsd).toBeUndefined();
+  });
+
+  it("does not treat a PR URL in diagnostic output as assistant-authored", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-diagnostic-pr"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+
+    child.emitStdout("warning: https://github.com/example/project/pull/123\n");
+    child.emitExit(0);
+
+    const evt = await exitP;
+    expect(evt.stdoutTail).toContain("https://github.com/example/project/pull/123");
+    expect(evt.detectedPrUrl).toBeNull();
+  });
+
+  it("bounds retained stdout and stderr by characters as well as lines", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-bounded-tail"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+    const suffix = "tail-marker";
+
+    child.emitStdout(
+      `${JSON.stringify({
+        type: "result",
+        result: `${"x".repeat(WORKER_STREAM_TEXT_CHARS + 100)}${suffix}`,
+      })}\n`
+    );
+    child.emitStderr(`${"e".repeat(WORKER_STREAM_TEXT_CHARS + 100)}${suffix}\n`);
+    child.emitExit(0);
+
+    const evt = await exitP;
+    expect(evt.stdoutTail.length).toBeLessThanOrEqual(WORKER_STREAM_TEXT_CHARS);
+    expect(evt.stderrTail.length).toBeLessThanOrEqual(WORKER_STREAM_TEXT_CHARS);
+    expect(evt.stdoutTail.endsWith(suffix)).toBe(true);
+    expect(evt.stderrTail.endsWith(suffix)).toBe(true);
+  });
+
+  it("omits oversized unterminated stdout and stderr lines", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-oversized-partial"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+    const oversized = "x".repeat(WORKER_STREAM_LINE_CHARS + 1);
+
+    child.emitStdout(oversized);
+    child.emitStderr(oversized);
+    child.emitExit(2);
+
+    const evt = await exitP;
+    expect(evt.stdoutTail).toContain("stdout line exceeded");
+    expect(evt.stderrTail).toContain("stderr line exceeded");
+    expect(evt.stdoutTail.length).toBeLessThanOrEqual(WORKER_STREAM_TEXT_CHARS);
+    expect(evt.stderrTail.length).toBeLessThanOrEqual(WORKER_STREAM_TEXT_CHARS);
   });
 
   it("parses a final partial result line before exit", async () => {

--- a/test/orchestrator/worker-spawner.test.ts
+++ b/test/orchestrator/worker-spawner.test.ts
@@ -32,7 +32,7 @@ import type {
   SandboxProvider,
   SandboxRef,
 } from "../../src/execution/sandbox.js";
-import { WorkerSpawner } from "../../src/orchestrator/worker-spawner.js";
+import { WorkerSpawner, type WorkerExitEvent } from "../../src/orchestrator/worker-spawner.js";
 
 type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
 type StdListener = (chunk: string) => void;
@@ -234,6 +234,9 @@ describe("WorkerSpawner", () => {
     expect(invoker.spawned).toHaveLength(1);
     expect(invoker.last().invocation.cwd).toBe(result.worktreePath);
     expect(invoker.last().invocation.command).toBe("claude");
+    expect(invoker.last().invocation.args).toContain("--output-format");
+    expect(invoker.last().invocation.args).toContain("stream-json");
+    expect(invoker.last().invocation.args).toContain("--verbose");
     expect(invoker.last().invocation.args).not.toContain("--dangerously-skip-permissions");
     expect(invoker.last().invocation.args).toContain("--permission-mode");
   });
@@ -267,26 +270,141 @@ describe("WorkerSpawner", () => {
     expect(args).not.toContain("--dangerously-skip-permissions");
   });
 
-  it("picks up PR URLs from stdout and surfaces them on the exit event", async () => {
+  it("parses structured output into a readable tail, PR URL, usage, model, and cost", async () => {
     const ticket = buildTicket("t-pr");
     const channel = buildChannel(false);
     const { handle } = await spawner.spawn({ ticket, repoAssignment: BACKEND, channel });
 
     const child = invoker.last();
-    const exitP = new Promise<{ detectedPrUrl: string | null; exitCode: number | null }>(
-      (resolve) => {
-        handle.onExit((e) => resolve({ detectedPrUrl: e.detectedPrUrl, exitCode: e.exitCode }));
-      }
-    );
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
 
-    child.emitStdout("opening PR...\nhttps://github.com/jcast90/relay/pull/42\ndone\n");
+    child.emitStdout(
+      [
+        JSON.stringify({ type: "system", subtype: "init", model: "claude-sonnet-4-5" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "text",
+                text: "Opened https://github.com/jcast90/relay/pull/42 for review.",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "done",
+          total_cost_usd: 0.42,
+          usage: { input_tokens: 100, output_tokens: 25, cache_read_input_tokens: 50 },
+        }),
+        "",
+      ].join("\n")
+    );
     child.emitExit(0);
 
     const evt = await exitP;
     expect(evt.detectedPrUrl).toBe("https://github.com/jcast90/relay/pull/42");
     expect(evt.exitCode).toBe(0);
+    expect(evt.stdoutTail).toBe(
+      "Opened https://github.com/jcast90/relay/pull/42 for review.\ndone"
+    );
+    expect(evt.stdoutTail).not.toContain('\"type\":\"assistant\"');
+    expect(evt.tokenUsage).toEqual({
+      inputTokens: 150,
+      outputTokens: 25,
+      cacheReadTokens: 50,
+    });
+    expect(evt.model).toBe("claude-sonnet-4-5");
+    expect(evt.reportedCostUsd).toBe(0.42);
     expect(handle.state).toBe("completed");
     expect(handle.detectedPrUrl).toBe("https://github.com/jcast90/relay/pull/42");
+  });
+
+  it("preserves non-JSON diagnostics and malformed structured lines", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-diagnostics"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+
+    child.emitStdout('starting worker\n{"type":"assistant"\n');
+    child.emitExit(2);
+
+    const evt = await exitP;
+    expect(evt.stdoutTail).toBe('starting worker\n{"type":"assistant"');
+    expect(evt.tokenUsage).toBeUndefined();
+    expect(evt.reportedCostUsd).toBeUndefined();
+  });
+
+  it("parses a final partial result line before exit", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-partial"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+
+    child.emitStdout(
+      JSON.stringify({
+        type: "result",
+        total_cost_usd: 0.01,
+        usage: { input_tokens: 3, output_tokens: 1 },
+      })
+    );
+    child.emitExit(0);
+
+    const evt = await exitP;
+    expect(evt.tokenUsage).toEqual({ inputTokens: 3, outputTokens: 1 });
+    expect(evt.reportedCostUsd).toBe(0.01);
+  });
+
+  it("does not emit a confident usage reading for an empty usage object", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-empty-usage"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+
+    child.emitStdout(`${JSON.stringify({ type: "result", usage: {} })}\n`);
+    child.emitExit(2);
+
+    expect((await exitP).tokenUsage).toBeUndefined();
+  });
+
+  it("retains terminal result text and its PR URL after earlier assistant output", async () => {
+    const { handle } = await spawner.spawn({
+      ticket: buildTicket("t-terminal-result"),
+      repoAssignment: BACKEND,
+      channel: buildChannel(false),
+    });
+    const child = invoker.last();
+    const exitP = new Promise<WorkerExitEvent>((resolve) => handle.onExit(resolve));
+
+    child.emitStdout(
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Still working." }] },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "Opened https://github.com/jcast90/relay/pull/43",
+          usage: { input_tokens: 10, output_tokens: 2 },
+        }),
+        "",
+      ].join("\n")
+    );
+    child.emitExit(0);
+
+    const evt = await exitP;
+    expect(evt.stdoutTail).toBe("Still working.\nOpened https://github.com/jcast90/relay/pull/43");
+    expect(evt.detectedPrUrl).toBe("https://github.com/jcast90/relay/pull/43");
   });
 
   it("reports failure + stdout/stderr tail on non-zero exit", async () => {

--- a/test/ticket.test.ts
+++ b/test/ticket.test.ts
@@ -112,4 +112,9 @@ describe("initializeTicketLedger", () => {
     expect(ledger[0].runId).toBe("run-abc");
     expect(ledger[1].runId).toBe("run-abc");
   });
+
+  it("tags every entry with the supplied task type", () => {
+    const ledger = initializeTicketLedger([ticket("a"), ticket("b")], "run-abc", "bugfix");
+    expect(ledger.map((entry) => entry.taskType)).toEqual(["bugfix", "bugfix"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Request Claude `stream-json` output in the live `WorkerSpawner` path, route it through the shared parser, and retain bounded human-readable assistant/diagnostic tails while only detecting PR URLs in parsed assistant text.
- Record one classified live-worker cost entry per completed call. Claude's latest `total_cost_usd` is treated as a client-side estimate and used once when available; Relay's token-price table is only the fallback, so the two sources are never added together.
- Preserve failure, cancellation, partial-output, stderr, and worktree-cleanup behavior; reject unsafe numeric/output sizes; document the observational (not billing-authoritative) cost semantics.

Closes #243

## Test plan

- [x] `pnpm test` (1,248 passed, 29 skipped)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `cargo check --workspace --locked`
- [x] `cargo test -p harness-data` (91 passed)
- [x] `cd gui && pnpm build`
- [x] `HARNESS_LIVE=1 ./node_modules/.bin/vitest run test/integration/live-worker-cost.test.ts` (real autonomous handler -> Claude -> cost ledger -> `rly cost`)
- [x] Focused fake-worker and regression coverage for parsed assistant/result output, PR URL detection, malformed and non-JSON diagnostics, partial/oversized output, missing/unsafe usage, provider-only cost, failures, stop behavior, task classification, and cost-source precedence

## Size check

Diff size: `1004` lines added / `95` deleted.

This exceeds 800 lines because 724 additions are focused regression and opt-in integration tests. The production/documentation change is 280 additions and 66 deletions across the existing worker, parser, cost-ledger, ticket-classification, and mirrored type paths; it does not introduce a parallel parsing or orchestration framework.

## Breaking changes?

No. The new ticket `taskType` field is optional and the Rust mirror uses a default for existing serialized tickets. Existing non-JSON diagnostics and failure/cleanup behavior remain supported.

## AI-assisted?

Yes. OpenAI Codex provided substantial assistance with investigation, implementation, tests, and review. Every commit includes the required `Co-Authored-By: OpenAI Codex <noreply@openai.com>` footer. The final diff was reviewed and validated at commit `666f4826b31dd1ea675475ff0ac8032609c4c7fd`.
